### PR TITLE
Fix Issue #573: Correct CIBA configuration parameter names and add authentication settings

### DIFF
--- a/documentation/docs/content_04_protocols/ciba-flow.md
+++ b/documentation/docs/content_04_protocols/ciba-flow.md
@@ -83,10 +83,13 @@ CIBA フローにおけるユーザー認証も、通常の認可コードフロ
 
 また、仕様には定義されていないけれど、CIBAフローを実現するために必要な項目も設定が可能となっています。
 
-| 項目                                   | 説明               | デフォルト |
-|--------------------------------------|------------------|-------|
-| `backchannel_auth_request_expire_in` | 認証リクエストの有効期限     | 300秒  |
-| `backchannel_auth_polling_interval`  | ポーリング間隔（pollモード） | 5秒    |
+| 項目                                              | 説明                                 | デフォルト                                |
+|-------------------------------------------------|------------------------------------|--------------------------------------|
+| `backchannel_authentication_request_expires_in` | 認証リクエストの有効期限                       | 300秒                                 |
+| `backchannel_authentication_polling_interval`   | ポーリング間隔（pollモード）                   | 5秒                                   |
+| `default_ciba_authentication_interaction_type`  | デフォルト認証インタラクションタイプ                 | `authentication-device-notification` |
+| `required_backchannel_auth_user_code`           | バックチャネル認証でユーザーコード入力を必須とするか         | `false`                              |
+| `backchannel_auth_user_code_type`               | ユーザーコードのタイプ（`password` / `numeric`） | `password`                           |
 
 ## クライアント認証
 


### PR DESCRIPTION
## Summary
Resolves #573

This PR fixes configuration parameter name inconsistencies in CIBA flow documentation and adds missing authentication settings.

## Changes

### 1. Fix Configuration Parameter Names
**Before** → **After**:
- `backchannel_auth_request_expire_in` → `backchannel_authentication_request_expires_in`
- `backchannel_auth_polling_interval` → `backchannel_authentication_polling_interval`

### 2. Add Missing CIBA Authentication Settings
**New entries added to documentation table**:

| Parameter | Description | Default |
|-----------|-------------|---------|
| `default_ciba_authentication_interaction_type` | デフォルト認証インタラクションタイプ | `authentication-device-notification` |
| `required_backchannel_auth_user_code` | バックチャネル認証でユーザーコード入力を必須とするか | `false` |
| `backchannel_auth_user_code_type` | ユーザーコードのタイプ（`password` / `numeric`） | `password` |

## Verification

All parameter names verified against:
- **JSON Schema**: `libs/idp-server-core/src/main/resources/schema/1.0/authorization-server.json`
- **Java Implementation**: `libs/idp-server-core/src/main/java/org/idp/server/core/openid/oauth/configuration/AuthorizationServerExtensionConfiguration.java`
- **Sample Configs**: `config-sample/local/admin-tenant/initial.json`

## Files Changed
- `documentation/docs/content_04_protocols/ciba-flow.md`
  - Fixed 2 parameter names
  - Added 3 authentication settings

## Impact
✅ Documentation now accurately reflects actual implementation
✅ Developers can correctly configure CIBA authentication
✅ No code changes required