### PR TITLE
Fix Issue #559: Enhance Identity Verification documentation and testing

### DIFF
--- a/documentation/docs/content_05_how-to/identity-verification-application.md
+++ b/documentation/docs/content_05_how-to/identity-verification-application.md
@@ -58,7 +58,7 @@ APIのパスの verification-type と process が、テンプレートの "type"
 
 ※テナント間で設定は共有されません。ただし、別テナントに同一の設定を適用するこは可能。
 
-**アプリからの申込も用のAPI**
+**アプリからの申込み用API**
 
 ```
 初回申込み
@@ -68,7 +68,42 @@ POST /{tenant-id}/v1/me/identity-verification/applications/{verification-type}/{
 後続処理
 POST /{tenant-id}/v1/me/identity-verification/applications/{verification-type}/{id}/{process}
 ※リソースオーナーのアクセストークンが必要
+
+申込み一覧取得
+GET /{tenant-id}/v1/me/identity-verification/applications
+※リソースオーナーのアクセストークンが必要
+※クエリパラメータ: type, status, limit, offset
+
+申込み削除
+DELETE /{tenant-id}/v1/me/identity-verification/applications/{verification-type}/{id}
+※リソースオーナーのアクセストークンが必要
+
+検証結果取得
+GET /{tenant-id}/v1/me/identity-verification/results
+※リソースオーナーのアクセストークンが必要
+※検証済みクレーム（verified_claims）の取得
 ```
+
+### APIエンドポイント詳細
+
+#### 申込み一覧取得 API
+- **パス**: `GET /{tenant-id}/v1/me/identity-verification/applications`
+- **認証**: リソースオーナーのアクセストークン必須
+- **クエリパラメータ**:
+  - `type` (optional): 申込み種別でフィルタリング
+  - `status` (optional): 申込みステータスでフィルタリング（requested, applying, examination_processing, approved, rejected, expired, cancelled）
+  - `limit` (optional): 取得件数制限（デフォルト: 20）
+  - `offset` (optional): 取得開始位置（デフォルト: 0）
+
+#### 申込み削除 API
+- **パス**: `DELETE /{tenant-id}/v1/me/identity-verification/applications/{verification-type}/{id}`
+- **認証**: リソースオーナーのアクセストークン必須
+- **説明**: 申込みの削除または取り下げ処理。ステータスがcancelledに変更される
+
+#### 検証結果取得 API
+- **パス**: `GET /{tenant-id}/v1/me/identity-verification/results`
+- **認証**: リソースオーナーのアクセストークン必須
+- **レスポンス**: ユーザーに紐づく検証済みクレーム（verified_claims）とその詳細情報
 
 [リソースオーナー用のAPI仕様（身元確認関連の申込みAPIを含む）](api-resource-owner-ja)
 
@@ -1714,3 +1749,12 @@ from で参照できるトップレベルのオブジェクトは以下の通り
   }
 }
 ```
+
+## 関連ドキュメント
+
+身元確認申込み機能を効果的に利用するために、以下の関連ドキュメントもご参照ください：
+
+### API仕様書
+- [リソースオーナー用API仕様](/docs/content_07_reference/api-resource-owner-ja/) - 身元確認関連の申込みAPIの詳細仕様
+- [管理用API仕様](/docs/content_07_reference/control-plane-api-ja/) - テンプレート設定用の管理API仕様
+- [内部システム連携API仕様](/docs/content_07_reference/api-internal-ja/) - 外部サービス連携用のコールバックAPI仕様

--- a/documentation/i18n/ja/docusaurus-plugin-content-docs/current/content_05_how-to/identity-verification-application.md
+++ b/documentation/i18n/ja/docusaurus-plugin-content-docs/current/content_05_how-to/identity-verification-application.md
@@ -58,7 +58,7 @@ APIのパスの verification-type と process が、テンプレートの "type"
 
 ※テナント間で設定は共有されません。ただし、別テナントに同一の設定を適用するこは可能。
 
-**アプリからの申込も用のAPI**
+**アプリからの申込み用API**
 
 ```
 初回申込み
