### PR TITLE
Add event_type filter to SecurityEvent search API (Issues #597, #541)

### DIFF
--- a/e2e/src/tests/scenario/control_plane/system/security-event-management.test.js
+++ b/e2e/src/tests/scenario/control_plane/system/security-event-management.test.js
@@ -95,6 +95,7 @@ describe("security event management api", () => {
       ["ex-sub", "external_user_id", "3ec055a8-8000-44a2-8677-e70ebff414e2"],
       ["user-id", "user_id", "3ec055a8-8000-44a2-8677-e70ebff414e2"],
       ["client-id", "client_id", "client"],
+      ["event-type", "event_type", "oauth_deny"],
       ["from", "from", "2025-06-20 19:51:39.901577"],
       ["to", "to", "2025-06-20 19:51:39.901577"],
       ["limit", "limit", "1"],

--- a/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/security/event/query/MysqlExecutor.java
+++ b/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/security/event/query/MysqlExecutor.java
@@ -59,6 +59,11 @@ public class MysqlExecutor implements SecurityEventSqlExecutor {
       params.add(queries.externalUserId());
     }
 
+    if (queries.hasEventType()) {
+      sql.append(" AND type = ?");
+      params.add(queries.eventType());
+    }
+
     if (queries.hasDetails()) {
       for (Map.Entry<String, String> entry : queries.details().entrySet()) {
         String key = entry.getKey();
@@ -101,6 +106,11 @@ public class MysqlExecutor implements SecurityEventSqlExecutor {
     if (queries.hasExternalUserId()) {
       sql.append(" AND external_user_id = ?");
       params.add(queries.externalUserId());
+    }
+
+    if (queries.hasEventType()) {
+      sql.append(" AND type = ?");
+      params.add(queries.eventType());
     }
 
     if (queries.hasDetails()) {

--- a/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/security/event/query/PostgresqlExecutor.java
+++ b/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/security/event/query/PostgresqlExecutor.java
@@ -59,6 +59,11 @@ public class PostgresqlExecutor implements SecurityEventSqlExecutor {
       params.add(queries.externalUserId());
     }
 
+    if (queries.hasEventType()) {
+      sql.append(" AND type = ?");
+      params.add(queries.eventType());
+    }
+
     if (queries.hasDetails()) {
       for (Map.Entry<String, String> entry : queries.details().entrySet()) {
         String key = entry.getKey();
@@ -101,6 +106,11 @@ public class PostgresqlExecutor implements SecurityEventSqlExecutor {
     if (queries.hasExternalUserId()) {
       sql.append(" AND external_user_id = ?");
       params.add(queries.externalUserId());
+    }
+
+    if (queries.hasEventType()) {
+      sql.append(" AND type = ?");
+      params.add(queries.eventType());
     }
 
     if (queries.hasDetails()) {

--- a/libs/idp-server-platform/src/main/java/org/idp/server/platform/security/SecurityEventQueries.java
+++ b/libs/idp-server-platform/src/main/java/org/idp/server/platform/security/SecurityEventQueries.java
@@ -88,6 +88,14 @@ public class SecurityEventQueries implements UuidConvertable {
     return values.containsKey("external_user_id");
   }
 
+  public boolean hasEventType() {
+    return values.containsKey("event_type");
+  }
+
+  public String eventType() {
+    return values.get("event_type");
+  }
+
   public boolean hasDetails() {
     return !details().isEmpty();
   }


### PR DESCRIPTION
## 概要
セキュリティイベント検索APIに`event_type`パラメータによるフィルタリング機能を追加します。

## 背景
現在、イベントタイプはレスポンスに含まれデータベースにも格納されていますが、検索条件として利用できません。これにより、特定タイプのイベント（例: oauth_deny、login_success等）を検索する際にクライアント側でフィルタリングが必要でした。

## 実装内容

### SecurityEventQueries.java
```java
public boolean hasEventType() {
  return values.containsKey("event_type");
}

public String eventType() {
  return values.get("event_type");
}
```

### PostgresqlExecutor.java / MysqlExecutor.java
両方の`selectCount()`と`selectList()`メソッドに以下を追加：
```java
if (queries.hasEventType()) {
  sql.append(" AND type = ?");
  params.add(queries.eventType());
}
```

### E2Eテスト
`event_type`パラメータでの検索テストケースを追加

## 使用例
```bash
GET /v1/management/tenants/{tenant-id}/security-events?event_type=oauth_deny
```

## ユースケース
- **セキュリティインシデント調査**: 特定タイプのイベントを効率的に抽出
- **監査・コンプライアンス**: イベントタイプ別の履歴確認
- **運用監視**: 特定イベントの傾向分析

## 参考
SecurityEventHookResultQueriesでは既に同様の実装あり（63-68行目）

## 今後の拡張候補（別Issue）
Issue #541で提案されている他の検索条件:
- `ip_address` - IPアドレス検索
- `user_agent` - ブラウザ/クライアント検索
- `description` - イベント説明での部分一致検索

Fixes #597
Fixes #541