### PR TITLE
Add created_at field to User API response

### DIFF
--- a/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/identity/ModelConverter.java
+++ b/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/identity/ModelConverter.java
@@ -60,6 +60,10 @@ class ModelConverter {
         parseDatabaseBoolean(stringMap.get("phone_number_verified"), false));
     user.setHashedPassword(stringMap.getOrDefault("hashed_password", ""));
 
+    if (stringMap.containsKey("created_at")) {
+      user.setCreatedAt(LocalDateTimeParser.parse(stringMap.get("created_at")));
+    }
+
     if (stringMap.containsKey("updated_at")) {
       user.setUpdatedAt(LocalDateTimeParser.parse(stringMap.get("updated_at")));
     }

--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/identity/User.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/identity/User.java
@@ -56,6 +56,7 @@ public class User implements JsonReadable, Serializable, UuidConvertable {
   String phoneNumber;
   Boolean phoneNumberVerified;
   Address address;
+  LocalDateTime createdAt;
   LocalDateTime updatedAt;
   String hashedPassword;
   String rawPassword;
@@ -305,6 +306,19 @@ public class User implements JsonReadable, Serializable, UuidConvertable {
     return this;
   }
 
+  public LocalDateTime createdAt() {
+    return createdAt;
+  }
+
+  public long createdAtAsLong() {
+    return SystemDateTime.toEpochSecond(createdAt);
+  }
+
+  public User setCreatedAt(LocalDateTime createdAt) {
+    this.createdAt = createdAt;
+    return this;
+  }
+
   public LocalDateTime updatedAt() {
     return updatedAt;
   }
@@ -530,6 +544,10 @@ public class User implements JsonReadable, Serializable, UuidConvertable {
     return Objects.nonNull(hashedPassword) && !hashedPassword.isEmpty();
   }
 
+  public boolean hasCreatedAt() {
+    return Objects.nonNull(createdAt);
+  }
+
   public boolean hasUpdatedAt() {
     return Objects.nonNull(updatedAt);
   }
@@ -729,6 +747,7 @@ public class User implements JsonReadable, Serializable, UuidConvertable {
     if (hasLocale()) map.put("locale", locale);
     if (hasPhoneNumber()) map.put("phone_number", phoneNumber);
     if (hasPhoneNumberVerified()) map.put("phone_number_verified", phoneNumberVerified);
+    if (hasCreatedAt()) map.put("created_at", createdAt.toString());
     if (hasUpdatedAt()) map.put("updated_at", updatedAt.toString());
     if (hasAddress()) map.put("address", address.toMap());
     if (hasCustomProperties()) map.put("custom_properties", new HashMap<>(customProperties));


### PR DESCRIPTION
## Summary
- Add `created_at` field to User API response to match `updated_at` functionality
- Fix issue where only `updated_at` was returned while `created_at` was missing from API response

## Changes
- **User.java**: Added `createdAt` field with getter/setter/hasCreatedAt methods
- **ModelConverter.java**: Added parsing logic for `created_at` database column
- **API Response**: Include `created_at` in `toMap()` method for API serialization

## Test Results
✅ API response now correctly includes both fields:
```json
{
  "created_at": "2025-09-29T07:18:38.243694",
  "updated_at": "2025-09-29T07:18:38.243694"
}
```

## Architecture Compliance
- Follows existing `updated_at` implementation pattern
- Maintains type safety with `LocalDateTime`
- Consistent naming convention with snake_case in API

Fixes #533

🤖 Generated with [Claude Code](https://claude.com/claude-code)