### PR TITLE
Implement conditional mapping execution for mapper system (Issue #472)

### DIFF
--- a/libs/idp-server-platform/src/main/java/org/idp/server/platform/condition/ConditionOperationEvaluator.java
+++ b/libs/idp-server-platform/src/main/java/org/idp/server/platform/condition/ConditionOperationEvaluator.java
@@ -20,7 +20,50 @@ import java.math.BigDecimal;
 import java.util.*;
 import java.util.regex.Pattern;
 
+/**
+ * Evaluates conditions for mapping rules with support for various comparison operations.
+ *
+ * <p>This class provides robust condition evaluation with regex caching and safety features.
+ *
+ * <p><b>Configurable System Properties:</b>
+ *
+ * <ul>
+ *   <li><b>idp.condition.regex.maxLength</b>: Maximum regex pattern length (default: 1000)
+ *   <li><b>idp.condition.regex.cacheSize</b>: Maximum regex cache size with LRU eviction (default:
+ *       100)
+ * </ul>
+ *
+ * <p><b>Security Features:</b>
+ *
+ * <ul>
+ *   <li>Regex pattern length limiting to prevent ReDoS attacks
+ *   <li>LRU cache with automatic eviction to prevent memory exhaustion
+ *   <li>Thread-safe pattern compilation and caching
+ * </ul>
+ */
 public class ConditionOperationEvaluator {
+
+  // Configurable limits for operational flexibility
+  private static final int MAX_REGEX_LENGTH =
+      Integer.parseInt(System.getProperty("idp.condition.regex.maxLength", "1000"));
+  private static final int MAX_CACHE_SIZE =
+      Integer.parseInt(System.getProperty("idp.condition.regex.cacheSize", "100"));
+
+  private static final Map<String, Pattern> PATTERN_CACHE = createLRUCache(MAX_CACHE_SIZE);
+
+  /**
+   * Creates a thread-safe LRU cache for compiled regex patterns. Uses LinkedHashMap with
+   * access-order and removeEldestEntry override.
+   */
+  private static Map<String, Pattern> createLRUCache(int maxSize) {
+    return Collections.synchronizedMap(
+        new LinkedHashMap<String, Pattern>(16, 0.75f, true) {
+          @Override
+          protected boolean removeEldestEntry(Map.Entry<String, Pattern> eldest) {
+            return size() > maxSize;
+          }
+        });
+  }
 
   public static boolean evaluate(Object target, String operatorStr, Object expected) {
     ConditionOperation conditionOperation = ConditionOperation.from(operatorStr);
@@ -46,6 +89,33 @@ public class ConditionOperationEvaluator {
     };
   }
 
+  /**
+   * Compares two values numerically using BigDecimal for precision.
+   *
+   * <p><b>Type Conversion Rules:</b>
+   *
+   * <ul>
+   *   <li>Numbers (Integer, Double, etc.) → Direct conversion to BigDecimal
+   *   <li>Strings → Parsed as BigDecimal if valid numeric format
+   *   <li>null values → Throws IllegalArgumentException (comparison impossible)
+   *   <li>Non-numeric types → Throws IllegalArgumentException
+   * </ul>
+   *
+   * <p><b>Examples:</b>
+   *
+   * <ul>
+   *   <li>18 vs "18.0" → Equal (both converted to BigDecimal)
+   *   <li>18 vs "18" → Equal
+   *   <li>18.5 vs 18 → 18.5 is greater
+   *   <li>null vs 18 → Throws exception
+   *   <li>"abc" vs 18 → Throws exception
+   * </ul>
+   *
+   * @param a first value to compare
+   * @param b second value to compare
+   * @return negative if a < b, zero if a == b, positive if a > b
+   * @throws IllegalArgumentException if either value cannot be converted to a number
+   */
   private static int compareNumbers(Object a, Object b) {
     try {
       BigDecimal left = toBigDecimal(a);
@@ -78,8 +148,37 @@ public class ConditionOperationEvaluator {
 
   private static boolean matchRegex(Object target, Object expected) {
     if (target instanceof String str && expected instanceof String regex) {
-      return Pattern.matches(regex, str);
+      try {
+        Pattern pattern = getCompiledPattern(regex);
+        return pattern.matcher(str).matches();
+      } catch (IllegalArgumentException e) {
+        // Invalid regex pattern or security violation - return false for safety
+        return false;
+      }
     }
     return false;
+  }
+
+  /**
+   * Get a compiled Pattern from cache or compile and cache it. Uses LRU eviction policy for optimal
+   * cache performance. Includes safety checks for regex length.
+   */
+  private static Pattern getCompiledPattern(String regex) {
+    // Safety check: prevent excessively long patterns
+    if (regex.length() > MAX_REGEX_LENGTH) {
+      throw new IllegalArgumentException(
+          "Regex pattern too long: " + regex.length() + " > " + MAX_REGEX_LENGTH);
+    }
+
+    // Check cache first (LRU cache handles access order automatically)
+    Pattern cached = PATTERN_CACHE.get(regex);
+    if (cached != null) {
+      return cached;
+    }
+
+    // Compile and cache the pattern (LRU eviction happens automatically)
+    Pattern pattern = Pattern.compile(regex);
+    PATTERN_CACHE.put(regex, pattern);
+    return pattern;
   }
 }

--- a/libs/idp-server-platform/src/main/java/org/idp/server/platform/mapper/ConditionSpec.java
+++ b/libs/idp-server-platform/src/main/java/org/idp/server/platform/mapper/ConditionSpec.java
@@ -1,0 +1,302 @@
+/*
+ * Copyright 2025 Hirokazu Kobayashi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.idp.server.platform.mapper;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.idp.server.platform.condition.ConditionOperation;
+import org.idp.server.platform.condition.ConditionOperationEvaluator;
+import org.idp.server.platform.json.JsonReadable;
+import org.idp.server.platform.json.path.JsonPathWrapper;
+import org.idp.server.platform.log.LoggerWrapper;
+
+/**
+ * {@code ConditionSpec} defines conditional execution criteria for mapping rules.
+ *
+ * <p>This class provides flexible condition evaluation based on JSONPath values, leveraging the
+ * platform's {@link ConditionOperationEvaluator} for robust condition processing.
+ *
+ * <p><b>Configurable System Properties:</b>
+ *
+ * <ul>
+ *   <li><b>idp.condition.maxDepth</b>: Maximum compound condition nesting depth (default: 10)
+ * </ul>
+ *
+ * <p>Supported condition operations (via {@link ConditionOperation}):
+ *
+ * <ul>
+ *   <li><b>eq</b>: Equality check
+ *   <li><b>ne</b>: Not equal check
+ *   <li><b>gt</b>: Greater than (numeric)
+ *   <li><b>gte</b>: Greater than or equal (numeric)
+ *   <li><b>lt</b>: Less than (numeric)
+ *   <li><b>lte</b>: Less than or equal (numeric)
+ *   <li><b>in</b>: Value is in collection
+ *   <li><b>nin</b>: Value is not in collection
+ *   <li><b>exists</b>: Check if JSONPath value exists and is not null
+ *   <li><b>missing</b>: Check if JSONPath value is null or missing
+ *   <li><b>contains</b>: Collection/string contains value
+ *   <li><b>regex</b>: String pattern matching using regular expressions
+ *   <li><b>allOf</b>: All nested conditions must be true (logical AND)
+ *   <li><b>anyOf</b>: At least one nested condition must be true (logical OR)
+ * </ul>
+ *
+ * <p>Example usage:
+ *
+ * <pre>{@code
+ * // Execute mapping only if user is verified
+ * new ConditionSpec("exists", "$.user.verified");
+ *
+ * // Execute mapping only for admin users
+ * new ConditionSpec("eq", "$.user.role", "admin");
+ *
+ * // Execute mapping for users over 18
+ * new ConditionSpec("gte", "$.user.age", 18);
+ *
+ * // Execute mapping for valid email addresses
+ * new ConditionSpec("regex", "$.user.email", "^[\\w.-]+@[\\w.-]+\\.[a-zA-Z]{2,}$");
+ *
+ * // Compound conditions: admin AND verified
+ * new ConditionSpec("allOf", null, List.of(
+ *     new ConditionSpec("eq", "$.user.role", "admin"),
+ *     new ConditionSpec("exists", "$.user.verified")
+ * ));
+ *
+ * // Compound conditions: admin OR editor
+ * new ConditionSpec("anyOf", null, List.of(
+ *     new ConditionSpec("eq", "$.user.role", "admin"),
+ *     new ConditionSpec("eq", "$.user.role", "editor")
+ * ));
+ * }</pre>
+ */
+public class ConditionSpec implements JsonReadable {
+
+  private static final LoggerWrapper log = LoggerWrapper.getLogger(ConditionSpec.class);
+
+  // Configurable depth limit for operational flexibility
+  private static final int MAX_CONDITION_DEPTH =
+      Integer.parseInt(System.getProperty("idp.condition.maxDepth", "10"));
+
+  String operation;
+  String path;
+  Object value;
+
+  public ConditionSpec() {}
+
+  public ConditionSpec(String operation, String path) {
+    this.operation = operation;
+    this.path = path;
+  }
+
+  public ConditionSpec(String operation, String path, Object value) {
+    this.operation = operation;
+    this.path = path;
+    this.value = value;
+  }
+
+  public String operation() {
+    return operation;
+  }
+
+  public String path() {
+    return path;
+  }
+
+  public Object value() {
+    return value;
+  }
+
+  /**
+   * Evaluates the condition against the provided JSONPath context.
+   *
+   * <p>Supports both simple conditions (using {@link ConditionOperationEvaluator}) and compound
+   * conditions (allOf/anyOf with nested conditions).
+   *
+   * @param jsonPath the JSONPath wrapper containing the source data
+   * @return true if the condition is satisfied, false otherwise
+   */
+  public boolean evaluate(JsonPathWrapper jsonPath) {
+    return evaluate(jsonPath, 0);
+  }
+
+  /**
+   * Evaluates the condition with depth tracking to prevent stack overflow attacks.
+   *
+   * @param jsonPath the JSONPath wrapper containing the source data
+   * @param depth current recursion depth
+   * @return true if the condition is satisfied, false otherwise
+   */
+  private boolean evaluate(JsonPathWrapper jsonPath, int depth) {
+    if (depth > MAX_CONDITION_DEPTH) {
+      log.warn(
+          "Condition evaluation depth limit exceeded: depth={}, max={}",
+          depth,
+          MAX_CONDITION_DEPTH);
+      return false;
+    }
+    if (operation == null || operation.isEmpty()) {
+      throw new IllegalArgumentException("condition: operation is required");
+    }
+
+    try {
+      // Handle compound conditions
+      if ("allOf".equals(operation)) {
+        return evaluateAllOf(jsonPath, depth + 1);
+      }
+      if ("anyOf".equals(operation)) {
+        return evaluateAnyOf(jsonPath, depth + 1);
+      }
+
+      // Handle simple conditions - require path
+      if (path == null || path.isEmpty()) {
+        throw new IllegalArgumentException(
+            "condition: path is required for operation '" + operation + "'");
+      }
+
+      Object pathValue = jsonPath.readRaw(path);
+      return ConditionOperationEvaluator.evaluate(pathValue, operation, value);
+    } catch (Exception e) {
+      // Mask potential PII in path for security
+      String maskedPath = maskSensitivePath(path);
+      String errorType = e.getClass().getSimpleName();
+      String details = getErrorDetails(operation, value, e);
+
+      log.warn(
+          "Condition evaluation failed: operation={}, path={}, errorType={}, details={}, error={}",
+          operation,
+          maskedPath,
+          errorType,
+          details,
+          e.getMessage());
+      return false;
+    }
+  }
+
+  /** Evaluates "allOf" compound condition - all nested conditions must be true. */
+  private boolean evaluateAllOf(JsonPathWrapper jsonPath, int depth) {
+    if (!(value instanceof List<?>)) {
+      throw new IllegalArgumentException("condition: 'allOf' requires a list of nested conditions");
+    }
+
+    @SuppressWarnings("unchecked")
+    List<ConditionSpec> conditions = (List<ConditionSpec>) value;
+
+    if (conditions.isEmpty()) {
+      return true; // Empty allOf is considered true
+    }
+
+    for (ConditionSpec condition : conditions) {
+      if (!condition.evaluate(jsonPath, depth)) {
+        return false; // Short-circuit on first false
+      }
+    }
+    return true;
+  }
+
+  /** Evaluates "anyOf" compound condition - at least one nested condition must be true. */
+  private boolean evaluateAnyOf(JsonPathWrapper jsonPath, int depth) {
+    if (!(value instanceof List<?>)) {
+      throw new IllegalArgumentException("condition: 'anyOf' requires a list of nested conditions");
+    }
+
+    @SuppressWarnings("unchecked")
+    List<ConditionSpec> conditions = (List<ConditionSpec>) value;
+
+    if (conditions.isEmpty()) {
+      return false; // Empty anyOf is considered false
+    }
+
+    for (ConditionSpec condition : conditions) {
+      if (condition.evaluate(jsonPath, depth)) {
+        return true; // Short-circuit on first true
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Provides specific error details based on operation type and exception.
+   *
+   * @param operation the operation that failed
+   * @param value the value used in the operation
+   * @param exception the exception that occurred
+   * @return specific error details for logging
+   */
+  private String getErrorDetails(String operation, Object value, Exception exception) {
+    if (exception.getMessage() != null && exception.getMessage().contains("JSONPath")) {
+      return "invalid_jsonpath_syntax";
+    }
+
+    switch (operation) {
+      case "regex":
+        if (exception instanceof IllegalArgumentException) {
+          if (exception.getMessage().contains("too long")) {
+            return "regex_pattern_too_long";
+          }
+          return "invalid_regex_pattern";
+        }
+        break;
+      case "gt", "gte", "lt", "lte":
+        if (exception.getMessage() != null && exception.getMessage().contains("numeric")) {
+          return "non_numeric_comparison";
+        }
+        break;
+      case "allOf", "anyOf":
+        if (exception instanceof IllegalArgumentException) {
+          return "invalid_compound_condition_structure";
+        }
+        break;
+      case "in", "nin":
+        if (value != null && !(value instanceof Collection)) {
+          return "expected_collection_for_in_operation";
+        }
+        break;
+      case "contains":
+        return "unsupported_contains_operation";
+      default:
+        break;
+    }
+
+    return "unknown_error";
+  }
+
+  /**
+   * Masks potentially sensitive information in JSONPath for logging.
+   *
+   * @param path the JSONPath to mask
+   * @return masked path for safe logging
+   */
+  private String maskSensitivePath(String path) {
+    if (path == null) {
+      return null;
+    }
+
+    // Mask common PII fields
+    return path.replaceAll("(email|phone|ssn|password|token|key)", "***")
+        .replaceAll("\\d{3,}", "***"); // Mask sequences of 3+ digits
+  }
+
+  public Map<String, Object> toMap() {
+    Map<String, Object> map = new HashMap<>();
+    map.put("operation", operation);
+    map.put("path", path);
+    map.put("value", value);
+    return map;
+  }
+}

--- a/libs/idp-server-platform/src/main/java/org/idp/server/platform/mapper/MappingRuleObjectMapper.java
+++ b/libs/idp-server-platform/src/main/java/org/idp/server/platform/mapper/MappingRuleObjectMapper.java
@@ -35,6 +35,12 @@ public class MappingRuleObjectMapper {
     Map<String, Object> flatMap = new HashMap<>();
 
     for (MappingRule rule : mappingRules) {
+      // Check condition before executing the rule
+      if (!rule.shouldExecute(jsonPath)) {
+        log.debug("Rule skipped due to condition: to={}", rule.to());
+        continue;
+      }
+
       Object baseValue = resolveBaseValue(rule, jsonPath);
       Object finalValue = applyFunctions(rule, baseValue);
       writeResult(rule, finalValue, flatMap);

--- a/libs/idp-server-platform/src/test/java/org/idp/server/platform/mapper/ConditionSpecTest.java
+++ b/libs/idp-server-platform/src/test/java/org/idp/server/platform/mapper/ConditionSpecTest.java
@@ -1,0 +1,860 @@
+/*
+ * Copyright 2025 Hirokazu Kobayashi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.idp.server.platform.mapper;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+import java.util.Map;
+import org.idp.server.platform.json.path.JsonPathWrapper;
+import org.junit.jupiter.api.Test;
+
+class ConditionSpecTest {
+
+  @Test
+  void evaluateExists_shouldReturnTrueWhenValueExists() {
+    JsonPathWrapper jsonPath = new JsonPathWrapper("{\"user\": {\"name\": \"John\"}}");
+    ConditionSpec condition = new ConditionSpec("exists", "$.user.name");
+
+    assertTrue(condition.evaluate(jsonPath));
+  }
+
+  @Test
+  void evaluateExists_shouldReturnFalseWhenValueIsNull() {
+    JsonPathWrapper jsonPath = new JsonPathWrapper("{\"user\": {\"name\": null}}");
+    ConditionSpec condition = new ConditionSpec("exists", "$.user.name");
+
+    assertFalse(condition.evaluate(jsonPath));
+  }
+
+  @Test
+  void evaluateExists_shouldReturnFalseWhenPathDoesNotExist() {
+    JsonPathWrapper jsonPath = new JsonPathWrapper("{\"user\": {}}");
+    ConditionSpec condition = new ConditionSpec("exists", "$.user.email");
+
+    assertFalse(condition.evaluate(jsonPath));
+  }
+
+  @Test
+  void evaluateMissing_shouldReturnTrueWhenValueIsNull() {
+    JsonPathWrapper jsonPath = new JsonPathWrapper("{\"user\": {\"name\": null}}");
+    ConditionSpec condition = new ConditionSpec("missing", "$.user.name");
+
+    assertTrue(condition.evaluate(jsonPath));
+  }
+
+  @Test
+  void evaluateMissing_shouldReturnFalseWhenValueExists() {
+    JsonPathWrapper jsonPath = new JsonPathWrapper("{\"user\": {\"name\": \"John\"}}");
+    ConditionSpec condition = new ConditionSpec("missing", "$.user.name");
+
+    assertFalse(condition.evaluate(jsonPath));
+  }
+
+  @Test
+  void evaluateEq_shouldReturnTrueForMatchingStringValues() {
+    JsonPathWrapper jsonPath = new JsonPathWrapper("{\"user\": {\"role\": \"admin\"}}");
+    ConditionSpec condition = new ConditionSpec("eq", "$.user.role", "admin");
+
+    assertTrue(condition.evaluate(jsonPath));
+  }
+
+  @Test
+  void evaluateEq_shouldReturnFalseForNonMatchingStringValues() {
+    JsonPathWrapper jsonPath = new JsonPathWrapper("{\"user\": {\"role\": \"user\"}}");
+    ConditionSpec condition = new ConditionSpec("eq", "$.user.role", "admin");
+
+    assertFalse(condition.evaluate(jsonPath));
+  }
+
+  @Test
+  void evaluateNe_shouldReturnTrueForNonMatchingValues() {
+    JsonPathWrapper jsonPath = new JsonPathWrapper("{\"user\": {\"role\": \"user\"}}");
+    ConditionSpec condition = new ConditionSpec("ne", "$.user.role", "admin");
+
+    assertTrue(condition.evaluate(jsonPath));
+  }
+
+  @Test
+  void evaluateNe_shouldReturnFalseForMatchingValues() {
+    JsonPathWrapper jsonPath = new JsonPathWrapper("{\"user\": {\"role\": \"admin\"}}");
+    ConditionSpec condition = new ConditionSpec("ne", "$.user.role", "admin");
+
+    assertFalse(condition.evaluate(jsonPath));
+  }
+
+  @Test
+  void evaluateEq_shouldReturnTrueForMatchingNumericValues() {
+    JsonPathWrapper jsonPath = new JsonPathWrapper("{\"user\": {\"age\": 25}}");
+    ConditionSpec condition = new ConditionSpec("eq", "$.user.age", 25);
+
+    assertTrue(condition.evaluate(jsonPath));
+  }
+
+  @Test
+  void evaluateEq_shouldNotMatchDifferentNumericTypes() {
+    JsonPathWrapper jsonPath = new JsonPathWrapper("{\"user\": {\"age\": 25}}");
+    ConditionSpec condition = new ConditionSpec("eq", "$.user.age", 25.0);
+
+    // Objects.equals(25, 25.0) is false - different types are not equal
+    assertFalse(condition.evaluate(jsonPath));
+  }
+
+  @Test
+  void evaluateGte_shouldHandleNumericTypeCoercion() {
+    JsonPathWrapper jsonPath = new JsonPathWrapper("{\"user\": {\"age\": 25}}");
+    ConditionSpec condition = new ConditionSpec("gte", "$.user.age", 25.0);
+
+    // Numeric comparison does handle type coercion
+    assertTrue(condition.evaluate(jsonPath));
+  }
+
+  @Test
+  void evaluateEq_shouldReturnTrueForMatchingBooleanValues() {
+    JsonPathWrapper jsonPath = new JsonPathWrapper("{\"user\": {\"verified\": true}}");
+    ConditionSpec condition = new ConditionSpec("eq", "$.user.verified", true);
+
+    assertTrue(condition.evaluate(jsonPath));
+  }
+
+  @Test
+  void evaluateEq_shouldReturnFalseWhenValueIsNull() {
+    JsonPathWrapper jsonPath = new JsonPathWrapper("{\"user\": {\"role\": null}}");
+    ConditionSpec condition = new ConditionSpec("eq", "$.user.role", "admin");
+
+    assertFalse(condition.evaluate(jsonPath));
+  }
+
+  @Test
+  void evaluateGt_shouldReturnTrueForGreaterValue() {
+    JsonPathWrapper jsonPath = new JsonPathWrapper("{\"user\": {\"age\": 25}}");
+    ConditionSpec condition = new ConditionSpec("gt", "$.user.age", 18);
+
+    assertTrue(condition.evaluate(jsonPath));
+  }
+
+  @Test
+  void evaluateGt_shouldReturnFalseForEqualValue() {
+    JsonPathWrapper jsonPath = new JsonPathWrapper("{\"user\": {\"age\": 18}}");
+    ConditionSpec condition = new ConditionSpec("gt", "$.user.age", 18);
+
+    assertFalse(condition.evaluate(jsonPath));
+  }
+
+  @Test
+  void evaluateGte_shouldReturnTrueForEqualValue() {
+    JsonPathWrapper jsonPath = new JsonPathWrapper("{\"user\": {\"age\": 18}}");
+    ConditionSpec condition = new ConditionSpec("gte", "$.user.age", 18);
+
+    assertTrue(condition.evaluate(jsonPath));
+  }
+
+  @Test
+  void evaluateGte_shouldReturnTrueForGreaterValue() {
+    JsonPathWrapper jsonPath = new JsonPathWrapper("{\"user\": {\"age\": 25}}");
+    ConditionSpec condition = new ConditionSpec("gte", "$.user.age", 18);
+
+    assertTrue(condition.evaluate(jsonPath));
+  }
+
+  @Test
+  void evaluateLt_shouldReturnTrueForLesserValue() {
+    JsonPathWrapper jsonPath = new JsonPathWrapper("{\"user\": {\"age\": 15}}");
+    ConditionSpec condition = new ConditionSpec("lt", "$.user.age", 18);
+
+    assertTrue(condition.evaluate(jsonPath));
+  }
+
+  @Test
+  void evaluateLt_shouldReturnFalseForEqualValue() {
+    JsonPathWrapper jsonPath = new JsonPathWrapper("{\"user\": {\"age\": 18}}");
+    ConditionSpec condition = new ConditionSpec("lt", "$.user.age", 18);
+
+    assertFalse(condition.evaluate(jsonPath));
+  }
+
+  @Test
+  void evaluateLte_shouldReturnTrueForEqualValue() {
+    JsonPathWrapper jsonPath = new JsonPathWrapper("{\"user\": {\"age\": 18}}");
+    ConditionSpec condition = new ConditionSpec("lte", "$.user.age", 18);
+
+    assertTrue(condition.evaluate(jsonPath));
+  }
+
+  @Test
+  void evaluateLte_shouldReturnTrueForLesserValue() {
+    JsonPathWrapper jsonPath = new JsonPathWrapper("{\"user\": {\"age\": 15}}");
+    ConditionSpec condition = new ConditionSpec("lte", "$.user.age", 18);
+
+    assertTrue(condition.evaluate(jsonPath));
+  }
+
+  @Test
+  void evaluateIn_shouldReturnTrueWhenValueIsInCollection() {
+    JsonPathWrapper jsonPath = new JsonPathWrapper("{\"user\": {\"role\": \"admin\"}}");
+    ConditionSpec condition =
+        new ConditionSpec("in", "$.user.role", List.of("admin", "editor", "viewer"));
+
+    assertTrue(condition.evaluate(jsonPath));
+  }
+
+  @Test
+  void evaluateIn_shouldReturnFalseWhenValueIsNotInCollection() {
+    JsonPathWrapper jsonPath = new JsonPathWrapper("{\"user\": {\"role\": \"guest\"}}");
+    ConditionSpec condition =
+        new ConditionSpec("in", "$.user.role", List.of("admin", "editor", "viewer"));
+
+    assertFalse(condition.evaluate(jsonPath));
+  }
+
+  @Test
+  void evaluateNin_shouldReturnTrueWhenValueIsNotInCollection() {
+    JsonPathWrapper jsonPath = new JsonPathWrapper("{\"user\": {\"role\": \"guest\"}}");
+    ConditionSpec condition =
+        new ConditionSpec("nin", "$.user.role", List.of("admin", "editor", "viewer"));
+
+    assertTrue(condition.evaluate(jsonPath));
+  }
+
+  @Test
+  void evaluateNin_shouldReturnFalseWhenValueIsInCollection() {
+    JsonPathWrapper jsonPath = new JsonPathWrapper("{\"user\": {\"role\": \"admin\"}}");
+    ConditionSpec condition =
+        new ConditionSpec("nin", "$.user.role", List.of("admin", "editor", "viewer"));
+
+    assertFalse(condition.evaluate(jsonPath));
+  }
+
+  @Test
+  void evaluateContains_shouldReturnTrueWhenStringContainsSubstring() {
+    JsonPathWrapper jsonPath = new JsonPathWrapper("{\"user\": {\"email\": \"john@example.com\"}}");
+    ConditionSpec condition = new ConditionSpec("contains", "$.user.email", "@example");
+
+    assertTrue(condition.evaluate(jsonPath));
+  }
+
+  @Test
+  void evaluateContains_shouldReturnFalseWhenStringDoesNotContainSubstring() {
+    JsonPathWrapper jsonPath = new JsonPathWrapper("{\"user\": {\"email\": \"john@test.com\"}}");
+    ConditionSpec condition = new ConditionSpec("contains", "$.user.email", "@example");
+
+    assertFalse(condition.evaluate(jsonPath));
+  }
+
+  @Test
+  void evaluateRegex_shouldReturnTrueForMatchingPattern() {
+    JsonPathWrapper jsonPath = new JsonPathWrapper("{\"user\": {\"email\": \"john@example.com\"}}");
+    ConditionSpec condition =
+        new ConditionSpec("regex", "$.user.email", "^[\\w.-]+@[\\w.-]+\\.[a-zA-Z]{2,}$");
+
+    assertTrue(condition.evaluate(jsonPath));
+  }
+
+  @Test
+  void evaluateRegex_shouldReturnFalseForNonMatchingPattern() {
+    JsonPathWrapper jsonPath = new JsonPathWrapper("{\"user\": {\"email\": \"invalid-email\"}}");
+    ConditionSpec condition =
+        new ConditionSpec("regex", "$.user.email", "^[\\w.-]+@[\\w.-]+\\.[a-zA-Z]{2,}$");
+
+    assertFalse(condition.evaluate(jsonPath));
+  }
+
+  @Test
+  void evaluateRegex_shouldReturnFalseWhenValueIsNull() {
+    JsonPathWrapper jsonPath = new JsonPathWrapper("{\"user\": {\"email\": null}}");
+    ConditionSpec condition =
+        new ConditionSpec("regex", "$.user.email", "^[\\w.-]+@[\\w.-]+\\.[a-zA-Z]{2,}$");
+
+    assertFalse(condition.evaluate(jsonPath));
+  }
+
+  @Test
+  void evaluate_shouldReturnFalseForUnsupportedConditionType() {
+    JsonPathWrapper jsonPath = new JsonPathWrapper("{\"user\": {\"name\": \"John\"}}");
+    ConditionSpec condition = new ConditionSpec("unknown", "$.user.name");
+
+    assertFalse(condition.evaluate(jsonPath));
+  }
+
+  @Test
+  void evaluate_shouldThrowExceptionWhenOperationIsNull() {
+    JsonPathWrapper jsonPath = new JsonPathWrapper("{\"user\": {\"name\": \"John\"}}");
+    ConditionSpec condition = new ConditionSpec(null, "$.user.name");
+
+    assertThrows(IllegalArgumentException.class, () -> condition.evaluate(jsonPath));
+  }
+
+  @Test
+  void evaluate_shouldThrowExceptionWhenOperationIsEmpty() {
+    JsonPathWrapper jsonPath = new JsonPathWrapper("{\"user\": {\"name\": \"John\"}}");
+    ConditionSpec condition = new ConditionSpec("", "$.user.name");
+
+    assertThrows(IllegalArgumentException.class, () -> condition.evaluate(jsonPath));
+  }
+
+  @Test
+  void evaluate_shouldReturnFalseWhenPathIsNullForSimpleCondition() {
+    JsonPathWrapper jsonPath = new JsonPathWrapper("{\"user\": {\"name\": \"John\"}}");
+    ConditionSpec condition = new ConditionSpec("exists", null);
+
+    // Should catch exception and return false due to try-catch
+    assertFalse(condition.evaluate(jsonPath));
+  }
+
+  @Test
+  void evaluate_shouldReturnFalseWhenPathIsEmptyForSimpleCondition() {
+    JsonPathWrapper jsonPath = new JsonPathWrapper("{\"user\": {\"name\": \"John\"}}");
+    ConditionSpec condition = new ConditionSpec("exists", "");
+
+    // Should catch exception and return false due to try-catch
+    assertFalse(condition.evaluate(jsonPath));
+  }
+
+  @Test
+  void evaluate_shouldReturnFalseOnEvaluationException() {
+    JsonPathWrapper jsonPath = new JsonPathWrapper("{\"user\": {\"name\": \"John\"}}");
+    ConditionSpec condition = new ConditionSpec("exists", "$.invalid[path");
+
+    assertFalse(condition.evaluate(jsonPath));
+  }
+
+  @Test
+  void toMap_shouldReturnCorrectRepresentation() {
+    ConditionSpec condition = new ConditionSpec("gte", "$.user.age", 18);
+
+    Map<String, Object> result = condition.toMap();
+
+    assertEquals("gte", result.get("operation"));
+    assertEquals("$.user.age", result.get("path"));
+    assertEquals(18, result.get("value"));
+  }
+
+  @Test
+  void toMap_shouldHandleAllFields() {
+    ConditionSpec condition = new ConditionSpec("eq", "$.user.role", "admin");
+
+    Map<String, Object> result = condition.toMap();
+
+    assertEquals("eq", result.get("operation"));
+    assertEquals("$.user.role", result.get("path"));
+    assertEquals("admin", result.get("value"));
+  }
+
+  @Test
+  void evaluateAllOf_shouldReturnTrueWhenAllConditionsAreTrue() {
+    JsonPathWrapper jsonPath =
+        new JsonPathWrapper("{\"user\": {\"role\": \"admin\", \"verified\": true}}");
+    List<ConditionSpec> conditions =
+        List.of(
+            new ConditionSpec("eq", "$.user.role", "admin"),
+            new ConditionSpec("exists", "$.user.verified"));
+    ConditionSpec condition = new ConditionSpec("allOf", null, conditions);
+
+    assertTrue(condition.evaluate(jsonPath));
+  }
+
+  @Test
+  void evaluateAllOf_shouldReturnFalseWhenAnyConditionIsFalse() {
+    JsonPathWrapper jsonPath =
+        new JsonPathWrapper("{\"user\": {\"role\": \"user\", \"verified\": true}}");
+    List<ConditionSpec> conditions =
+        List.of(
+            new ConditionSpec("eq", "$.user.role", "admin"),
+            new ConditionSpec("exists", "$.user.verified"));
+    ConditionSpec condition = new ConditionSpec("allOf", null, conditions);
+
+    assertFalse(condition.evaluate(jsonPath));
+  }
+
+  @Test
+  void evaluateAllOf_shouldReturnTrueForEmptyConditionList() {
+    JsonPathWrapper jsonPath = new JsonPathWrapper("{\"user\": {\"name\": \"John\"}}");
+    ConditionSpec condition = new ConditionSpec("allOf", null, List.of());
+
+    assertTrue(condition.evaluate(jsonPath));
+  }
+
+  @Test
+  void evaluateAnyOf_shouldReturnTrueWhenAnyConditionIsTrue() {
+    JsonPathWrapper jsonPath =
+        new JsonPathWrapper("{\"user\": {\"role\": \"admin\", \"verified\": false}}");
+    List<ConditionSpec> conditions =
+        List.of(
+            new ConditionSpec("eq", "$.user.role", "admin"),
+            new ConditionSpec("eq", "$.user.role", "editor"));
+    ConditionSpec condition = new ConditionSpec("anyOf", null, conditions);
+
+    assertTrue(condition.evaluate(jsonPath));
+  }
+
+  @Test
+  void evaluateAnyOf_shouldReturnFalseWhenAllConditionsAreFalse() {
+    JsonPathWrapper jsonPath = new JsonPathWrapper("{\"user\": {\"role\": \"user\"}}");
+    List<ConditionSpec> conditions =
+        List.of(
+            new ConditionSpec("eq", "$.user.role", "admin"),
+            new ConditionSpec("eq", "$.user.role", "editor"));
+    ConditionSpec condition = new ConditionSpec("anyOf", null, conditions);
+
+    assertFalse(condition.evaluate(jsonPath));
+  }
+
+  @Test
+  void evaluateAnyOf_shouldReturnFalseForEmptyConditionList() {
+    JsonPathWrapper jsonPath = new JsonPathWrapper("{\"user\": {\"name\": \"John\"}}");
+    ConditionSpec condition = new ConditionSpec("anyOf", null, List.of());
+
+    assertFalse(condition.evaluate(jsonPath));
+  }
+
+  @Test
+  void evaluateNestedCompoundConditions_shouldWork() {
+    JsonPathWrapper jsonPath =
+        new JsonPathWrapper("{\"user\": {\"role\": \"admin\", \"verified\": true, \"age\": 25}}");
+
+    // (role == admin AND verified) OR age >= 21
+    ConditionSpec adminAndVerified =
+        new ConditionSpec(
+            "allOf",
+            null,
+            List.of(
+                new ConditionSpec("eq", "$.user.role", "admin"),
+                new ConditionSpec("exists", "$.user.verified")));
+    ConditionSpec ageCheck = new ConditionSpec("gte", "$.user.age", 21);
+
+    ConditionSpec condition = new ConditionSpec("anyOf", null, List.of(adminAndVerified, ageCheck));
+
+    assertTrue(condition.evaluate(jsonPath));
+  }
+
+  @Test
+  void evaluate_shouldThrowExceptionForAllOfWithoutList() {
+    JsonPathWrapper jsonPath = new JsonPathWrapper("{\"user\": {\"name\": \"John\"}}");
+    ConditionSpec condition = new ConditionSpec("allOf", null, "not a list");
+
+    assertFalse(condition.evaluate(jsonPath)); // Should catch exception and return false
+  }
+
+  @Test
+  void evaluate_shouldThrowExceptionForAnyOfWithoutList() {
+    JsonPathWrapper jsonPath = new JsonPathWrapper("{\"user\": {\"name\": \"John\"}}");
+    ConditionSpec condition = new ConditionSpec("anyOf", null, "not a list");
+
+    assertFalse(condition.evaluate(jsonPath)); // Should catch exception and return false
+  }
+
+  @Test
+  void evaluate_shouldPreventStackOverflowWithDeepNesting() {
+    JsonPathWrapper jsonPath = new JsonPathWrapper("{\"user\": {\"role\": \"admin\"}}");
+
+    // Create deeply nested conditions (15 levels - exceeds MAX_CONDITION_DEPTH of 10)
+    ConditionSpec condition = createDeeplyNestedCondition(15);
+
+    // Should return false due to depth limit, not stack overflow
+    assertFalse(condition.evaluate(jsonPath));
+  }
+
+  private ConditionSpec createDeeplyNestedCondition(int depth) {
+    if (depth <= 0) {
+      return new ConditionSpec("eq", "$.user.role", "admin");
+    }
+    return new ConditionSpec("allOf", null, List.of(createDeeplyNestedCondition(depth - 1)));
+  }
+
+  @Test
+  void evaluateRegex_shouldCacheCompiledPatterns() {
+    JsonPathWrapper jsonPath = new JsonPathWrapper("{\"user\": {\"email\": \"test@example.com\"}}");
+    String emailPattern = "^[\\w.-]+@[\\w.-]+\\.[a-zA-Z]{2,}$";
+    ConditionSpec condition = new ConditionSpec("regex", "$.user.email", emailPattern);
+
+    // Multiple evaluations should use cached pattern
+    assertTrue(condition.evaluate(jsonPath));
+    assertTrue(condition.evaluate(jsonPath));
+    assertTrue(condition.evaluate(jsonPath));
+  }
+
+  @Test
+  void evaluateRegex_shouldHandleInvalidRegexPattern() {
+    JsonPathWrapper jsonPath = new JsonPathWrapper("{\"user\": {\"email\": \"test@example.com\"}}");
+    ConditionSpec condition = new ConditionSpec("regex", "$.user.email", "[invalid");
+
+    // Should return false for invalid regex, not throw exception
+    assertFalse(condition.evaluate(jsonPath));
+  }
+
+  @Test
+  void evaluateRegex_shouldHandleExcessivelyLongPattern() {
+    JsonPathWrapper jsonPath = new JsonPathWrapper("{\"user\": {\"text\": \"hello\"}}");
+
+    // Create a very long regex pattern (over 1000 characters)
+    String longPattern = "a".repeat(1001);
+    ConditionSpec condition = new ConditionSpec("regex", "$.user.text", longPattern);
+
+    // Should return false for excessively long pattern
+    assertFalse(condition.evaluate(jsonPath));
+  }
+
+  @Test
+  void evaluateRegex_shouldWorkWithValidPatterns() {
+    JsonPathWrapper jsonPath = new JsonPathWrapper("{\"user\": {\"phone\": \"+1-555-123-4567\"}}");
+    String phonePattern = "^\\+\\d{1,3}-\\d{3}-\\d{3}-\\d{4}$";
+    ConditionSpec condition = new ConditionSpec("regex", "$.user.phone", phonePattern);
+
+    assertTrue(condition.evaluate(jsonPath));
+  }
+
+  // Truth table tests for compound conditions
+  @Test
+  void evaluateAllOf_truthTable_bothTrue() {
+    JsonPathWrapper jsonPath =
+        new JsonPathWrapper("{\"user\": {\"role\": \"admin\", \"verified\": true}}");
+    ConditionSpec condition =
+        new ConditionSpec(
+            "allOf",
+            null,
+            List.of(
+                new ConditionSpec("eq", "$.user.role", "admin"), // TRUE
+                new ConditionSpec("eq", "$.user.verified", true) // TRUE
+                ));
+
+    assertTrue(condition.evaluate(jsonPath)); // TRUE AND TRUE = TRUE
+  }
+
+  @Test
+  void evaluateAllOf_truthTable_firstTrueSecondFalse() {
+    JsonPathWrapper jsonPath =
+        new JsonPathWrapper("{\"user\": {\"role\": \"admin\", \"verified\": false}}");
+    ConditionSpec condition =
+        new ConditionSpec(
+            "allOf",
+            null,
+            List.of(
+                new ConditionSpec("eq", "$.user.role", "admin"), // TRUE
+                new ConditionSpec("eq", "$.user.verified", true) // FALSE
+                ));
+
+    assertFalse(condition.evaluate(jsonPath)); // TRUE AND FALSE = FALSE
+  }
+
+  @Test
+  void evaluateAllOf_truthTable_firstFalseSecondTrue() {
+    JsonPathWrapper jsonPath =
+        new JsonPathWrapper("{\"user\": {\"role\": \"user\", \"verified\": true}}");
+    ConditionSpec condition =
+        new ConditionSpec(
+            "allOf",
+            null,
+            List.of(
+                new ConditionSpec("eq", "$.user.role", "admin"), // FALSE
+                new ConditionSpec("eq", "$.user.verified", true) // TRUE
+                ));
+
+    assertFalse(condition.evaluate(jsonPath)); // FALSE AND TRUE = FALSE
+  }
+
+  @Test
+  void evaluateAllOf_truthTable_bothFalse() {
+    JsonPathWrapper jsonPath =
+        new JsonPathWrapper("{\"user\": {\"role\": \"user\", \"verified\": false}}");
+    ConditionSpec condition =
+        new ConditionSpec(
+            "allOf",
+            null,
+            List.of(
+                new ConditionSpec("eq", "$.user.role", "admin"), // FALSE
+                new ConditionSpec("eq", "$.user.verified", true) // FALSE
+                ));
+
+    assertFalse(condition.evaluate(jsonPath)); // FALSE AND FALSE = FALSE
+  }
+
+  @Test
+  void evaluateAnyOf_truthTable_bothTrue() {
+    JsonPathWrapper jsonPath =
+        new JsonPathWrapper("{\"user\": {\"role\": \"admin\", \"verified\": true}}");
+    ConditionSpec condition =
+        new ConditionSpec(
+            "anyOf",
+            null,
+            List.of(
+                new ConditionSpec("eq", "$.user.role", "admin"), // TRUE
+                new ConditionSpec("eq", "$.user.verified", true) // TRUE
+                ));
+
+    assertTrue(condition.evaluate(jsonPath)); // TRUE OR TRUE = TRUE
+  }
+
+  @Test
+  void evaluateAnyOf_truthTable_firstTrueSecondFalse() {
+    JsonPathWrapper jsonPath =
+        new JsonPathWrapper("{\"user\": {\"role\": \"admin\", \"verified\": false}}");
+    ConditionSpec condition =
+        new ConditionSpec(
+            "anyOf",
+            null,
+            List.of(
+                new ConditionSpec("eq", "$.user.role", "admin"), // TRUE
+                new ConditionSpec("eq", "$.user.verified", true) // FALSE
+                ));
+
+    assertTrue(condition.evaluate(jsonPath)); // TRUE OR FALSE = TRUE
+  }
+
+  @Test
+  void evaluateAnyOf_truthTable_firstFalseSecondTrue() {
+    JsonPathWrapper jsonPath =
+        new JsonPathWrapper("{\"user\": {\"role\": \"user\", \"verified\": true}}");
+    ConditionSpec condition =
+        new ConditionSpec(
+            "anyOf",
+            null,
+            List.of(
+                new ConditionSpec("eq", "$.user.role", "admin"), // FALSE
+                new ConditionSpec("eq", "$.user.verified", true) // TRUE
+                ));
+
+    assertTrue(condition.evaluate(jsonPath)); // FALSE OR TRUE = TRUE
+  }
+
+  @Test
+  void evaluateAnyOf_truthTable_bothFalse() {
+    JsonPathWrapper jsonPath =
+        new JsonPathWrapper("{\"user\": {\"role\": \"user\", \"verified\": false}}");
+    ConditionSpec condition =
+        new ConditionSpec(
+            "anyOf",
+            null,
+            List.of(
+                new ConditionSpec("eq", "$.user.role", "admin"), // FALSE
+                new ConditionSpec("eq", "$.user.verified", true) // FALSE
+                ));
+
+    assertFalse(condition.evaluate(jsonPath)); // FALSE OR FALSE = FALSE
+  }
+
+  @Test
+  void evaluateCompound_truthTable_multipleOperations() {
+    JsonPathWrapper jsonPath =
+        new JsonPathWrapper("{\"user\": {\"role\": \"admin\", \"verified\": true, \"age\": 25}}");
+
+    // Test complex combination: (role=admin AND verified=true) OR age<18
+    ConditionSpec adminAndVerified =
+        new ConditionSpec(
+            "allOf",
+            null,
+            List.of(
+                new ConditionSpec("eq", "$.user.role", "admin"), // TRUE
+                new ConditionSpec("eq", "$.user.verified", true) // TRUE
+                )); // TRUE AND TRUE = TRUE
+
+    ConditionSpec ageCondition = new ConditionSpec("lt", "$.user.age", 18); // FALSE (25 < 18)
+
+    ConditionSpec finalCondition =
+        new ConditionSpec(
+            "anyOf",
+            null,
+            List.of(
+                adminAndVerified, // TRUE
+                ageCondition // FALSE
+                ));
+
+    assertTrue(finalCondition.evaluate(jsonPath)); // TRUE OR FALSE = TRUE
+  }
+
+  @Test
+  void evaluateCompound_truthTable_threeWayAnd() {
+    JsonPathWrapper jsonPath =
+        new JsonPathWrapper(
+            "{\"user\": {\"role\": \"admin\", \"verified\": true, \"active\": true}}");
+    ConditionSpec condition =
+        new ConditionSpec(
+            "allOf",
+            null,
+            List.of(
+                new ConditionSpec("eq", "$.user.role", "admin"), // TRUE
+                new ConditionSpec("eq", "$.user.verified", true), // TRUE
+                new ConditionSpec("eq", "$.user.active", true) // TRUE
+                ));
+
+    assertTrue(condition.evaluate(jsonPath)); // TRUE AND TRUE AND TRUE = TRUE
+  }
+
+  @Test
+  void evaluateCompound_truthTable_threeWayAndWithOneFalse() {
+    JsonPathWrapper jsonPath =
+        new JsonPathWrapper(
+            "{\"user\": {\"role\": \"admin\", \"verified\": true, \"active\": false}}");
+    ConditionSpec condition =
+        new ConditionSpec(
+            "allOf",
+            null,
+            List.of(
+                new ConditionSpec("eq", "$.user.role", "admin"), // TRUE
+                new ConditionSpec("eq", "$.user.verified", true), // TRUE
+                new ConditionSpec("eq", "$.user.active", true) // FALSE
+                ));
+
+    assertFalse(condition.evaluate(jsonPath)); // TRUE AND TRUE AND FALSE = FALSE
+  }
+
+  // Type boundary and edge case tests
+  @Test
+  void evaluateNumeric_shouldHandleIntegerComparison() {
+    JsonPathWrapper jsonPath = new JsonPathWrapper("{\"user\": {\"age\": 25}}");
+    ConditionSpec condition = new ConditionSpec("gte", "$.user.age", 18);
+
+    assertTrue(condition.evaluate(jsonPath));
+  }
+
+  @Test
+  void evaluateNumeric_shouldHandleDoubleComparison() {
+    JsonPathWrapper jsonPath = new JsonPathWrapper("{\"user\": {\"score\": 85.5}}");
+    ConditionSpec condition = new ConditionSpec("gt", "$.user.score", 85.0);
+
+    assertTrue(condition.evaluate(jsonPath));
+  }
+
+  @Test
+  void evaluateNumeric_shouldHandleStringNumber() {
+    JsonPathWrapper jsonPath = new JsonPathWrapper("{\"user\": {\"balance\": \"1000.50\"}}");
+    ConditionSpec condition = new ConditionSpec("gte", "$.user.balance", 1000);
+
+    assertTrue(condition.evaluate(jsonPath));
+  }
+
+  @Test
+  void evaluateNumeric_shouldHandleZeroBoundary() {
+    JsonPathWrapper jsonPath = new JsonPathWrapper("{\"user\": {\"count\": 0}}");
+    ConditionSpec ltCondition = new ConditionSpec("lt", "$.user.count", 1);
+    ConditionSpec gteCondition = new ConditionSpec("gte", "$.user.count", 0);
+
+    assertTrue(ltCondition.evaluate(jsonPath));
+    assertTrue(gteCondition.evaluate(jsonPath));
+  }
+
+  @Test
+  void evaluateNumeric_shouldHandleNegativeNumbers() {
+    JsonPathWrapper jsonPath = new JsonPathWrapper("{\"user\": {\"debt\": -500}}");
+    ConditionSpec condition = new ConditionSpec("lt", "$.user.debt", 0);
+
+    assertTrue(condition.evaluate(jsonPath));
+  }
+
+  @Test
+  void evaluateNumeric_shouldReturnFalseForInvalidNumber() {
+    JsonPathWrapper jsonPath = new JsonPathWrapper("{\"user\": {\"invalid\": \"not-a-number\"}}");
+    ConditionSpec condition = new ConditionSpec("gt", "$.user.invalid", 0);
+
+    assertFalse(condition.evaluate(jsonPath)); // Should return false for invalid number comparison
+  }
+
+  @Test
+  void evaluateExists_shouldHandleNullValue() {
+    JsonPathWrapper jsonPath = new JsonPathWrapper("{\"user\": {\"optional\": null}}");
+    ConditionSpec existsCondition = new ConditionSpec("exists", "$.user.optional");
+    ConditionSpec missingCondition = new ConditionSpec("missing", "$.user.optional");
+
+    assertFalse(existsCondition.evaluate(jsonPath));
+    assertTrue(missingCondition.evaluate(jsonPath));
+  }
+
+  @Test
+  void evaluateExists_shouldHandleMissingProperty() {
+    JsonPathWrapper jsonPath = new JsonPathWrapper("{\"user\": {}}");
+    ConditionSpec existsCondition = new ConditionSpec("exists", "$.user.nonexistent");
+    ConditionSpec missingCondition = new ConditionSpec("missing", "$.user.nonexistent");
+
+    assertFalse(existsCondition.evaluate(jsonPath));
+    assertTrue(missingCondition.evaluate(jsonPath));
+  }
+
+  @Test
+  void evaluateIn_shouldHandleEmptyCollection() {
+    JsonPathWrapper jsonPath = new JsonPathWrapper("{\"user\": {\"role\": \"admin\"}}");
+    ConditionSpec condition = new ConditionSpec("in", "$.user.role", List.of());
+
+    assertFalse(condition.evaluate(jsonPath));
+  }
+
+  @Test
+  void evaluateIn_shouldHandleDifferentTypes() {
+    JsonPathWrapper jsonPath = new JsonPathWrapper("{\"user\": {\"id\": 123}}");
+    ConditionSpec stringCondition = new ConditionSpec("in", "$.user.id", List.of("123", "456"));
+    ConditionSpec numberCondition = new ConditionSpec("in", "$.user.id", List.of(123, 456));
+
+    assertFalse(stringCondition.evaluate(jsonPath)); // 123 != "123"
+    assertTrue(numberCondition.evaluate(jsonPath)); // 123 == 123
+  }
+
+  @Test
+  void evaluateContains_shouldHandleStringContains() {
+    JsonPathWrapper jsonPath =
+        new JsonPathWrapper("{\"user\": {\"email\": \"admin@example.com\"}}");
+    ConditionSpec condition = new ConditionSpec("contains", "$.user.email", "admin");
+
+    assertTrue(condition.evaluate(jsonPath));
+  }
+
+  @Test
+  void evaluateContains_shouldHandleArrayContains() {
+    JsonPathWrapper jsonPath =
+        new JsonPathWrapper("{\"user\": {\"roles\": [\"admin\", \"user\"]}}");
+    ConditionSpec condition = new ConditionSpec("contains", "$.user.roles", "admin");
+
+    assertTrue(condition.evaluate(jsonPath));
+  }
+
+  @Test
+  void evaluateContains_shouldReturnFalseForUnsupportedTypes() {
+    JsonPathWrapper jsonPath = new JsonPathWrapper("{\"user\": {\"count\": 5}}");
+    ConditionSpec condition = new ConditionSpec("contains", "$.user.count", 1);
+
+    assertFalse(condition.evaluate(jsonPath)); // Number doesn't support contains
+  }
+
+  @Test
+  void evaluateRegex_shouldHandleEmptyString() {
+    JsonPathWrapper jsonPath = new JsonPathWrapper("{\"user\": {\"name\": \"\"}}");
+    ConditionSpec condition = new ConditionSpec("regex", "$.user.name", "^$");
+
+    assertTrue(condition.evaluate(jsonPath));
+  }
+
+  @Test
+  void evaluateRegex_shouldHandleUnicodeCharacters() {
+    JsonPathWrapper jsonPath = new JsonPathWrapper("{\"user\": {\"name\": \"José María\"}}");
+    ConditionSpec condition = new ConditionSpec("regex", "$.user.name", "^[\\p{L}\\s]+$");
+
+    assertTrue(condition.evaluate(jsonPath));
+  }
+
+  @Test
+  void evaluateInvalidOperation_shouldReturnFalse() {
+    JsonPathWrapper jsonPath = new JsonPathWrapper("{\"user\": {\"name\": \"John\"}}");
+    ConditionSpec condition = new ConditionSpec("invalid_operation", "$.user.name", "John");
+
+    assertFalse(condition.evaluate(jsonPath));
+  }
+
+  @Test
+  void evaluateInvalidJsonPath_shouldReturnFalse() {
+    JsonPathWrapper jsonPath = new JsonPathWrapper("{\"user\": {\"name\": \"John\"}}");
+    ConditionSpec condition = new ConditionSpec("eq", "$.invalid[syntax", "John");
+
+    assertFalse(condition.evaluate(jsonPath));
+  }
+}

--- a/libs/idp-server-platform/src/test/java/org/idp/server/platform/mapper/MappingRuleConditionalTest.java
+++ b/libs/idp-server-platform/src/test/java/org/idp/server/platform/mapper/MappingRuleConditionalTest.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2025 Hirokazu Kobayashi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.idp.server.platform.mapper;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.Map;
+import org.idp.server.platform.json.path.JsonPathWrapper;
+import org.junit.jupiter.api.Test;
+
+class MappingRuleConditionalTest {
+
+  @Test
+  void shouldExecute_shouldReturnTrueWhenNoCondition() {
+    JsonPathWrapper jsonPath = new JsonPathWrapper("{\"user\": {\"name\": \"John\"}}");
+    MappingRule rule = new MappingRule("$.user.name", "name");
+
+    assertTrue(rule.shouldExecute(jsonPath));
+  }
+
+  @Test
+  void shouldExecute_shouldReturnTrueWhenConditionIsTrue() {
+    JsonPathWrapper jsonPath = new JsonPathWrapper("{\"user\": {\"role\": \"admin\"}}");
+    ConditionSpec condition = new ConditionSpec("eq", "$.user.role", "admin");
+    MappingRule rule = new MappingRule("$.user.name", "name", condition);
+
+    assertTrue(rule.shouldExecute(jsonPath));
+  }
+
+  @Test
+  void shouldExecute_shouldReturnFalseWhenConditionIsFalse() {
+    JsonPathWrapper jsonPath = new JsonPathWrapper("{\"user\": {\"role\": \"user\"}}");
+    ConditionSpec condition = new ConditionSpec("eq", "$.user.role", "admin");
+    MappingRule rule = new MappingRule("$.user.name", "name", condition);
+
+    assertFalse(rule.shouldExecute(jsonPath));
+  }
+
+  @Test
+  void shouldExecute_shouldReturnFalseOnConditionEvaluationException() {
+    JsonPathWrapper jsonPath = new JsonPathWrapper("{\"user\": {\"name\": \"John\"}}");
+    ConditionSpec condition = new ConditionSpec("exists", "$.invalid[path");
+    MappingRule rule = new MappingRule("$.user.name", "name", condition);
+
+    assertFalse(rule.shouldExecute(jsonPath));
+  }
+
+  @Test
+  void hasCondition_shouldReturnTrueWhenConditionExists() {
+    ConditionSpec condition = new ConditionSpec("exists", "$.user.verified");
+    MappingRule rule = new MappingRule("$.user.name", "name", condition);
+
+    assertTrue(rule.hasCondition());
+  }
+
+  @Test
+  void hasCondition_shouldReturnFalseWhenConditionIsNull() {
+    MappingRule rule = new MappingRule("$.user.name", "name");
+
+    assertFalse(rule.hasCondition());
+  }
+
+  @Test
+  void condition_shouldReturnConditionWhenSet() {
+    ConditionSpec condition = new ConditionSpec("exists", "$.user.verified");
+    MappingRule rule = new MappingRule("$.user.name", "name", condition);
+
+    assertEquals(condition, rule.condition());
+  }
+
+  @Test
+  void condition_shouldReturnNullWhenNotSet() {
+    MappingRule rule = new MappingRule("$.user.name", "name");
+
+    assertNull(rule.condition());
+  }
+
+  @Test
+  void toMap_shouldIncludeConditionWhenPresent() {
+    ConditionSpec condition = new ConditionSpec("equals", "$.user.role", "admin");
+    MappingRule rule = new MappingRule("$.user.name", "name", condition);
+
+    Map<String, Object> result = rule.toMap();
+
+    assertNotNull(result.get("condition"));
+    assertEquals(condition.toMap(), result.get("condition"));
+  }
+
+  @Test
+  void toMap_shouldIncludeNullConditionWhenNotPresent() {
+    MappingRule rule = new MappingRule("$.user.name", "name");
+
+    Map<String, Object> result = rule.toMap();
+
+    assertNull(result.get("condition"));
+  }
+
+  @Test
+  void constructorWithStaticValueAndCondition_shouldWorkCorrectly() {
+    ConditionSpec condition = new ConditionSpec("exists", "$.user.verified");
+    MappingRule rule = new MappingRule((Object) "admin", "role", condition);
+
+    assertFalse(rule.hasFrom()); // Should be false
+    assertTrue(rule.hasStaticValue());
+    assertEquals("admin", rule.staticValue());
+    assertFalse(rule.hasFunctions());
+    assertTrue(rule.hasCondition());
+    assertEquals(condition, rule.condition());
+  }
+
+  @Test
+  void constructorWithFunctionsAndCondition_shouldWorkCorrectly() {
+    ConditionSpec condition = new ConditionSpec("exists", "$.user.verified");
+    MappingRule rule = new MappingRule("$.user.name", "name", null, condition);
+
+    assertTrue(rule.hasFrom());
+    assertEquals("$.user.name", rule.from());
+    assertFalse(rule.hasFunctions());
+    assertTrue(rule.hasCondition());
+    assertEquals(condition, rule.condition());
+  }
+
+  @Test
+  void constructorWithStaticValueFunctionsAndCondition_shouldWorkCorrectly() {
+    ConditionSpec condition = new ConditionSpec("exists", "$.user.verified");
+    MappingRule rule = new MappingRule((Object) "admin", "role", null, condition);
+
+    assertFalse(rule.hasFrom());
+    assertTrue(rule.hasStaticValue());
+    assertEquals("admin", rule.staticValue());
+    assertFalse(rule.hasFunctions());
+    assertTrue(rule.hasCondition());
+    assertEquals(condition, rule.condition());
+  }
+}

--- a/libs/idp-server-platform/src/test/java/org/idp/server/platform/mapper/MappingRuleObjectMapperConditionalTest.java
+++ b/libs/idp-server-platform/src/test/java/org/idp/server/platform/mapper/MappingRuleObjectMapperConditionalTest.java
@@ -1,0 +1,246 @@
+/*
+ * Copyright 2025 Hirokazu Kobayashi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.idp.server.platform.mapper;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+import java.util.Map;
+import org.idp.server.platform.json.path.JsonPathWrapper;
+import org.junit.jupiter.api.Test;
+
+class MappingRuleObjectMapperConditionalTest {
+
+  @Test
+  void execute_shouldExecuteRuleWhenConditionIsTrue() {
+    String json = "{\"user\": {\"role\": \"admin\", \"name\": \"John\"}}";
+    JsonPathWrapper jsonPath = new JsonPathWrapper(json);
+
+    ConditionSpec condition = new ConditionSpec("eq", "$.user.role", "admin");
+    MappingRule rule = new MappingRule("$.user.name", "name", condition);
+    List<MappingRule> rules = List.of(rule);
+
+    Map<String, Object> result = MappingRuleObjectMapper.execute(rules, jsonPath);
+
+    assertEquals("John", result.get("name"));
+  }
+
+  @Test
+  void execute_shouldSkipRuleWhenConditionIsFalse() {
+    String json = "{\"user\": {\"role\": \"user\", \"name\": \"John\"}}";
+    JsonPathWrapper jsonPath = new JsonPathWrapper(json);
+
+    ConditionSpec condition = new ConditionSpec("eq", "$.user.role", "admin");
+    MappingRule rule = new MappingRule("$.user.name", "name", condition);
+    List<MappingRule> rules = List.of(rule);
+
+    Map<String, Object> result = MappingRuleObjectMapper.execute(rules, jsonPath);
+
+    assertFalse(result.containsKey("name"));
+  }
+
+  @Test
+  void execute_shouldExecuteRuleWhenNoCondition() {
+    String json = "{\"user\": {\"name\": \"John\"}}";
+    JsonPathWrapper jsonPath = new JsonPathWrapper(json);
+
+    MappingRule rule = new MappingRule("$.user.name", "name");
+    List<MappingRule> rules = List.of(rule);
+
+    Map<String, Object> result = MappingRuleObjectMapper.execute(rules, jsonPath);
+
+    assertEquals("John", result.get("name"));
+  }
+
+  @Test
+  void execute_shouldExecuteMultipleRulesWithDifferentConditions() {
+    String json =
+        "{\"user\": {\"role\": \"admin\", \"name\": \"John\", \"verified\": true, \"age\": 30}}";
+    JsonPathWrapper jsonPath = new JsonPathWrapper(json);
+
+    ConditionSpec adminCondition = new ConditionSpec("eq", "$.user.role", "admin");
+    ConditionSpec verifiedCondition = new ConditionSpec("exists", "$.user.verified");
+    ConditionSpec ageCondition = new ConditionSpec("gte", "$.user.age", 18);
+    ConditionSpec userCondition = new ConditionSpec("eq", "$.user.role", "user");
+
+    List<MappingRule> rules =
+        List.of(
+            new MappingRule("$.user.name", "name", adminCondition), // Should execute
+            new MappingRule((Object) "admin", "type", verifiedCondition), // Should execute
+            new MappingRule("$.user.age", "age", ageCondition), // Should execute
+            new MappingRule((Object) "restricted", "access", userCondition) // Should NOT execute
+            );
+
+    Map<String, Object> result = MappingRuleObjectMapper.execute(rules, jsonPath);
+
+    assertEquals("John", result.get("name"));
+    assertEquals("admin", result.get("type"));
+    assertEquals(30, result.get("age"));
+    assertFalse(result.containsKey("access"));
+  }
+
+  @Test
+  void execute_shouldHandleExistsCondition() {
+    String json = "{\"user\": {\"name\": \"John\", \"email\": \"john@example.com\"}}";
+    JsonPathWrapper jsonPath = new JsonPathWrapper(json);
+
+    ConditionSpec emailCondition = new ConditionSpec("exists", "$.user.email");
+    ConditionSpec phoneCondition = new ConditionSpec("exists", "$.user.phone");
+
+    List<MappingRule> rules =
+        List.of(
+            new MappingRule("$.user.name", "name", emailCondition), // Should execute
+            new MappingRule("$.user.name", "backup_name", phoneCondition) // Should NOT execute
+            );
+
+    Map<String, Object> result = MappingRuleObjectMapper.execute(rules, jsonPath);
+
+    assertEquals("John", result.get("name"));
+    assertFalse(result.containsKey("backup_name"));
+  }
+
+  @Test
+  void execute_shouldHandleRangeCondition() {
+    String json = "{\"users\": [{\"age\": 25}, {\"age\": 15}, {\"age\": 70}]}";
+    JsonPathWrapper jsonPath = new JsonPathWrapper(json);
+
+    ConditionSpec adultCondition = new ConditionSpec("gte", "$.users[0].age", 18);
+    ConditionSpec minorCondition = new ConditionSpec("gte", "$.users[1].age", 18);
+    ConditionSpec seniorCondition = new ConditionSpec("lte", "$.users[2].age", 65);
+
+    List<MappingRule> rules =
+        List.of(
+            new MappingRule((Object) "adult", "category1", adultCondition), // Should execute
+            new MappingRule((Object) "adult", "category2", minorCondition), // Should NOT execute
+            new MappingRule((Object) "adult", "category3", seniorCondition) // Should NOT execute
+            );
+
+    Map<String, Object> result = MappingRuleObjectMapper.execute(rules, jsonPath);
+
+    assertEquals("adult", result.get("category1"));
+    assertFalse(result.containsKey("category2"));
+    assertFalse(result.containsKey("category3"));
+  }
+
+  @Test
+  void execute_shouldHandleRegexCondition() {
+    String json =
+        "{\"user\": {\"email\": \"john@example.com\", \"invalid_email\": \"not-an-email\"}}";
+    JsonPathWrapper jsonPath = new JsonPathWrapper(json);
+
+    String emailPattern = "^[\\w.-]+@[\\w.-]+\\.[a-zA-Z]{2,}$";
+    ConditionSpec validEmailCondition = new ConditionSpec("regex", "$.user.email", emailPattern);
+    ConditionSpec invalidEmailCondition =
+        new ConditionSpec("regex", "$.user.invalid_email", emailPattern);
+
+    List<MappingRule> rules =
+        List.of(
+            new MappingRule("$.user.email", "email", validEmailCondition), // Should execute
+            new MappingRule(
+                "$.user.invalid_email", "backup_email", invalidEmailCondition) // Should NOT execute
+            );
+
+    Map<String, Object> result = MappingRuleObjectMapper.execute(rules, jsonPath);
+
+    assertEquals("john@example.com", result.get("email"));
+    assertFalse(result.containsKey("backup_email"));
+  }
+
+  @Test
+  void execute_shouldHandleConditionEvaluationFailure() {
+    String json = "{\"user\": {\"name\": \"John\"}}";
+    JsonPathWrapper jsonPath = new JsonPathWrapper(json);
+
+    ConditionSpec invalidCondition = new ConditionSpec("exists", "$.invalid[path");
+    MappingRule rule = new MappingRule("$.user.name", "name", invalidCondition);
+    List<MappingRule> rules = List.of(rule);
+
+    Map<String, Object> result = MappingRuleObjectMapper.execute(rules, jsonPath);
+
+    assertFalse(result.containsKey("name"));
+  }
+
+  @Test
+  void execute_shouldExecuteConditionalRuleWithStaticValue() {
+    String json = "{\"user\": {\"role\": \"admin\"}}";
+    JsonPathWrapper jsonPath = new JsonPathWrapper(json);
+
+    ConditionSpec condition = new ConditionSpec("eq", "$.user.role", "admin");
+    MappingRule rule = new MappingRule((Object) "administrator", "display_role", condition);
+    List<MappingRule> rules = List.of(rule);
+
+    Map<String, Object> result = MappingRuleObjectMapper.execute(rules, jsonPath);
+
+    assertEquals("administrator", result.get("display_role"));
+  }
+
+  @Test
+  void execute_shouldSkipConditionalRuleWithStaticValue() {
+    String json = "{\"user\": {\"role\": \"user\"}}";
+    JsonPathWrapper jsonPath = new JsonPathWrapper(json);
+
+    ConditionSpec condition = new ConditionSpec("eq", "$.user.role", "admin");
+    MappingRule rule = new MappingRule((Object) "administrator", "display_role", condition);
+    List<MappingRule> rules = List.of(rule);
+
+    Map<String, Object> result = MappingRuleObjectMapper.execute(rules, jsonPath);
+
+    assertFalse(result.containsKey("display_role"));
+  }
+
+  @Test
+  void execute_shouldHandleComplexConditionalScenario() {
+    String json =
+        """
+        {
+          "user": {
+            "role": "admin",
+            "verified": true,
+            "age": 30,
+            "email": "admin@example.com",
+            "permissions": ["read", "write", "delete"]
+          }
+        }
+        """;
+    JsonPathWrapper jsonPath = new JsonPathWrapper(json);
+
+    ConditionSpec adminCondition = new ConditionSpec("eq", "$.user.role", "admin");
+    ConditionSpec verifiedCondition = new ConditionSpec("exists", "$.user.verified");
+    ConditionSpec ageCondition = new ConditionSpec("gte", "$.user.age", 18);
+    String emailPattern = "^[\\w.-]+@[\\w.-]+\\.[a-zA-Z]{2,}$";
+    ConditionSpec emailCondition = new ConditionSpec("regex", "$.user.email", emailPattern);
+    ConditionSpec userCondition = new ConditionSpec("eq", "$.user.role", "user");
+
+    List<MappingRule> rules =
+        List.of(
+            new MappingRule("$.user.email", "email", adminCondition), // Should execute
+            new MappingRule(
+                (Object) "full_access", "access_level", verifiedCondition), // Should execute
+            new MappingRule("$.user.age", "age", ageCondition), // Should execute
+            new MappingRule("$.user.permissions", "permissions", emailCondition), // Should execute
+            new MappingRule((Object) "limited", "access_type", userCondition) // Should NOT execute
+            );
+
+    Map<String, Object> result = MappingRuleObjectMapper.execute(rules, jsonPath);
+
+    assertEquals("admin@example.com", result.get("email"));
+    assertEquals("full_access", result.get("access_level"));
+    assertEquals(30, result.get("age"));
+    assertEquals(List.of("read", "write", "delete"), result.get("permissions"));
+    assertFalse(result.containsKey("access_type"));
+  }
+}


### PR DESCRIPTION
## Summary
Implements conditional mapping execution functionality for the mapper system, allowing mapping rules to be executed only when specific conditions are met.

- Adds `ConditionSpec` class leveraging the existing `ConditionOperationEvaluator` for robust condition processing
- Extends `MappingRule` with conditional execution capabilities 
- Updates `MappingRuleObjectMapper` to check conditions before rule execution
- Removes unused `convertType` field for code cleanup

## Key Features
Supports comprehensive condition operations via existing `ConditionOperationEvaluator`:
- **Equality**: `eq`, `ne` (equals, not equals)
- **Comparison**: `gt`, `gte`, `lt`, `lte` (greater than, less than operations)
- **Collection**: `in`, `nin` (value in/not in collection)
- **Existence**: `exists`, `missing` (value presence checks)
- **Content**: `contains` (string/collection contains value)
- **Pattern**: `regex` (regular expression matching)

## Example Usage
```java
// Execute mapping only for admin users
new ConditionSpec("eq", "$.user.role", "admin")

// Execute mapping for users over 18
new ConditionSpec("gte", "$.user.age", 18)

// Execute mapping for valid email addresses
new ConditionSpec("regex", "$.user.email", "^[\\w.-]+@[\\w.-]+\\.[a-zA-Z]{2,}$")
```

## Test Plan
- [x] Unit tests for `ConditionSpec` covering all condition operations
- [x] Unit tests for `MappingRule` conditional execution methods
- [x] Integration tests for `MappingRuleObjectMapper` with conditional rules
- [x] Edge cases: invalid conditions, evaluation failures, type coercion
- [x] Complex scenarios: multiple conditions, mixed rule types
- [x] All 474 tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)