### PR TITLE
Add PostgreSQL Primary/Replica configuration for Issue #382

### DIFF
--- a/app/src/main/resources/application.yaml
+++ b/app/src/main/resources/application.yaml
@@ -17,7 +17,7 @@ idp:
             maximum-pool-size: ${ADMIN_DB_WRITER_MAX_POOL_SIZE:10}
             minimum-idle: ${ADMIN_DB_WRITER_MIN_IDLE:5}
         reader:
-          url: "${DB_READER_URL:jdbc:postgresql://localhost:5432/idpserver}"
+          url: "${DB_READER_URL:jdbc:postgresql://localhost:5433/idpserver}"
           username: "${ADMIN_DB_READER_USER_NAME:idpserver}"
           password: "${ADMIN_DB_READER_PASSWORD:idpserver}"
           hikari:
@@ -53,7 +53,7 @@ idp:
             maximum-pool-size: ${DB_WRITER_MAX_POOL_SIZE:30}
             minimum-idle: ${DB_WRITER_MIN_IDLE:10}
         reader:
-          url: "${DB_READER_URL:jdbc:postgresql://localhost:5432/idpserver}"
+          url: "${DB_READER_URL:jdbc:postgresql://localhost:5433/idpserver}"
           username: "${DB_READER_USER_NAME:idp_app_user}"
           password: "${DB_READER_PASSWORD:idp_app_user}"
           hikari:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,16 +2,22 @@ version: '3'
 
 services:
   idp-server-1:
+    build: .
     image: idp-server:latest
     container_name: idp-server-1
     ports:
       - "8081:8080"
     depends_on:
-      - postgresql
-      - postgresql-reader
-      - mysql
-      - redis
-      - flyway-migrator
+      postgres-primary:
+        condition: service_healthy
+      postgres-replica:
+        condition: service_healthy
+      mysql: 
+        condition: service_healthy
+      redis:
+        condition: service_started
+      flyway-migrator:
+        condition: service_completed_successfully
     deploy:
       resources:
         limits:
@@ -22,10 +28,10 @@ services:
           memory: 1g
     environment:
       SERVER_URL: "http://localhost:8081"
-      IDP_SERVER_API_KEY: $IDP_SERVER_API_KEY
-      IDP_SERVER_API_SECRET: $IDP_SERVER_API_SECRET
-      ENCRYPTION_KEY: $ENCRYPTION_KEY
-      DB_WRITER_URL: jdbc:postgresql://postgresql:5432/idpserver
+      IDP_SERVER_API_KEY: ${IDP_SERVER_API_KEY:-30113151-4ee1-4f6a-a1ac-cc1be9eaf695}
+      IDP_SERVER_API_SECRET: ${IDP_SERVER_API_SECRET:-MTY5YjM3NmYtOTY0ZC00Nzg0LWIyOTMtOWQyNDhjMTkyNmIwCg==}
+      ENCRYPTION_KEY: ${ENCRYPTION_KEY:-JjN9c6N4STeA+g9d+TtBGp5MC3sbqOWs+S9qzJG42iY=}
+      DB_WRITER_URL: jdbc:postgresql://postgres-primary:5432/idpserver
       ADMIN_DB_WRITER_USER_NAME: idpserver
       ADMIN_DB_WRITER_PASSWORD: idpserver
       ADMIN_DB_READER_USER_NAME: idpserver
@@ -41,7 +47,7 @@ services:
       DB_WRITER_TIMEOUT: 2000
       DB_WRITER_MAX_POOL_SIZE: 30
       DB_WRITER_MIN_IDLE: 10
-      DB_READER_URL: jdbc:postgresql://postgresql:5432/idpserver
+      DB_READER_URL: jdbc:postgresql://postgres-replica:5432/idpserver
       DB_READER_USER_NAME: idp_app_user
       DB_READER_PASSWORD: idp_app_user
       DB_READER_TIMEOUT: 2000
@@ -61,16 +67,22 @@ services:
         -XX:MaxGCPauseMillis=100
 
   idp-server-2:
+    build: .
     image: idp-server:latest
     container_name: idp-server-2
     ports:
       - "8082:8080"
     depends_on:
-      - postgresql
-      - postgresql-reader
-      - mysql
-      - redis
-      - flyway-migrator
+      postgres-primary:
+        condition: service_healthy
+      postgres-replica:
+        condition: service_healthy
+      mysql: 
+        condition: service_healthy
+      redis:
+        condition: service_started
+      flyway-migrator:
+        condition: service_completed_successfully
     deploy:
       resources:
         limits:
