### PR TITLE
Implement asynchronous audit log processing infrastructure

### DIFF
--- a/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/identity/verification/IdentityVerificationConfigRegistrationContext.java
+++ b/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/identity/verification/IdentityVerificationConfigRegistrationContext.java
@@ -40,7 +40,7 @@ public class IdentityVerificationConfigRegistrationContext implements ConfigRegi
   }
 
   public Tenant tenant() {
-    return null;
+    return tenant;
   }
 
   public IdentityVerificationConfiguration configuration() {

--- a/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/security/event/MysqlExecutor.java
+++ b/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/security/event/MysqlExecutor.java
@@ -21,8 +21,6 @@ import java.util.List;
 import org.idp.server.platform.datasource.SqlExecutor;
 import org.idp.server.platform.json.JsonConverter;
 import org.idp.server.platform.security.SecurityEvent;
-import org.idp.server.platform.security.SecurityEvents;
-import org.idp.server.platform.security.event.SecurityEventSearchCriteria;
 
 public class MysqlExecutor implements SecurityEventSqlExecutor {
 
@@ -89,15 +87,5 @@ public class MysqlExecutor implements SecurityEventSqlExecutor {
     params.add(converter.write(securityEvent.detail().toMap()));
 
     sqlExecutor.execute(sqlTemplate, params);
-  }
-
-  @Override
-  public SecurityEvents selectListByUser(String eventServerId, String userId) {
-    return null;
-  }
-
-  @Override
-  public SecurityEvents selectList(String eventServerId, SecurityEventSearchCriteria criteria) {
-    return null;
   }
 }

--- a/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/security/event/PostgresqlExecutor.java
+++ b/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/security/event/PostgresqlExecutor.java
@@ -21,8 +21,6 @@ import java.util.List;
 import org.idp.server.platform.datasource.SqlExecutor;
 import org.idp.server.platform.json.JsonConverter;
 import org.idp.server.platform.security.SecurityEvent;
-import org.idp.server.platform.security.SecurityEvents;
-import org.idp.server.platform.security.event.SecurityEventSearchCriteria;
 
 public class PostgresqlExecutor implements SecurityEventSqlExecutor {
 
@@ -89,15 +87,5 @@ public class PostgresqlExecutor implements SecurityEventSqlExecutor {
     params.add(converter.write(securityEvent.detail().toMap()));
 
     sqlExecutor.execute(sqlTemplate, params);
-  }
-
-  @Override
-  public SecurityEvents selectListByUser(String eventServerId, String userId) {
-    return null;
-  }
-
-  @Override
-  public SecurityEvents selectList(String eventServerId, SecurityEventSearchCriteria criteria) {
-    return null;
   }
 }

--- a/libs/idp-server-platform/src/main/java/org/idp/server/platform/audit/AuditLogApi.java
+++ b/libs/idp-server-platform/src/main/java/org/idp/server/platform/audit/AuditLogApi.java
@@ -14,10 +14,11 @@
  * limitations under the License.
  */
 
-package org.idp.server.core.adapters.datasource.security.event;
+package org.idp.server.platform.audit;
 
-import org.idp.server.platform.security.SecurityEvent;
+import org.idp.server.platform.multi_tenancy.tenant.TenantIdentifier;
 
-public interface SecurityEventSqlExecutor {
-  void insert(SecurityEvent securityEvent);
+public interface AuditLogApi {
+
+  void handle(TenantIdentifier tenantIdentifier, AuditLog auditLog);
 }

--- a/libs/idp-server-platform/src/main/java/org/idp/server/platform/audit/AuditLogPublisher.java
+++ b/libs/idp-server-platform/src/main/java/org/idp/server/platform/audit/AuditLogPublisher.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2025 Hirokazu Kobayashi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.idp.server.platform.audit;
+
+/**
+ * Publisher interface for asynchronous audit log processing.
+ *
+ * <p>This interface provides a platform-agnostic way to publish audit log events for asynchronous
+ * processing, similar to SecurityEventPublisher.
+ *
+ * <p>The implementation will handle the actual event publishing mechanism, whether it's Spring
+ * Events, message queues, or other event systems.
+ */
+public interface AuditLogPublisher {
+
+  /**
+   * Publishes an audit log event for asynchronous processing.
+   *
+   * @param auditLog the audit log to be processed asynchronously
+   */
+  void publish(AuditLog auditLog);
+}

--- a/libs/idp-server-springboot-adapter/src/main/java/org/idp/server/adapters/springboot/IdPServerConfiguration.java
+++ b/libs/idp-server-springboot-adapter/src/main/java/org/idp/server/adapters/springboot/IdPServerConfiguration.java
@@ -21,6 +21,7 @@ import org.idp.server.IdpServerApplication;
 import org.idp.server.adapters.springboot.application.delegation.PasswordEncoder;
 import org.idp.server.adapters.springboot.application.delegation.PasswordVerification;
 import org.idp.server.adapters.springboot.application.event.SecurityEventPublisherService;
+import org.idp.server.adapters.springboot.application.event.SpringAuditLogPublisher;
 import org.idp.server.adapters.springboot.application.event.UserLifecycleEventPublisherService;
 import org.idp.server.adapters.springboot.application.property.AdminDatabaseConfigProperties;
 import org.idp.server.adapters.springboot.application.property.AppDatabaseConfigProperties;
@@ -95,6 +96,7 @@ public class IdPServerConfiguration {
   public IdpServerApplication idpServerApplication(
       OAuthSessionService oAuthSessionService,
       SecurityEventPublisherService eventPublisherService,
+      SpringAuditLogPublisher auditLogPublisher,
       UserLifecycleEventPublisherService userLifecycleEventPublisherService) {
 
     ApplicationDatabaseTypeProvider applicationDatabaseTypeProvider =
@@ -122,6 +124,7 @@ public class IdPServerConfiguration {
         passwordEncoder,
         passwordVerification,
         eventPublisherService,
+        auditLogPublisher,
         userLifecycleEventPublisherService,
         timeConfig);
   }

--- a/libs/idp-server-springboot-adapter/src/main/java/org/idp/server/adapters/springboot/application/event/AuditLogEventListener.java
+++ b/libs/idp-server-springboot-adapter/src/main/java/org/idp/server/adapters/springboot/application/event/AuditLogEventListener.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2025 Hirokazu Kobayashi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.idp.server.adapters.springboot.application.event;
+
+import org.idp.server.IdpServerApplication;
+import org.idp.server.platform.audit.AuditLog;
+import org.idp.server.platform.audit.AuditLogApi;
+import org.idp.server.platform.log.LoggerWrapper;
+import org.idp.server.platform.log.TenantLoggingContext;
+import org.idp.server.platform.multi_tenancy.tenant.TenantIdentifier;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.event.EventListener;
+import org.springframework.core.task.TaskExecutor;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+
+/**
+ * Asynchronous event listener for audit log processing.
+ *
+ * <p>This service handles audit log events asynchronously to improve performance and enable
+ * read-only transactions in management APIs.
+ *
+ * <p>Similar to SecurityEventListerService, this follows the same pattern: - @Async for
+ * non-blocking processing - TaskExecutor for background execution - Proper tenant context
+ * management
+ */
+@Service
+public class AuditLogEventListener {
+
+  LoggerWrapper log = LoggerWrapper.getLogger(AuditLogEventListener.class);
+  TaskExecutor taskExecutor;
+  AuditLogApi auditLogApi;
+
+  public AuditLogEventListener(
+      @Qualifier("auditLogTaskExecutor") TaskExecutor taskExecutor,
+      IdpServerApplication idpServerApplication) {
+    this.taskExecutor = taskExecutor;
+    this.auditLogApi = idpServerApplication.auditLogApi();
+  }
+
+  @Async
+  @EventListener
+  public void onAuditLogEvent(AuditLog auditLog) {
+    TenantIdentifier tenantIdentifier = new TenantIdentifier(auditLog.tenantId());
+    TenantLoggingContext.setTenant(tenantIdentifier);
+
+    try {
+      log.info(
+          "AuditLogEventListener.onEvent, type: {}, resource: {}",
+          auditLog.type(),
+          auditLog.targetResource());
+
+      taskExecutor.execute(
+          new AuditLogRunnable(
+              auditLog,
+              tenantIdentifier,
+              event -> {
+                auditLogApi.handle(tenantIdentifier, event);
+              }));
+    } finally {
+      TenantLoggingContext.clearAll();
+    }
+  }
+}

--- a/libs/idp-server-springboot-adapter/src/main/java/org/idp/server/adapters/springboot/application/event/AuditLogRunnable.java
+++ b/libs/idp-server-springboot-adapter/src/main/java/org/idp/server/adapters/springboot/application/event/AuditLogRunnable.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2025 Hirokazu Kobayashi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.idp.server.adapters.springboot.application.event;
+
+import java.util.function.Consumer;
+import org.idp.server.platform.audit.AuditLog;
+import org.idp.server.platform.log.TenantLoggingContext;
+import org.idp.server.platform.multi_tenancy.tenant.TenantIdentifier;
+
+/**
+ * Runnable implementation for asynchronous audit log processing.
+ *
+ * <p>This class encapsulates the audit log processing logic to be executed asynchronously in a
+ * background thread, following the same pattern as SecurityEventRunnable.
+ */
+public class AuditLogRunnable implements Runnable {
+
+  AuditLog auditLog;
+  TenantIdentifier tenantIdentifier;
+  Consumer<AuditLog> handler;
+
+  public AuditLogRunnable(
+      AuditLog auditLog, TenantIdentifier tenantIdentifier, Consumer<AuditLog> handler) {
+    this.auditLog = auditLog;
+    this.tenantIdentifier = tenantIdentifier;
+    this.handler = handler;
+  }
+
+  public AuditLog getAuditLog() {
+    return auditLog;
+  }
+
+  @Override
+  public void run() {
+    TenantLoggingContext.setTenant(tenantIdentifier);
+    try {
+      handler.accept(auditLog);
+    } finally {
+      TenantLoggingContext.clearAll();
+    }
+  }
+}

--- a/libs/idp-server-springboot-adapter/src/main/java/org/idp/server/adapters/springboot/application/event/SpringAuditLogPublisher.java
+++ b/libs/idp-server-springboot-adapter/src/main/java/org/idp/server/adapters/springboot/application/event/SpringAuditLogPublisher.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2025 Hirokazu Kobayashi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.idp.server.adapters.springboot.application.event;
+
+import org.idp.server.platform.audit.AuditLog;
+import org.idp.server.platform.audit.AuditLogPublisher;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Component;
+
+/**
+ * Spring-based implementation of AuditLogPublisher.
+ *
+ * <p>This implementation uses Spring's ApplicationEventPublisher to publish audit log events for
+ * asynchronous processing by AuditLogEventListener.
+ */
+@Component
+public class SpringAuditLogPublisher implements AuditLogPublisher {
+
+  private final ApplicationEventPublisher eventPublisher;
+
+  public SpringAuditLogPublisher(ApplicationEventPublisher eventPublisher) {
+    this.eventPublisher = eventPublisher;
+  }
+
+  @Override
+  public void publish(AuditLog auditLog) {
+    eventPublisher.publishEvent(auditLog);
+  }
+}

--- a/libs/idp-server-use-cases/src/main/java/org/idp/server/IdpServerApplication.java
+++ b/libs/idp-server-use-cases/src/main/java/org/idp/server/IdpServerApplication.java
@@ -123,6 +123,8 @@ import org.idp.server.core.openid.userinfo.UserinfoProtocol;
 import org.idp.server.core.openid.userinfo.UserinfoProtocols;
 import org.idp.server.federation.sso.oidc.OidcSsoExecutorPluginLoader;
 import org.idp.server.federation.sso.oidc.OidcSsoExecutors;
+import org.idp.server.platform.audit.AuditLogApi;
+import org.idp.server.platform.audit.AuditLogPublisher;
 import org.idp.server.platform.audit.AuditLogQueryRepository;
 import org.idp.server.platform.audit.AuditLogWriters;
 import org.idp.server.platform.crypto.AesCipher;
@@ -193,6 +195,7 @@ public class IdpServerApplication {
   IdentityVerificationCallbackApi identityVerificationCallbackApi;
   IdentityVerificationApi identityVerificationApi;
   SecurityEventApi securityEventApi;
+  AuditLogApi auditLogApi;
   SharedSignalsFrameworkMetaDataApi sharedSignalsFrameworkMetaDataApi;
   TenantMetaDataApi tenantMetaDataApi;
   TenantInvitationMetaDataApi tenantInvitationMetaDataApi;
@@ -248,6 +251,7 @@ public class IdpServerApplication {
       PasswordEncodeDelegation passwordEncodeDelegation,
       PasswordVerificationDelegation passwordVerificationDelegation,
       SecurityEventPublisher securityEventPublisher,
+      AuditLogPublisher auditLogPublisher,
       UserLifecycleEventPublisher userLifecycleEventPublisher,
       TimeConfig timeConfig) {
 
@@ -635,6 +639,12 @@ public class IdpServerApplication {
             SecurityEventApi.class,
             databaseTypeProvider);
 
+    this.auditLogApi =
+        TenantAwareEntryServiceProxy.createProxy(
+            new AuditLogEntryService(auditLogWriters, tenantQueryRepository),
+            AuditLogApi.class,
+            databaseTypeProvider);
+
     this.sharedSignalsFrameworkMetaDataApi =
         TenantAwareEntryServiceProxy.createProxy(
             new SharedSignalsFrameworkMetaDataEntryService(
@@ -718,7 +728,7 @@ public class IdpServerApplication {
                 organizationRepository,
                 authorizationServerConfigurationCommandRepository,
                 userCommandRepository,
-                auditLogWriters),
+                auditLogPublisher),
             TenantManagementApi.class,
             databaseTypeProvider);
 
@@ -739,7 +749,7 @@ public class IdpServerApplication {
                 tenantQueryRepository,
                 authorizationServerConfigurationQueryRepository,
                 authorizationServerConfigurationCommandRepository,
-                auditLogWriters),
+                auditLogPublisher),
             AuthorizationServerManagementApi.class,
             databaseTypeProvider);
 
@@ -749,7 +759,7 @@ public class IdpServerApplication {
                 tenantQueryRepository,
                 clientConfigurationCommandRepository,
                 clientConfigurationQueryRepository,
-                auditLogWriters),
+                auditLogPublisher),
             ClientManagementApi.class,
             databaseTypeProvider);
 
@@ -763,7 +773,7 @@ public class IdpServerApplication {
                 organizationRepository,
                 passwordEncodeDelegation,
                 userLifecycleEventPublisher,
-                auditLogWriters),
+                auditLogPublisher),
             UserManagementApi.class,
             databaseTypeProvider);
 
@@ -773,7 +783,7 @@ public class IdpServerApplication {
                 authenticationConfigurationCommandRepository,
                 authenticationConfigurationQueryRepository,
                 tenantQueryRepository,
-                auditLogWriters),
+                auditLogPublisher),
             AuthenticationConfigurationManagementApi.class,
             databaseTypeProvider);
 
@@ -783,7 +793,7 @@ public class IdpServerApplication {
                 authenticationPolicyConfigurationCommandRepository,
                 authenticationPolicyConfigurationQueryRepository,
                 tenantQueryRepository,
-                auditLogWriters),
+                auditLogPublisher),
             AuthenticationPolicyConfigurationManagementApi.class,
             databaseTypeProvider);
 
@@ -793,7 +803,7 @@ public class IdpServerApplication {
                 federationConfigurationQueryRepository,
                 federationConfigurationCommandRepository,
                 tenantQueryRepository,
-                auditLogWriters),
+                auditLogPublisher),
             FederationConfigurationManagementApi.class,
             databaseTypeProvider);
 
@@ -803,7 +813,7 @@ public class IdpServerApplication {
                 securityEventHookConfigurationCommandRepository,
                 securityEventHookConfigurationQueryRepository,
                 tenantQueryRepository,
-                auditLogWriters),
+                auditLogPublisher),
             SecurityEventHookConfigurationManagementApi.class,
             databaseTypeProvider);
 
@@ -813,35 +823,35 @@ public class IdpServerApplication {
                 identityVerificationConfigurationCommandRepository,
                 identityVerificationConfigurationQueryRepository,
                 tenantQueryRepository,
-                auditLogWriters),
+                auditLogPublisher),
             IdentityVerificationConfigManagementApi.class,
             databaseTypeProvider);
 
     this.securityEventManagementApi =
         TenantAwareEntryServiceProxy.createProxy(
             new SecurityEventManagementEntryService(
-                securityEventQueryRepository, tenantQueryRepository, auditLogWriters),
+                securityEventQueryRepository, tenantQueryRepository, auditLogPublisher),
             SecurityEventManagementApi.class,
             databaseTypeProvider);
 
     this.auditLogManagementApi =
         TenantAwareEntryServiceProxy.createProxy(
             new AuditLogManagementEntryService(
-                auditLogQueryRepository, tenantQueryRepository, auditLogWriters),
+                auditLogQueryRepository, tenantQueryRepository, auditLogPublisher),
             AuditLogManagementApi.class,
             databaseTypeProvider);
 
     this.authenticationInteractionManagementApi =
         TenantAwareEntryServiceProxy.createProxy(
             new AuthenticationInteractionManagementEntryService(
-                authenticationInteractionQueryRepository, tenantQueryRepository, auditLogWriters),
+                authenticationInteractionQueryRepository, tenantQueryRepository, auditLogPublisher),
             AuthenticationInteractionManagementApi.class,
             databaseTypeProvider);
 
     this.authenticationTransactionManagementApi =
         TenantAwareEntryServiceProxy.createProxy(
             new AuthenticationTransactionManagementEntryService(
-                authenticationTransactionQueryRepository, tenantQueryRepository, auditLogWriters),
+                authenticationTransactionQueryRepository, tenantQueryRepository, auditLogPublisher),
             AuthenticationTransactionManagementApi.class,
             databaseTypeProvider);
 
