### PR TITLE
Fix Issue #593: Update CIBA notification implementation description

### DIFF
--- a/documentation/docs/content_04_protocols/ciba-flow.md
+++ b/documentation/docs/content_04_protocols/ciba-flow.md
@@ -48,8 +48,9 @@ CIBA 仕様 に準拠し、login_hint はユーザー識別のヒントとして
 
 ## ユーザー通知・端末連携
 
-- 通知は FCM (Firebase Cloud Messaging) や APNs を介してスマホに送信します。
-- 認証内容（取引明細など）は `authentication_context` 経由で端末に提示
+- ユーザー端末への通知は `AuthenticationDeviceNotifier` プラグインにより実行されます
+  - デフォルト実装: FCM (Firebase Cloud Messaging) / APNs対応
+  - 通知チャネルは `AuthenticationDevice` の設定で制御
 
 ## 認証方式
 


### PR DESCRIPTION
## Summary

Resolves #593

Issue #593で指摘された2つの問題のうち、設定キー名 `backchannel_authentication_request_expires_in` はすでに修正済みでした。
本PRでは、通知実装の説明を実装詳細に合わせて更新します。

## Changes

### ✅ 設定キー名（すでに修正済み）
- `backchannel_authentication_request_expires_in` は正しく記載されていることを確認

### 📝 通知実装の説明を更新
**Before:**
```markdown
- 通知は FCM (Firebase Cloud Messaging) や APNs を介してスマホに送信します。
- 認証内容（取引明細など）は `authentication_context` 経由で端末に提示
```

**After:**
```markdown
- ユーザー端末への通知は `AuthenticationDeviceNotifier` プラグインにより実行されます
  - デフォルト実装: FCM (Firebase Cloud Messaging) / APNs対応
  - 通知チャネルは `AuthenticationDevice` の設定で制御
```

## 変更理由

1. **プラグインアーキテクチャの明示**: 実装では `AuthenticationDeviceNotifier` プラグイン経由で通知を実行
2. **通知チャネル制御の説明**: `AuthenticationDevice` の設定で制御することを明記
3. **未実装機能の削除**: `authentication_context` による認証内容提示は未実装のため記載削除

## Test plan

- [x] ドキュメントの可読性確認
- [x] 実装コードとの整合性確認
  - `AuthenticationDeviceNotificationInteractor.java:107`
  - `config-sample/local/admin-tenant/authentication-configurations/multi-push-notification.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)