@@ -81,10 +93,10 @@ services:
           memory: 1g
     environment:
       SERVER_URL: "http://localhost:8082"
-      IDP_SERVER_API_KEY: $IDP_SERVER_API_KEY
-      IDP_SERVER_API_SECRET: $IDP_SERVER_API_SECRET
-      ENCRYPTION_KEY: $ENCRYPTION_KEY
-      DB_WRITER_URL: jdbc:postgresql://postgresql:5432/idpserver
+      IDP_SERVER_API_KEY: ${IDP_SERVER_API_KEY:-30113151-4ee1-4f6a-a1ac-cc1be9eaf695}
+      IDP_SERVER_API_SECRET: ${IDP_SERVER_API_SECRET:-MTY5YjM3NmYtOTY0ZC00Nzg0LWIyOTMtOWQyNDhjMTkyNmIwCg==}
+      ENCRYPTION_KEY: ${ENCRYPTION_KEY:-JjN9c6N4STeA+g9d+TtBGp5MC3sbqOWs+S9qzJG42iY=}
+      DB_WRITER_URL: jdbc:postgresql://postgres-primary:5432/idpserver
       ADMIN_DB_WRITER_USER_NAME: idpserver
       ADMIN_DB_WRITER_PASSWORD: idpserver
       ADMIN_DB_READER_USER_NAME: idpserver
@@ -100,7 +112,7 @@ services:
       DB_WRITER_TIMEOUT: 2000
       DB_WRITER_MAX_POOL_SIZE: 30
       DB_WRITER_MIN_IDLE: 10
-      DB_READER_URL: jdbc:postgresql://postgresql:5432/idpserver
+      DB_READER_URL: jdbc:postgresql://postgres-replica:5432/idpserver
       DB_READER_USER_NAME: idp_app_user
       DB_READER_PASSWORD: idp_app_user
       DB_READER_TIMEOUT: 2000
@@ -130,9 +142,9 @@ services:
     ports:
       - "8080:80"
 
-  postgresql:
+  postgres-primary:
     image: postgres:15
-    container_name: postgres
+    container_name: postgres-primary
     environment:
       - POSTGRES_USER=idpserver
       - POSTGRES_PASSWORD=idpserver
@@ -143,24 +155,35 @@ services:
     command: [ "postgres", "-c", "shared_preload_libraries=pg_stat_statements" ]
     volumes:
       - ./libs/idp-server-database/postgresql/operation:/docker-entrypoint-initdb.d
+      - ./docker/postgresql/primary/init-replication.sh:/docker-entrypoint-initdb.d/99-init-replication.sh
+      - postgres_primary_data:/var/lib/postgresql/data
     healthcheck:
       test: [ "CMD-SHELL", "pg_isready -U idpserver -d idpserver" ]
       interval: 5s
       timeout: 3s
       retries: 20
 
-  postgresql-reader:
-    image: postgres:15
-    container_name: postgres-reader
+  postgres-replica:
+    build:
+      context: ./docker/postgresql/replica
+    container_name: postgres-replica
     environment:
       - POSTGRES_USER=idpserver
       - POSTGRES_PASSWORD=idpserver
-      - POSTGRES_DB=idpserver_reader
+      - POSTGRES_DB=idpserver
+      - TZ=UTC
     ports:
-      - "54321:5432"
-    command: [ "postgres", "-c", "shared_preload_libraries=pg_stat_statements" ]
+      - "5433:5432"
+    depends_on:
+      postgres-primary:
+        condition: service_healthy
     volumes:
-      - ./libs/idp-server-database/postgresql/operation:/docker-entrypoint-initdb.d
+      - postgres_replica_data:/var/lib/postgresql/data
+    healthcheck:
+      test: [ "CMD-SHELL", "pg_isready -U idpserver -d idpserver && psql -U idpserver -d idpserver -c 'SELECT pg_is_in_recovery();' | grep -q 't'" ]
+      interval: 10s
+      timeout: 5s
+      retries: 20
 
   mysql:
     image: mysql:8.0
@@ -174,19 +197,27 @@ services:
     ports:
       - "3306:3306"
     command: --default-authentication-plugin=mysql_native_password
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
 
   flyway-migrator:
+    build:
+      context: ./libs/idp-server-database
+      dockerfile: Dockerfile-flyway
     image: idp-flyway-migrator:latest
+    restart: "no"
     depends_on:
-      postgresql:
+      postgres-primary:
         condition: service_healthy
     environment:
       DB_TYPE: postgresql
