### PR TITLE
Fix UUID type casting in SecurityEvent queries (Issue #598)

### DIFF
--- a/e2e/src/tests/scenario/control_plane/system/security-event-management.test.js
+++ b/e2e/src/tests/scenario/control_plane/system/security-event-management.test.js
@@ -91,6 +91,7 @@ describe("security event management api", () => {
     });
 
     const successCases = [
+      ["id", "id", "3ec055a8-8000-44a2-8677-e70ebff414e2"],
       ["ex-sub", "external_user_id", "3ec055a8-8000-44a2-8677-e70ebff414e2"],
       ["user-id", "user_id", "3ec055a8-8000-44a2-8677-e70ebff414e2"],
       ["client-id", "client_id", "client"],

--- a/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/security/event/query/PostgresqlExecutor.java
+++ b/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/security/event/query/PostgresqlExecutor.java
@@ -40,8 +40,8 @@ public class PostgresqlExecutor implements SecurityEventSqlExecutor {
     params.add(queries.to());
 
     if (queries.hasId()) {
-      sql.append(" AND id = ?");
-      params.add(queries.id());
+      sql.append(" AND id = ?::uuid");
+      params.add(queries.idAsUuid());
     }
 
     if (queries.hasClientId()) {
@@ -84,8 +84,8 @@ public class PostgresqlExecutor implements SecurityEventSqlExecutor {
     params.add(queries.to());
 
     if (queries.hasId()) {
-      sql.append(" AND id = ?");
-      params.add(queries.id());
+      sql.append(" AND id = ?::uuid");
+      params.add(queries.idAsUuid());
     }
 
     if (queries.hasClientId()) {


### PR DESCRIPTION
## 概要
SecurityEventの検索APIで`id`パラメータを使用した際に発生するPostgreSQL型エラーを修正します。

## 問題
PostgreSQL環境で以下のエラーが発生：
```
ERROR: operator does not exist: uuid = character varying
Hint: No operator matches the given name and argument types. You might need to add explicit type casts.
```

## 原因
- `security_event`テーブルの`id`カラムはUUID型
- クエリでは文字列として比較していた（`::uuid`キャストなし）
- 同じファイル内の`user_id`検索では正しく`::uuid`キャストを使用

## 修正内容

### PostgresqlExecutor.java
- `selectCount`メソッド: `id = ?` → `id = ?::uuid`
- `selectList`メソッド: `id = ?` → `id = ?::uuid`
- パラメータ: `queries.id()` → `queries.idAsUuid()`

### E2Eテスト
- `id`パラメータでの検索テストケースを追加

## 参考
- SecurityEventHookResultは既に修正済み（commit e4e5c53bd, Issue #542）
- 同じパターンの修正をSecurityEventにも適用

## 影響範囲
- PostgreSQL環境のみ
- `id`パラメータを使用した検索のみ
- 他の検索パラメータ（`client_id`、`user_id`等）は影響なし

Fixes #598