### PR TITLE
Add request-level timeout configuration for HTTP requests

### DIFF
--- a/libs/idp-server-core-extension-ida/src/main/java/org/idp/server/core/extension/identity/verification/application/pre_hook/additional_parameter/AdditionalParameterHttpRequestConfig.java
+++ b/libs/idp-server-core-extension-ida/src/main/java/org/idp/server/core/extension/identity/verification/application/pre_hook/additional_parameter/AdditionalParameterHttpRequestConfig.java
@@ -37,6 +37,7 @@ public class AdditionalParameterHttpRequestConfig
   List<MappingRule> bodyMappingRules = new ArrayList<>();
   List<MappingRule> queryMappingRules = new ArrayList<>();
   HttpRetryConfiguration retryConfiguration = HttpRetryConfiguration.noRetry();
+  Integer requestTimeoutSeconds;
 
   public AdditionalParameterHttpRequestConfig() {}
 
@@ -118,6 +119,16 @@ public class AdditionalParameterHttpRequestConfig
     return retryConfiguration;
   }
 
+  @Override
+  public boolean hasRequestTimeout() {
+    return requestTimeoutSeconds != null && requestTimeoutSeconds > 0;
+  }
+
+  @Override
+  public int requestTimeoutSeconds() {
+    return requestTimeoutSeconds != null ? requestTimeoutSeconds : 30;
+  }
+
   public boolean exists() {
     return url != null && !url.isEmpty();
   }
@@ -130,6 +141,7 @@ public class AdditionalParameterHttpRequestConfig
     if (hasOAuthAuthorization()) map.put("oauth_authorization", oauthAuthorization.toMap());
     if (hasHmacAuthentication()) map.put("hmac_authentication", hmacAuthentication.toMap());
     if (hasRetryConfiguration()) map.put("retry_configuration", retryConfiguration.toMap());
+    if (hasRequestTimeout()) map.put("request_timeout_seconds", requestTimeoutSeconds);
     return map;
   }
 }

--- a/libs/idp-server-core-extension-ida/src/main/java/org/idp/server/core/extension/identity/verification/configuration/process/IdentityVerificationHttpRequestConfig.java
+++ b/libs/idp-server-core-extension-ida/src/main/java/org/idp/server/core/extension/identity/verification/configuration/process/IdentityVerificationHttpRequestConfig.java
@@ -37,6 +37,7 @@ public class IdentityVerificationHttpRequestConfig
   List<MappingRule> bodyMappingRules = new ArrayList<>();
   List<MappingRule> queryMappingRules = new ArrayList<>();
   HttpRetryConfiguration retryConfiguration = HttpRetryConfiguration.noRetry();
+  Integer requestTimeoutSeconds;
 
   public IdentityVerificationHttpRequestConfig() {}
 
@@ -150,6 +151,16 @@ public class IdentityVerificationHttpRequestConfig
     return retryConfiguration;
   }
 
+  @Override
+  public boolean hasRequestTimeout() {
+    return requestTimeoutSeconds != null && requestTimeoutSeconds > 0;
+  }
+
+  @Override
+  public int requestTimeoutSeconds() {
+    return requestTimeoutSeconds != null ? requestTimeoutSeconds : 30;
+  }
+
   public boolean exists() {
     return url != null && !url.isEmpty();
   }
@@ -166,6 +177,7 @@ public class IdentityVerificationHttpRequestConfig
     if (hasBodyMappingRules()) map.put("body_mapping_rules", bodyMappingRulesMap());
     if (hasQueryMappingRules()) map.put("query_mapping_rules", queryMappingRulesMap());
     if (hasRetryConfiguration()) map.put("retry_configuration", retryConfiguration.toMap());
+    if (hasRequestTimeout()) map.put("request_timeout_seconds", requestTimeoutSeconds);
     return map;
   }
 }

--- a/libs/idp-server-platform/src/main/java/org/idp/server/platform/http/HttpRequestExecutionConfig.java
+++ b/libs/idp-server-platform/src/main/java/org/idp/server/platform/http/HttpRequestExecutionConfig.java
@@ -36,6 +36,7 @@ public class HttpRequestExecutionConfig
   List<MappingRule> bodyMappingRules = new ArrayList<>();
   List<MappingRule> queryMappingRules = new ArrayList<>();
   HttpRetryConfiguration retryConfiguration = HttpRetryConfiguration.noRetry();
+  Integer requestTimeoutSeconds;
 
   public HttpRequestExecutionConfig() {}
 
@@ -149,6 +150,16 @@ public class HttpRequestExecutionConfig
     return retryConfiguration;
   }
 
