### PR TITLE
Add user_code parameter to CIBA backchannel authentication request

### DIFF
--- a/documentation/openapi/swagger-rp-ja.yaml
+++ b/documentation/openapi/swagger-rp-ja.yaml
@@ -2067,6 +2067,9 @@ components:
         acr_values:
           type: string
           description: "要求する認証強度（ACR値）"
+        user_code:
+          type: string
+          description: "ユーザー認証デバイスでの認証リクエスト送信を許可するためのコード。悪意のある認証リクエストからユーザーを保護するためのオプショナルパラメータ。"
         authorization_details:
           $ref: '#/components/schemas/AuthorizationDetails'
       required:


### PR DESCRIPTION
## Summary

Add the missing `user_code` parameter to the CIBA (Client-Initiated Backchannel Authentication) backchannel authentication request in the OpenAPI specification.

## Changes

- Add `user_code` parameter to `BackchannelAuthenticationRequest` schema in `swagger-rp-ja.yaml`
- Include proper Japanese description explaining the security purpose of this parameter

## Specification Compliance

This change aligns with **OpenID Connect CIBA Core 1.0** specification:

- **Parameter**: `user_code` (optional)
- **Purpose**: Security mechanism to protect users from unsolicited authentication requests
- **Function**: Secret code known only to the user, verified by Authorization Server
- **Benefit**: Prevents malicious clients from initiating unauthorized CIBA flows

## Error Handling

The related error codes (`missing_user_code` and `invalid_user_code`) are already properly defined in the OpenAPI specification.

## Validation

- [x] YAML syntax validation passed
- [x] Parameter description in Japanese
- [x] Follows existing OpenAPI schema patterns
- [x] Aligns with CIBA specification requirements

Fixes #518

🤖 Generated with [Claude Code](https://claude.ai/code)