### PR TITLE
Docs: Minor improvements for ciba-flow-fido-uaf.md

### DIFF
--- a/documentation/docs/content_05_how-to/ciba-flow-fido-uaf.md
+++ b/documentation/docs/content_05_how-to/ciba-flow-fido-uaf.md
@@ -1,7 +1,6 @@
 # CIBA + FIDO-UAF
 
-このドキュメントでは、`idp-server`がサポートする **CIBA (Client-Initiated Backchannel Authentication) フロー** における *
-*FIDO-UAF 認証** の利用方法を説明します。
+このドキュメントでは、CIBAフローにおけるFIDO-UAF認証の利用方法を説明します。
 
 FIDO-UAF認証を利用するためには、事前にFIDO-UAFを利用できる[デバイスの登録](mfa-fido-uaf-registration.md)が必要となります。
 
@@ -370,9 +369,12 @@ grant_type=urn:openid:params:grant-type:ciba&auth_req_id=...&client_id=...&clien
 GET {tenant-id}/v1/jwks
 ```
 
-IDの検証後、ペイロードに `amr`（Authentication Method Reference）に`fido-uaf` 値が含まれることを確認できます。
+IDトークン検証後、`amr`（Authentication Method Reference）クレームに以下の値が含まれることを確認できます：
 
-※今後、amrの標準パラメータとしてフィッシング耐性のある認証を実施した証である、`hwk` も含める想定です。
+- `fido-uaf`: FIDO-UAF認証を使用したことを示す
+
+**将来の拡張:**
+フィッシング耐性のある認証を証明するため、RFC 8176標準の`hwk`（Hardware Key Proof-of-Possession）をamrに追加する予定です。
 
 ---
 


### PR DESCRIPTION
## Summary
Resolves #575

This PR implements minor documentation improvements for ciba-flow-fido-uaf.md to enhance readability and clarity.

## Changes

### 1. Simplify Verbose Description (Lines 3-4)

**Before**:
```markdown
このドキュメントでは、`idp-server`がサポートする **CIBA (Client-Initiated Backchannel Authentication) フロー** における **FIDO-UAF 認証** の利用方法を説明します。
```

**After**:
```markdown
このドキュメントでは、CIBAフローにおけるFIDO-UAF認証の利用方法を説明します。
```

**Benefits**:
- ✅ Removed redundant explanations (`idp-server`がサポートする, acronym expansions)
- ✅ More concise and readable

### 2. Clarify amr Value Description (Lines 372-377)

**Before**:
```markdown
IDの検証後、ペイロードに `amr`（Authentication Method Reference）に`fido-uaf` 値が含まれることを確認できます。

※今後、amrの標準パラメータとしてフィッシング耐性のある認証を実施した証である、`hwk` も含める想定です。
```

**After**:
```markdown
IDトークン検証後、`amr`（Authentication Method Reference）クレームに以下の値が含まれることを確認できます：

- `fido-uaf`: FIDO-UAF認証を使用したことを示す

**将来の拡張:**
フィッシング耐性のある認証を証明するため、RFC 8176標準の`hwk`（Hardware Key Proof-of-Possession）をamrに追加する予定です。
```

**Benefits**:
- ✅ Better structured with bullet points
- ✅ Clear explanation of `fido-uaf` value
- ✅ Enhanced future extension note with RFC reference
- ✅ Clear separation: current implementation vs future plans

## Implementation Verification

All content verified against implementation:
- ✅ `fido-uaf` implemented: `StandardAuthenticationMethod.java:23`
- ✅ `hwk` defined but not yet added to amr: `StandardAuthenticationMethodReference.java:25-27`
- ✅ Future extension note is accurate

## Impact

✅ Improved readability and maintainability  
✅ Better user experience for documentation readers  
✅ Clearer technical communication  
✅ No technical changes, documentation only  

## Files Changed
- `documentation/docs/content_05_how-to/ciba-flow-fido-uaf.md`
  - 2 sections improved
  - 6 insertions, 4 deletions