### PR TITLE
Fix UserStatus enum compatibility by restoring UNREGISTERED status

### DIFF
--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/identity/UserStatus.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/identity/UserStatus.java
@@ -17,6 +17,7 @@
 package org.idp.server.core.openid.identity;
 
 public enum UserStatus {
+  UNREGISTERED("Account has not been created"),
   INITIALIZED("User has initiated your account"),
   FEDERATED("Federated External IdP"),
   REGISTERED("Registered"),
@@ -55,5 +56,9 @@ public enum UserStatus {
 
   public boolean isInitialized() {
     return this == INITIALIZED;
+  }
+
+  public boolean isUnregistered() {
+    return this == UNREGISTERED;
   }
 }


### PR DESCRIPTION
## Problem
- MFA registration fails with deserialization error when updating to new JAR version
- Error: Cannot deserialize "UNREGISTERED" status  
- Existing data/code references UNREGISTERED status that was previously removed

## Root Cause
The `UNREGISTERED` status was removed in a previous commit (`45019c07`), breaking backward compatibility with:
- Existing serialized data in databases/caches
- Legacy code that expects UNREGISTERED status
- MFA registration workflows that depend on this status

## Solution
✅ **Restore UNREGISTERED enum value**
```java
// Added back to UserStatus enum
UNREGISTERED("Account has not been created"),
```

✅ **Restore convenience method**  
```java
public boolean isUnregistered() {
  return this == UNREGISTERED;
}
```

✅ **Maintain logical ordering**
- UNREGISTERED placed first as it represents the initial state
- All other enum values preserved in existing order

## Benefits
- 🔄 **Backward Compatibility**: Existing data deserializes correctly
- 🛠️ **Legacy Code Support**: Applications using `isUnregistered()` work without changes  
- 🚀 **Seamless Migration**: No data migration required for existing deployments
- 📊 **State Completeness**: Full user lifecycle status representation

## Testing
- ✅ Core module compilation successful
- ✅ Full project build successful
- ✅ No breaking changes to existing functionality
- ✅ Enum deserialization verified

## Impact
- **Zero Breaking Changes**: All existing enum values maintained
- **Immediate Fix**: Resolves MFA registration deserialization errors
- **Future-Proof**: Prevents similar compatibility issues

Fixes #425

## Enum Values (After Fix)
```
UNREGISTERED ← ✅ RESTORED
INITIALIZED  
FEDERATED
REGISTERED
IDENTITY_VERIFIED
IDENTITY_VERIFICATION_REQUIRED
LOCKED
DISABLED
SUSPENDED  
DEACTIVATED
DELETED_PENDING
DELETED
UNKNOWN
```