### PR TITLE
Improve HttpRequestExecutor debug logging to JSON format

### DIFF
--- a/libs/idp-server-platform/src/main/java/org/idp/server/platform/http/HttpRequestExecutor.java
+++ b/libs/idp-server-platform/src/main/java/org/idp/server/platform/http/HttpRequestExecutor.java
@@ -966,7 +966,7 @@ public class HttpRequestExecutor {
   private void setHeaders(
       HttpRequest.Builder httpRequestBuilder, Map<String, String> httpRequestStaticHeaders) {
 
-    log.debug("Http Request headers: {}", httpRequestStaticHeaders);
+    log.debug("Http Request headers: {}", jsonConverter.write(httpRequestStaticHeaders));
 
     httpRequestStaticHeaders.forEach(httpRequestBuilder::header);
     if (!httpRequestStaticHeaders.containsKey("Content-Type")) {
@@ -986,7 +986,7 @@ public class HttpRequestExecutor {
         break;
       case POST:
         {
-          log.debug("Http Request body: {}", requestBody);
+          log.debug("Http Request body: {}", jsonConverter.write(requestBody));
           if ("application/x-www-form-urlencoded".equals(headers.get("Content-Type"))) {
             HttpQueryParams httpQueryParams = HttpQueryParams.fromMapObject(requestBody);
             builder.POST(HttpRequest.BodyPublishers.ofString(httpQueryParams.params()));
@@ -997,7 +997,7 @@ public class HttpRequestExecutor {
         }
       case PUT:
         {
-          log.debug("Http Request body: {}", requestBody);
+          log.debug("Http Request body: {}", jsonConverter.write(requestBody));
           if ("application/x-www-form-urlencoded".equals(headers.get("Content-Type"))) {
             HttpQueryParams httpQueryParams = HttpQueryParams.fromMapObject(requestBody);
             builder.PUT(HttpRequest.BodyPublishers.ofString(httpQueryParams.params()));
@@ -1008,7 +1008,7 @@ public class HttpRequestExecutor {
         }
       case DELETE:
         {
-          log.debug("Http Request body: {}", requestBody);
+          log.debug("Http Request body: {}", jsonConverter.write(requestBody));
           if ("application/x-www-form-urlencoded".equals(headers.get("Content-Type"))) {
             HttpQueryParams httpQueryParams = HttpQueryParams.fromMapObject(requestBody);
             builder.method("DELETE", HttpRequest.BodyPublishers.ofString(httpQueryParams.params()));


### PR DESCRIPTION
## Summary
Issue #511対応: HttpRequestExecutorのデバッグログをJSONフォーマットに改善

## Changes
- **setHeaders()**: リクエストヘッダーのログ出力をJSONフォーマットに変更
- **POST/PUT/DELETE**: リクエストボディのログ出力をJSONフォーマットに変更
- Map.toString()から`jsonConverter.write()`に統一

## Before/After

### Before
```
Http Request headers: {Authorization=Bearer token123, Content-Type=application/json}
Http Request body: {user_id=12345, action=login}
```

### After
```
Http Request headers: {"authorization":"Bearer token123","content_type":"application/json"}
Http Request body: {"user_id":"12345","action":"login"}
```

## Benefits
- **可読性向上**: 構造化されたJSONフォーマットで情報把握が容易
- **解析しやすさ**: ログ解析ツールでの処理が効率的
- **一貫性**: 他のログ出力と統一されたフォーマット

## Test plan
- [x] platform moduleのテスト実行確認
- [x] ログ出力フォーマット変更による副作用なし確認

Resolves #511

🤖 Generated with [Claude Code](https://claude.ai/code)