### PR TITLE
Fix Issue #583: Correct security event user identifier mapping

### DIFF
--- a/libs/idp-server-platform/src/main/java/org/idp/server/platform/security/event/SecurityEventUser.java
+++ b/libs/idp-server-platform/src/main/java/org/idp/server/platform/security/event/SecurityEventUser.java
@@ -100,12 +100,13 @@ public class SecurityEventUser implements UuidConvertable, JsonReadable {
     HashMap<String, Object> result = new HashMap<>();
     if (id != null) {
       result.put("id", id);
+      result.put("sub", id);
     }
     if (name != null) {
       result.put("name", name);
     }
     if (exSub != null) {
-      result.put("sub", exSub);
+      result.put("ex_sub", exSub);
     }
     if (email != null) {
       result.put("email", email);


### PR DESCRIPTION
## Summary
- Fix security event user identifier to use internal user ID instead of external provider ID
- Add `ex_sub` field for external provider ID

## Changes
- Modified `SecurityEventUser.toMap()` to correctly map user identifiers:
  - `id` → both `"id"` and `"sub"` (internal user ID)
  - `exSub` → `"ex_sub"` (external provider ID)

## Before
```json
{
  "user": {
    "id": "17b8a4a9-d710-476c-bde9-7305bfc25712",
    "sub": "3002847833"  // ❌ External provider ID
  }
}
```

## After
```json
{
  "user": {
    "id": "17b8a4a9-d710-476c-bde9-7305bfc25712",
    "sub": "17b8a4a9-d710-476c-bde9-7305bfc25712",  // ✅ Internal user ID
    "ex_sub": "3002847833"  // ✅ External provider ID
  }
}
```

## Test plan
- [x] Build successful
- [x] All tests passing
- [x] Verified SecurityEventUser.toMap() output structure

Fixes #583

🤖 Generated with [Claude Code](https://claude.com/claude-code)