### PR TITLE
Fix MDX compilation error: Change <br> to <br /> in table

### DIFF
--- a/documentation/docs/content_05_how-to/identity-verification-application-guide.md
+++ b/documentation/docs/content_05_how-to/identity-verification-application-guide.md
@@ -129,7 +129,7 @@ pre_hook、execution、store、response…あらゆる場所で出てくる超�
 | `from`         | 取得元を [JsonPath](https://github.com/json-path/JsonPath) で指定                                                                                 |
 | `to`           | セット先キー名。`.`区切りでネスト可能、`*`指定でマージ展開も可能                                                                                                        |
 | `static_value` | 定数を使いたいときに指定（from の代わりに）                                                                                                                   |
-| `functions`    | 値変換関数のリスト。`convert_type`関数で型変換可能。<br>サポート型: `string`, `integer`, `long`, `double`, `boolean`, `datetime` |
+| `functions`    | 値変換関数のリスト。`convert_type`関数で型変換可能。<br />サポート型: `string`, `integer`, `long`, `double`, `boolean`, `datetime` |
 
 > 💡 `from` or `static_value` のどちらかは必須。両方未指定はエラーになる！
 


### PR DESCRIPTION
## Summary

Fix MDX compilation error caused by unclosed `<br>` tag in identity-verification-application-guide.md.

## Error

```
ERROR in ./docs/content_05_how-to/identity-verification-application-guide.md
Error: MDX compilation failed for file
Cause: Expected a closing tag for `<br>` (132:53–132:57) before the end of `tableData`
```

## Fix

Changed `<br>` to `<br />` on line 132 to comply with MDX self-closing tag requirement.

**Before:**
```markdown
| `functions`    | 値変換関数のリスト。`convert_type`関数で型変換可能。<br>サポート型: ... |
```

**After:**
```markdown
| `functions`    | 値変換関数のリスト。`convert_type`関数で型変換可能。<br />サポート型: ... |
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)