### PR TITLE
Fix UUID type casting in SecurityEventHookResult queries

### DIFF
--- a/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/security/hook/result/query/PostgresqlExecutor.java
+++ b/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/security/hook/result/query/PostgresqlExecutor.java
@@ -35,14 +35,14 @@ public class PostgresqlExecutor implements SecurityEventHookResultSqlExecutor {
             """;
     StringBuilder sql = new StringBuilder(selectSql).append(" WHERE tenant_id = ?::uuid");
     List<Object> params = new ArrayList<>();
-    params.add(tenant.identifierValue());
+    params.add(tenant.identifierUUID());
     sql.append(" AND created_at BETWEEN ? AND ?");
     params.add(queries.from());
     params.add(queries.to());
 
     if (queries.hasId()) {
-      sql.append(" AND id = ?");
-      params.add(queries.id());
+      sql.append(" AND id = ?::uuid");
+      params.add(queries.idAsUuid());
     }
 
     if (queries.hasEventType()) {
@@ -90,14 +90,14 @@ public class PostgresqlExecutor implements SecurityEventHookResultSqlExecutor {
 
     StringBuilder sql = new StringBuilder(selectSql).append(" WHERE tenant_id = ?::uuid");
     List<Object> params = new ArrayList<>();
-    params.add(tenant.identifierValue());
+    params.add(tenant.identifierUUID());
     sql.append(" AND created_at BETWEEN ? AND ?");
     params.add(queries.from());
     params.add(queries.to());
 
     if (queries.hasId()) {
-      sql.append(" AND id = ?");
-      params.add(queries.id());
+      sql.append(" AND id = ?::uuid");
+      params.add(queries.idAsUuid());
     }
 
     if (queries.hasEventType()) {


### PR DESCRIPTION
## Summary
- Fixes PostgreSQL error "operator does not exist: uuid = character varying" when searching security event hook results by ID
- Ensures proper UUID type parameters are passed for both tenant_id and id columns in database queries

## Problem
The security event hook search API was throwing a 500 error when specifying an ID parameter due to PostgreSQL type mismatch. The database expected UUID type but was receiving character varying (string) type.

## Solution
- **Tenant ID parameter**: Changed from `tenant.identifierValue()` to `tenant.identifierUUID()`
- **Search ID parameter**: Changed from `queries.id()` to `queries.idAsUuid()`  
- **SQL casting**: Added explicit `::uuid` casting for both parameters
- **Consistency**: Aligned `selectCount()` and `selectList()` methods with existing `selectOne()` method

## Changes
- Modified `PostgresqlExecutor.selectCount()` method
- Modified `PostgresqlExecutor.selectList()` method  
- Both methods now use proper UUID parameters and explicit type casting

## Test Plan
- [x] Code compiles successfully
- [ ] Manual testing of security event hook search API with ID parameter
- [ ] Verify no 500 errors when searching by specific ID
- [ ] Ensure search results are returned correctly

Resolves #542

🤖 Generated with [Claude Code](https://claude.com/claude-code)