+  @Override
+  public boolean hasRequestTimeout() {
+    return requestTimeoutSeconds != null && requestTimeoutSeconds > 0;
+  }
+
+  @Override
+  public int requestTimeoutSeconds() {
+    return requestTimeoutSeconds != null ? requestTimeoutSeconds : 30;
+  }
+
   public boolean exists() {
     return url != null && !url.isEmpty();
   }
@@ -165,6 +176,7 @@ public class HttpRequestExecutionConfig
     if (hasBodyMappingRules()) map.put("body_mapping_rules", bodyMappingRulesMap());
     if (hasQueryMappingRules()) map.put("query_mapping_rules", queryMappingRulesMap());
     if (hasRetryConfiguration()) map.put("retry_configuration", retryConfiguration.toMap());
+    if (hasRequestTimeout()) map.put("request_timeout_seconds", requestTimeoutSeconds);
     return map;
   }
 }

--- a/libs/idp-server-platform/src/main/java/org/idp/server/platform/http/HttpRequestExecutionConfigInterface.java
+++ b/libs/idp-server-platform/src/main/java/org/idp/server/platform/http/HttpRequestExecutionConfigInterface.java
@@ -50,78 +50,11 @@ public interface HttpRequestExecutionConfigInterface {
     return HttpRetryConfiguration.noRetry();
   }
 
-  /**
-   * Creates HttpRetryConfiguration from JSON configuration.
-   *
-   * <p>Expected JSON format:
-   *
-   * <pre>{@code
-   * {
-   *   "max_retries": 3,
-   *   "backoff_delays": [1000, 5000, 30000],
-   *   "retryable_status_codes": [500, 502, 503, 504, 408, 429],
-   *   "idempotency_required": false,
-   *   "strategy": "EXPONENTIAL_BACKOFF"
-   * }
-   * }</pre>
-   *
-   * @param retryConfigJson JSON object containing retry configuration
-   * @return configured HttpRetryConfiguration instance
-   */
-  static HttpRetryConfiguration createRetryConfigurationFromJson(
-      org.idp.server.platform.json.JsonNodeWrapper retryConfigJson) {
+  default boolean hasRequestTimeout() {
+    return false;
+  }
 
-    if (retryConfigJson == null || !retryConfigJson.exists()) {
-      return HttpRetryConfiguration.noRetry();
-    }
-
-    HttpRetryConfiguration.Builder builder = HttpRetryConfiguration.builder();
-
-    // Max retries
-    if (retryConfigJson.contains("max_retries")) {
-      builder.maxRetries(retryConfigJson.getValueAsInt("max_retries"));
-    }
-
-    // Backoff delays
-    if (retryConfigJson.contains("backoff_delays")) {
-      java.util.List<org.idp.server.platform.json.JsonNodeWrapper> delayNodes =
-          retryConfigJson.getValueAsJsonNodeList("backoff_delays");
-
-      java.time.Duration[] delays =
-          delayNodes.stream()
-              .mapToInt(node -> node.asInt())
-              .mapToObj(millis -> java.time.Duration.ofMillis(millis))
-              .toArray(java.time.Duration[]::new);
-
-      if (delays.length > 0) {
-        builder.backoffDelays(delays);
-      }
-    }
-
-    // Retryable status codes
-    if (retryConfigJson.contains("retryable_status_codes")) {
-      java.util.List<org.idp.server.platform.json.JsonNodeWrapper> statusNodes =
-          retryConfigJson.getValueAsJsonNodeList("retryable_status_codes");
-
-      java.util.Set<Integer> statusCodes =
-          statusNodes.stream()
-              .mapToInt(node -> node.asInt())
-              .boxed()
-              .collect(java.util.stream.Collectors.toSet());
-
-      builder.retryableStatusCodes(statusCodes);
-    }
-
-    // Idempotency required
-    if (retryConfigJson.contains("idempotency_required")) {
-      builder.idempotencyRequired(retryConfigJson.getValueAsBoolean("idempotency_required"));
-    }
-
-    // Strategy
-    if (retryConfigJson.contains("strategy")) {
-      builder.strategy(retryConfigJson.getValueOrEmptyAsString("strategy"));
-    }
-
-    return builder.build();
+  default int requestTimeoutSeconds() {
+    return 30;
   }
 }

--- a/libs/idp-server-platform/src/main/java/org/idp/server/platform/http/HttpRequestExecutor.java
+++ b/libs/idp-server-platform/src/main/java/org/idp/server/platform/http/HttpRequestExecutor.java
@@ -262,7 +262,9 @@ public class HttpRequestExecutor {
     }
 
     HttpRequest.Builder httpRequestBuilder =
-        HttpRequest.newBuilder().uri(URI.create(interpolatedUrl.value()));
+        HttpRequest.newBuilder()
+            .uri(URI.create(interpolatedUrl.value()))
+            .timeout(Duration.ofSeconds(configuration.requestTimeoutSeconds()));
 
     setHeaders(httpRequestBuilder, headers);
     setParams(httpRequestBuilder, configuration.httpMethod(), headers, requestBody);