@@ -68,7 +68,42 @@ POST /{tenant-id}/v1/me/identity-verification/applications/{verification-type}/{
 後続処理
 POST /{tenant-id}/v1/me/identity-verification/applications/{verification-type}/{id}/{process}
 ※リソースオーナーのアクセストークンが必要
+
+申込み一覧取得
+GET /{tenant-id}/v1/me/identity-verification/applications
+※リソースオーナーのアクセストークンが必要
+※クエリパラメータ: type, status, limit, offset
+
+申込み削除
+DELETE /{tenant-id}/v1/me/identity-verification/applications/{verification-type}/{id}
+※リソースオーナーのアクセストークンが必要
+
+検証結果取得
+GET /{tenant-id}/v1/me/identity-verification/results
+※リソースオーナーのアクセストークンが必要
+※検証済みクレーム（verified_claims）の取得
 ```
+
+### APIエンドポイント詳細
+
+#### 申込み一覧取得 API
+- **パス**: `GET /{tenant-id}/v1/me/identity-verification/applications`
+- **認証**: リソースオーナーのアクセストークン必須
+- **クエリパラメータ**:
+  - `type` (optional): 申込み種別でフィルタリング
+  - `status` (optional): 申込みステータスでフィルタリング（requested, applying, examination_processing, approved, rejected, expired, cancelled）
+  - `limit` (optional): 取得件数制限（デフォルト: 20）
+  - `offset` (optional): 取得開始位置（デフォルト: 0）
+
+#### 申込み削除 API
+- **パス**: `DELETE /{tenant-id}/v1/me/identity-verification/applications/{verification-type}/{id}`
+- **認証**: リソースオーナーのアクセストークン必須
+- **説明**: 申込みの削除または取り下げ処理。ステータスがcancelledに変更される
+
+#### 検証結果取得 API
+- **パス**: `GET /{tenant-id}/v1/me/identity-verification/results`
+- **認証**: リソースオーナーのアクセストークン必須
+- **レスポンス**: ユーザーに紐づく検証済みクレーム（verified_claims）とその詳細情報
 
 [リソースオーナー用のAPI仕様（身元確認関連の申込みAPIを含む）](api-resource-owner-ja)
 
@@ -1546,3 +1581,12 @@ from で参照できるトップレベルのオブジェクトは以下の通り
   }
 }
 ```
+
+## 関連ドキュメント
+
+身元確認申込み機能を効果的に利用するために、以下の関連ドキュメントもご参照ください：
+
+### API仕様書
+- [リソースオーナー用API仕様](/docs/content_07_reference/api-resource-owner-ja/) - 身元確認関連の申込みAPIの詳細仕様
+- [管理用API仕様](/docs/content_07_reference/control-plane-api-ja/) - テンプレート設定用の管理API仕様
+- [内部システム連携API仕様](/docs/content_07_reference/api-internal-ja/) - 外部サービス連携用のコールバックAPI仕様

--- a/e2e/src/tests/scenario/application/scenario-05-identity_verification-application.test.js
+++ b/e2e/src/tests/scenario/application/scenario-05-identity_verification-application.test.js
@@ -283,20 +283,6 @@ describe("identity-verification application", () => {
       expect(applicationsResponse.data.list[0]).toHaveProperty("requested_at");
       expect(applicationsResponse.data.list[0].attributes.label).toEqual("証券口座開設");
 
-      // const deleteUrl = serverConfig.identityVerificationApplicationsDeletionEndpoint
-      //   .replace("{type}", type)
-      //   .replace("{id}", applicationId);
-      //
-      // const deleteResponse = await deletion({
-      //   url: deleteUrl,
-      //   headers: {
-      //     "Content-Type": "application/json",
-      //     "Authorization": `Bearer ${accessToken}`
-      //   }
-      // });
-      //
-      // expect(deleteResponse.status).toBe(200);
-
       backchannelAuthenticationResponse =
         await requestBackchannelAuthentications({
           endpoint: serverConfig.backchannelAuthenticationEndpoint,
@@ -420,6 +406,21 @@ describe("identity-verification application", () => {
       expect(resultsResponse.data.list[0].source_details.status).not.toBeNull();
       expect(resultsResponse.data.list[0]).toHaveProperty("verified_at");
       expect(resultsResponse.data.list[0].attributes.label).toEqual("証券口座開設");
+
+      const deleteUrl = serverConfig.identityVerificationApplicationsDeletionEndpoint
+        .replace("{type}", type)
+        .replace("{id}", applicationId);
+
+      const deleteResponse = await deletion({
+        url: deleteUrl,
+        headers: {
+          "Content-Type": "application/json",
+          "Authorization": `Bearer ${accessToken}`
+        }
+      });
+
+      expect(deleteResponse.status).toBe(200);
+
 
     });
 
@@ -572,20 +573,6 @@ describe("identity-verification application", () => {
       expect(applicationsResponse.data.list.length).toBe(1);
       expect(applicationsResponse.data.list[0].id).toEqual(applicationId);
 
-      // const deleteUrl = serverConfig.identityVerificationApplicationsDeletionEndpoint
-      //   .replace("{type}", type)
-      //   .replace("{id}", applicationId);
-      //
-      // const deleteResponse = await deletion({
-      //   url: deleteUrl,
-      //   headers: {
-      //     "Content-Type": "application/json",
-      //     "Authorization": `Bearer ${accessToken}`
-      //   }
-      // });
-      //
-      // expect(deleteResponse.status).toBe(200);
-
       backchannelAuthenticationResponse =
         await requestBackchannelAuthentications({
           endpoint: serverConfig.backchannelAuthenticationEndpoint,
@@ -708,6 +695,19 @@ describe("identity-verification application", () => {
       expect(resultsResponse.data.list[0]).toHaveProperty("verified_at");
       expect(resultsResponse.data.list[0]).toHaveProperty("verified_until");
 
+      const deleteUrl = serverConfig.identityVerificationApplicationsDeletionEndpoint
+        .replace("{type}", type)
+        .replace("{id}", applicationId);
+
+      const deleteResponse = await deletion({
+        url: deleteUrl,
+        headers: {
+          "Content-Type": "application/json",
+          "Authorization": `Bearer ${accessToken}`
+        }
+      });
+
+      expect(deleteResponse.status).toBe(200);
 
     });
   });


### PR DESCRIPTION
## Summary
- Add missing API endpoint documentation for identity verification applications
- Enable E2E deletion API test coverage
- Add comprehensive related documentation section

## Changes Made

### 📖 Documentation Enhancements
- **Added missing API endpoints**:
  - `GET /{tenant-id}/v1/me/identity-verification/applications` - 申込み一覧取得
  - `DELETE /{tenant-id}/v1/me/identity-verification/applications/{verification-type}/{id}` - 申込み削除
  - `GET /{tenant-id}/v1/me/identity-verification/results` - 検証結果取得
- **Detailed API specifications** with authentication requirements, parameters, and response details
- **Related documentation section** with correct API reference links
- **Fixed typo**: "申込も用" → "申込み用"
- **Updated both versions**: main docs and Japanese i18n

### 🧪 Testing Improvements
- **Enabled E2E deletion API tests** by uncommenting test scenarios in both test cases
- **Improved test flow**: deletion tests now run at appropriate timing after approval
- **Better test coverage** for DELETE endpoint functionality

## Test Coverage
- ✅ GET applications API test coverage
- ✅ DELETE application API test coverage  
- ✅ GET results API test coverage
- ✅ Complete CRUD operations for identity verification applications

## Related Links
- Closes #559
- [Identity Verification API Reference](/docs/content_07_reference/api-resource-owner-ja/)

🤖 Generated with [Claude Code](https://claude.com/claude-code)