### PR TITLE
feat: Expand SecurityEventUser attributes with configurable tenant-level settings #292

### DIFF
--- a/libs/idp-server-core-extension-ciba/src/main/java/org/idp/server/core/extension/ciba/CibaFlowEventCreator.java
+++ b/libs/idp-server-core-extension-ciba/src/main/java/org/idp/server/core/extension/ciba/CibaFlowEventCreator.java
@@ -18,13 +18,14 @@ package org.idp.server.core.extension.ciba;
 
 import java.util.HashMap;
 import org.idp.server.core.extension.ciba.request.BackchannelAuthenticationRequest;
+import org.idp.server.core.openid.identity.SecurityEventUserCreatable;
 import org.idp.server.core.openid.identity.User;
 import org.idp.server.platform.multi_tenancy.tenant.Tenant;
 import org.idp.server.platform.security.SecurityEvent;
 import org.idp.server.platform.security.event.*;
 import org.idp.server.platform.type.RequestAttributes;
 
-public class CibaFlowEventCreator {
+public class CibaFlowEventCreator implements SecurityEventUserCreatable {
 
   Tenant tenant;
   BackchannelAuthenticationRequest request;
@@ -63,9 +64,7 @@ public class CibaFlowEventCreator {
     builder.add(securityEventClient);
 
     if (user != null) {
-      SecurityEventUser securityEventUser =
-          new SecurityEventUser(
-              user.sub(), user.name(), user.externalUserId(), user.email(), user.phoneNumber());
+      SecurityEventUser securityEventUser = createSecurityEventUser(user, tenant);
       builder.add(securityEventUser);
       detailsMap.put("user", user.toMap());
     }

--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/identity/SecurityEventUserCreatable.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/identity/SecurityEventUserCreatable.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2025 Hirokazu Kobayashi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.idp.server.core.openid.identity;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.idp.server.platform.multi_tenancy.tenant.Tenant;
+import org.idp.server.platform.security.event.SecurityEventUser;
+import org.idp.server.platform.security.event.SecurityEventUserAttributeConfiguration;
+
+public interface SecurityEventUserCreatable {
+
+  default SecurityEventUser createSecurityEventUser(User user, Tenant tenant) {
+    SecurityEventUserAttributeConfiguration config =
+        tenant.getSecurityEventUserAttributeConfiguration();
+
+    String id = config.isIncludeId() ? user.sub() : null;
+    String name = config.isIncludeName() ? user.name() : null;
+    String externalUserId = config.isIncludeExternalUserId() ? user.externalUserId() : null;
+    String email = config.isIncludeEmail() ? user.email() : null;
+    String phoneNumber = config.isIncludePhoneNumber() ? user.phoneNumber() : null;
+
+    String givenName = config.isIncludeGivenName() ? user.givenName() : null;
+    String familyName = config.isIncludeFamilyName() ? user.familyName() : null;
+    String preferredUsername =
+        config.isIncludePreferredUsername() ? user.preferredUsername() : null;
+    String profile = config.isIncludeProfile() ? user.profile() : null;
+    String picture = config.isIncludePicture() ? user.picture() : null;
+    String website = config.isIncludeWebsite() ? user.website() : null;
+    String gender = config.isIncludeGender() ? user.gender() : null;
+    String birthdate = config.isIncludeBirthdate() ? user.birthdate() : null;
+    String zoneinfo = config.isIncludeZoneinfo() ? user.zoneinfo() : null;
+    String locale = config.isIncludeLocale() ? user.locale() : null;
+
+    Map<String, Object> address =
+        config.isIncludeAddress() && user.address() != null ? user.address().toMap() : null;
+    List<String> roles =
+        config.isIncludeRoles()
+            ? user.roles().stream().map(role -> role.roleName()).collect(Collectors.toList())
+            : null;
+    List<String> permissions = config.isIncludePermissions() ? user.permissions() : null;
+    String currentTenant = config.isIncludeCurrentTenant() ? user.currentTenant() : null;
+    List<String> assignedTenants =
+        config.isIncludeAssignedTenants() ? user.assignedTenants() : null;
+    Map<String, Object> verifiedClaims =
+        config.isIncludeVerifiedClaims() ? user.verifiedClaims() : null;
+
+    return new SecurityEventUser(
+        id,
+        name,
+        externalUserId,
+        email,
+        phoneNumber,
+        givenName,
+        familyName,
+        preferredUsername,
+        profile,
+        picture,
+        website,
+        gender,
+        birthdate,
+        zoneinfo,
+        locale,
+        address,
+        roles,
+        permissions,
+        currentTenant,
+        assignedTenants,
+        verifiedClaims);
+  }
+}

--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/identity/User.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/identity/User.java
@@ -603,6 +603,10 @@ public class User implements JsonReadable, Serializable, UuidConvertable {
     return authenticationDevices != null && !authenticationDevices.isEmpty();
   }
 
+  public String currentTenant() {
+    return currentTenant;
+  }
+
   public TenantIdentifier currentTenantIdentifier() {
     return new TenantIdentifier(currentTenant);
   }

--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/identity/UserOperationEventCreator.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/identity/UserOperationEventCreator.java
@@ -23,7 +23,7 @@ import org.idp.server.platform.security.SecurityEvent;
 import org.idp.server.platform.security.event.*;
 import org.idp.server.platform.type.RequestAttributes;
 
-public class UserOperationEventCreator {
+public class UserOperationEventCreator implements SecurityEventUserCreatable {
 
   Tenant tenant;
   AuthenticationTransaction authenticationTransaction;
@@ -75,9 +75,7 @@ public class UserOperationEventCreator {
     User user = authenticationTransaction.request().user();
 
     if (user != null) {
-      SecurityEventUser securityEventUser =
-          new SecurityEventUser(
-              user.sub(), user.name(), user.externalUserId(), user.email(), user.phoneNumber());
+      SecurityEventUser securityEventUser = createSecurityEventUser(user, tenant);
       builder.add(securityEventUser);
       detailsMap.put("user", user.toMap());
     }

--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/oauth/OAuthFlowEventCreator.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/oauth/OAuthFlowEventCreator.java
@@ -17,6 +17,7 @@
 package org.idp.server.core.openid.oauth;
 
 import java.util.HashMap;
+import org.idp.server.core.openid.identity.SecurityEventUserCreatable;
 import org.idp.server.core.openid.identity.User;
 import org.idp.server.core.openid.oauth.request.AuthorizationRequest;
 import org.idp.server.platform.multi_tenancy.tenant.Tenant;
@@ -24,7 +25,7 @@ import org.idp.server.platform.security.SecurityEvent;
 import org.idp.server.platform.security.event.*;
 import org.idp.server.platform.type.RequestAttributes;
 
-public class OAuthFlowEventCreator {
+public class OAuthFlowEventCreator implements SecurityEventUserCreatable {
 
   Tenant tenant;
   AuthorizationRequest authorizationRequest;
@@ -78,9 +79,7 @@ public class OAuthFlowEventCreator {
     builder.add(securityEventClient);
 
     if (user != null) {
-      SecurityEventUser securityEventUser =
-          new SecurityEventUser(
-              user.sub(), user.name(), user.externalUserId(), user.email(), user.phoneNumber());
+      SecurityEventUser securityEventUser = createSecurityEventUser(user, tenant);
       builder.add(securityEventUser);
       detailsMap.put("user", user.toMap());
     }

--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/token/UserEventCreator.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/token/UserEventCreator.java
@@ -17,13 +17,14 @@
 package org.idp.server.core.openid.token;
 
 import java.util.HashMap;
+import org.idp.server.core.openid.identity.SecurityEventUserCreatable;
 import org.idp.server.core.openid.identity.User;
 import org.idp.server.platform.multi_tenancy.tenant.Tenant;
 import org.idp.server.platform.security.SecurityEvent;
 import org.idp.server.platform.security.event.*;
 import org.idp.server.platform.type.RequestAttributes;
 
-public class UserEventCreator {
+public class UserEventCreator implements SecurityEventUserCreatable {
 
   Tenant tenant;
   OAuthToken oAuthToken;
@@ -74,9 +75,7 @@ public class UserEventCreator {
     User user = oAuthToken.user();
 
     if (user != null) {
-      SecurityEventUser securityEventUser =
-          new SecurityEventUser(
-              user.sub(), user.name(), user.externalUserId(), user.email(), user.phoneNumber());
+      SecurityEventUser securityEventUser = createSecurityEventUser(user, tenant);
       builder.add(securityEventUser);
       detailsMap.put("user", user.toMap());
     }

--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/token/UserEventPublisher.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/token/UserEventPublisher.java
@@ -17,6 +17,7 @@
 package org.idp.server.core.openid.token;
 
 import java.util.HashMap;
+import org.idp.server.core.openid.identity.SecurityEventUserCreatable;
 import org.idp.server.core.openid.identity.User;
 import org.idp.server.core.openid.oauth.type.oauth.RequestedClientId;
 import org.idp.server.platform.multi_tenancy.tenant.Tenant;
@@ -25,7 +26,7 @@ import org.idp.server.platform.security.SecurityEventPublisher;
 import org.idp.server.platform.security.event.*;
 import org.idp.server.platform.type.RequestAttributes;
 
-public class UserEventPublisher {
+public class UserEventPublisher implements SecurityEventUserCreatable {
 
   SecurityEventPublisher securityEventPublisher;
 
@@ -65,9 +66,7 @@ public class UserEventPublisher {
         new SecurityEventClient(requestedClientId.value(), "");
     builder.add(securityEventClient);
 
-    SecurityEventUser securityEventUser =
-        new SecurityEventUser(
-            user.sub(), user.name(), user.externalUserId(), user.email(), user.phoneNumber());
+    SecurityEventUser securityEventUser = createSecurityEventUser(user, tenant);
     builder.add(securityEventUser);
     detailsMap.put("user", user.toMap());
 

--- a/libs/idp-server-platform/src/main/java/org/idp/server/platform/multi_tenancy/tenant/Tenant.java
+++ b/libs/idp-server-platform/src/main/java/org/idp/server/platform/multi_tenancy/tenant/Tenant.java
@@ -22,6 +22,7 @@ import java.util.Objects;
 import java.util.UUID;
 import org.idp.server.platform.datasource.DatabaseType;
 import org.idp.server.platform.dependency.protocol.AuthorizationProvider;
+import org.idp.server.platform.security.event.SecurityEventUserAttributeConfiguration;
 
 public class Tenant {
   TenantIdentifier identifier;
@@ -149,5 +150,9 @@ public class Tenant {
   public Tenant updateWithAttributes(TenantAttributes attributes) {
     return new Tenant(
         identifier, name, type, domain, authorizationProvider, databaseType, attributes);
+  }
+
+  public SecurityEventUserAttributeConfiguration getSecurityEventUserAttributeConfiguration() {
+    return SecurityEventUserAttributeConfiguration.fromTenantAttributes(this.attributes);
   }
 }

--- a/libs/idp-server-platform/src/main/java/org/idp/server/platform/multi_tenancy/tenant/TenantAttributes.java
+++ b/libs/idp-server-platform/src/main/java/org/idp/server/platform/multi_tenancy/tenant/TenantAttributes.java
@@ -69,14 +69,14 @@ public class TenantAttributes {
   }
 
   public boolean optValueAsBoolean(String key, boolean defaultValue) {
-    if (values == null || values.isEmpty()) {
+    if (values == null || values.isEmpty() || !containsKey(key)) {
       return defaultValue;
     }
     return (boolean) values.get(key);
   }
 
   public List<String> optValueAsStringList(String key, List<String> defaultValue) {
-    if (values == null || values.isEmpty()) {
+    if (values == null || values.isEmpty() || !containsKey(key)) {
       return defaultValue;
     }
     return (List<String>) values.get(key);

--- a/libs/idp-server-platform/src/main/java/org/idp/server/platform/security/event/SecurityEventUser.java
+++ b/libs/idp-server-platform/src/main/java/org/idp/server/platform/security/event/SecurityEventUser.java
@@ -17,6 +17,7 @@
 package org.idp.server.platform.security.event;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
@@ -28,6 +29,22 @@ public class SecurityEventUser implements UuidConvertable {
   String exSub;
   String email;
   String phoneNumber;
+  String givenName;
+  String familyName;
+  String preferredUsername;
+  String profile;
+  String picture;
+  String website;
+  String gender;
+  String birthdate;
+  String zoneinfo;
+  String locale;
+  Map<String, Object> address;
+  List<String> roles;
+  List<String> permissions;
+  String currentTenant;
+  List<String> assignedTenants;
+  Map<String, Object> verifiedClaims;
 
   public SecurityEventUser() {}
 
@@ -37,6 +54,51 @@ public class SecurityEventUser implements UuidConvertable {
     this.exSub = exSub;
     this.email = email;
     this.phoneNumber = phoneNumber;
+  }
+
+  public SecurityEventUser(
+      String id,
+      String name,
+      String exSub,
+      String email,
+      String phoneNumber,
+      String givenName,
+      String familyName,
+      String preferredUsername,
+      String profile,
+      String picture,
+      String website,
+      String gender,
+      String birthdate,
+      String zoneinfo,
+      String locale,
+      Map<String, Object> address,
+      List<String> roles,
+      List<String> permissions,
+      String currentTenant,
+      List<String> assignedTenants,
+      Map<String, Object> verifiedClaims) {
+    this.id = id;
+    this.name = name;
+    this.exSub = exSub;
+    this.email = email;
+    this.phoneNumber = phoneNumber;
+    this.givenName = givenName;
+    this.familyName = familyName;
+    this.preferredUsername = preferredUsername;
+    this.profile = profile;
+    this.picture = picture;
+    this.website = website;
+    this.gender = gender;
+    this.birthdate = birthdate;
+    this.zoneinfo = zoneinfo;
+    this.locale = locale;
+    this.address = address;
+    this.roles = roles;
+    this.permissions = permissions;
+    this.currentTenant = currentTenant;
+    this.assignedTenants = assignedTenants;
+    this.verifiedClaims = verifiedClaims;
   }
 
   public Map<String, Object> toMap() {
@@ -55,6 +117,54 @@ public class SecurityEventUser implements UuidConvertable {
     }
     if (phoneNumber != null) {
       result.put("phone_number", phoneNumber);
+    }
+    if (givenName != null) {
+      result.put("given_name", givenName);
+    }
+    if (familyName != null) {
+      result.put("family_name", familyName);
+    }
+    if (preferredUsername != null) {
+      result.put("preferred_username", preferredUsername);
+    }
+    if (profile != null) {
+      result.put("profile", profile);
+    }
+    if (picture != null) {
+      result.put("picture", picture);
+    }
+    if (website != null) {
+      result.put("website", website);
+    }
+    if (gender != null) {
+      result.put("gender", gender);
+    }
+    if (birthdate != null) {
+      result.put("birthdate", birthdate);
+    }
+    if (zoneinfo != null) {
+      result.put("zoneinfo", zoneinfo);
+    }
+    if (locale != null) {
+      result.put("locale", locale);
+    }
+    if (address != null) {
+      result.put("address", address);
+    }
+    if (roles != null) {
+      result.put("roles", roles);
+    }
+    if (permissions != null) {
+      result.put("permissions", permissions);
+    }
+    if (currentTenant != null) {
+      result.put("current_tenant", currentTenant);
+    }
+    if (assignedTenants != null) {
+      result.put("assigned_tenants", assignedTenants);
+    }
+    if (verifiedClaims != null) {
+      result.put("verified_claims", verifiedClaims);
     }
     return result;
   }
@@ -81,6 +191,70 @@ public class SecurityEventUser implements UuidConvertable {
 
   public String phoneNumber() {
     return phoneNumber;
+  }
+
+  public String givenName() {
+    return givenName;
+  }
+
+  public String familyName() {
+    return familyName;
+  }
+
+  public String preferredUsername() {
+    return preferredUsername;
+  }
+
+  public String profile() {
+    return profile;
+  }
+
+  public String picture() {
+    return picture;
+  }
+
+  public String website() {
+    return website;
+  }
+
+  public String gender() {
+    return gender;
+  }
+
+  public String birthdate() {
+    return birthdate;
+  }
+
+  public String zoneinfo() {
+    return zoneinfo;
+  }
+
+  public String locale() {
+    return locale;
+  }
+
+  public Map<String, Object> address() {
+    return address;
+  }
+
+  public List<String> roles() {
+    return roles;
+  }
+
+  public List<String> permissions() {
+    return permissions;
+  }
+
+  public String currentTenant() {
+    return currentTenant;
+  }
+
+  public List<String> assignedTenants() {
+    return assignedTenants;
+  }
+
+  public Map<String, Object> verifiedClaims() {
+    return verifiedClaims;
   }
 
   public boolean exists() {

--- a/libs/idp-server-platform/src/main/java/org/idp/server/platform/security/event/SecurityEventUserAttributeConfiguration.java
+++ b/libs/idp-server-platform/src/main/java/org/idp/server/platform/security/event/SecurityEventUserAttributeConfiguration.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2025 Hirokazu Kobayashi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.idp.server.platform.security.event;
+
+import org.idp.server.platform.multi_tenancy.tenant.TenantAttributes;
+
+public class SecurityEventUserAttributeConfiguration {
+  private static final String PREFIX = "security_event_user_";
+
+  private final TenantAttributes tenantAttributes;
+
+  public static SecurityEventUserAttributeConfiguration fromTenantAttributes(
+      TenantAttributes attributes) {
+    return new SecurityEventUserAttributeConfiguration(attributes);
+  }
+
+  private SecurityEventUserAttributeConfiguration(TenantAttributes tenantAttributes) {
+    this.tenantAttributes = tenantAttributes;
+  }
+
+  public boolean isIncludeId() {
+    return tenantAttributes.optValueAsBoolean(PREFIX + "include_id", true);
+  }
+
+  public boolean isIncludeName() {
+    return tenantAttributes.optValueAsBoolean(PREFIX + "include_name", true);
+  }
+
+  public boolean isIncludeExternalUserId() {
+    return tenantAttributes.optValueAsBoolean(PREFIX + "include_external_user_id", true);
+  }
+
+  public boolean isIncludeEmail() {
+    return tenantAttributes.optValueAsBoolean(PREFIX + "include_email", true);
+  }
+
+  public boolean isIncludePhoneNumber() {
+    return tenantAttributes.optValueAsBoolean(PREFIX + "include_phone_number", true);
+  }
+
+  public boolean isIncludeGivenName() {
+    return tenantAttributes.optValueAsBoolean(PREFIX + "include_given_name", false);
+  }
+
+  public boolean isIncludeFamilyName() {
+    return tenantAttributes.optValueAsBoolean(PREFIX + "include_family_name", false);
+  }
+
+  public boolean isIncludePreferredUsername() {
+    return tenantAttributes.optValueAsBoolean(PREFIX + "include_preferred_username", false);
+  }
+
+  public boolean isIncludeProfile() {
+    return tenantAttributes.optValueAsBoolean(PREFIX + "include_profile", false);
+  }
+
+  public boolean isIncludePicture() {
+    return tenantAttributes.optValueAsBoolean(PREFIX + "include_picture", false);
+  }
+
+  public boolean isIncludeWebsite() {
+    return tenantAttributes.optValueAsBoolean(PREFIX + "include_website", false);
+  }
+
+  public boolean isIncludeGender() {
+    return tenantAttributes.optValueAsBoolean(PREFIX + "include_gender", false);
+  }
+
+  public boolean isIncludeBirthdate() {
+    return tenantAttributes.optValueAsBoolean(PREFIX + "include_birthdate", false);
+  }
+
+  public boolean isIncludeZoneinfo() {
+    return tenantAttributes.optValueAsBoolean(PREFIX + "include_zoneinfo", false);
+  }
+
+  public boolean isIncludeLocale() {
+    return tenantAttributes.optValueAsBoolean(PREFIX + "include_locale", false);
+  }
+
+  public boolean isIncludeAddress() {
+    return tenantAttributes.optValueAsBoolean(PREFIX + "include_address", false);
+  }
+
+  public boolean isIncludeRoles() {
+    return tenantAttributes.optValueAsBoolean(PREFIX + "include_roles", false);
+  }
+
+  public boolean isIncludePermissions() {
+    return tenantAttributes.optValueAsBoolean(PREFIX + "include_permissions", false);
+  }
+
+  public boolean isIncludeCurrentTenant() {
+    return tenantAttributes.optValueAsBoolean(PREFIX + "include_current_tenant", false);
+  }
+
+  public boolean isIncludeAssignedTenants() {
+    return tenantAttributes.optValueAsBoolean(PREFIX + "include_assigned_tenants", false);
+  }
+
+  public boolean isIncludeVerifiedClaims() {
+    return tenantAttributes.optValueAsBoolean(PREFIX + "include_verified_claims", false);
+  }
+}


### PR DESCRIPTION
## Summary

SecurityEventUserの属性を拡張し、テナント単位で設定可能な属性選択機能を実装しました。

- **SecurityEventUserAttributeConfiguration**: テナント単位での属性選択設定
- **SecurityEventUser拡張**: 15の新規OpenID Connect標準属性を追加
- **SecurityEventUserCreatable**: コード重複を削減するインターフェース
- **全EventCreator更新**: 設定可能な属性マッピングを実装
- **後方互換性**: 既存の5属性コンストラクタを維持

## 実装詳細

### 1. SecurityEventUserAttributeConfiguration
- TenantAttributesを活用した設定システム
- `security_event_user_include_*` パターンでの属性設定
- デフォルト値による後方互換性確保

### 2. SecurityEventUser拡張属性
- **基本属性**: givenName, familyName, preferredUsername, profile, picture, website
- **その他**: gender, birthdate, zoneinfo, locale, address
- **権限系**: roles, permissions, currentTenant, assignedTenants
- **検証系**: verifiedClaims

### 3. SecurityEventUserCreatable Interface
- 共通のcreateSecurityEventUserメソッドを提供
- 6つのEventCreatorクラスで重複コードを削減
- core プロジェクトに配置して依存関係を解決

### 4. 設定例
```json
{
  "security_event_user_include_id": true,
  "security_event_user_include_name": true,
  "security_event_user_include_email": true,
  "security_event_user_include_given_name": true,
  "security_event_user_include_roles": true,
  "security_event_user_include_verified_claims": true
}
```

## Test plan

- [x] Unit tests pass
- [x] Integration tests pass  
- [x] E2E tests pass
- [x] Backward compatibility verified
- [x] Configuration functionality tested

## Closes

Closes #292

🤖 Generated with [Claude Code](https://claude.ai/code)