### PR TITLE
Add Spring Boot Actuator configuration (Issue #413)

### DIFF
--- a/app/src/main/resources/application.yaml
+++ b/app/src/main/resources/application.yaml
@@ -130,3 +130,19 @@ server:
     threads:
       max: ${SERVER_TOMCAT_THREADS_MAX:300}
       min-spare: ${SERVER_TOMCAT_THREADS_MIN_SPARE:50}
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: "${MANAGEMENT_ENDPOINTS_WEB_EXPOSURE_INCLUDE:health,info,metrics,prometheus}"
+      base-path: "${MANAGEMENT_ENDPOINTS_WEB_BASE_PATH:/actuator}"
+  endpoint:
+    health:
+      show-details: "${MANAGEMENT_ENDPOINT_HEALTH_SHOW_DETAILS:when-authorized}"
+      probes:
+        enabled: ${MANAGEMENT_ENDPOINT_HEALTH_PROBES_ENABLED:true}
+  metrics:
+    export:
+      prometheus:
+        enabled: ${MANAGEMENT_METRICS_EXPORT_PROMETHEUS_ENABLED:true}


### PR DESCRIPTION
## Summary

Adds comprehensive Spring Boot Actuator configuration to `application.yaml`, addressing the critical gap identified in Issue #413 for OSS users.

## Changes

Added management configuration with environment variable support:
- health: Application health checks with Kubernetes probes
- info: Application information
- metrics: Application metrics  
- prometheus: Prometheus metrics export

## Environment Variables

| Variable | Default | Purpose |
|----------|---------|---------|
| `MANAGEMENT_ENDPOINTS_WEB_EXPOSURE_INCLUDE` | `health,info,metrics,prometheus` | Exposed endpoints |
| `MANAGEMENT_ENDPOINT_HEALTH_SHOW_DETAILS` | `when-authorized` | Health details visibility |
| `MANAGEMENT_ENDPOINT_HEALTH_PROBES_ENABLED` | `true` | Kubernetes probes |
| `MANAGEMENT_METRICS_EXPORT_PROMETHEUS_ENABLED` | `true` | Prometheus export |

## Test Plan

- [x] Build successful
- [x] Environment variables with proper defaults
- [x] Follows Spring Boot Actuator conventions

## Related Issues

Closes part of #413

🤖 Generated with [Claude Code](https://claude.com/claude-code)