### PR TITLE
Implement OAuth authorization support for SSF transmissions (Issue #479)

### DIFF
--- a/libs/idp-server-security-event-framework/src/main/java/org/idp/server/security/event/hook/ssf/SharedSignalFrameworkTransmissionConfig.java
+++ b/libs/idp-server-security-event-framework/src/main/java/org/idp/server/security/event/hook/ssf/SharedSignalFrameworkTransmissionConfig.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Map;
 import org.idp.server.platform.json.JsonReadable;
 import org.idp.server.platform.mapper.MappingRule;
+import org.idp.server.platform.oauth.OAuthAuthorizationConfiguration;
 
 public class SharedSignalFrameworkTransmissionConfig implements JsonReadable {
 
@@ -30,6 +31,7 @@ public class SharedSignalFrameworkTransmissionConfig implements JsonReadable {
   Map<String, Object> securityEventTokenHeaders = new HashMap<>();
   String kid;
   List<MappingRule> securityEventTokenAdditionalPayloadMappingRules = new ArrayList<>();
+  OAuthAuthorizationConfiguration oauthAuthorization;
 
   public SharedSignalFrameworkTransmissionConfig() {}
 
@@ -64,5 +66,9 @@ public class SharedSignalFrameworkTransmissionConfig implements JsonReadable {
 
   public SecurityEventTypeIdentifier securityEventTypeIdentifier() {
     return new SecurityEventTypeIdentifier(securityEventTypeIdentifier);
+  }
+
+  public OAuthAuthorizationConfiguration oauthAuthorization() {
+    return oauthAuthorization;
   }
 }

--- a/libs/idp-server-security-event-framework/src/main/java/org/idp/server/security/event/hook/ssf/SsfHookExecutorFactory.java
+++ b/libs/idp-server-security-event-framework/src/main/java/org/idp/server/security/event/hook/ssf/SsfHookExecutorFactory.java
@@ -17,12 +17,15 @@
 package org.idp.server.security.event.hook.ssf;
 
 import org.idp.server.platform.dependency.ApplicationComponentContainer;
+import org.idp.server.platform.oauth.OAuthAuthorizationResolvers;
 import org.idp.server.platform.security.hook.SecurityEventHook;
 import org.idp.server.platform.security.hook.SecurityEventHookFactory;
 
 public class SsfHookExecutorFactory implements SecurityEventHookFactory {
   @Override
   public SecurityEventHook create(ApplicationComponentContainer container) {
-    return new SsfHookExecutor();
+    OAuthAuthorizationResolvers oAuthAuthorizationResolvers =
+        container.resolve(OAuthAuthorizationResolvers.class);
+    return new SsfHookExecutor(oAuthAuthorizationResolvers);
   }
 }


### PR DESCRIPTION
## Summary
- HttpRequestExecutorにOAuth認証サポートを追加（executeWithOAuthメソッド）
- SharedSignalFrameworkTransmissionConfigにOAuth設定フィールドを追加  
- SsfHookExecutorをHttpRequestExecutorベースの実装に移行してOAuth認証をサポート
- SsfHookExecutorFactoryでDI（依存性注入）を正しく実装

## 主な変更点

### HttpRequestExecutor拡張
- `executeWithOAuth(HttpRequest, OAuthAuthorizationConfiguration)`メソッドを追加
- 既存のHttpRequestにOAuth認証ヘッダー（Authorization: Bearer {token}）を動的追加
- OAuth設定がnullの場合は従来のexecute()メソッドにフォールバック

### SharedSignalFrameworkTransmissionConfig拡張  
- `OAuthAuthorizationConfiguration oauthAuthorization`フィールドを追加
- `oauthAuthorization()`メソッドでOAuth設定の取得をサポート

### SsfHookExecutor更新
- 直接HttpClientを使用していた実装をHttpRequestExecutorベースに移行
- OAuth設定の有無に応じて適切なメソッドを選択（executeWithOAuth vs execute）
- TODOコメント「Add OAuth authorization headers when configured」を実装で解決

### SsfHookExecutorFactory修正
- ApplicationComponentContainerからOAuthAuthorizationResolversを正しく注入
- container.resolve()メソッドを使用してDIを実装

## 設定例
SSF transmissionでOAuth認証が必要な場合の設定:
```json
{
  "url": "https://example.com/ssf/receiver",
  "oauth_authorization": {
    "type": "client_credentials",
    "client_id": "ssf-transmitter", 
    "client_secret": "secret",
    "token_endpoint": "https://example.com/oauth/token"
  }
}
```

## Test plan
- [x] コンパイルエラーなし
- [x] フォーマットチェック通過  
- [x] 全テスト通過
- [x] DI（依存性注入）が正常に動作することを確認

Fixes #479

🤖 Generated with [Claude Code](https://claude.ai/code)