### PR TITLE
Fix Issue #574: Correct introspection.md error response documentation

### DIFF
--- a/documentation/docs/content_04_protocols/introspection.md
+++ b/documentation/docs/content_04_protocols/introspection.md
@@ -48,95 +48,44 @@ sequenceDiagram
 
 ---
 
-### 3.2 トークンが無効な場合（active: false, エラー理由明示）
+### 3.2 トークンが無効な場合（active: false）
 
-以下のように、エラー理由が明確な場合のみ `active: false` とともに詳細情報が返却されます。
-
-#### mTLS証明書が付与されていない
+RFC 7662に準拠し、トークンが無効な場合は以下のレスポンスのみ返却されます：
 
 ```json
 {
-  "active": false,
-  "error": "invalid_token",
-  "error_description": "Sender-constrained access token requires mTLS client certificate, but none was provided.",
-  "status_code": 401
+  "active": false
 }
 ```
 
-#### mTLS証明書のサムプリントが一致しない
-
-```json
-{
-  "active": false,
-  "error": "invalid_token",
-  "error_description": "mTLS client certificate thumbprint does not match the sender-constrained access token.",
-  "status_code": 401
-}
-```
-
-#### スコープ不足（insufficient_scope）
-
-```json
-{
-  "active": false,
-  "error": "insufficient_scope",
-  "error_description": "Requested scopes are not granted. Requested: management, Granted: phone openid profile write email",
-  "status_code": 403
-}
-```
-
-#### アクセストークンが期限切れ（リフレッシュは有効）
-
-```json
-{
-  "active": false,
-  "error": "invalid_token",
-  "error_description": "Access token has expired, but the refresh token is still valid.",
-  "status_code": 401
-}
-```
-
-#### アクセストークンもリフレッシュトークンも期限切れ
-
-```json
-{
-  "active": false,
-  "error": "invalid_token",
-  "error_description": "Token has expired (access and refresh tokens).",
-  "status_code": 401
-}
-```
+**重要**: セキュリティ上の理由から、無効理由の詳細情報は含まれません。これにより、トークン列挙攻撃を防止します。
 
 ---
 
 ## 4. レスポンス属性一覧
 
-| パラメータ         | 型      | 説明                              | 有効時 | 無効時 |
-|--------------------|---------|-----------------------------------|--------|-----|
-| active             | boolean | トークンが有効かどうか            | ○      | ○   |
-| scope              | string  | トークン付与時のスコープ          | ○      | ×   |
-| client_id          | string  | 発行元クライアントID              | ○      | ×   |
-| username           | string  | トークン紐付けユーザ名            | ○      | ×   |
-| exp                | number  | 有効期限（UNIXタイムスタンプ）    | ○      | ×   |
-| iat                | number  | 発行日時（UNIXタイムスタンプ）    | ○      | ×   |
-| nbf                | number  | Not Before（有効開始）            | ○      | ×   |
-| aud                | string  | Audience                          | ○      | ×   |
-| iss                | string  | Issuer                            | ○      | ×   |
-| sub                | string  | Subject (ユーザID)                | ○      | ×   |
-| cnf                | object  | mTLS等の証明書情報                | △      | ×   |
-| error              | string  | エラーコード                      | ×      | ○    |
-| error_description  | string  | エラー詳細                        | ×      | ○    |
-| status_code        | number  | HTTPステータスコード相当          | ×      | ○    |
+| パラメータ | 型      | 説明                           | 有効時 | 無効時 |
+|-----------|---------|--------------------------------|--------|--------|
+| active    | boolean | トークンが有効かどうか         | ○      | ○      |
+| scope     | string  | トークン付与時のスコープ       | ○      | ×      |
+| client_id | string  | 発行元クライアントID           | ○      | ×      |
+| sub       | string  | Subject (ユーザID)             | ○      | ×      |
+| exp       | number  | 有効期限（UNIXタイムスタンプ） | ○      | ×      |
+| iat       | number  | 発行日時（UNIXタイムスタンプ） | ○      | ×      |
+| iss       | string  | Issuer                         | ○      | ×      |
+| cnf       | object  | mTLS等の証明書情報             | △      | ×      |
 
 ○: 返却される　×: 返却されない　△: 条件により返却
+
+**注意**: `username`, `nbf`, `aud` は現在の実装では含まれません。
 
 ---
 
 ## 5. セキュリティ要件
 
 - クライアント認証必須（不正な照会を防ぐ）
-- active: true のときのみ、必要最小限の情報を返却
-- active: false の場合は上記のようなエラー情報を付与
+- `active: true` のときのみ、必要最小限の情報を返却
+- `active: false` の場合は、RFC 7662に準拠し詳細情報を含めない（トークン列挙攻撃の防止）
 
 ---
 


### PR DESCRIPTION
## Summary
Resolves #574

This PR corrects critical inaccuracies in introspection.md documentation, particularly regarding error responses that were inconsistent with both RFC 7662 specification and actual implementation.

## 🚨 Critical Fixes

### 1. Removed Incorrect Error Response Section (3.2)

**Before** (Incorrect):
```json
{
  "active": false,
  "error": "invalid_token",
  "error_description": "...",
  "status_code": 401
}
```

**After** (RFC 7662 Compliant):
```json
{
  "active": false
}
```

**Implementation Verification**:
```java
// TokenIntrospectionContentsCreator.java:50-52
public static Map<String, Object> createFailureContents() {
    return Map.of("active", false);  // Only this!
}
```

**RFC 7662 Spec**:
> "the authorization server MUST return an introspection response with the 'active' field set to 'false' and **without any other claims**"

### 2. Fixed Response Attributes Table

**Removed non-existent attributes**:
- ❌ `username` (only `sub` is implemented)
- ❌ `nbf` (only `iat`/`exp` are implemented)
- ❌ `aud` (not implemented)
- ❌ `error`, `error_description`, `status_code` (never returned for invalid tokens)

**Current implementation attributes** (verified):
| Attribute  | Implemented | Source                          |
|------------|-------------|---------------------------------|
| active     | ✅          | Always returned                 |
| scope      | ✅          | Line 35                         |
| client_id  | ✅          | Line 34                         |
| sub        | ✅          | Line 31-33                      |
| exp        | ✅          | Line 46                         |
| iat        | ✅          | Line 45                         |
| iss        | ✅          | Line 30                         |
| cnf        | ✅          | Line 42-44 (conditional)        |

### 3. Updated Security Requirements

**Before**:
- active: false の場合は上記のようなエラー情報を付与

**After**:
- `active: false` の場合は、RFC 7662に準拠し詳細情報を含めない（トークン列挙攻撃の防止）

## Impact

✅ Documentation now accurately reflects implementation  
✅ RFC 7662 compliance properly documented  
✅ Security best practices emphasized (token enumeration attack prevention)  
✅ Developers will no longer expect non-existent error fields  

## Files Changed
- `documentation/docs/content_04_protocols/introspection.md`
  - Section 3.2: 51 lines removed, 6 lines added
  - Section 4: Attributes table corrected
  - Section 5: Security requirements clarified

## Verification

Verified against implementation:
- `libs/idp-server-core/src/main/java/org/idp/server/core/openid/token/tokenintrospection/TokenIntrospectionContentsCreator.java`