@@ -851,7 +861,7 @@ public class IdpServerApplication {
                 tenantQueryRepository,
                 permissionQueryRepository,
                 permissionCommandRepository,
-                auditLogWriters),
+                auditLogPublisher),
             PermissionManagementApi.class,
             databaseTypeProvider);
 
@@ -862,7 +872,7 @@ public class IdpServerApplication {
                 roleQueryRepository,
                 roleCommandRepository,
                 permissionQueryRepository,
-                auditLogWriters),
+                auditLogPublisher),
             RoleManagementApi.class,
             databaseTypeProvider);
 
@@ -895,7 +905,7 @@ public class IdpServerApplication {
                 organizationRepository,
                 authorizationServerConfigurationCommandRepository,
                 userCommandRepository,
-                auditLogWriters),
+                auditLogPublisher),
             OrgTenantManagementApi.class,
             databaseTypeProvider);
 
@@ -906,7 +916,7 @@ public class IdpServerApplication {
                 organizationRepository,
                 clientConfigurationCommandRepository,
                 clientConfigurationQueryRepository,
-                auditLogWriters),
+                auditLogPublisher),
             OrgClientManagementApi.class,
             databaseTypeProvider);
 
@@ -920,7 +930,7 @@ public class IdpServerApplication {
                 roleQueryRepository,
                 passwordEncodeDelegation,
                 userLifecycleEventPublisher,
-                auditLogWriters),
+                auditLogPublisher),
             OrgUserManagementApi.class,
             databaseTypeProvider);
 
@@ -930,7 +940,7 @@ public class IdpServerApplication {
                 tenantQueryRepository,
                 organizationRepository,
                 securityEventQueryRepository,
-                auditLogWriters),
+                auditLogPublisher),
             OrgSecurityEventManagementApi.class,
             databaseTypeProvider);
 
@@ -941,7 +951,7 @@ public class IdpServerApplication {
                 organizationRepository,
                 authenticationConfigurationCommandRepository,
                 authenticationConfigurationQueryRepository,
-                auditLogWriters),
+                auditLogPublisher),
             OrgAuthenticationConfigManagementApi.class,
             databaseTypeProvider);
 
@@ -952,7 +962,7 @@ public class IdpServerApplication {
                 organizationRepository,
                 federationConfigurationCommandRepository,
                 federationConfigurationQueryRepository,
-                auditLogWriters),
+                auditLogPublisher),
             OrgFederationConfigManagementApi.class,
             databaseTypeProvider);
 
@@ -963,7 +973,7 @@ public class IdpServerApplication {
                 organizationRepository,
                 securityEventHookConfigurationCommandRepository,
                 securityEventHookConfigurationQueryRepository,
-                auditLogWriters),
+                auditLogPublisher),
             OrgSecurityEventHookConfigManagementApi.class,
             databaseTypeProvider);
 
@@ -973,7 +983,7 @@ public class IdpServerApplication {
                 tenantQueryRepository,
                 organizationRepository,
                 authenticationInteractionQueryRepository,
-                auditLogWriters),
+                auditLogPublisher),
             OrgAuthenticationInteractionManagementApi.class,
             databaseTypeProvider);
 
@@ -983,7 +993,7 @@ public class IdpServerApplication {
                 tenantQueryRepository,
                 organizationRepository,
                 authenticationTransactionQueryRepository,
-                auditLogWriters),
+                auditLogPublisher),
             OrgAuthenticationTransactionManagementApi.class,
             databaseTypeProvider);
 
@@ -994,7 +1004,7 @@ public class IdpServerApplication {
                 organizationRepository,
                 authorizationServerConfigurationQueryRepository,
                 authorizationServerConfigurationCommandRepository,
-                auditLogWriters),
+                auditLogPublisher),
             OrgAuthorizationServerManagementApi.class,
             databaseTypeProvider);
 
@@ -1005,7 +1015,7 @@ public class IdpServerApplication {
                 organizationRepository,
                 permissionQueryRepository,
                 permissionCommandRepository,
-                auditLogWriters),
+                auditLogPublisher),
             OrgPermissionManagementApi.class,
             databaseTypeProvider);
 
@@ -1017,7 +1027,7 @@ public class IdpServerApplication {
                 roleQueryRepository,
                 roleCommandRepository,
                 permissionQueryRepository,
-                auditLogWriters),
+                auditLogPublisher),
             OrgRoleManagementApi.class,
             databaseTypeProvider);
 
@@ -1028,7 +1038,7 @@ public class IdpServerApplication {
                 organizationRepository,
                 authenticationPolicyConfigurationCommandRepository,
                 authenticationPolicyConfigurationQueryRepository,
-                auditLogWriters),
+                auditLogPublisher),
             OrgAuthenticationPolicyConfigManagementApi.class,
             databaseTypeProvider);
 
@@ -1039,7 +1049,7 @@ public class IdpServerApplication {
                 organizationRepository,
                 identityVerificationConfigurationCommandRepository,
                 identityVerificationConfigurationQueryRepository,
-                auditLogWriters),
+                auditLogPublisher),
             OrgIdentityVerificationConfigManagementApi.class,
             databaseTypeProvider);
 
@@ -1049,7 +1059,7 @@ public class IdpServerApplication {
                 tenantQueryRepository,
                 organizationRepository,
                 auditLogQueryRepository,
-                auditLogWriters),
+                auditLogPublisher),
             OrgAuditLogManagementApi.class,
             databaseTypeProvider);
   }