-      DB_URL: jdbc:postgresql://postgresql:5432/idpserver
+      DB_URL: jdbc:postgresql://postgres-primary:5432/idpserver
       DB_USER_NAME: idpserver
       DB_PASSWORD: idpserver
     command: [ "migrate" ]    # info / repair / clean
-  #    profiles: [ "migrate" ]
 
   redis:
     image: redis:7.2-alpine
@@ -204,3 +235,7 @@ services:
     ]
     ports:
       - "4000:4000"
+
+volumes:
+  postgres_primary_data:
+  postgres_replica_data:

--- a/docker/postgresql/primary/init-replication.sh
+++ b/docker/postgresql/primary/init-replication.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -e
+
+# Create replication user for streaming replication
+psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" <<-EOSQL
+    CREATE USER replicator WITH REPLICATION ENCRYPTED PASSWORD 'replicator_password';
+    SELECT pg_create_physical_replication_slot('replica_slot');
+EOSQL
+
+# Configure PostgreSQL for replication
+cat >> /var/lib/postgresql/data/postgresql.conf <<EOF
+# Replication settings
+wal_level = replica
+max_wal_senders = 3
+max_replication_slots = 3
+hot_standby = on
+EOF
+
+# Configure client authentication for replication
+echo "host replication replicator 0.0.0.0/0 md5" >> /var/lib/postgresql/data/pg_hba.conf
+
+echo "Primary PostgreSQL replication setup completed"

--- a/docker/postgresql/replica/Dockerfile
+++ b/docker/postgresql/replica/Dockerfile
@@ -1,0 +1,17 @@
+FROM postgres:15
+
+# Install additional tools
+USER root
+
+# Copy initialization script
+COPY init-replica.sh /usr/local/bin/init-replica.sh
+RUN chmod +x /usr/local/bin/init-replica.sh
+
+# Custom entrypoint that handles replica initialization
+COPY entrypoint-replica.sh /usr/local/bin/entrypoint-replica.sh
+RUN chmod +x /usr/local/bin/entrypoint-replica.sh
+
+USER postgres
+
+ENTRYPOINT ["/usr/local/bin/entrypoint-replica.sh"]
+CMD ["postgres"]

--- a/docker/postgresql/replica/entrypoint-replica.sh
+++ b/docker/postgresql/replica/entrypoint-replica.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+set -e
+
+# If data directory is empty or doesn't exist, initialize as replica
+if [ ! -s "/var/lib/postgresql/data/PG_VERSION" ]; then
+    echo "Initializing PostgreSQL replica..."
+    
+    # Wait for primary to be ready
+    until pg_isready -h postgres-primary -p 5432 -U replicator -d postgres; do
+        echo "Waiting for primary database to be ready..."
+        sleep 5
+    done
+    
+    # Perform base backup from primary
+    echo "Performing base backup from primary..."
+    PGPASSWORD=replicator_password pg_basebackup -h postgres-primary -D /var/lib/postgresql/data -U replicator -v -P -R
+    
+    # Create standby.signal to enable standby mode
+    touch /var/lib/postgresql/data/standby.signal
+    
+    echo "Replica initialization completed"
+fi
+
+# Start PostgreSQL with original entrypoint
+exec docker-entrypoint.sh "$@"

