### PR TITLE
Fix Issue #603: Extract SecurityEventUser from detail field and rename id to sub

### DIFF
--- a/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/security/event/command/MysqlExecutor.java
+++ b/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/security/event/command/MysqlExecutor.java
@@ -72,7 +72,7 @@ public class MysqlExecutor implements SecurityEventSqlExecutor {
     params.add(securityEvent.client().name());
 
     if (securityEvent.hasUser()) {
-      params.add(securityEvent.user().id());
+      params.add(securityEvent.user().sub());
       params.add(securityEvent.user().name());
       params.add(securityEvent.user().exSub());
     } else {

--- a/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/security/event/command/PostgresqlExecutor.java
+++ b/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/security/event/command/PostgresqlExecutor.java
@@ -72,7 +72,7 @@ public class PostgresqlExecutor implements SecurityEventSqlExecutor {
     params.add(securityEvent.client().name());
 
     if (securityEvent.hasUser()) {
-      params.add(securityEvent.user().idAsUuid());
+      params.add(securityEvent.user().subAsUuid());
       params.add(securityEvent.user().name());
       params.add(securityEvent.user().exSub());
     } else {

--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/identity/SecurityEventUserCreatable.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/identity/SecurityEventUserCreatable.java
@@ -83,7 +83,7 @@ public interface SecurityEventUserCreatable {
 
     // Always included safe fields
     if (userConfig.isIncludeId()) {
-      result.put("id", user.sub());
+      result.put("sub", user.sub());
     }
     if (userConfig.isIncludeExternalUserId() && user.hasExternalUserId()) {
       result.put("ex_sub", user.externalUserId());

--- a/libs/idp-server-platform/src/main/java/org/idp/server/platform/security/SecurityEvent.java
+++ b/libs/idp-server-platform/src/main/java/org/idp/server/platform/security/SecurityEvent.java
@@ -90,7 +90,7 @@ public class SecurityEvent {
     if (user == null) {
       return "";
     }
-    return user.id();
+    return user.sub();
   }
 
   public String userExSub() {

--- a/libs/idp-server-platform/src/main/java/org/idp/server/platform/security/event/SecurityEventUser.java
+++ b/libs/idp-server-platform/src/main/java/org/idp/server/platform/security/event/SecurityEventUser.java
@@ -25,7 +25,7 @@ import org.idp.server.platform.json.JsonReadable;
 import org.idp.server.platform.uuid.UuidConvertable;
 
 public class SecurityEventUser implements UuidConvertable, JsonReadable {
-  String id;
+  String sub;
   String name;
   String exSub;
   String email;
@@ -47,8 +47,9 @@ public class SecurityEventUser implements UuidConvertable, JsonReadable {
 
   public SecurityEventUser() {}
 
-  public SecurityEventUser(String id, String name, String exSub, String email, String phoneNumber) {
-    this.id = id;
+  public SecurityEventUser(
+      String sub, String name, String exSub, String email, String phoneNumber) {
+    this.sub = sub;
     this.name = name;
     this.exSub = exSub;
     this.email = email;
@@ -56,7 +57,7 @@ public class SecurityEventUser implements UuidConvertable, JsonReadable {
   }
 
   public SecurityEventUser(
-      String id,
+      String sub,
       String name,
       String exSub,
       String email,
@@ -75,7 +76,7 @@ public class SecurityEventUser implements UuidConvertable, JsonReadable {
       List<String> permissions,
       String currentTenant,
       List<String> assignedTenants) {
-    this.id = id;
+    this.sub = sub;
     this.name = name;
     this.exSub = exSub;
     this.email = email;
@@ -98,9 +99,8 @@ public class SecurityEventUser implements UuidConvertable, JsonReadable {
 
   public Map<String, Object> toMap() {
     HashMap<String, Object> result = new HashMap<>();
-    if (id != null) {
-      result.put("id", id);
-      result.put("sub", id);
+    if (sub != null) {
+      result.put("sub", sub);
     }
     if (name != null) {
       result.put("name", name);
@@ -160,12 +160,12 @@ public class SecurityEventUser implements UuidConvertable, JsonReadable {
     return result;
   }
 
-  public String id() {
-    return id;
+  public String sub() {
+    return sub;
   }
 
-  public UUID idAsUuid() {
-    return convertUuid(id);
+  public UUID subAsUuid() {
+    return convertUuid(sub);
   }
 
   public String name() {
@@ -241,6 +241,6 @@ public class SecurityEventUser implements UuidConvertable, JsonReadable {
   }
 
   public boolean exists() {
-    return Objects.nonNull(id) && !id.isEmpty();
+    return Objects.nonNull(sub) && !sub.isEmpty();
   }
 }


### PR DESCRIPTION
## Summary
Resolves #603

This PR implements two main improvements:
1. **SecurityEventUser field renaming**: `id` → `sub` for OIDC compliance
2. **ModelConvertor improvement**: Extract full user data from `detail` JSONB field instead of using empty strings

## Changes

### 1. SecurityEventUser Field Renaming
**Files**: `SecurityEventUser.java`
- Rename field: `id` → `sub`
- Rename methods: `id()` → `sub()`, `idAsUuid()` → `subAsUuid()`
- Update `toMap()`: output `"sub"` key only (remove `"id"` key)

### 2. ModelConvertor Improvement (Main Fix)
**Files**: `security/event/query/ModelConvertor.java`
- Add `JsonConverter` for consistent deserialization
- Implement `extractUserFromDetail()` method to restore full user data from `detail.user`
- Remove TODO comment
- Maintain backward compatibility for old data without `detail.user`

**Pattern Consistency**: Now follows the same approach as `security/hook/result/query/ModelConvertor`

### 3. Update All Affected Code
- `SecurityEvent.java`: `user.id()` → `user.sub()`
- `PostgresqlExecutor.java`: `user.idAsUuid()` → `user.subAsUuid()`
- `MysqlExecutor.java`: `user.id()` → `user.sub()`
- `SecurityEventUserCreatable.java`: detail key `"id"` → `"sub"`

## Benefits
✅ **Pattern Unification**: Both ModelConvertors now use JsonConverter
✅ **Complete Restoration**: `detail.user` contains all user attributes saved by `toDetailWithSensitiveData()`
✅ **Backward Compatibility**: Old data without `detail.user` still works
✅ **DDL Change Free**: Works with existing database schema
✅ **TODO Removal**: Proper implementation replaces TODO comment

## Test Plan
- [x] Build successful
- [x] Code formatting applied
- [x] All tests pass

## Related
- Issue #603: Resolve TODO in ModelConvertor
- Issue #583: SecurityEvent user identifier mapping