@@ -1104,6 +1114,10 @@ public class IdpServerApplication {
 
   public SecurityEventApi securityEventApi() {
     return securityEventApi;
+  }
+
+  public AuditLogApi auditLogApi() {
+    return auditLogApi;
   }
 
   public TenantMetaDataApi tenantMetadataApi() {

--- a/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/application/system/AuditLogEntryService.java
+++ b/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/application/system/AuditLogEntryService.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2025 Hirokazu Kobayashi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.idp.server.usecases.application.system;
+
+import org.idp.server.platform.audit.AuditLog;
+import org.idp.server.platform.audit.AuditLogApi;
+import org.idp.server.platform.audit.AuditLogWriters;
+import org.idp.server.platform.datasource.Transaction;
+import org.idp.server.platform.multi_tenancy.tenant.Tenant;
+import org.idp.server.platform.multi_tenancy.tenant.TenantIdentifier;
+import org.idp.server.platform.multi_tenancy.tenant.TenantQueryRepository;
+
+@Transaction
+public class AuditLogEntryService implements AuditLogApi {
+
+  AuditLogWriters auditLogWriters;
+  TenantQueryRepository tenantQueryRepository;
+
+  public AuditLogEntryService(
+      AuditLogWriters auditLogWriters, TenantQueryRepository tenantQueryRepository) {
+    this.auditLogWriters = auditLogWriters;
+    this.tenantQueryRepository = tenantQueryRepository;
+  }
+
+  @Override
+  public void handle(TenantIdentifier tenantIdentifier, AuditLog auditLog) {
+    Tenant tenant = tenantQueryRepository.get(tenantIdentifier);
+    auditLogWriters.write(tenant, auditLog);
+  }
+}

--- a/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/control_plane/organization_manager/OrgAuditLogManagementEntryService.java
+++ b/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/control_plane/organization_manager/OrgAuditLogManagementEntryService.java
@@ -66,7 +66,7 @@ public class OrgAuditLogManagementEntryService implements OrgAuditLogManagementA
   TenantQueryRepository tenantQueryRepository;
   OrganizationRepository organizationRepository;
   AuditLogQueryRepository auditLogQueryRepository;
-  AuditLogWriters auditLogWriters;
+  AuditLogPublisher auditLogPublisher;
   OrganizationAccessVerifier organizationAccessVerifier;
 
   LoggerWrapper log = LoggerWrapper.getLogger(OrgAuditLogManagementEntryService.class);
@@ -77,21 +77,21 @@ public class OrgAuditLogManagementEntryService implements OrgAuditLogManagementA
    * @param tenantQueryRepository the tenant query repository
    * @param organizationRepository the organization repository
    * @param auditLogQueryRepository the audit log query repository
-   * @param auditLogWriters the audit log writers
+   * @param auditLogPublisher the audit log publisher
    */
   public OrgAuditLogManagementEntryService(
       TenantQueryRepository tenantQueryRepository,
       OrganizationRepository organizationRepository,
       AuditLogQueryRepository auditLogQueryRepository,
-      AuditLogWriters auditLogWriters) {
+      AuditLogPublisher auditLogPublisher) {
     this.tenantQueryRepository = tenantQueryRepository;
     this.organizationRepository = organizationRepository;
     this.auditLogQueryRepository = auditLogQueryRepository;
-    this.auditLogWriters = auditLogWriters;
+    this.auditLogPublisher = auditLogPublisher;
     this.organizationAccessVerifier = new OrganizationAccessVerifier();
   }
 
-  @Override
+  @Transaction(readOnly = true)
   public AuditLogManagementResponse findList(
       OrganizationIdentifier organizationIdentifier,
       TenantIdentifier adminTenant,
@@ -117,7 +117,7 @@ public class OrgAuditLogManagementEntryService implements OrgAuditLogManagementA
             operator,
             oAuthToken,
             requestAttributes);
-    auditLogWriters.write(targetTenant, auditLog);
+    auditLogPublisher.publish(auditLog);
 
     if (!accessResult.isSuccess()) {
       Map<String, Object> response = new HashMap<>();
@@ -148,6 +148,7 @@ public class OrgAuditLogManagementEntryService implements OrgAuditLogManagementA
   }
 
   @Override
+  @Transaction(readOnly = true)
   public AuditLogManagementResponse get(
       OrganizationIdentifier organizationIdentifier,
       TenantIdentifier adminTenant,
@@ -175,7 +176,7 @@ public class OrgAuditLogManagementEntryService implements OrgAuditLogManagementA
             operator,
             oAuthToken,
             requestAttributes);
-    auditLogWriters.write(targetTenant, auditLog);
+    auditLogPublisher.publish(auditLog);
 
     if (!accessResult.isSuccess()) {
       Map<String, Object> response = new HashMap<>();

--- a/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/control_plane/organization_manager/OrgAuthenticationConfigManagementEntryService.java
+++ b/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/control_plane/organization_manager/OrgAuthenticationConfigManagementEntryService.java
@@ -38,7 +38,7 @@ import org.idp.server.core.openid.authentication.repository.AuthenticationConfig
 import org.idp.server.core.openid.identity.User;
 import org.idp.server.core.openid.token.OAuthToken;
 import org.idp.server.platform.audit.AuditLog;
-import org.idp.server.platform.audit.AuditLogWriters;
+import org.idp.server.platform.audit.AuditLogPublisher;
 import org.idp.server.platform.datasource.Transaction;
 import org.idp.server.platform.log.LoggerWrapper;
 import org.idp.server.platform.multi_tenancy.organization.Organization;
@@ -81,7 +81,7 @@ public class OrgAuthenticationConfigManagementEntryService
   OrganizationRepository organizationRepository;
   AuthenticationConfigurationCommandRepository authenticationConfigurationCommandRepository;
   AuthenticationConfigurationQueryRepository authenticationConfigurationQueryRepository;
-  AuditLogWriters auditLogWriters;
+  AuditLogPublisher auditLogPublisher;
   OrganizationAccessVerifier organizationAccessVerifier;
 
   LoggerWrapper log = LoggerWrapper.getLogger(OrgAuthenticationConfigManagementEntryService.class);
@@ -95,20 +95,20 @@ public class OrgAuthenticationConfigManagementEntryService
    *     repository
    * @param authenticationConfigurationQueryRepository the authentication configuration query
    *     repository
-   * @param auditLogWriters the audit log writers
+   * @param auditLogPublisher the audit log publisher
    */
   public OrgAuthenticationConfigManagementEntryService(
       TenantQueryRepository tenantQueryRepository,
       OrganizationRepository organizationRepository,
       AuthenticationConfigurationCommandRepository authenticationConfigurationCommandRepository,
       AuthenticationConfigurationQueryRepository authenticationConfigurationQueryRepository,
-      AuditLogWriters auditLogWriters) {
+      AuditLogPublisher auditLogPublisher) {
     this.tenantQueryRepository = tenantQueryRepository;
     this.organizationRepository = organizationRepository;
     this.authenticationConfigurationCommandRepository =
         authenticationConfigurationCommandRepository;
     this.authenticationConfigurationQueryRepository = authenticationConfigurationQueryRepository;
-    this.auditLogWriters = auditLogWriters;
+    this.auditLogPublisher = auditLogPublisher;
     this.organizationAccessVerifier = new OrganizationAccessVerifier();
   }
 
@@ -152,7 +152,7 @@ public class OrgAuthenticationConfigManagementEntryService
             oAuthToken,
             context,
             requestAttributes);
-    auditLogWriters.write(targetTenant, auditLog);
+    auditLogPublisher.publish(auditLog);
 
     if (context.isDryRun()) {
       return context.toResponse();
@@ -163,7 +163,7 @@ public class OrgAuthenticationConfigManagementEntryService
     return context.toResponse();
   }
 
-  @Override
+  @Transaction(readOnly = true)
   public AuthenticationConfigManagementResponse findList(
       OrganizationIdentifier organizationIdentifier,
       TenantIdentifier tenantIdentifier,
@@ -191,7 +191,7 @@ public class OrgAuthenticationConfigManagementEntryService
             operator,
             oAuthToken,
             requestAttributes);
-    auditLogWriters.write(targetTenant, auditLog);
+    auditLogPublisher.publish(auditLog);
 
     if (!accessResult.isSuccess()) {
       Map<String, Object> response = new HashMap<>();
@@ -226,6 +226,7 @@ public class OrgAuthenticationConfigManagementEntryService
   }
 
   @Override
+  @Transaction(readOnly = true)
   public AuthenticationConfigManagementResponse get(
       OrganizationIdentifier organizationIdentifier,
       TenantIdentifier tenantIdentifier,
@@ -255,7 +256,7 @@ public class OrgAuthenticationConfigManagementEntryService
             operator,
             oAuthToken,
             requestAttributes);
-    auditLogWriters.write(targetTenant, auditLog);
+    auditLogPublisher.publish(auditLog);
 
     if (!accessResult.isSuccess()) {
       Map<String, Object> response = new HashMap<>();
@@ -324,7 +325,7 @@ public class OrgAuthenticationConfigManagementEntryService
             oAuthToken,
             context,
             requestAttributes);
-    auditLogWriters.write(targetTenant, auditLog);
+    auditLogPublisher.publish(auditLog);
 
     if (context.isDryRun()) {
       return context.toResponse();
@@ -367,7 +368,7 @@ public class OrgAuthenticationConfigManagementEntryService
             oAuthToken,
             configuration.toMap(),
             requestAttributes);
-    auditLogWriters.write(targetTenant, auditLog);
+    auditLogPublisher.publish(auditLog);
 
     if (!accessResult.isSuccess()) {
       Map<String, Object> response = new HashMap<>();

--- a/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/control_plane/organization_manager/OrgAuthenticationInteractionManagementEntryService.java
+++ b/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/control_plane/organization_manager/OrgAuthenticationInteractionManagementEntryService.java
@@ -33,7 +33,7 @@ import org.idp.server.core.openid.authentication.repository.AuthenticationIntera
 import org.idp.server.core.openid.identity.User;
 import org.idp.server.core.openid.token.OAuthToken;
 import org.idp.server.platform.audit.AuditLog;
-import org.idp.server.platform.audit.AuditLogWriters;
+import org.idp.server.platform.audit.AuditLogPublisher;
 import org.idp.server.platform.datasource.Transaction;
 import org.idp.server.platform.log.LoggerWrapper;
 import org.idp.server.platform.multi_tenancy.organization.Organization;
@@ -75,7 +75,7 @@ public class OrgAuthenticationInteractionManagementEntryService
   TenantQueryRepository tenantQueryRepository;
   OrganizationRepository organizationRepository;
   AuthenticationInteractionQueryRepository authenticationInteractionQueryRepository;
-  AuditLogWriters auditLogWriters;
+  AuditLogPublisher auditLogPublisher;
   OrganizationAccessVerifier organizationAccessVerifier;
 
   LoggerWrapper log =
@@ -87,21 +87,21 @@ public class OrgAuthenticationInteractionManagementEntryService
    * @param tenantQueryRepository the tenant query repository
    * @param organizationRepository the organization repository
    * @param authenticationInteractionQueryRepository the authentication interaction query repository
-   * @param auditLogWriters the audit log writers
+   * @param auditLogPublisher the audit log publisher
    */
   public OrgAuthenticationInteractionManagementEntryService(
       TenantQueryRepository tenantQueryRepository,
       OrganizationRepository organizationRepository,
       AuthenticationInteractionQueryRepository authenticationInteractionQueryRepository,
-      AuditLogWriters auditLogWriters) {
+      AuditLogPublisher auditLogPublisher) {
     this.tenantQueryRepository = tenantQueryRepository;
     this.organizationRepository = organizationRepository;
     this.authenticationInteractionQueryRepository = authenticationInteractionQueryRepository;
-    this.auditLogWriters = auditLogWriters;
+    this.auditLogPublisher = auditLogPublisher;
     this.organizationAccessVerifier = new OrganizationAccessVerifier();
   }
 
-  @Override
+  @Transaction(readOnly = true)
   public AuthenticationInteractionManagementResponse findList(
       OrganizationIdentifier organizationIdentifier,
       TenantIdentifier tenantIdentifier,
@@ -151,7 +151,7 @@ public class OrgAuthenticationInteractionManagementEntryService
             operator,
             oAuthToken,
             requestAttributes);
-    auditLogWriters.write(targetTenant, auditLog);
+    auditLogPublisher.publish(auditLog);
 
     Map<String, Object> response = new HashMap<>();
     response.put("list", interactions.stream().map(AuthenticationInteraction::toMap).toList());
@@ -161,6 +161,7 @@ public class OrgAuthenticationInteractionManagementEntryService
   }
 
   @Override
+  @Transaction(readOnly = true)
   public AuthenticationInteractionManagementResponse get(
       OrganizationIdentifier organizationIdentifier,
       TenantIdentifier tenantIdentifier,
@@ -207,7 +208,7 @@ public class OrgAuthenticationInteractionManagementEntryService
             operator,
             oAuthToken,
             requestAttributes);
-    auditLogWriters.write(targetTenant, auditLog);
+    auditLogPublisher.publish(auditLog);
 
     Map<String, Object> response = new HashMap<>();
     response.put("result", interaction.toMap());

--- a/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/control_plane/organization_manager/OrgAuthenticationPolicyConfigManagementEntryService.java
+++ b/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/control_plane/organization_manager/OrgAuthenticationPolicyConfigManagementEntryService.java
@@ -38,7 +38,7 @@ import org.idp.server.core.openid.authentication.repository.AuthenticationPolicy
 import org.idp.server.core.openid.identity.User;
 import org.idp.server.core.openid.token.OAuthToken;
 import org.idp.server.platform.audit.AuditLog;
-import org.idp.server.platform.audit.AuditLogWriters;
+import org.idp.server.platform.audit.AuditLogPublisher;
 import org.idp.server.platform.datasource.Transaction;
 import org.idp.server.platform.log.LoggerWrapper;
 import org.idp.server.platform.multi_tenancy.organization.Organization;
@@ -82,7 +82,7 @@ public class OrgAuthenticationPolicyConfigManagementEntryService
   AuthenticationPolicyConfigurationCommandRepository
       authenticationPolicyConfigurationCommandRepository;
   AuthenticationPolicyConfigurationQueryRepository authenticationPolicyConfigurationQueryRepository;
-  AuditLogWriters auditLogWriters;
+  AuditLogPublisher auditLogPublisher;
   OrganizationAccessVerifier organizationAccessVerifier;
 
   LoggerWrapper log =
@@ -97,7 +97,7 @@ public class OrgAuthenticationPolicyConfigManagementEntryService
    *     configuration command repository
    * @param authenticationPolicyConfigurationQueryRepository the authentication policy configuration
    *     query repository
-   * @param auditLogWriters the audit log writers
+   * @param auditLogPublisher the audit log publisher
    */
   public OrgAuthenticationPolicyConfigManagementEntryService(
       TenantQueryRepository tenantQueryRepository,
@@ -106,14 +106,14 @@ public class OrgAuthenticationPolicyConfigManagementEntryService
           authenticationPolicyConfigurationCommandRepository,
       AuthenticationPolicyConfigurationQueryRepository
           authenticationPolicyConfigurationQueryRepository,
-      AuditLogWriters auditLogWriters) {
+      AuditLogPublisher auditLogPublisher) {
     this.tenantQueryRepository = tenantQueryRepository;
     this.organizationRepository = organizationRepository;
     this.authenticationPolicyConfigurationCommandRepository =
         authenticationPolicyConfigurationCommandRepository;
     this.authenticationPolicyConfigurationQueryRepository =
         authenticationPolicyConfigurationQueryRepository;
-    this.auditLogWriters = auditLogWriters;
+    this.auditLogPublisher = auditLogPublisher;
     this.organizationAccessVerifier = new OrganizationAccessVerifier();
   }
 
@@ -158,7 +158,7 @@ public class OrgAuthenticationPolicyConfigManagementEntryService
             oAuthToken,
             context,
             requestAttributes);
-    auditLogWriters.write(targetTenant, auditLog);
+    auditLogPublisher.publish(auditLog);
 
     if (context.isDryRun()) {
       return context.toResponse();
@@ -170,7 +170,7 @@ public class OrgAuthenticationPolicyConfigManagementEntryService
     return context.toResponse();
   }
 
-  @Override
+  @Transaction(readOnly = true)
   public AuthenticationPolicyConfigManagementResponse findList(
       OrganizationIdentifier organizationIdentifier,
       TenantIdentifier tenantIdentifier,
@@ -198,7 +198,7 @@ public class OrgAuthenticationPolicyConfigManagementEntryService
             operator,
             oAuthToken,
             requestAttributes);
-    auditLogWriters.write(targetTenant, auditLog);
+    auditLogPublisher.publish(auditLog);
 
     if (!accessResult.isSuccess()) {
       Map<String, Object> response = new HashMap<>();
@@ -234,6 +234,7 @@ public class OrgAuthenticationPolicyConfigManagementEntryService
   }
 
   @Override
+  @Transaction(readOnly = true)
   public AuthenticationPolicyConfigManagementResponse get(
       OrganizationIdentifier organizationIdentifier,
       TenantIdentifier tenantIdentifier,
@@ -264,7 +265,7 @@ public class OrgAuthenticationPolicyConfigManagementEntryService
             operator,
             oAuthToken,
             requestAttributes);
-    auditLogWriters.write(targetTenant, auditLog);
+    auditLogPublisher.publish(auditLog);
 
     if (!accessResult.isSuccess()) {
       Map<String, Object> response = new HashMap<>();
@@ -334,7 +335,7 @@ public class OrgAuthenticationPolicyConfigManagementEntryService
             oAuthToken,
             context,
             requestAttributes);
-    auditLogWriters.write(targetTenant, auditLog);
+    auditLogPublisher.publish(auditLog);
 
     if (context.isDryRun()) {
       return context.toResponse();
@@ -378,7 +379,7 @@ public class OrgAuthenticationPolicyConfigManagementEntryService
             oAuthToken,
             configuration.toMap(),
             requestAttributes);
-    auditLogWriters.write(targetTenant, auditLog);
+    auditLogPublisher.publish(auditLog);
 
     if (!accessResult.isSuccess()) {
       Map<String, Object> response = new HashMap<>();

--- a/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/control_plane/organization_manager/OrgAuthenticationTransactionManagementEntryService.java
+++ b/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/control_plane/organization_manager/OrgAuthenticationTransactionManagementEntryService.java
@@ -33,7 +33,7 @@ import org.idp.server.core.openid.authentication.repository.AuthenticationTransa
 import org.idp.server.core.openid.identity.User;
 import org.idp.server.core.openid.token.OAuthToken;
 import org.idp.server.platform.audit.AuditLog;
-import org.idp.server.platform.audit.AuditLogWriters;
+import org.idp.server.platform.audit.AuditLogPublisher;
 import org.idp.server.platform.datasource.Transaction;
 import org.idp.server.platform.log.LoggerWrapper;
 import org.idp.server.platform.multi_tenancy.organization.Organization;
@@ -75,7 +75,7 @@ public class OrgAuthenticationTransactionManagementEntryService
   TenantQueryRepository tenantQueryRepository;
   OrganizationRepository organizationRepository;
   AuthenticationTransactionQueryRepository authenticationTransactionQueryRepository;
-  AuditLogWriters auditLogWriters;
+  AuditLogPublisher auditLogPublisher;
   OrganizationAccessVerifier organizationAccessVerifier;
 
   LoggerWrapper log =
@@ -87,21 +87,21 @@ public class OrgAuthenticationTransactionManagementEntryService
    * @param tenantQueryRepository the tenant query repository
    * @param organizationRepository the organization repository
    * @param authenticationTransactionQueryRepository the authentication transaction query repository
-   * @param auditLogWriters the audit log writers
+   * @param auditLogPublisher the audit log publisher
    */
   public OrgAuthenticationTransactionManagementEntryService(
       TenantQueryRepository tenantQueryRepository,
       OrganizationRepository organizationRepository,
       AuthenticationTransactionQueryRepository authenticationTransactionQueryRepository,
-      AuditLogWriters auditLogWriters) {
+      AuditLogPublisher auditLogPublisher) {
     this.tenantQueryRepository = tenantQueryRepository;
     this.organizationRepository = organizationRepository;
     this.authenticationTransactionQueryRepository = authenticationTransactionQueryRepository;
-    this.auditLogWriters = auditLogWriters;
+    this.auditLogPublisher = auditLogPublisher;
     this.organizationAccessVerifier = new OrganizationAccessVerifier();
   }
 
-  @Override
+  @Transaction(readOnly = true)
   public AuthenticationTransactionManagementResponse findList(
       OrganizationIdentifier organizationIdentifier,
       TenantIdentifier tenantIdentifier,
@@ -145,7 +145,7 @@ public class OrgAuthenticationTransactionManagementEntryService
               operator,
               oAuthToken,
               requestAttributes);
-      auditLogWriters.write(targetTenant, auditLog);
+      auditLogPublisher.publish(auditLog);
 
       return new AuthenticationTransactionManagementResponse(
           AuthenticationTransactionManagementStatus.OK, response);
@@ -162,7 +162,7 @@ public class OrgAuthenticationTransactionManagementEntryService
             operator,
             oAuthToken,
             requestAttributes);
-    auditLogWriters.write(targetTenant, auditLog);
+    auditLogPublisher.publish(auditLog);
 
     Map<String, Object> response = new HashMap<>();
     response.put(
@@ -175,6 +175,7 @@ public class OrgAuthenticationTransactionManagementEntryService
   }
 
   @Override
+  @Transaction(readOnly = true)
   public AuthenticationTransactionManagementResponse get(
       OrganizationIdentifier organizationIdentifier,
       TenantIdentifier tenantIdentifier,
@@ -220,7 +221,7 @@ public class OrgAuthenticationTransactionManagementEntryService
             operator,
             oAuthToken,
             requestAttributes);
-    auditLogWriters.write(targetTenant, auditLog);
+    auditLogPublisher.publish(auditLog);
 
     return new AuthenticationTransactionManagementResponse(
         AuthenticationTransactionManagementStatus.OK, transaction.toRequestMap());

--- a/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/control_plane/organization_manager/OrgAuthorizationServerManagementEntryService.java
+++ b/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/control_plane/organization_manager/OrgAuthorizationServerManagementEntryService.java
@@ -36,7 +36,7 @@ import org.idp.server.core.openid.oauth.configuration.AuthorizationServerConfigu
 import org.idp.server.core.openid.oauth.configuration.AuthorizationServerConfigurationQueryRepository;
 import org.idp.server.core.openid.token.OAuthToken;
 import org.idp.server.platform.audit.AuditLog;
-import org.idp.server.platform.audit.AuditLogWriters;
+import org.idp.server.platform.audit.AuditLogPublisher;
 import org.idp.server.platform.datasource.Transaction;
 import org.idp.server.platform.log.LoggerWrapper;
 import org.idp.server.platform.multi_tenancy.organization.Organization;
@@ -80,7 +80,7 @@ public class OrgAuthorizationServerManagementEntryService
   AuthorizationServerConfigurationQueryRepository authorizationServerConfigurationQueryRepository;
   AuthorizationServerConfigurationCommandRepository
       authorizationServerConfigurationCommandRepository;
-  AuditLogWriters auditLogWriters;
+  AuditLogPublisher auditLogPublisher;
   OrganizationAccessVerifier organizationAccessVerifier;
 
   LoggerWrapper log = LoggerWrapper.getLogger(OrgAuthorizationServerManagementEntryService.class);
@@ -94,7 +94,7 @@ public class OrgAuthorizationServerManagementEntryService
    *     query repository
    * @param authorizationServerConfigurationCommandRepository the authorization server configuration
    *     command repository
-   * @param auditLogWriters the audit log writers
+   * @param auditLogPublisher the audit log publisher
    */
   public OrgAuthorizationServerManagementEntryService(
       TenantQueryRepository tenantQueryRepository,
@@ -103,18 +103,19 @@ public class OrgAuthorizationServerManagementEntryService
           authorizationServerConfigurationQueryRepository,
       AuthorizationServerConfigurationCommandRepository
           authorizationServerConfigurationCommandRepository,
-      AuditLogWriters auditLogWriters) {
+      AuditLogPublisher auditLogPublisher) {
     this.tenantQueryRepository = tenantQueryRepository;
     this.organizationRepository = organizationRepository;
     this.authorizationServerConfigurationQueryRepository =
         authorizationServerConfigurationQueryRepository;
     this.authorizationServerConfigurationCommandRepository =
         authorizationServerConfigurationCommandRepository;
-    this.auditLogWriters = auditLogWriters;
+    this.auditLogPublisher = auditLogPublisher;
     this.organizationAccessVerifier = new OrganizationAccessVerifier();
   }
 
   @Override
+  @Transaction(readOnly = true)
   public AuthorizationServerManagementResponse get(
       OrganizationIdentifier organizationIdentifier,
       TenantIdentifier tenantIdentifier,
@@ -150,7 +151,7 @@ public class OrgAuthorizationServerManagementEntryService
             operator,
             oAuthToken,
             requestAttributes);
-    auditLogWriters.write(targetTenant, auditLog);
+    auditLogPublisher.publish(auditLog);
 
     return new AuthorizationServerManagementResponse(
         AuthorizationServerManagementStatus.OK, authorizationServerConfiguration.toMap());
@@ -206,7 +207,7 @@ public class OrgAuthorizationServerManagementEntryService
             oAuthToken,
             context,
             requestAttributes);