--- a/docker/postgresql/replica/init-replica.sh
+++ b/docker/postgresql/replica/init-replica.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+set -e
+
+echo "Starting replica initialization..."
+
+# Wait for primary to be ready
+until pg_isready -h postgres-primary -p 5432 -U replicator; do
+    echo "Waiting for primary database to be ready..."
+    sleep 5
+done
+
+# Remove any existing data directory
+rm -rf /var/lib/postgresql/data/*
+
+# Perform base backup from primary
+echo "Performing base backup from primary..."
+PGPASSWORD=replicator_password pg_basebackup -h postgres-primary -D /var/lib/postgresql/data -U replicator -v -P -W -x
+
+# Create recovery configuration
+cat > /var/lib/postgresql/data/postgresql.conf <<EOF
+# Replica configuration
+hot_standby = on
+primary_conninfo = 'host=postgres-primary port=5432 user=replicator password=replicator_password'
+primary_slot_name = 'replica_slot'
+EOF
+
+# Create standby.signal to enable standby mode
+touch /var/lib/postgresql/data/standby.signal
+
+# Set proper permissions
+chown -R postgres:postgres /var/lib/postgresql/data
+chmod 700 /var/lib/postgresql/data
+
+echo "Replica initialization completed"

--- a/scripts/verify-replication.sh
+++ b/scripts/verify-replication.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+set -e
+
+echo "=== PostgreSQL Primary/Replica Replication Verification ==="
+
+# Wait for services to be ready
+echo "Waiting for primary and replica to be healthy..."
+docker compose up -d postgres-primary postgres-replica
+sleep 30
+
+# Check primary status
+echo -e "\n1. Checking Primary Status:"
+echo "Primary pg_is_in_recovery():"
+docker compose exec postgres-primary psql -U idpserver -d idpserver -c "SELECT pg_is_in_recovery();"
+
+echo -e "\nPrimary replication slots:"
+docker compose exec postgres-primary psql -U idpserver -d idpserver -c "SELECT slot_name, slot_type, active FROM pg_replication_slots;"
+
+# Check replica status
+echo -e "\n2. Checking Replica Status:"
+echo "Replica pg_is_in_recovery():"
+docker compose exec postgres-replica psql -U idpserver -d idpserver -c "SELECT pg_is_in_recovery();"
+
+echo -e "\nReplica status:"
+docker compose exec postgres-replica psql -U idpserver -d idpserver -c "SELECT status, received_tli, last_msg_send_time FROM pg_stat_wal_receiver;"
+
+# Test replication
+echo -e "\n3. Testing Replication:"
+echo "Creating test table on primary..."
+docker compose exec postgres-primary psql -U idpserver -d idpserver -c "CREATE TABLE IF NOT EXISTS replication_test (id SERIAL PRIMARY KEY, message TEXT, created_at TIMESTAMP DEFAULT NOW());"
+
+echo "Inserting test data on primary..."
+docker compose exec postgres-primary psql -U idpserver -d idpserver -c "INSERT INTO replication_test (message) VALUES ('Test message from primary at $(date)');"
+
+echo "Waiting for replication..."
+sleep 5
+
+echo "Checking if data exists on replica:"
+docker compose exec postgres-replica psql -U idpserver -d idpserver -c "SELECT * FROM replication_test ORDER BY created_at DESC LIMIT 1;"
+
+# Test write restriction on replica
+echo -e "\n4. Testing Write Restriction on Replica:"
+echo "Attempting to insert on replica (should fail):"
+if docker compose exec postgres-replica psql -U idpserver -d idpserver -c "INSERT INTO replication_test (message) VALUES ('This should fail');" 2>/dev/null; then
+    echo "ERROR: Write succeeded on replica (should not happen)"
+    exit 1
+else
+    echo "SUCCESS: Write correctly failed on replica"
+fi
+
+# Connection test
+echo -e "\n5. Connection Test:"
+echo "Primary connection (port 5432):"
+docker compose exec postgres-primary psql -U idpserver -d idpserver -c "SELECT 'Connected to PRIMARY on port 5432' as status;"
+
+echo "Replica connection (port 5433):"
+docker compose exec postgres-replica psql -U idpserver -d idpserver -c "SELECT 'Connected to REPLICA on port 5433' as status;"
+
+echo -e "\n=== Verification Complete ==="
+echo "✅ Primary/Replica replication is working correctly!"
+echo ""
+echo "Connection Information:"
+echo "  Primary (Write): postgresql://idpserver:idpserver@localhost:5432/idpserver"
+echo "  Replica (Read):  postgresql://idpserver:idpserver@localhost:5433/idpserver"


### PR DESCRIPTION
## Summary

This PR implements PostgreSQL streaming replication for development and testing of read/write separation to resolve Issue #382.

### Key Changes

• **PostgreSQL Primary/Replica Setup**
  - Added streaming replication configuration with automatic initialization
  - Primary (port 5432) handles all write operations
  - Replica (port 5433) handles read-only operations
  - Automatic base backup and standby setup

• **Docker Compose Improvements**
  - Simplified initialization to just `docker compose build && docker compose up -d`
  - Added comprehensive health checks and service dependencies
  - Included default environment variables (no .env.local required)
  - Automatic database migration execution

• **Application Configuration**
  - Updated application.yaml to use replica for read operations
  - Proper read/write separation at application level

• **Verification & Testing**
  - Added comprehensive replication verification script
  - Includes replication status checks, data sync tests, and connection validation

• **Documentation Updates**
  - Updated README.md with complete database configuration guide
  - Updated Japanese getting-started.md with new setup process
  - Simplified configuration commands to match current implementation

## Test plan

- [x] Verify PostgreSQL Primary/Replica replication is working
- [x] Confirm simplified Docker Compose setup works
- [x] Test application read/write separation
- [x] Run E2E tests to validate complete system functionality
- [x] Verify documentation accuracy

🤖 Generated with [Claude Code](https://claude.ai/code)