### PR TITLE
Add APNS support to notification_channel enum

### DIFF
--- a/documentation/openapi/swagger-resource-owner-ja.yaml
+++ b/documentation/openapi/swagger-resource-owner-ja.yaml
@@ -717,8 +717,8 @@ components:
           description: 言語設定。（例：ja, en）
         notification_channel:
           type: string
-          enum: [ fcm ]
-          description: 通知チャネル（"fcm" など）。※現在サポートしているPush通知チャネルはfcmのみ。
+          enum: [ fcm, apns ]
+          description: 通知チャネル（"fcm", "apns"）。Firebase Cloud Messaging（Android）またはApple Push Notification Service（iOS）を指定。
         notification_token:
           type: string
           description: 通知を送信するためのトークン（例：FCMトークン）。

--- a/libs/idp-server-core/src/main/resources/schema/1.0/authentication-device-patch.json
+++ b/libs/idp-server-core/src/main/resources/schema/1.0/authentication-device-patch.json
@@ -18,7 +18,7 @@
     },
     "notification_channel": {
       "type": "string",
-      "enum": ["fcm"]
+      "enum": ["fcm", "apns"]
     },
     "notification_token": {
       "type": "string"


### PR DESCRIPTION
## Summary
- Add support for APNS (Apple Push Notification Service) to notification_channel enum
- Update both JSON schema and OpenAPI documentation for consistency
- Enhance documentation to clarify FCM for Android and APNS for iOS

## Changes
- Modified `authentication-device-patch.json` to support both "fcm" and "apns" values
- Updated OpenAPI documentation in `swagger-resource-owner-ja.yaml`
- Enhanced description to specify platform-specific usage

## Test plan
- [ ] Verify JSON schema accepts both "fcm" and "apns" values
- [ ] Confirm OpenAPI documentation reflects the changes
- [ ] Test authentication device PATCH requests with both notification channels

Fixes #520

🤖 Generated with [Claude Code](https://claude.ai/code)