-    auditLogWriters.write(targetTenant, auditLog);
+    auditLogPublisher.publish(auditLog);
 
     if (dryRun) {
       return context.toResponse();

--- a/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/control_plane/organization_manager/OrgClientManagementEntryService.java
+++ b/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/control_plane/organization_manager/OrgClientManagementEntryService.java
@@ -38,7 +38,7 @@ import org.idp.server.core.openid.oauth.configuration.client.ClientIdentifier;
 import org.idp.server.core.openid.oauth.configuration.client.ClientQueries;
 import org.idp.server.core.openid.token.OAuthToken;
 import org.idp.server.platform.audit.AuditLog;
-import org.idp.server.platform.audit.AuditLogWriters;
+import org.idp.server.platform.audit.AuditLogPublisher;
 import org.idp.server.platform.datasource.Transaction;
 import org.idp.server.platform.log.LoggerWrapper;
 import org.idp.server.platform.multi_tenancy.organization.Organization;
@@ -78,7 +78,7 @@ public class OrgClientManagementEntryService implements OrgClientManagementApi {
   OrganizationRepository organizationRepository;
   ClientConfigurationCommandRepository clientConfigurationCommandRepository;
   ClientConfigurationQueryRepository clientConfigurationQueryRepository;
-  AuditLogWriters auditLogWriters;
+  AuditLogPublisher auditLogPublisher;
   OrganizationAccessVerifier organizationAccessVerifier;
 
   LoggerWrapper log = LoggerWrapper.getLogger(OrgClientManagementEntryService.class);
@@ -90,19 +90,19 @@ public class OrgClientManagementEntryService implements OrgClientManagementApi {
    * @param organizationRepository the organization repository
    * @param clientConfigurationCommandRepository the client configuration command repository
    * @param clientConfigurationQueryRepository the client configuration query repository
-   * @param auditLogWriters the audit log writers
+   * @param auditLogPublisher the audit log publisher
    */
   public OrgClientManagementEntryService(
       TenantQueryRepository tenantQueryRepository,
       OrganizationRepository organizationRepository,
       ClientConfigurationCommandRepository clientConfigurationCommandRepository,
       ClientConfigurationQueryRepository clientConfigurationQueryRepository,
-      AuditLogWriters auditLogWriters) {
+      AuditLogPublisher auditLogPublisher) {
     this.tenantQueryRepository = tenantQueryRepository;
     this.organizationRepository = organizationRepository;
     this.clientConfigurationCommandRepository = clientConfigurationCommandRepository;
     this.clientConfigurationQueryRepository = clientConfigurationQueryRepository;
-    this.auditLogWriters = auditLogWriters;
+    this.auditLogPublisher = auditLogPublisher;
     this.organizationAccessVerifier = new OrganizationAccessVerifier();
   }
 
@@ -138,7 +138,7 @@ public class OrgClientManagementEntryService implements OrgClientManagementApi {
             oAuthToken,
             context,
             requestAttributes);
-    auditLogWriters.write(targetTenant, auditLog);
+    auditLogPublisher.publish(auditLog);
 
     if (!accessResult.isSuccess()) {
       Map<String, Object> response = new HashMap<>();
@@ -165,6 +165,7 @@ public class OrgClientManagementEntryService implements OrgClientManagementApi {
   }
 
   @Override
+  @Transaction(readOnly = true)
   public ClientManagementResponse findList(
       OrganizationIdentifier organizationIdentifier,
       TenantIdentifier tenantIdentifier,
@@ -191,7 +192,7 @@ public class OrgClientManagementEntryService implements OrgClientManagementApi {
             operator,
             oAuthToken,
             requestAttributes);
-    auditLogWriters.write(targetTenant, auditLog);
+    auditLogPublisher.publish(auditLog);
 
     ClientQueryValidator validator = new ClientQueryValidator(queries);
     ClientRegistrationRequestValidationResult validated = validator.validate();
@@ -229,6 +230,7 @@ public class OrgClientManagementEntryService implements OrgClientManagementApi {
   }
 
   @Override
+  @Transaction(readOnly = true)
   public ClientManagementResponse get(
       OrganizationIdentifier organizationIdentifier,
       TenantIdentifier tenantIdentifier,
@@ -258,7 +260,7 @@ public class OrgClientManagementEntryService implements OrgClientManagementApi {
             operator,
             oAuthToken,
             requestAttributes);
-    auditLogWriters.write(targetTenant, auditLog);
+    auditLogPublisher.publish(auditLog);
 
     if (!accessResult.isSuccess()) {
       Map<String, Object> response = new HashMap<>();
@@ -314,7 +316,7 @@ public class OrgClientManagementEntryService implements OrgClientManagementApi {
             oAuthToken,
             context,
             requestAttributes);
-    auditLogWriters.write(targetTenant, auditLog);
+    auditLogPublisher.publish(auditLog);
 
     if (!accessResult.isSuccess()) {
       Map<String, Object> response = new HashMap<>();
@@ -372,7 +374,7 @@ public class OrgClientManagementEntryService implements OrgClientManagementApi {
             oAuthToken,
             clientConfiguration.toMap(),
             requestAttributes);
-    auditLogWriters.write(targetTenant, auditLog);
+    auditLogPublisher.publish(auditLog);
 
     if (!accessResult.isSuccess()) {
       Map<String, Object> response = new HashMap<>();

--- a/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/control_plane/organization_manager/OrgFederationConfigManagementEntryService.java
+++ b/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/control_plane/organization_manager/OrgFederationConfigManagementEntryService.java
@@ -35,7 +35,7 @@ import org.idp.server.core.openid.federation.repository.FederationConfigurationQ
 import org.idp.server.core.openid.identity.User;
 import org.idp.server.core.openid.token.OAuthToken;
 import org.idp.server.platform.audit.AuditLog;
-import org.idp.server.platform.audit.AuditLogWriters;
+import org.idp.server.platform.audit.AuditLogPublisher;
 import org.idp.server.platform.datasource.Transaction;
 import org.idp.server.platform.log.LoggerWrapper;
 import org.idp.server.platform.multi_tenancy.organization.Organization;
@@ -77,7 +77,7 @@ public class OrgFederationConfigManagementEntryService implements OrgFederationC
   OrganizationRepository organizationRepository;
   FederationConfigurationCommandRepository federationConfigurationCommandRepository;
   FederationConfigurationQueryRepository federationConfigurationQueryRepository;
-  AuditLogWriters auditLogWriters;
+  AuditLogPublisher auditLogPublisher;
   OrganizationAccessVerifier organizationAccessVerifier;
 
   LoggerWrapper log = LoggerWrapper.getLogger(OrgFederationConfigManagementEntryService.class);
@@ -89,19 +89,19 @@ public class OrgFederationConfigManagementEntryService implements OrgFederationC
    * @param organizationRepository the organization repository
    * @param federationConfigurationCommandRepository the federation configuration command repository
    * @param federationConfigurationQueryRepository the federation configuration query repository
-   * @param auditLogWriters the audit log writers
+   * @param auditLogPublisher the audit log publisher
    */
   public OrgFederationConfigManagementEntryService(
       TenantQueryRepository tenantQueryRepository,
       OrganizationRepository organizationRepository,
       FederationConfigurationCommandRepository federationConfigurationCommandRepository,
       FederationConfigurationQueryRepository federationConfigurationQueryRepository,
-      AuditLogWriters auditLogWriters) {
+      AuditLogPublisher auditLogPublisher) {
     this.tenantQueryRepository = tenantQueryRepository;
     this.organizationRepository = organizationRepository;
     this.federationConfigurationCommandRepository = federationConfigurationCommandRepository;
     this.federationConfigurationQueryRepository = federationConfigurationQueryRepository;
-    this.auditLogWriters = auditLogWriters;
+    this.auditLogPublisher = auditLogPublisher;
     this.organizationAccessVerifier = new OrganizationAccessVerifier();
   }
 
@@ -146,7 +146,7 @@ public class OrgFederationConfigManagementEntryService implements OrgFederationC
             oAuthToken,
             context,
             requestAttributes);
-    auditLogWriters.write(targetTenant, auditLog);
+    auditLogPublisher.publish(auditLog);
 
     if (context.isDryRun()) {
       return context.toResponse();
@@ -158,6 +158,7 @@ public class OrgFederationConfigManagementEntryService implements OrgFederationC
   }
 
   @Override
+  @Transaction(readOnly = true)
   public FederationConfigManagementResponse findList(
       OrganizationIdentifier organizationIdentifier,
       TenantIdentifier tenantIdentifier,
@@ -195,7 +196,7 @@ public class OrgFederationConfigManagementEntryService implements OrgFederationC
             operator,
             oAuthToken,
             requestAttributes);
-    auditLogWriters.write(targetTenant, auditLog);
+    auditLogPublisher.publish(auditLog);
 
     Map<String, Object> response = new HashMap<>();
     response.put("results", configurations.stream().map(FederationConfiguration::toMap).toList());
@@ -248,7 +249,7 @@ public class OrgFederationConfigManagementEntryService implements OrgFederationC
             operator,
             oAuthToken,
             requestAttributes);
-    auditLogWriters.write(targetTenant, auditLog);
+    auditLogPublisher.publish(auditLog);
 
     Map<String, Object> response = new HashMap<>();
     response.put("result", configuration.toMap());
@@ -299,7 +300,7 @@ public class OrgFederationConfigManagementEntryService implements OrgFederationC
             oAuthToken,
             context,
             requestAttributes);
-    auditLogWriters.write(targetTenant, auditLog);
+    auditLogPublisher.publish(auditLog);
 
     if (!before.exists()) {
       return new FederationConfigManagementResponse(
@@ -354,7 +355,7 @@ public class OrgFederationConfigManagementEntryService implements OrgFederationC
             oAuthToken,
             configuration.payload(),
             requestAttributes);
-    auditLogWriters.write(targetTenant, auditLog);
+    auditLogPublisher.publish(auditLog);
 
     if (!configuration.exists()) {
       return new FederationConfigManagementResponse(

--- a/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/control_plane/organization_manager/OrgIdentityVerificationConfigManagementEntryService.java
+++ b/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/control_plane/organization_manager/OrgIdentityVerificationConfigManagementEntryService.java
@@ -39,7 +39,7 @@ import org.idp.server.core.extension.identity.verification.repository.IdentityVe
 import org.idp.server.core.openid.identity.User;
 import org.idp.server.core.openid.token.OAuthToken;
 import org.idp.server.platform.audit.AuditLog;
-import org.idp.server.platform.audit.AuditLogWriters;
+import org.idp.server.platform.audit.AuditLogPublisher;
 import org.idp.server.platform.datasource.Transaction;
 import org.idp.server.platform.log.LoggerWrapper;
 import org.idp.server.platform.multi_tenancy.organization.Organization;
@@ -59,7 +59,7 @@ public class OrgIdentityVerificationConfigManagementEntryService
   IdentityVerificationConfigurationCommandRepository
       identityVerificationConfigurationCommandRepository;
   IdentityVerificationConfigurationQueryRepository identityVerificationConfigurationQueryRepository;
-  AuditLogWriters auditLogWriters;
+  AuditLogPublisher auditLogPublisher;
   OrganizationAccessVerifier organizationAccessVerifier;
 
   LoggerWrapper log =
@@ -72,14 +72,14 @@ public class OrgIdentityVerificationConfigManagementEntryService
           identityVerificationConfigurationCommandRepository,
       IdentityVerificationConfigurationQueryRepository
           identityVerificationConfigurationQueryRepository,
-      AuditLogWriters auditLogWriters) {
+      AuditLogPublisher auditLogPublisher) {
     this.tenantQueryRepository = tenantQueryRepository;
     this.organizationRepository = organizationRepository;
     this.identityVerificationConfigurationCommandRepository =
         identityVerificationConfigurationCommandRepository;
     this.identityVerificationConfigurationQueryRepository =
         identityVerificationConfigurationQueryRepository;
-    this.auditLogWriters = auditLogWriters;
+    this.auditLogPublisher = auditLogPublisher;
     this.organizationAccessVerifier = new OrganizationAccessVerifier();
   }
 
@@ -124,7 +124,7 @@ public class OrgIdentityVerificationConfigManagementEntryService
             oAuthToken,
             context,
             requestAttributes);
-    auditLogWriters.write(targetTenant, auditLog);
+    auditLogPublisher.publish(auditLog);
 
     if (context.isDryRun()) {
       return context.toResponse();
@@ -137,6 +137,7 @@ public class OrgIdentityVerificationConfigManagementEntryService
   }
 
   @Override
+  @Transaction(readOnly = true)
   public IdentityVerificationConfigManagementResponse findList(
       OrganizationIdentifier organizationIdentifier,
       TenantIdentifier tenantIdentifier,
@@ -171,7 +172,7 @@ public class OrgIdentityVerificationConfigManagementEntryService
             operator,
             oAuthToken,
             requestAttributes);
-    auditLogWriters.write(targetTenant, auditLog);
+    auditLogPublisher.publish(auditLog);
 
     long totalCount =
         identityVerificationConfigurationQueryRepository.findTotalCount(targetTenant, queries);
@@ -200,6 +201,7 @@ public class OrgIdentityVerificationConfigManagementEntryService
   }
 
   @Override
+  @Transaction(readOnly = true)
   public IdentityVerificationConfigManagementResponse get(
       OrganizationIdentifier organizationIdentifier,
       TenantIdentifier tenantIdentifier,
@@ -237,7 +239,7 @@ public class OrgIdentityVerificationConfigManagementEntryService
             operator,
             oAuthToken,
             requestAttributes);
-    auditLogWriters.write(targetTenant, auditLog);
+    auditLogPublisher.publish(auditLog);
 
     if (!configuration.exists()) {
       return new IdentityVerificationConfigManagementResponse(
@@ -293,7 +295,7 @@ public class OrgIdentityVerificationConfigManagementEntryService
             oAuthToken,
             context,
             requestAttributes);
-    auditLogWriters.write(targetTenant, auditLog);
+    auditLogPublisher.publish(auditLog);
 
     if (!configuration.exists()) {
       return new IdentityVerificationConfigManagementResponse(
@@ -350,7 +352,7 @@ public class OrgIdentityVerificationConfigManagementEntryService
             oAuthToken,
             configuration.toMap(),
             requestAttributes);
-    auditLogWriters.write(targetTenant, auditLog);
+    auditLogPublisher.publish(auditLog);
 
     if (!configuration.exists()) {
       return new IdentityVerificationConfigManagementResponse(

--- a/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/control_plane/organization_manager/OrgRoleManagementEntryService.java
+++ b/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/control_plane/organization_manager/OrgRoleManagementEntryService.java
@@ -36,7 +36,7 @@ import org.idp.server.core.openid.identity.permission.*;
 import org.idp.server.core.openid.identity.role.*;
 import org.idp.server.core.openid.token.OAuthToken;
 import org.idp.server.platform.audit.AuditLog;
-import org.idp.server.platform.audit.AuditLogWriters;
+import org.idp.server.platform.audit.AuditLogPublisher;
 import org.idp.server.platform.datasource.Transaction;
 import org.idp.server.platform.log.LoggerWrapper;
 import org.idp.server.platform.multi_tenancy.organization.Organization;
@@ -77,7 +77,7 @@ public class OrgRoleManagementEntryService implements OrgRoleManagementApi {
   RoleQueryRepository roleQueryRepository;
   RoleCommandRepository roleCommandRepository;
   PermissionQueryRepository permissionQueryRepository;
-  AuditLogWriters auditLogWriters;
+  AuditLogPublisher auditLogPublisher;
   OrganizationAccessVerifier organizationAccessVerifier;
 
   LoggerWrapper log = LoggerWrapper.getLogger(OrgRoleManagementEntryService.class);
@@ -89,7 +89,7 @@ public class OrgRoleManagementEntryService implements OrgRoleManagementApi {
    * @param organizationRepository the organization repository
    * @param roleQueryRepository the role query repository
    * @param roleCommandRepository the role command repository
-   * @param auditLogWriters the audit log writers
+   * @param auditLogPublisher the audit log publisher
    */
   public OrgRoleManagementEntryService(
       TenantQueryRepository tenantQueryRepository,
@@ -97,13 +97,13 @@ public class OrgRoleManagementEntryService implements OrgRoleManagementApi {
       RoleQueryRepository roleQueryRepository,
       RoleCommandRepository roleCommandRepository,
       PermissionQueryRepository permissionQueryRepository,
-      AuditLogWriters auditLogWriters) {
+      AuditLogPublisher auditLogPublisher) {
     this.tenantQueryRepository = tenantQueryRepository;
     this.organizationRepository = organizationRepository;
     this.roleQueryRepository = roleQueryRepository;
     this.roleCommandRepository = roleCommandRepository;
     this.permissionQueryRepository = permissionQueryRepository;
-    this.auditLogWriters = auditLogWriters;
+    this.auditLogPublisher = auditLogPublisher;
     this.organizationAccessVerifier = new OrganizationAccessVerifier();
   }
 
@@ -158,7 +158,7 @@ public class OrgRoleManagementEntryService implements OrgRoleManagementApi {
             oAuthToken,
             context,
             requestAttributes);
-    auditLogWriters.write(targetTenant, auditLog);
+    auditLogPublisher.publish(auditLog);
 
     if (!verificationResult.isValid()) {
       return verificationResult.errorResponse();
@@ -174,6 +174,7 @@ public class OrgRoleManagementEntryService implements OrgRoleManagementApi {
   }
 
   @Override
+  @Transaction(readOnly = true)
   public RoleManagementResponse findList(
       OrganizationIdentifier organizationIdentifier,
       TenantIdentifier tenantIdentifier,
@@ -215,7 +216,7 @@ public class OrgRoleManagementEntryService implements OrgRoleManagementApi {
               operator,
               oAuthToken,
               requestAttributes);
-      auditLogWriters.write(targetTenant, auditLog);
+      auditLogPublisher.publish(auditLog);
 
       return new RoleManagementResponse(RoleManagementStatus.OK, response);
     }
@@ -230,7 +231,7 @@ public class OrgRoleManagementEntryService implements OrgRoleManagementApi {
             operator,
             oAuthToken,
             requestAttributes);
-    auditLogWriters.write(targetTenant, auditLog);
+    auditLogPublisher.publish(auditLog);
 
     Map<String, Object> response = new HashMap<>();
     response.put("list", roleList.stream().map(Role::toMap).toList());
@@ -241,6 +242,7 @@ public class OrgRoleManagementEntryService implements OrgRoleManagementApi {
   }
 
   @Override
+  @Transaction(readOnly = true)
   public RoleManagementResponse get(
       OrganizationIdentifier organizationIdentifier,
       TenantIdentifier tenantIdentifier,
@@ -283,7 +285,7 @@ public class OrgRoleManagementEntryService implements OrgRoleManagementApi {
             operator,
             oAuthToken,
             requestAttributes);
-    auditLogWriters.write(targetTenant, auditLog);
+    auditLogPublisher.publish(auditLog);
 
     return new RoleManagementResponse(RoleManagementStatus.OK, role.toMap());
   }
@@ -349,7 +351,7 @@ public class OrgRoleManagementEntryService implements OrgRoleManagementApi {
             oAuthToken,
             context,
             requestAttributes);
-    auditLogWriters.write(targetTenant, auditLog);
+    auditLogPublisher.publish(auditLog);
 
     if (!verificationResult.isValid()) {
       return verificationResult.errorResponse();
@@ -409,7 +411,7 @@ public class OrgRoleManagementEntryService implements OrgRoleManagementApi {
             oAuthToken,
             role.toMap(),
             requestAttributes);
-    auditLogWriters.write(targetTenant, auditLog);
+    auditLogPublisher.publish(auditLog);
 
     if (dryRun) {
       return new RoleManagementResponse(RoleManagementStatus.NO_CONTENT, Map.of());

--- a/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/control_plane/organization_manager/OrgSecurityEventHookConfigManagementEntryService.java
+++ b/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/control_plane/organization_manager/OrgSecurityEventHookConfigManagementEntryService.java
@@ -32,7 +32,7 @@ import org.idp.server.control_plane.organization.access.OrganizationAccessVerifi
 import org.idp.server.core.openid.identity.User;
 import org.idp.server.core.openid.token.OAuthToken;
 import org.idp.server.platform.audit.AuditLog;
-import org.idp.server.platform.audit.AuditLogWriters;
+import org.idp.server.platform.audit.AuditLogPublisher;
 import org.idp.server.platform.datasource.Transaction;
 import org.idp.server.platform.log.LoggerWrapper;
 import org.idp.server.platform.multi_tenancy.organization.Organization;
@@ -79,7 +79,7 @@ public class OrgSecurityEventHookConfigManagementEntryService
   OrganizationRepository organizationRepository;
   SecurityEventHookConfigurationCommandRepository securityEventHookConfigurationCommandRepository;
   SecurityEventHookConfigurationQueryRepository securityEventHookConfigurationQueryRepository;
-  AuditLogWriters auditLogWriters;
+  AuditLogPublisher auditLogPublisher;
   OrganizationAccessVerifier organizationAccessVerifier;
 
   LoggerWrapper log =
@@ -94,7 +94,7 @@ public class OrgSecurityEventHookConfigManagementEntryService
    *     command repository
    * @param securityEventHookConfigurationQueryRepository the security event hook configuration
    *     query repository
-   * @param auditLogWriters the audit log writers
+   * @param auditLogPublisher the audit log publisher
    */
   public OrgSecurityEventHookConfigManagementEntryService(
       TenantQueryRepository tenantQueryRepository,
@@ -102,14 +102,14 @@ public class OrgSecurityEventHookConfigManagementEntryService
       SecurityEventHookConfigurationCommandRepository
           securityEventHookConfigurationCommandRepository,
       SecurityEventHookConfigurationQueryRepository securityEventHookConfigurationQueryRepository,
-      AuditLogWriters auditLogWriters) {
+      AuditLogPublisher auditLogPublisher) {
     this.tenantQueryRepository = tenantQueryRepository;
     this.organizationRepository = organizationRepository;
     this.securityEventHookConfigurationCommandRepository =
         securityEventHookConfigurationCommandRepository;
     this.securityEventHookConfigurationQueryRepository =
         securityEventHookConfigurationQueryRepository;
-    this.auditLogWriters = auditLogWriters;
+    this.auditLogPublisher = auditLogPublisher;
     this.organizationAccessVerifier = new OrganizationAccessVerifier();
   }
 
@@ -161,7 +161,7 @@ public class OrgSecurityEventHookConfigManagementEntryService
             oAuthToken,
             context,
             requestAttributes);
-    auditLogWriters.write(targetTenant, auditLog);
+    auditLogPublisher.publish(auditLog);
 
     if (context.isDryRun()) {
       return context.toResponse();
@@ -173,6 +173,7 @@ public class OrgSecurityEventHookConfigManagementEntryService
   }
 
   @Override
+  @Transaction(readOnly = true)
   public SecurityEventHookConfigManagementResponse findList(
       OrganizationIdentifier organizationIdentifier,
       TenantIdentifier tenantIdentifier,
@@ -199,7 +200,7 @@ public class OrgSecurityEventHookConfigManagementEntryService
             operator,
             oAuthToken,
             requestAttributes);
-    auditLogWriters.write(targetTenant, auditLog);
+    auditLogPublisher.publish(auditLog);
 
     if (!accessResult.isSuccess()) {
       Map<String, Object> response = new HashMap<>();
@@ -235,6 +236,7 @@ public class OrgSecurityEventHookConfigManagementEntryService
   }
 
   @Override
+  @Transaction(readOnly = true)
   public SecurityEventHookConfigManagementResponse get(
       OrganizationIdentifier organizationIdentifier,
       TenantIdentifier tenantIdentifier,
@@ -263,7 +265,7 @@ public class OrgSecurityEventHookConfigManagementEntryService
             operator,
             oAuthToken,
             requestAttributes);
-    auditLogWriters.write(targetTenant, auditLog);
+    auditLogPublisher.publish(auditLog);
 
     if (!accessResult.isSuccess()) {
       Map<String, Object> response = new HashMap<>();
@@ -327,7 +329,7 @@ public class OrgSecurityEventHookConfigManagementEntryService
             oAuthToken,
             context,
             requestAttributes);
-    auditLogWriters.write(targetTenant, auditLog);
+    auditLogPublisher.publish(auditLog);
 
     if (!before.exists()) {
       return new SecurityEventHookConfigManagementResponse(
@@ -373,7 +375,7 @@ public class OrgSecurityEventHookConfigManagementEntryService
             oAuthToken,
             configuration.toMap(),
             requestAttributes);
-    auditLogWriters.write(targetTenant, auditLog);
+    auditLogPublisher.publish(auditLog);
 
     if (!accessResult.isSuccess()) {
       Map<String, Object> response = new HashMap<>();

--- a/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/control_plane/organization_manager/OrgSecurityEventManagementEntryService.java
+++ b/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/control_plane/organization_manager/OrgSecurityEventManagementEntryService.java
@@ -29,7 +29,7 @@ import org.idp.server.control_plane.organization.access.OrganizationAccessVerifi
 import org.idp.server.core.openid.identity.User;
 import org.idp.server.core.openid.token.OAuthToken;
 import org.idp.server.platform.audit.AuditLog;
-import org.idp.server.platform.audit.AuditLogWriters;
+import org.idp.server.platform.audit.AuditLogPublisher;
 import org.idp.server.platform.datasource.Transaction;
 import org.idp.server.platform.log.LoggerWrapper;
 import org.idp.server.platform.multi_tenancy.organization.Organization;
@@ -72,7 +72,7 @@ public class OrgSecurityEventManagementEntryService implements OrgSecurityEventM
   TenantQueryRepository tenantQueryRepository;
   OrganizationRepository organizationRepository;
   SecurityEventQueryRepository securityEventQueryRepository;
-  AuditLogWriters auditLogWriters;
+  AuditLogPublisher auditLogPublisher;
   OrganizationAccessVerifier organizationAccessVerifier;
 
   LoggerWrapper log = LoggerWrapper.getLogger(OrgSecurityEventManagementEntryService.class);
@@ -83,21 +83,22 @@ public class OrgSecurityEventManagementEntryService implements OrgSecurityEventM
    * @param tenantQueryRepository the tenant query repository
    * @param organizationRepository the organization repository
    * @param securityEventQueryRepository the security event query repository
-   * @param auditLogWriters the audit log writers
+   * @param auditLogPublisher the audit log publisher
    */
   public OrgSecurityEventManagementEntryService(
       TenantQueryRepository tenantQueryRepository,
       OrganizationRepository organizationRepository,
       SecurityEventQueryRepository securityEventQueryRepository,
-      AuditLogWriters auditLogWriters) {
+      AuditLogPublisher auditLogPublisher) {
     this.tenantQueryRepository = tenantQueryRepository;
     this.organizationRepository = organizationRepository;
     this.securityEventQueryRepository = securityEventQueryRepository;
-    this.auditLogWriters = auditLogWriters;
+    this.auditLogPublisher = auditLogPublisher;
     this.organizationAccessVerifier = new OrganizationAccessVerifier();
   }
 
   @Override
+  @Transaction(readOnly = true)
   public SecurityEventManagementResponse findList(
       OrganizationIdentifier organizationIdentifier,
       TenantIdentifier tenantIdentifier,
@@ -124,7 +125,7 @@ public class OrgSecurityEventManagementEntryService implements OrgSecurityEventM
             operator,
             oAuthToken,
             requestAttributes);
-    auditLogWriters.write(targetTenant, auditLog);
+    auditLogPublisher.publish(auditLog);
 
     if (!accessResult.isSuccess()) {
       Map<String, Object> response = new HashMap<>();
@@ -155,6 +156,7 @@ public class OrgSecurityEventManagementEntryService implements OrgSecurityEventM
   }
 
   @Override
+  @Transaction(readOnly = true)
   public SecurityEventManagementResponse get(
       OrganizationIdentifier organizationIdentifier,
       TenantIdentifier tenantIdentifier,
@@ -183,7 +185,7 @@ public class OrgSecurityEventManagementEntryService implements OrgSecurityEventM
             operator,
             oAuthToken,
             requestAttributes);
-    auditLogWriters.write(targetTenant, auditLog);
+    auditLogPublisher.publish(auditLog);
 
     if (!accessResult.isSuccess()) {
       Map<String, Object> response = new HashMap<>();

--- a/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/control_plane/organization_manager/OrgTenantManagementEntryService.java
+++ b/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/control_plane/organization_manager/OrgTenantManagementEntryService.java
@@ -37,7 +37,7 @@ import org.idp.server.core.openid.identity.repository.UserCommandRepository;
 import org.idp.server.core.openid.oauth.configuration.AuthorizationServerConfigurationCommandRepository;
 import org.idp.server.core.openid.token.OAuthToken;
 import org.idp.server.platform.audit.AuditLog;
-import org.idp.server.platform.audit.AuditLogWriters;
+import org.idp.server.platform.audit.AuditLogPublisher;
 import org.idp.server.platform.datasource.Transaction;
 import org.idp.server.platform.log.LoggerWrapper;
 import org.idp.server.platform.multi_tenancy.organization.Organization;
@@ -59,7 +59,7 @@ public class OrgTenantManagementEntryService implements OrgTenantManagementApi {
       authorizationServerConfigurationCommandRepository;
   TenantManagementVerifier tenantManagementVerifier;
   UserCommandRepository userCommandRepository;
-  AuditLogWriters auditLogWriters;
+  AuditLogPublisher auditLogPublisher;
   OrganizationAccessVerifier organizationAccessVerifier;
 
   LoggerWrapper log = LoggerWrapper.getLogger(OrgTenantManagementEntryService.class);
@@ -71,7 +71,7 @@ public class OrgTenantManagementEntryService implements OrgTenantManagementApi {
       AuthorizationServerConfigurationCommandRepository
           authorizationServerConfigurationCommandRepository,
       UserCommandRepository userCommandRepository,
-      AuditLogWriters auditLogWriters) {
+      AuditLogPublisher auditLogPublisher) {
     this.tenantCommandRepository = tenantCommandRepository;
     this.tenantQueryRepository = tenantQueryRepository;
     this.organizationRepository = organizationRepository;
@@ -80,7 +80,7 @@ public class OrgTenantManagementEntryService implements OrgTenantManagementApi {
     this.userCommandRepository = userCommandRepository;
     TenantVerifier tenantVerifier = new TenantVerifier(tenantQueryRepository);
     this.tenantManagementVerifier = new TenantManagementVerifier(tenantVerifier);
-    this.auditLogWriters = auditLogWriters;
+    this.auditLogPublisher = auditLogPublisher;
     this.organizationAccessVerifier = new OrganizationAccessVerifier();
   }
 
@@ -124,7 +124,7 @@ public class OrgTenantManagementEntryService implements OrgTenantManagementApi {
             oAuthToken,
             context,
             requestAttributes);
-    auditLogWriters.write(orgTenant, auditLog);
+    auditLogPublisher.publish(auditLog);
 
     if (!accessResult.isSuccess()) {
       return accessResult.toErrorResponse();
@@ -148,6 +148,7 @@ public class OrgTenantManagementEntryService implements OrgTenantManagementApi {
   }
 
   @Override
+  @Transaction(readOnly = true)
   public TenantManagementResponse findList(
       OrganizationIdentifier organizationId,
       User operator,
@@ -180,6 +181,7 @@ public class OrgTenantManagementEntryService implements OrgTenantManagementApi {
   }
 
   @Override
+  @Transaction(readOnly = true)
   public TenantManagementResponse get(
       OrganizationIdentifier organizationId,
       User operator,
@@ -244,7 +246,7 @@ public class OrgTenantManagementEntryService implements OrgTenantManagementApi {
             oAuthToken,
             context,
             requestAttributes);
-    auditLogWriters.write(orgTenant, auditLog);
+    auditLogPublisher.publish(auditLog);
 
     if (!before.exists()) {
       return new TenantManagementResponse(TenantManagementStatus.NOT_FOUND, Map.of());
@@ -291,7 +293,7 @@ public class OrgTenantManagementEntryService implements OrgTenantManagementApi {
             oAuthToken,
             before.toMap(),
             requestAttributes);
-    auditLogWriters.write(orgTenant, auditLog);
+    auditLogPublisher.publish(auditLog);
 
     if (!before.exists()) {
       return new TenantManagementResponse(TenantManagementStatus.NOT_FOUND, Map.of());

--- a/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/control_plane/organization_manager/OrgUserManagementEntryService.java
+++ b/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/control_plane/organization_manager/OrgUserManagementEntryService.java
@@ -43,7 +43,7 @@ import org.idp.server.core.openid.identity.repository.UserQueryRepository;
 import org.idp.server.core.openid.identity.role.RoleQueryRepository;
 import org.idp.server.core.openid.token.OAuthToken;
 import org.idp.server.platform.audit.AuditLog;
-import org.idp.server.platform.audit.AuditLogWriters;
+import org.idp.server.platform.audit.AuditLogPublisher;
 import org.idp.server.platform.datasource.Transaction;
 import org.idp.server.platform.log.LoggerWrapper;
 import org.idp.server.platform.multi_tenancy.organization.Organization;
@@ -88,7 +88,7 @@ public class OrgUserManagementEntryService implements OrgUserManagementApi {
   UserRegistrationVerifier verifier;
   UserRegistrationRelatedDataVerifier updateVerifier;
   UserLifecycleEventPublisher userLifecycleEventPublisher;
-  AuditLogWriters auditLogWriters;
+  AuditLogPublisher auditLogPublisher;
   OrganizationAccessVerifier organizationAccessVerifier;
 
   LoggerWrapper log = LoggerWrapper.getLogger(OrgUserManagementEntryService.class);
@@ -103,7 +103,7 @@ public class OrgUserManagementEntryService implements OrgUserManagementApi {
    * @param roleQueryRepository the role query repository
    * @param passwordEncodeDelegation the password encode delegation
    * @param userLifecycleEventPublisher the user lifecycle event publisher
-   * @param auditLogWriters the audit log writers
+   * @param auditLogPublisher the audit log publisher
    */
   public OrgUserManagementEntryService(
       TenantQueryRepository tenantQueryRepository,
@@ -113,7 +113,7 @@ public class OrgUserManagementEntryService implements OrgUserManagementApi {
       RoleQueryRepository roleQueryRepository,
       PasswordEncodeDelegation passwordEncodeDelegation,
       UserLifecycleEventPublisher userLifecycleEventPublisher,
-      AuditLogWriters auditLogWriters) {
+      AuditLogPublisher auditLogPublisher) {
     this.tenantQueryRepository = tenantQueryRepository;
     this.organizationRepository = organizationRepository;
     this.userQueryRepository = userQueryRepository;
@@ -127,7 +127,7 @@ public class OrgUserManagementEntryService implements OrgUserManagementApi {
     this.verifier = new UserRegistrationVerifier(userVerifier, userRegistrationRelatedDataVerifier);
     this.updateVerifier = userRegistrationRelatedDataVerifier;
     this.userLifecycleEventPublisher = userLifecycleEventPublisher;
-    this.auditLogWriters = auditLogWriters;
+    this.auditLogPublisher = auditLogPublisher;
     this.organizationAccessVerifier = new OrganizationAccessVerifier();
   }
 
@@ -171,7 +171,7 @@ public class OrgUserManagementEntryService implements OrgUserManagementApi {
             oAuthToken,
             context,
             requestAttributes);
-    auditLogWriters.write(targetTenant, auditLog);
+    auditLogPublisher.publish(auditLog);
 
     if (!accessResult.isSuccess()) {
       Map<String, Object> response = new HashMap<>();
@@ -204,6 +204,7 @@ public class OrgUserManagementEntryService implements OrgUserManagementApi {
   }
 
   @Override
+  @Transaction(readOnly = true)
   public UserManagementResponse findList(
       OrganizationIdentifier organizationIdentifier,
       TenantIdentifier tenantIdentifier,
@@ -230,7 +231,7 @@ public class OrgUserManagementEntryService implements OrgUserManagementApi {
             operator,
             oAuthToken,
             requestAttributes);
-    auditLogWriters.write(targetTenant, auditLog);
+    auditLogPublisher.publish(auditLog);
 
     if (!accessResult.isSuccess()) {
       Map<String, Object> response = new HashMap<>();
@@ -261,6 +262,7 @@ public class OrgUserManagementEntryService implements OrgUserManagementApi {
   }
 
   @Override
+  @Transaction(readOnly = true)
   public UserManagementResponse get(
       OrganizationIdentifier organizationIdentifier,
       TenantIdentifier tenantIdentifier,
@@ -289,7 +291,7 @@ public class OrgUserManagementEntryService implements OrgUserManagementApi {
             operator,
             oAuthToken,
             requestAttributes);
-    auditLogWriters.write(targetTenant, auditLog);
+    auditLogPublisher.publish(auditLog);
 
     if (!accessResult.isSuccess()) {
       Map<String, Object> response = new HashMap<>();
@@ -343,7 +345,7 @@ public class OrgUserManagementEntryService implements OrgUserManagementApi {
             oAuthToken,
             context,
             requestAttributes);
-    auditLogWriters.write(targetTenant, auditLog);
+    auditLogPublisher.publish(auditLog);
 
     if (!accessResult.isSuccess()) {
       Map<String, Object> response = new HashMap<>();
@@ -408,7 +410,7 @@ public class OrgUserManagementEntryService implements OrgUserManagementApi {
             oAuthToken,
             user.toMap(),
             requestAttributes);
-    auditLogWriters.write(targetTenant, auditLog);
+    auditLogPublisher.publish(auditLog);
 
     if (!accessResult.isSuccess()) {
       Map<String, Object> response = new HashMap<>();
@@ -483,7 +485,7 @@ public class OrgUserManagementEntryService implements OrgUserManagementApi {
             oAuthToken,
             context,
             requestAttributes);
-    auditLogWriters.write(targetTenant, auditLog);
+    auditLogPublisher.publish(auditLog);
 
     if (!accessResult.isSuccess()) {
       Map<String, Object> response = new HashMap<>();
@@ -549,7 +551,7 @@ public class OrgUserManagementEntryService implements OrgUserManagementApi {
             oAuthToken,
             context,
             requestAttributes);
-    auditLogWriters.write(targetTenant, auditLog);
+    auditLogPublisher.publish(auditLog);
 
     if (!accessResult.isSuccess()) {
       Map<String, Object> response = new HashMap<>();
@@ -613,7 +615,7 @@ public class OrgUserManagementEntryService implements OrgUserManagementApi {
             oAuthToken,
             context,
             requestAttributes);
-    auditLogWriters.write(targetTenant, auditLog);
+    auditLogPublisher.publish(auditLog);
 
     if (!accessResult.isSuccess()) {
       Map<String, Object> response = new HashMap<>();
@@ -687,7 +689,7 @@ public class OrgUserManagementEntryService implements OrgUserManagementApi {
             oAuthToken,
             context,
             requestAttributes);
-    auditLogWriters.write(targetTenant, auditLog);
+    auditLogPublisher.publish(auditLog);
 
     if (!accessResult.isSuccess()) {
       Map<String, Object> response = new HashMap<>();
@@ -750,7 +752,7 @@ public class OrgUserManagementEntryService implements OrgUserManagementApi {
             oAuthToken,
             context,
             requestAttributes);
-    auditLogWriters.write(targetTenant, auditLog);
+    auditLogPublisher.publish(auditLog);
 
     if (!accessResult.isSuccess()) {
       Map<String, Object> response = new HashMap<>();

--- a/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/control_plane/system_manager/AuthenticationConfigurationManagementEntryService.java
+++ b/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/control_plane/system_manager/AuthenticationConfigurationManagementEntryService.java
@@ -32,7 +32,7 @@ import org.idp.server.core.openid.authentication.repository.AuthenticationConfig
 import org.idp.server.core.openid.identity.User;
 import org.idp.server.core.openid.token.OAuthToken;
 import org.idp.server.platform.audit.AuditLog;
-import org.idp.server.platform.audit.AuditLogWriters;
+import org.idp.server.platform.audit.AuditLogPublisher;
 import org.idp.server.platform.datasource.Transaction;
 import org.idp.server.platform.log.LoggerWrapper;
 import org.idp.server.platform.multi_tenancy.tenant.Tenant;
@@ -47,7 +47,7 @@ public class AuthenticationConfigurationManagementEntryService
   AuthenticationConfigurationCommandRepository authenticationConfigurationCommandRepository;
   AuthenticationConfigurationQueryRepository authenticationConfigurationQueryRepository;
   TenantQueryRepository tenantQueryRepository;
-  AuditLogWriters auditLogWriters;
+  AuditLogPublisher auditLogPublisher;
   LoggerWrapper log =
       LoggerWrapper.getLogger(AuthenticationConfigurationManagementEntryService.class);
 
@@ -55,12 +55,12 @@ public class AuthenticationConfigurationManagementEntryService
       AuthenticationConfigurationCommandRepository authenticationConfigurationCommandRepository,
       AuthenticationConfigurationQueryRepository authenticationConfigurationQueryRepository,
       TenantQueryRepository tenantQueryRepository,
-      AuditLogWriters auditLogWriters) {
+      AuditLogPublisher auditLogPublisher) {
     this.authenticationConfigurationCommandRepository =
         authenticationConfigurationCommandRepository;
     this.authenticationConfigurationQueryRepository = authenticationConfigurationQueryRepository;
     this.tenantQueryRepository = tenantQueryRepository;
-    this.auditLogWriters = auditLogWriters;
+    this.auditLogPublisher = auditLogPublisher;
   }
 
   @Override
@@ -88,7 +88,7 @@ public class AuthenticationConfigurationManagementEntryService
             oAuthToken,
             context,
             requestAttributes);
-    auditLogWriters.write(tenant, auditLog);
+    auditLogPublisher.publish(auditLog);
 
     if (!permissions.includesAll(operator.permissionsAsSet())) {
       Map<String, Object> response = new HashMap<>();
@@ -113,6 +113,7 @@ public class AuthenticationConfigurationManagementEntryService
   }
 
   @Override
+  @Transaction(readOnly = true)
   public AuthenticationConfigManagementResponse findList(
       TenantIdentifier tenantIdentifier,
       User operator,
@@ -146,7 +147,7 @@ public class AuthenticationConfigurationManagementEntryService
             operator,
             oAuthToken,
             requestAttributes);
-    auditLogWriters.write(tenant, auditLog);
+    auditLogPublisher.publish(auditLog);
 
     if (!permissions.includesAll(operator.permissionsAsSet())) {
       Map<String, Object> response = new HashMap<>();
@@ -172,6 +173,7 @@ public class AuthenticationConfigurationManagementEntryService
   }
 
   @Override
+  @Transaction(readOnly = true)
   public AuthenticationConfigManagementResponse get(
       TenantIdentifier tenantIdentifier,
       User operator,
@@ -193,7 +195,7 @@ public class AuthenticationConfigurationManagementEntryService
             operator,
             oAuthToken,
             requestAttributes);
-    auditLogWriters.write(tenant, auditLog);
+    auditLogPublisher.publish(auditLog);
 
     if (!permissions.includesAll(operator.permissionsAsSet())) {
       Map<String, Object> response = new HashMap<>();
@@ -245,7 +247,7 @@ public class AuthenticationConfigurationManagementEntryService
             oAuthToken,
             context,
             requestAttributes);
-    auditLogWriters.write(tenant, auditLog);
+    auditLogPublisher.publish(auditLog);
 
     if (!permissions.includesAll(operator.permissionsAsSet())) {
       Map<String, Object> response = new HashMap<>();
@@ -293,7 +295,7 @@ public class AuthenticationConfigurationManagementEntryService
             oAuthToken,
             configuration.toMap(),
             requestAttributes);
-    auditLogWriters.write(tenant, auditLog);
+    auditLogPublisher.publish(auditLog);
 
     if (!permissions.includesAll(operator.permissionsAsSet())) {
       Map<String, Object> response = new HashMap<>();

--- a/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/control_plane/system_manager/AuthenticationInteractionManagementEntryService.java
+++ b/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/control_plane/system_manager/AuthenticationInteractionManagementEntryService.java
@@ -44,20 +44,21 @@ public class AuthenticationInteractionManagementEntryService
 
   AuthenticationInteractionQueryRepository authenticationInteractionQueryRepository;
   TenantQueryRepository tenantQueryRepository;
-  AuditLogWriters auditLogWriters;
+  AuditLogPublisher auditLogPublisher;
   LoggerWrapper log =
       LoggerWrapper.getLogger(AuthenticationInteractionManagementEntryService.class);
 
   public AuthenticationInteractionManagementEntryService(
       AuthenticationInteractionQueryRepository authenticationInteractionQueryRepository,
       TenantQueryRepository tenantQueryRepository,
-      AuditLogWriters auditLogWriters) {
+      AuditLogPublisher auditLogPublisher) {
     this.authenticationInteractionQueryRepository = authenticationInteractionQueryRepository;
     this.tenantQueryRepository = tenantQueryRepository;
-    this.auditLogWriters = auditLogWriters;
+    this.auditLogPublisher = auditLogPublisher;
   }
 
   @Override
+  @Transaction(readOnly = true)
   public AuthenticationInteractionManagementResponse findList(
       TenantIdentifier tenantIdentifier,
       User operator,
@@ -75,7 +76,7 @@ public class AuthenticationInteractionManagementEntryService
             operator,
             oAuthToken,
             requestAttributes);
-    auditLogWriters.write(tenant, auditLog);
+    auditLogPublisher.publish(auditLog);
 
     if (!permissions.includesAll(operator.permissionsAsSet())) {
       Map<String, Object> response = new HashMap<>();
@@ -116,6 +117,7 @@ public class AuthenticationInteractionManagementEntryService
   }
 
   @Override
+  @Transaction(readOnly = true)
   public AuthenticationInteractionManagementResponse get(
       TenantIdentifier tenantIdentifier,
       User operator,
@@ -137,7 +139,7 @@ public class AuthenticationInteractionManagementEntryService
             operator,
             oAuthToken,
             requestAttributes);
-    auditLogWriters.write(tenant, auditLog);
+    auditLogPublisher.publish(auditLog);
 
     if (!permissions.includesAll(operator.permissionsAsSet())) {
       Map<String, Object> response = new HashMap<>();

--- a/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/control_plane/system_manager/AuthenticationPolicyConfigurationManagementEntryService.java
+++ b/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/control_plane/system_manager/AuthenticationPolicyConfigurationManagementEntryService.java
@@ -32,7 +32,7 @@ import org.idp.server.core.openid.authentication.repository.AuthenticationPolicy
 import org.idp.server.core.openid.identity.User;
 import org.idp.server.core.openid.token.OAuthToken;
 import org.idp.server.platform.audit.AuditLog;
-import org.idp.server.platform.audit.AuditLogWriters;
+import org.idp.server.platform.audit.AuditLogPublisher;
 import org.idp.server.platform.datasource.Transaction;
 import org.idp.server.platform.log.LoggerWrapper;
 import org.idp.server.platform.multi_tenancy.tenant.Tenant;
@@ -48,7 +48,7 @@ public class AuthenticationPolicyConfigurationManagementEntryService
       authenticationPolicyConfigurationCommandRepository;
   AuthenticationPolicyConfigurationQueryRepository authenticationPolicyConfigurationQueryRepository;
   TenantQueryRepository tenantQueryRepository;
-  AuditLogWriters auditLogWriters;
+  AuditLogPublisher auditLogPublisher;
   LoggerWrapper log =
       LoggerWrapper.getLogger(AuthenticationPolicyConfigurationManagementEntryService.class);
 
@@ -58,13 +58,13 @@ public class AuthenticationPolicyConfigurationManagementEntryService
       AuthenticationPolicyConfigurationQueryRepository
           authenticationPolicyConfigurationQueryRepository,
       TenantQueryRepository tenantQueryRepository,
-      AuditLogWriters auditLogWriters) {
+      AuditLogPublisher auditLogPublisher) {
     this.authenticationPolicyConfigurationCommandRepository =
         authenticationPolicyConfigurationCommandRepository;
     this.authenticationPolicyConfigurationQueryRepository =
         authenticationPolicyConfigurationQueryRepository;
     this.tenantQueryRepository = tenantQueryRepository;
-    this.auditLogWriters = auditLogWriters;
+    this.auditLogPublisher = auditLogPublisher;
   }
 
   @Override
@@ -92,7 +92,7 @@ public class AuthenticationPolicyConfigurationManagementEntryService
             oAuthToken,
             context,
             requestAttributes);
-    auditLogWriters.write(tenant, auditLog);
+    auditLogPublisher.publish(auditLog);
 
     if (!permissions.includesAll(operator.permissionsAsSet())) {
       Map<String, Object> response = new HashMap<>();
@@ -117,6 +117,7 @@ public class AuthenticationPolicyConfigurationManagementEntryService
   }
 
   @Override
+  @Transaction(readOnly = true)
   public AuthenticationPolicyConfigManagementResponse findList(
       TenantIdentifier tenantIdentifier,
       User operator,
@@ -150,7 +151,7 @@ public class AuthenticationPolicyConfigurationManagementEntryService
             operator,
             oAuthToken,
             requestAttributes);
-    auditLogWriters.write(tenant, auditLog);
+    auditLogPublisher.publish(auditLog);
 
     if (!permissions.includesAll(operator.permissionsAsSet())) {
       Map<String, Object> response = new HashMap<>();
@@ -177,6 +178,7 @@ public class AuthenticationPolicyConfigurationManagementEntryService
   }
 
   @Override
+  @Transaction(readOnly = true)
   public AuthenticationPolicyConfigManagementResponse get(
       TenantIdentifier tenantIdentifier,
       User operator,
@@ -198,7 +200,7 @@ public class AuthenticationPolicyConfigurationManagementEntryService
             operator,
             oAuthToken,
             requestAttributes);
-    auditLogWriters.write(tenant, auditLog);
+    auditLogPublisher.publish(auditLog);
 
     if (!permissions.includesAll(operator.permissionsAsSet())) {
       Map<String, Object> response = new HashMap<>();
@@ -250,7 +252,7 @@ public class AuthenticationPolicyConfigurationManagementEntryService
             oAuthToken,
             context,
             requestAttributes);
-    auditLogWriters.write(tenant, auditLog);
+    auditLogPublisher.publish(auditLog);
 
     if (!permissions.includesAll(operator.permissionsAsSet())) {
       Map<String, Object> response = new HashMap<>();
@@ -298,7 +300,7 @@ public class AuthenticationPolicyConfigurationManagementEntryService
             oAuthToken,
             configuration.toMap(),
             requestAttributes);
-    auditLogWriters.write(tenant, auditLog);
+    auditLogPublisher.publish(auditLog);
 
     if (!permissions.includesAll(operator.permissionsAsSet())) {
       Map<String, Object> response = new HashMap<>();

--- a/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/control_plane/system_manager/AuthenticationTransactionManagementEntryService.java
+++ b/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/control_plane/system_manager/AuthenticationTransactionManagementEntryService.java
@@ -31,7 +31,7 @@ import org.idp.server.core.openid.authentication.repository.AuthenticationTransa
 import org.idp.server.core.openid.identity.User;
 import org.idp.server.core.openid.token.OAuthToken;
 import org.idp.server.platform.audit.AuditLog;
-import org.idp.server.platform.audit.AuditLogWriters;
+import org.idp.server.platform.audit.AuditLogPublisher;
 import org.idp.server.platform.datasource.Transaction;
 import org.idp.server.platform.log.LoggerWrapper;
 import org.idp.server.platform.multi_tenancy.tenant.Tenant;
@@ -45,20 +45,21 @@ public class AuthenticationTransactionManagementEntryService
 
   AuthenticationTransactionQueryRepository authenticationTransactionQueryRepository;
   TenantQueryRepository tenantQueryRepository;
-  AuditLogWriters auditLogWriters;
+  AuditLogPublisher auditLogPublisher;
   LoggerWrapper log =
       LoggerWrapper.getLogger(AuthenticationTransactionManagementEntryService.class);
 
   public AuthenticationTransactionManagementEntryService(
       AuthenticationTransactionQueryRepository authenticationTransactionQueryRepository,
       TenantQueryRepository tenantQueryRepository,
-      AuditLogWriters auditLogWriters) {
+      AuditLogPublisher auditLogPublisher) {
     this.authenticationTransactionQueryRepository = authenticationTransactionQueryRepository;
     this.tenantQueryRepository = tenantQueryRepository;
-    this.auditLogWriters = auditLogWriters;
+    this.auditLogPublisher = auditLogPublisher;
   }
 
   @Override
+  @Transaction(readOnly = true)
   public AuthenticationTransactionManagementResponse findList(
       TenantIdentifier tenantIdentifier,
       User operator,
@@ -76,7 +77,7 @@ public class AuthenticationTransactionManagementEntryService
             operator,
             oAuthToken,
             requestAttributes);
-    auditLogWriters.write(tenant, auditLog);
+    auditLogPublisher.publish(auditLog);
 
     if (!permissions.includesAll(operator.permissionsAsSet())) {
       Map<String, Object> response = new HashMap<>();
@@ -118,6 +119,7 @@ public class AuthenticationTransactionManagementEntryService
   }
 
   @Override
+  @Transaction(readOnly = true)
   public AuthenticationTransactionManagementResponse get(
       TenantIdentifier tenantIdentifier,
       User operator,
@@ -138,7 +140,7 @@ public class AuthenticationTransactionManagementEntryService
             operator,
             oAuthToken,
             requestAttributes);
-    auditLogWriters.write(tenant, auditLog);
+    auditLogPublisher.publish(auditLog);
 
     if (!permissions.includesAll(operator.permissionsAsSet())) {
       Map<String, Object> response = new HashMap<>();

--- a/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/control_plane/system_manager/AuthorizationServerManagementEntryService.java
+++ b/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/control_plane/system_manager/AuthorizationServerManagementEntryService.java
@@ -34,7 +34,7 @@ import org.idp.server.core.openid.oauth.configuration.AuthorizationServerConfigu
 import org.idp.server.core.openid.oauth.configuration.AuthorizationServerConfigurationQueryRepository;
 import org.idp.server.core.openid.token.OAuthToken;
 import org.idp.server.platform.audit.AuditLog;
-import org.idp.server.platform.audit.AuditLogWriters;
+import org.idp.server.platform.audit.AuditLogPublisher;
 import org.idp.server.platform.datasource.Transaction;
 import org.idp.server.platform.log.LoggerWrapper;
 import org.idp.server.platform.multi_tenancy.tenant.Tenant;
@@ -49,7 +49,7 @@ public class AuthorizationServerManagementEntryService implements AuthorizationS
   AuthorizationServerConfigurationQueryRepository authorizationServerConfigurationQueryRepository;
   AuthorizationServerConfigurationCommandRepository
       authorizationServerConfigurationCommandRepository;
-  AuditLogWriters auditLogWriters;
+  AuditLogPublisher auditLogPublisher;
   LoggerWrapper log = LoggerWrapper.getLogger(AuthorizationServerManagementEntryService.class);
 
   public AuthorizationServerManagementEntryService(
@@ -58,16 +58,17 @@ public class AuthorizationServerManagementEntryService implements AuthorizationS
           authorizationServerConfigurationQueryRepository,
       AuthorizationServerConfigurationCommandRepository
           authorizationServerConfigurationCommandRepository,
-      AuditLogWriters auditLogWriters) {
+      AuditLogPublisher auditLogPublisher) {
     this.tenantQueryRepository = tenantQueryRepository;
     this.authorizationServerConfigurationQueryRepository =
         authorizationServerConfigurationQueryRepository;
     this.authorizationServerConfigurationCommandRepository =
         authorizationServerConfigurationCommandRepository;
-    this.auditLogWriters = auditLogWriters;
+    this.auditLogPublisher = auditLogPublisher;
   }
 
   @Override
+  @Transaction(readOnly = true)
   public AuthorizationServerManagementResponse get(
       TenantIdentifier tenantIdentifier,
       User operator,
@@ -88,7 +89,7 @@ public class AuthorizationServerManagementEntryService implements AuthorizationS
             operator,
             oAuthToken,
             requestAttributes);
-    auditLogWriters.write(tenant, auditLog);
+    auditLogPublisher.publish(auditLog);
 
     if (!permissions.includesAll(operator.permissionsAsSet())) {
       Map<String, Object> response = new HashMap<>();
@@ -138,7 +139,7 @@ public class AuthorizationServerManagementEntryService implements AuthorizationS
             oAuthToken,
             context,
             requestAttributes);
-    auditLogWriters.write(tenant, auditLog);
+    auditLogPublisher.publish(auditLog);
 
     if (!permissions.includesAll(operator.permissionsAsSet())) {
       Map<String, Object> response = new HashMap<>();

--- a/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/control_plane/system_manager/FederationConfigurationManagementEntryService.java
+++ b/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/control_plane/system_manager/FederationConfigurationManagementEntryService.java
@@ -33,7 +33,7 @@ import org.idp.server.core.openid.federation.repository.FederationConfigurationQ
 import org.idp.server.core.openid.identity.User;
 import org.idp.server.core.openid.token.OAuthToken;
 import org.idp.server.platform.audit.AuditLog;
-import org.idp.server.platform.audit.AuditLogWriters;
+import org.idp.server.platform.audit.AuditLogPublisher;
 import org.idp.server.platform.datasource.Transaction;
 import org.idp.server.platform.log.LoggerWrapper;
 import org.idp.server.platform.multi_tenancy.tenant.Tenant;
@@ -48,18 +48,18 @@ public class FederationConfigurationManagementEntryService
   FederationConfigurationQueryRepository federationConfigurationQueryRepository;
   FederationConfigurationCommandRepository federationConfigurationCommandRepository;
   TenantQueryRepository tenantQueryRepository;
-  AuditLogWriters auditLogWriters;
+  AuditLogPublisher auditLogPublisher;
   LoggerWrapper log = LoggerWrapper.getLogger(FederationConfigurationManagementEntryService.class);
 
   public FederationConfigurationManagementEntryService(
       FederationConfigurationQueryRepository federationConfigurationQueryRepository,
       FederationConfigurationCommandRepository federationConfigurationCommandRepository,
       TenantQueryRepository tenantQueryRepository,
-      AuditLogWriters auditLogWriters) {
+      AuditLogPublisher auditLogPublisher) {
     this.federationConfigurationQueryRepository = federationConfigurationQueryRepository;
     this.federationConfigurationCommandRepository = federationConfigurationCommandRepository;
     this.tenantQueryRepository = tenantQueryRepository;
-    this.auditLogWriters = auditLogWriters;
+    this.auditLogPublisher = auditLogPublisher;
   }
 
   @Override
@@ -86,7 +86,7 @@ public class FederationConfigurationManagementEntryService
             oAuthToken,
             context,
             requestAttributes);
-    auditLogWriters.write(tenant, auditLog);
+    auditLogPublisher.publish(auditLog);
 
     if (!permissions.includesAll(operator.permissionsAsSet())) {
       Map<String, Object> response = new HashMap<>();
@@ -111,6 +111,7 @@ public class FederationConfigurationManagementEntryService
   }
 
   @Override
+  @Transaction(readOnly = true)
   public FederationConfigManagementResponse findList(
       TenantIdentifier tenantIdentifier,
       User operator,
@@ -129,7 +130,7 @@ public class FederationConfigurationManagementEntryService
             operator,
             oAuthToken,
             requestAttributes);
-    auditLogWriters.write(tenant, auditLog);
+    auditLogPublisher.publish(auditLog);
 
     if (!permissions.includesAll(operator.permissionsAsSet())) {
       Map<String, Object> response = new HashMap<>();
@@ -168,6 +169,7 @@ public class FederationConfigurationManagementEntryService
   }
 
   @Override
+  @Transaction(readOnly = true)
   public FederationConfigManagementResponse get(
       TenantIdentifier tenantIdentifier,
       User operator,
@@ -188,7 +190,7 @@ public class FederationConfigurationManagementEntryService
             operator,
             oAuthToken,
             requestAttributes);
-    auditLogWriters.write(tenant, auditLog);
+    auditLogPublisher.publish(auditLog);
 
     if (!permissions.includesAll(operator.permissionsAsSet())) {
       Map<String, Object> response = new HashMap<>();
@@ -239,7 +241,7 @@ public class FederationConfigurationManagementEntryService
             oAuthToken,
             context,
             requestAttributes);
-    auditLogWriters.write(tenant, auditLog);
+    auditLogPublisher.publish(auditLog);
 
     if (!permissions.includesAll(operator.permissionsAsSet())) {
       Map<String, Object> response = new HashMap<>();
@@ -291,7 +293,7 @@ public class FederationConfigurationManagementEntryService
             oAuthToken,
             configuration.payload(),
             requestAttributes);
-    auditLogWriters.write(tenant, auditLog);
+    auditLogPublisher.publish(auditLog);
 
     if (!permissions.includesAll(operator.permissionsAsSet())) {
       Map<String, Object> response = new HashMap<>();

--- a/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/control_plane/system_manager/IdentityVerificationConfigManagementEntryService.java
+++ b/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/control_plane/system_manager/IdentityVerificationConfigManagementEntryService.java
@@ -34,7 +34,7 @@ import org.idp.server.core.extension.identity.verification.repository.IdentityVe
 import org.idp.server.core.openid.identity.User;
 import org.idp.server.core.openid.token.OAuthToken;
 import org.idp.server.platform.audit.AuditLog;
-import org.idp.server.platform.audit.AuditLogWriters;
+import org.idp.server.platform.audit.AuditLogPublisher;
 import org.idp.server.platform.datasource.Transaction;
 import org.idp.server.platform.log.LoggerWrapper;
 import org.idp.server.platform.multi_tenancy.tenant.Tenant;
@@ -50,7 +50,7 @@ public class IdentityVerificationConfigManagementEntryService
       identityVerificationConfigurationCommandRepository;
   IdentityVerificationConfigurationQueryRepository identityVerificationConfigurationQueryRepository;
   TenantQueryRepository tenantQueryRepository;
-  AuditLogWriters auditLogWriters;
+  AuditLogPublisher auditLogPublisher;
   LoggerWrapper log =
       LoggerWrapper.getLogger(IdentityVerificationConfigManagementEntryService.class);
 
@@ -60,13 +60,13 @@ public class IdentityVerificationConfigManagementEntryService
       IdentityVerificationConfigurationQueryRepository
           identityVerificationConfigurationQueryRepository,
       TenantQueryRepository tenantQueryRepository,
-      AuditLogWriters auditLogWriters) {
+      AuditLogPublisher auditLogPublisher) {
     this.identityVerificationConfigurationCommandRepository =
         identityVerificationConfigurationCommandRepository;
     this.identityVerificationConfigurationQueryRepository =
         identityVerificationConfigurationQueryRepository;
     this.tenantQueryRepository = tenantQueryRepository;
-    this.auditLogWriters = auditLogWriters;
+    this.auditLogPublisher = auditLogPublisher;
   }
 
   @Override
@@ -94,7 +94,7 @@ public class IdentityVerificationConfigManagementEntryService
             oAuthToken,
             context,
             requestAttributes);
-    auditLogWriters.write(tenant, auditLog);
+    auditLogPublisher.publish(auditLog);
 
     if (!permissions.includesAll(operator.permissionsAsSet())) {
       Map<String, Object> response = new HashMap<>();
@@ -120,6 +120,7 @@ public class IdentityVerificationConfigManagementEntryService
   }
 
   @Override
+  @Transaction(readOnly = true)
   public IdentityVerificationConfigManagementResponse findList(
       TenantIdentifier tenantIdentifier,
       User operator,
@@ -138,7 +139,7 @@ public class IdentityVerificationConfigManagementEntryService
             operator,
             oAuthToken,
             requestAttributes);
-    auditLogWriters.write(tenant, auditLog);
+    auditLogPublisher.publish(auditLog);
 
     if (!permissions.includesAll(operator.permissionsAsSet())) {
       Map<String, Object> response = new HashMap<>();
@@ -180,6 +181,7 @@ public class IdentityVerificationConfigManagementEntryService
   }
 
   @Override
+  @Transaction(readOnly = true)
   public IdentityVerificationConfigManagementResponse get(
       TenantIdentifier tenantIdentifier,
       User operator,
@@ -201,7 +203,7 @@ public class IdentityVerificationConfigManagementEntryService
             operator,
             oAuthToken,
             requestAttributes);
-    auditLogWriters.write(tenant, auditLog);
+    auditLogPublisher.publish(auditLog);
 
     if (!permissions.includesAll(operator.permissionsAsSet())) {
       Map<String, Object> response = new HashMap<>();
@@ -253,7 +255,7 @@ public class IdentityVerificationConfigManagementEntryService
             oAuthToken,
             context,
             requestAttributes);
-    auditLogWriters.write(tenant, auditLog);
+    auditLogPublisher.publish(auditLog);
 
     if (!permissions.includesAll(operator.permissionsAsSet())) {
       Map<String, Object> response = new HashMap<>();
@@ -307,7 +309,7 @@ public class IdentityVerificationConfigManagementEntryService
             oAuthToken,
             configuration.toMap(),
             requestAttributes);
-    auditLogWriters.write(tenant, auditLog);
+    auditLogPublisher.publish(auditLog);
 
     if (!permissions.includesAll(operator.permissionsAsSet())) {
       Map<String, Object> response = new HashMap<>();

--- a/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/control_plane/system_manager/PermissionManagementEntryService.java
+++ b/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/control_plane/system_manager/PermissionManagementEntryService.java
@@ -35,7 +35,7 @@ import org.idp.server.core.openid.identity.User;
 import org.idp.server.core.openid.identity.permission.*;
 import org.idp.server.core.openid.token.OAuthToken;
 import org.idp.server.platform.audit.AuditLog;
-import org.idp.server.platform.audit.AuditLogWriters;
+import org.idp.server.platform.audit.AuditLogPublisher;
 import org.idp.server.platform.datasource.Transaction;
 import org.idp.server.platform.log.LoggerWrapper;
 import org.idp.server.platform.multi_tenancy.tenant.Tenant;
@@ -50,20 +50,20 @@ public class PermissionManagementEntryService implements PermissionManagementApi
   PermissionQueryRepository permissionQueryRepository;
   PermissionCommandRepository permissionCommandRepository;
   PermissionRegistrationVerifier verifier;
-  AuditLogWriters auditLogWriters;
+  AuditLogPublisher auditLogPublisher;
   LoggerWrapper log = LoggerWrapper.getLogger(PermissionManagementEntryService.class);
 
   public PermissionManagementEntryService(
       TenantQueryRepository tenantQueryRepository,
       PermissionQueryRepository permissionQueryRepository,
       PermissionCommandRepository permissionCommandRepository,
-      AuditLogWriters auditLogWriters) {
+      AuditLogPublisher auditLogPublisher) {
     this.tenantQueryRepository = tenantQueryRepository;
     this.permissionQueryRepository = permissionQueryRepository;
     this.permissionCommandRepository = permissionCommandRepository;
     PermissionVerifier permissionVerifier = new PermissionVerifier(permissionQueryRepository);
     this.verifier = new PermissionRegistrationVerifier(permissionVerifier);
-    this.auditLogWriters = auditLogWriters;
+    this.auditLogPublisher = auditLogPublisher;
   }
 
   @Override
@@ -96,7 +96,7 @@ public class PermissionManagementEntryService implements PermissionManagementApi
             oAuthToken,
             context,
             requestAttributes);
-    auditLogWriters.write(tenant, auditLog);
+    auditLogPublisher.publish(auditLog);
 
     if (!permissions.includesAll(operator.permissionsAsSet())) {
       Map<String, Object> response = new HashMap<>();
@@ -128,6 +128,7 @@ public class PermissionManagementEntryService implements PermissionManagementApi
   }
 
   @Override
+  @Transaction(readOnly = true)
   public PermissionManagementResponse findList(
       TenantIdentifier tenantIdentifier,
       User operator,
@@ -147,7 +148,7 @@ public class PermissionManagementEntryService implements PermissionManagementApi
             operator,
             oAuthToken,
             requestAttributes);
-    auditLogWriters.write(tenant, auditLog);
+    auditLogPublisher.publish(auditLog);
 
     if (!permissions.includesAll(operator.permissionsAsSet())) {
       Map<String, Object> response = new HashMap<>();
@@ -182,6 +183,7 @@ public class PermissionManagementEntryService implements PermissionManagementApi
   }
 
   @Override
+  @Transaction(readOnly = true)
   public PermissionManagementResponse get(
       TenantIdentifier tenantIdentifier,
       User operator,
@@ -197,7 +199,7 @@ public class PermissionManagementEntryService implements PermissionManagementApi
     AuditLog auditLog =
         AuditLogCreator.createOnRead(
             "PermissionManagementApi.get", "get", tenant, operator, oAuthToken, requestAttributes);
-    auditLogWriters.write(tenant, auditLog);
+    auditLogPublisher.publish(auditLog);
 
     if (!permissions.includesAll(operator.permissionsAsSet())) {
       Map<String, Object> response = new HashMap<>();
@@ -249,7 +251,7 @@ public class PermissionManagementEntryService implements PermissionManagementApi
             operator,
             oAuthToken,
             requestAttributes);
-    auditLogWriters.write(tenant, auditLog);
+    auditLogPublisher.publish(auditLog);
 
     if (!permissions.includesAll(operator.permissionsAsSet())) {
       Map<String, Object> response = new HashMap<>();
@@ -302,7 +304,7 @@ public class PermissionManagementEntryService implements PermissionManagementApi
             oAuthToken,
             permission.toMap(),
             requestAttributes);
-    auditLogWriters.write(tenant, auditLog);
+    auditLogPublisher.publish(auditLog);
 
     if (!permissions.includesAll(operator.permissionsAsSet())) {
       Map<String, Object> response = new HashMap<>();

--- a/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/control_plane/system_manager/RoleManagementEntryService.java
+++ b/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/control_plane/system_manager/RoleManagementEntryService.java
@@ -35,7 +35,7 @@ import org.idp.server.core.openid.identity.permission.*;
 import org.idp.server.core.openid.identity.role.*;
 import org.idp.server.core.openid.token.OAuthToken;
 import org.idp.server.platform.audit.AuditLog;
-import org.idp.server.platform.audit.AuditLogWriters;
+import org.idp.server.platform.audit.AuditLogPublisher;
 import org.idp.server.platform.datasource.Transaction;
 import org.idp.server.platform.log.LoggerWrapper;
 import org.idp.server.platform.multi_tenancy.tenant.Tenant;
@@ -50,7 +50,7 @@ public class RoleManagementEntryService implements RoleManagementApi {
   RoleQueryRepository roleQueryRepository;
   RoleCommandRepository roleCommandRepository;
   PermissionQueryRepository permissionQueryRepository;
-  AuditLogWriters auditLogWriters;
+  AuditLogPublisher auditLogPublisher;
   LoggerWrapper log = LoggerWrapper.getLogger(RoleManagementEntryService.class);
 
   public RoleManagementEntryService(
@@ -58,12 +58,12 @@ public class RoleManagementEntryService implements RoleManagementApi {
       RoleQueryRepository roleQueryRepository,
       RoleCommandRepository roleCommandRepository,
       PermissionQueryRepository permissionQueryRepository,
-      AuditLogWriters auditLogWriters) {
+      AuditLogPublisher auditLogPublisher) {
     this.tenantQueryRepository = tenantQueryRepository;
     this.roleQueryRepository = roleQueryRepository;
     this.roleCommandRepository = roleCommandRepository;
     this.permissionQueryRepository = permissionQueryRepository;
-    this.auditLogWriters = auditLogWriters;
+    this.auditLogPublisher = auditLogPublisher;
   }
 
   @Override
@@ -94,7 +94,7 @@ public class RoleManagementEntryService implements RoleManagementApi {
     AuditLog auditLog =
         AuditLogCreator.create(
             "RoleManagementApi.create", tenant, operator, oAuthToken, context, requestAttributes);
-    auditLogWriters.write(tenant, auditLog);
+    auditLogPublisher.publish(auditLog);
 
     if (!permissions.includesAll(operator.permissionsAsSet())) {
       Map<String, Object> response = new HashMap<>();
@@ -126,6 +126,7 @@ public class RoleManagementEntryService implements RoleManagementApi {
   }
 
   @Override
+  @Transaction(readOnly = true)
   public RoleManagementResponse findList(
       TenantIdentifier tenantIdentifier,
       User operator,
@@ -145,7 +146,7 @@ public class RoleManagementEntryService implements RoleManagementApi {
             operator,
             oAuthToken,
             requestAttributes);
-    auditLogWriters.write(tenant, auditLog);
+    auditLogPublisher.publish(auditLog);
 
     if (!permissions.includesAll(operator.permissionsAsSet())) {
       Map<String, Object> response = new HashMap<>();
@@ -180,6 +181,7 @@ public class RoleManagementEntryService implements RoleManagementApi {
   }
 
   @Override
+  @Transaction(readOnly = true)
   public RoleManagementResponse get(
       TenantIdentifier tenantIdentifier,
       User operator,
@@ -195,7 +197,7 @@ public class RoleManagementEntryService implements RoleManagementApi {
     AuditLog auditLog =
         AuditLogCreator.createOnRead(
             "RoleManagementApi.get", "get", tenant, operator, oAuthToken, requestAttributes);
-    auditLogWriters.write(tenant, auditLog);
+    auditLogPublisher.publish(auditLog);
 
     if (!permissions.includesAll(operator.permissionsAsSet())) {
       Map<String, Object> response = new HashMap<>();
@@ -250,7 +252,7 @@ public class RoleManagementEntryService implements RoleManagementApi {
     AuditLog auditLog =
         AuditLogCreator.createOnUpdate(
             "RoleManagementApi.update", tenant, operator, oAuthToken, context, requestAttributes);
-    auditLogWriters.write(tenant, auditLog);
+    auditLogPublisher.publish(auditLog);
 
     if (!permissions.includesAll(operator.permissionsAsSet())) {
       Map<String, Object> response = new HashMap<>();
@@ -312,7 +314,7 @@ public class RoleManagementEntryService implements RoleManagementApi {
             oAuthToken,
             context,
             requestAttributes);
-    auditLogWriters.write(tenant, auditLog);
+    auditLogPublisher.publish(auditLog);
 
     if (!permissions.includesAll(operator.permissionsAsSet())) {
       Map<String, Object> response = new HashMap<>();
@@ -365,7 +367,7 @@ public class RoleManagementEntryService implements RoleManagementApi {
             oAuthToken,
             role.toMap(),
             requestAttributes);
-    auditLogWriters.write(tenant, auditLog);
+    auditLogPublisher.publish(auditLog);
 
     if (!permissions.includesAll(operator.permissionsAsSet())) {
       Map<String, Object> response = new HashMap<>();

--- a/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/control_plane/system_manager/SecurityEventHookConfigurationManagementEntryService.java
+++ b/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/control_plane/system_manager/SecurityEventHookConfigurationManagementEntryService.java
@@ -28,7 +28,7 @@ import org.idp.server.control_plane.management.security.hook.io.SecurityEventHoo
 import org.idp.server.core.openid.identity.User;
 import org.idp.server.core.openid.token.OAuthToken;
 import org.idp.server.platform.audit.AuditLog;
-import org.idp.server.platform.audit.AuditLogWriters;
+import org.idp.server.platform.audit.AuditLogPublisher;
 import org.idp.server.platform.datasource.Transaction;
 import org.idp.server.platform.log.LoggerWrapper;
 import org.idp.server.platform.multi_tenancy.tenant.Tenant;
@@ -47,7 +47,7 @@ public class SecurityEventHookConfigurationManagementEntryService
   SecurityEventHookConfigurationCommandRepository securityEventHookConfigurationCommandRepository;
   SecurityEventHookConfigurationQueryRepository securityEventHookConfigurationQueryRepository;
   TenantQueryRepository tenantQueryRepository;
-  AuditLogWriters auditLogWriters;
+  AuditLogPublisher auditLogPublisher;
   LoggerWrapper log =
       LoggerWrapper.getLogger(SecurityEventHookConfigurationManagementEntryService.class);
 
@@ -56,13 +56,13 @@ public class SecurityEventHookConfigurationManagementEntryService
           securityEventHookConfigurationCommandRepository,
       SecurityEventHookConfigurationQueryRepository securityEventHookConfigurationQueryRepository,
       TenantQueryRepository tenantQueryRepository,
-      AuditLogWriters auditLogWriters) {
+      AuditLogPublisher auditLogPublisher) {
     this.securityEventHookConfigurationCommandRepository =
         securityEventHookConfigurationCommandRepository;
     this.securityEventHookConfigurationQueryRepository =
         securityEventHookConfigurationQueryRepository;
     this.tenantQueryRepository = tenantQueryRepository;
-    this.auditLogWriters = auditLogWriters;
+    this.auditLogPublisher = auditLogPublisher;
   }
 
   @Override
@@ -89,7 +89,7 @@ public class SecurityEventHookConfigurationManagementEntryService
             oAuthToken,
             context,
             requestAttributes);
-    auditLogWriters.write(tenant, auditLog);
+    auditLogPublisher.publish(auditLog);
 
     if (!permissions.includesAll(operator.permissionsAsSet())) {
       Map<String, Object> response = new HashMap<>();
@@ -114,6 +114,7 @@ public class SecurityEventHookConfigurationManagementEntryService
   }
 
   @Override
+  @Transaction(readOnly = true)
   public SecurityEventHookConfigManagementResponse findList(
       TenantIdentifier tenantIdentifier,
       User operator,
@@ -135,7 +136,7 @@ public class SecurityEventHookConfigurationManagementEntryService
             operator,
             oAuthToken,
             requestAttributes);
-    auditLogWriters.write(tenant, auditLog);
+    auditLogPublisher.publish(auditLog);
 
     if (!permissions.includesAll(operator.permissionsAsSet())) {
       Map<String, Object> response = new HashMap<>();
@@ -159,6 +160,7 @@ public class SecurityEventHookConfigurationManagementEntryService
   }
 
   @Override
+  @Transaction(readOnly = true)
   public SecurityEventHookConfigManagementResponse get(
       TenantIdentifier tenantIdentifier,
       User operator,
@@ -179,7 +181,7 @@ public class SecurityEventHookConfigurationManagementEntryService
             operator,
             oAuthToken,
             requestAttributes);
-    auditLogWriters.write(tenant, auditLog);
+    auditLogPublisher.publish(auditLog);
 
     if (!permissions.includesAll(operator.permissionsAsSet())) {
       Map<String, Object> response = new HashMap<>();
@@ -231,7 +233,7 @@ public class SecurityEventHookConfigurationManagementEntryService
             oAuthToken,
             context,
             requestAttributes);
-    auditLogWriters.write(tenant, auditLog);
+    auditLogPublisher.publish(auditLog);
 
     if (!permissions.includesAll(operator.permissionsAsSet())) {
       Map<String, Object> response = new HashMap<>();
@@ -283,7 +285,7 @@ public class SecurityEventHookConfigurationManagementEntryService
             oAuthToken,
             configuration.toMap(),
             requestAttributes);
-    auditLogWriters.write(tenant, auditLog);
+    auditLogPublisher.publish(auditLog);
 
     if (!permissions.includesAll(operator.permissionsAsSet())) {
       Map<String, Object> response = new HashMap<>();

--- a/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/control_plane/system_manager/SecurityEventManagementEntryService.java
+++ b/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/control_plane/system_manager/SecurityEventManagementEntryService.java
@@ -27,7 +27,7 @@ import org.idp.server.control_plane.management.security.event.io.SecurityEventMa
 import org.idp.server.core.openid.identity.User;
 import org.idp.server.core.openid.token.OAuthToken;
 import org.idp.server.platform.audit.AuditLog;
-import org.idp.server.platform.audit.AuditLogWriters;
+import org.idp.server.platform.audit.AuditLogPublisher;
 import org.idp.server.platform.datasource.Transaction;
 import org.idp.server.platform.log.LoggerWrapper;
 import org.idp.server.platform.multi_tenancy.tenant.Tenant;
@@ -44,19 +44,20 @@ public class SecurityEventManagementEntryService implements SecurityEventManagem
 
   SecurityEventQueryRepository securityEventQueryRepository;
   TenantQueryRepository tenantQueryRepository;
-  AuditLogWriters auditLogWriters;
+  AuditLogPublisher auditLogPublisher;
   LoggerWrapper log = LoggerWrapper.getLogger(SecurityEventManagementEntryService.class);
 
   public SecurityEventManagementEntryService(
       SecurityEventQueryRepository securityEventQueryRepository,
       TenantQueryRepository tenantQueryRepository,
-      AuditLogWriters auditLogWriters) {
+      AuditLogPublisher auditLogPublisher) {
     this.securityEventQueryRepository = securityEventQueryRepository;
     this.tenantQueryRepository = tenantQueryRepository;
-    this.auditLogWriters = auditLogWriters;
+    this.auditLogPublisher = auditLogPublisher;
   }
 
   @Override
+  @Transaction(readOnly = true)
   public SecurityEventManagementResponse findList(
       TenantIdentifier tenantIdentifier,
       User operator,
@@ -74,7 +75,7 @@ public class SecurityEventManagementEntryService implements SecurityEventManagem
             operator,
             oAuthToken,
             requestAttributes);
-    auditLogWriters.write(tenant, auditLog);
+    auditLogPublisher.publish(auditLog);
 
     if (!permissions.includesAll(operator.permissionsAsSet())) {
       Map<String, Object> response = new HashMap<>();
@@ -110,6 +111,7 @@ public class SecurityEventManagementEntryService implements SecurityEventManagem
   }
 
   @Override
+  @Transaction(readOnly = true)
   public SecurityEventManagementResponse get(
       TenantIdentifier tenantIdentifier,
       User operator,
@@ -129,7 +131,7 @@ public class SecurityEventManagementEntryService implements SecurityEventManagem
             operator,
             oAuthToken,
             requestAttributes);
-    auditLogWriters.write(tenant, auditLog);
+    auditLogPublisher.publish(auditLog);
 
     if (!permissions.includesAll(operator.permissionsAsSet())) {
       Map<String, Object> response = new HashMap<>();

--- a/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/control_plane/system_manager/TenantInvitationManagementEntryService.java
+++ b/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/control_plane/system_manager/TenantInvitationManagementEntryService.java
@@ -95,8 +95,8 @@ public class TenantInvitationManagementEntryService implements TenantInvitationM
     return context.toResponse();
   }
 
-  @Transaction
   @Override
+  @Transaction(readOnly = true)
   public TenantInvitationManagementResponse findList(
       TenantIdentifier tenantIdentifier,
       User operator,
@@ -114,8 +114,8 @@ public class TenantInvitationManagementEntryService implements TenantInvitationM
     return new TenantInvitationManagementResponse(TenantInvitationManagementStatus.OK, response);
   }
 
-  @Transaction
   @Override
+  @Transaction(readOnly = true)
   public TenantInvitationManagementResponse get(
       TenantIdentifier tenantIdentifier,
       User operator,

--- a/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/control_plane/system_manager/TenantManagementEntryService.java
+++ b/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/control_plane/system_manager/TenantManagementEntryService.java
@@ -35,7 +35,7 @@ import org.idp.server.core.openid.identity.repository.UserCommandRepository;
 import org.idp.server.core.openid.oauth.configuration.AuthorizationServerConfigurationCommandRepository;
 import org.idp.server.core.openid.token.OAuthToken;
 import org.idp.server.platform.audit.AuditLog;
-import org.idp.server.platform.audit.AuditLogWriters;
+import org.idp.server.platform.audit.AuditLogPublisher;
 import org.idp.server.platform.datasource.Transaction;
 import org.idp.server.platform.log.LoggerWrapper;
 import org.idp.server.platform.multi_tenancy.organization.Organization;
@@ -57,7 +57,7 @@ public class TenantManagementEntryService implements TenantManagementApi {
       authorizationServerConfigurationCommandRepository;
   TenantManagementVerifier tenantManagementVerifier;
   UserCommandRepository userCommandRepository;
-  AuditLogWriters auditLogWriters;
+  AuditLogPublisher auditLogPublisher;
 
   LoggerWrapper log = LoggerWrapper.getLogger(TenantManagementEntryService.class);
 
@@ -68,7 +68,7 @@ public class TenantManagementEntryService implements TenantManagementApi {
       AuthorizationServerConfigurationCommandRepository
           authorizationServerConfigurationCommandRepository,
       UserCommandRepository userCommandRepository,
-      AuditLogWriters auditLogWriters) {
+      AuditLogPublisher auditLogPublisher) {
     this.tenantCommandRepository = tenantCommandRepository;
     this.tenantQueryRepository = tenantQueryRepository;
     this.organizationRepository = organizationRepository;
@@ -77,7 +77,7 @@ public class TenantManagementEntryService implements TenantManagementApi {
     this.userCommandRepository = userCommandRepository;
     TenantVerifier tenantVerifier = new TenantVerifier(tenantQueryRepository);
     this.tenantManagementVerifier = new TenantManagementVerifier(tenantVerifier);
-    this.auditLogWriters = auditLogWriters;
+    this.auditLogPublisher = auditLogPublisher;
   }
 
   @Override
@@ -110,7 +110,7 @@ public class TenantManagementEntryService implements TenantManagementApi {
             oAuthToken,
             context,
             requestAttributes);
-    auditLogWriters.write(adminTenant, auditLog);
+    auditLogPublisher.publish(auditLog);
 
     if (!permissions.includesAll(operator.permissionsAsSet())) {
       Map<String, Object> response = new HashMap<>();
@@ -149,6 +149,7 @@ public class TenantManagementEntryService implements TenantManagementApi {
   }
 
   @Override
+  @Transaction(readOnly = true)
   public TenantManagementResponse findList(
       TenantIdentifier adminTenantIdentifier,
       User operator,
@@ -180,6 +181,7 @@ public class TenantManagementEntryService implements TenantManagementApi {
   }
 
   @Override
+  @Transaction(readOnly = true)
   public TenantManagementResponse get(
       TenantIdentifier adminTenantIdentifier,
       User operator,
@@ -236,7 +238,7 @@ public class TenantManagementEntryService implements TenantManagementApi {
             oAuthToken,
             context,
             requestAttributes);
-    auditLogWriters.write(adminTenant, auditLog);
+    auditLogPublisher.publish(auditLog);
 
     if (!permissions.includesAll(operator.permissionsAsSet())) {
       Map<String, Object> response = new HashMap<>();
@@ -285,7 +287,7 @@ public class TenantManagementEntryService implements TenantManagementApi {
             oAuthToken,
             before.toMap(),
             requestAttributes);
-    auditLogWriters.write(adminTenant, auditLog);
+    auditLogPublisher.publish(auditLog);
 
     if (!permissions.includesAll(operator.permissionsAsSet())) {
       Map<String, Object> response = new HashMap<>();

--- a/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/control_plane/system_manager/UserManagementEntryService.java
+++ b/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/control_plane/system_manager/UserManagementEntryService.java
@@ -46,7 +46,7 @@ import org.idp.server.core.openid.identity.repository.UserQueryRepository;
 import org.idp.server.core.openid.identity.role.RoleQueryRepository;
 import org.idp.server.core.openid.token.OAuthToken;
 import org.idp.server.platform.audit.AuditLog;
-import org.idp.server.platform.audit.AuditLogWriters;
+import org.idp.server.platform.audit.AuditLogPublisher;
 import org.idp.server.platform.datasource.Transaction;
 import org.idp.server.platform.log.LoggerWrapper;
 import org.idp.server.platform.multi_tenancy.organization.OrganizationRepository;
@@ -67,7 +67,7 @@ public class UserManagementEntryService implements UserManagementApi {
   UserRegistrationVerifier verifier;
   UserRegistrationRelatedDataVerifier updateVerifier;
   UserLifecycleEventPublisher userLifecycleEventPublisher;
-  AuditLogWriters auditLogWriters;
+  AuditLogPublisher auditLogPublisher;
   LoggerWrapper log = LoggerWrapper.getLogger(UserManagementEntryService.class);
 
   public UserManagementEntryService(
@@ -78,7 +78,7 @@ public class UserManagementEntryService implements UserManagementApi {
       OrganizationRepository organizationRepository,
       PasswordEncodeDelegation passwordEncodeDelegation,
       UserLifecycleEventPublisher userLifecycleEventPublisher,
-      AuditLogWriters auditLogWriters) {
+      AuditLogPublisher auditLogPublisher) {
     this.tenantQueryRepository = tenantQueryRepository;
     this.userQueryRepository = userQueryRepository;
     this.userCommandRepository = userCommandRepository;
@@ -92,7 +92,7 @@ public class UserManagementEntryService implements UserManagementApi {
     this.verifier = new UserRegistrationVerifier(userVerifier, userRegistrationRelatedDataVerifier);
     this.updateVerifier = userRegistrationRelatedDataVerifier;
     this.userLifecycleEventPublisher = userLifecycleEventPublisher;
-    this.auditLogWriters = auditLogWriters;
+    this.auditLogPublisher = auditLogPublisher;
   }
 
   @Override
@@ -121,7 +121,7 @@ public class UserManagementEntryService implements UserManagementApi {
     AuditLog auditLog =
         AuditLogCreator.create(
             "UserManagementApi.create", tenant, operator, oAuthToken, context, requestAttributes);
-    auditLogWriters.write(tenant, auditLog);
+    auditLogPublisher.publish(auditLog);
 
     if (!permissions.includesAll(operator.permissionsAsSet())) {
       Map<String, Object> response = new HashMap<>();
@@ -153,6 +153,7 @@ public class UserManagementEntryService implements UserManagementApi {
   }
 
   @Override
+  @Transaction(readOnly = true)
   public UserManagementResponse findList(
       TenantIdentifier tenantIdentifier,
       User operator,
@@ -172,7 +173,7 @@ public class UserManagementEntryService implements UserManagementApi {
             operator,
             oAuthToken,
             requestAttributes);
-    auditLogWriters.write(tenant, auditLog);
+    auditLogPublisher.publish(auditLog);
 
     if (!permissions.includesAll(operator.permissionsAsSet())) {
       Map<String, Object> response = new HashMap<>();
@@ -207,6 +208,7 @@ public class UserManagementEntryService implements UserManagementApi {
   }
 
   @Override
+  @Transaction(readOnly = true)
   public UserManagementResponse get(
       TenantIdentifier tenantIdentifier,
       User operator,
@@ -222,7 +224,7 @@ public class UserManagementEntryService implements UserManagementApi {
     AuditLog auditLog =
         AuditLogCreator.createOnRead(
             "UserManagementApi.get", "get", tenant, operator, oAuthToken, requestAttributes);
-    auditLogWriters.write(tenant, auditLog);
+    auditLogPublisher.publish(auditLog);
 
     if (!permissions.includesAll(operator.permissionsAsSet())) {
       Map<String, Object> response = new HashMap<>();
@@ -418,7 +420,7 @@ public class UserManagementEntryService implements UserManagementApi {
             oAuthToken,
             user.toMaskedValueMap(),
             requestAttributes);
-    auditLogWriters.write(tenant, auditLog);
+    auditLogPublisher.publish(auditLog);
 
     if (!permissions.includesAll(operator.permissionsAsSet())) {
       Map<String, Object> response = new HashMap<>();
@@ -464,7 +466,7 @@ public class UserManagementEntryService implements UserManagementApi {
     //        AuditLogCreator.createOnUpdate(
     //            "UserManagementApi.updateRoles", "updateRoles", tenant, operator, oAuthToken,
     // requestAttributes);
-    //    auditLogWriters.write(tenant, auditLog);
+    //    auditLogPublisher.publish(auditLog);
 
     if (!permissions.includesAll(operator.permissionsAsSet())) {
       Map<String, Object> response = new HashMap<>();
@@ -522,7 +524,7 @@ public class UserManagementEntryService implements UserManagementApi {
     //        AuditLogCreator.createOnUpdate(
     //            "UserManagementApi.updateTenantAssignments", "updateTenantAssignments", tenant,
     // operator, oAuthToken, requestAttributes);
-    //    auditLogWriters.write(tenant, auditLog);
+    //    auditLogPublisher.publish(auditLog);
 
     if (!permissions.includesAll(operator.permissionsAsSet())) {
       Map<String, Object> response = new HashMap<>();
@@ -592,7 +594,7 @@ public class UserManagementEntryService implements UserManagementApi {
     //                "UserManagementApi.updateOrganizationAssignments", tenant, operator,
     // oAuthToken,
     //     requestAttributes);
-    //        auditLogWriters.write(tenant, auditLog);
+    //        auditLogPublisher.publish(auditLog);
 
     if (!permissions.includesAll(operator.permissionsAsSet())) {
       Map<String, Object> response = new HashMap<>();


### PR DESCRIPTION
This implementation follows the same pattern as SecurityEvent to enable future support for @Transaction(readOnly = true) on management APIs by providing asynchronous audit log processing capabilities.

Key components added:
- AuditLogEventListener: @Async @EventListener for async processing
- AuditLogRunnable: Background task executor with tenant context management
- AuditLogApi: Interface following SecurityEventApi pattern
- AuditLogEntryService: Implementation of AuditLogApi
- SpringAuditLogPublisher: Spring ApplicationEventPublisher integration
- auditLogTaskExecutor: Dedicated thread pool configuration (5-10 threads)

The infrastructure is ready for future migration of management APIs to use AuditLogPublisher instead of direct AuditLogWriters calls, which will enable database load balancing through read-only transactions.

Addresses #527

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>

Migrate all management APIs to use AuditLogPublisher for async processing

This completes the migration from AuditLogWriters to AuditLogPublisher for all management APIs, enabling full asynchronous audit log processing.

Changes made:
- Updated 30+ ManagementEntryService classes to use AuditLogPublisher
- Changed constructor parameters from AuditLogWriters to AuditLogPublisher
- Replaced auditLogWriters.write() calls with auditLogPublisher.publish()
- Updated Javadoc comments for parameter documentation
- Modified IdpServerApplication to inject AuditLogPublisher
- Updated IdPServerConfiguration for Spring DI integration

All management APIs now use asynchronous audit logging through:
- SpringAuditLogPublisher publishes events to Spring ApplicationEventPublisher
- AuditLogEventListener processes events asynchronously with @Async
- AuditLogRunnable executes background tasks with tenant context management
- Dedicated auditLogTaskExecutor thread pool handles the processing

This enables future support for @Transaction(readOnly = true) on management APIs to achieve database load balancing and improved performance.

Addresses #527

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>

change transaction to readOnly