@@ -270,7 +272,7 @@ public class HttpRequestExecutor {
     return httpRequestBuilder.build();
   }
 
-  private HttpRequestResult get(
+  public HttpRequestResult get(
       HttpRequestExecutionConfigInterface configuration,
       HttpRequestBaseParams httpRequestBaseParams) {
     HttpRequest httpRequest = buildGetRequest(configuration, httpRequestBaseParams);
@@ -305,7 +307,9 @@ public class HttpRequestExecutor {
     String urlWithQueryParams = interpolatedUrl.withQueryParams(new HttpQueryParams(queryParams));
 
     HttpRequest.Builder httpRequestBuilder =
-        HttpRequest.newBuilder().uri(URI.create(urlWithQueryParams));
+        HttpRequest.newBuilder()
+            .uri(URI.create(urlWithQueryParams))
+            .timeout(Duration.ofSeconds(configuration.requestTimeoutSeconds()));
 
     setHeaders(httpRequestBuilder, headers);
     setParams(httpRequestBuilder, HttpMethod.GET, headers, Map.of());

--- a/libs/idp-server-platform/src/main/java/org/idp/server/platform/http/IdempotencyKeyManager.java
+++ b/libs/idp-server-platform/src/main/java/org/idp/server/platform/http/IdempotencyKeyManager.java
@@ -94,6 +94,9 @@ public class IdempotencyKeyManager {
                 request.method(),
                 request.bodyPublisher().orElse(HttpRequest.BodyPublishers.noBody()));
 
+    // Copy timeout if present
+    request.timeout().ifPresent(builder::timeout);
+
     // Copy existing headers
     request
         .headers()

--- a/libs/idp-server-platform/src/main/java/org/idp/server/platform/security/hook/configuration/SecurityEventHttpRequestConfig.java
+++ b/libs/idp-server-platform/src/main/java/org/idp/server/platform/security/hook/configuration/SecurityEventHttpRequestConfig.java
@@ -37,6 +37,7 @@ public class SecurityEventHttpRequestConfig
   List<MappingRule> bodyMappingRules = new ArrayList<>();
   List<MappingRule> queryMappingRules = new ArrayList<>();
   HttpRetryConfiguration retryConfiguration = HttpRetryConfiguration.noRetry();
+  Integer requestTimeoutSeconds;
 
   public SecurityEventHttpRequestConfig() {}
 
@@ -150,6 +151,16 @@ public class SecurityEventHttpRequestConfig
     return retryConfiguration;
   }
 
+  @Override
+  public boolean hasRequestTimeout() {
+    return requestTimeoutSeconds != null && requestTimeoutSeconds > 0;
+  }
+
+  @Override
+  public int requestTimeoutSeconds() {
+    return requestTimeoutSeconds != null ? requestTimeoutSeconds : 30;
+  }
+
   public boolean exists() {
     return url != null && !url.isEmpty();
   }
@@ -166,6 +177,7 @@ public class SecurityEventHttpRequestConfig
     if (hasBodyMappingRules()) map.put("body_mapping_rules", bodyMappingRulesMap());
     if (hasQueryMappingRules()) map.put("query_mapping_rules", queryMappingRulesMap());
     if (hasRetryConfiguration()) map.put("retry_configuration", retryConfiguration.toMap());
+    if (hasRequestTimeout()) map.put("request_timeout_seconds", requestTimeoutSeconds);
     return map;
   }
 }


### PR DESCRIPTION
## Summary
- Implements HttpRequest.timeout() support for all HTTP requests with default 30-second timeout
- Adds configurable per-request timeout via HttpRequestExecutionConfigInterface
- Removes unused createRetryConfigurationFromJson() method
- Makes HttpRequestExecutor.get() public for external access

## Technical Implementation
- **HttpRequestExecutionConfigInterface**: Added hasRequestTimeout() and requestTimeoutSeconds() methods
- **HttpRequestExecutor**: Applied Duration.ofSeconds() to all HttpRequest.Builder instances
- **All Config Classes**: Updated SecurityEventHttpRequestConfig, IdentityVerificationHttpRequestConfig, AdditionalParameterHttpRequestConfig
- **JSON Support**: Added 'request_timeout_seconds' field for configuration

## Test Plan
- [x] Build successful with all modules
- [x] Spotless formatting applied
- [x] All HttpRequestExecutor methods updated (buildHttpRequest, buildGetRequest)
- [x] Default 30-second timeout applies when no configuration specified

Fixes #505

🤖 Generated with [Claude Code](https://claude.ai/code)