### PR TITLE
Fix Issue #589: Update FIDO-UAF authentication documentation

### DIFF
--- a/documentation/docs/content_06_developer-guide/configuration/authn/fido-uaf.md
+++ b/documentation/docs/content_06_developer-guide/configuration/authn/fido-uaf.md
@@ -24,54 +24,422 @@ FIDO-UAF認証は以下の複数のインタラクションを連続的に実行
 
 ## 設定
 
-設定には `fido-uaf` をキーとする `AuthenticationConfiguration` をテナントごとに登録する必要があります。
+設定には `type = "fido-uaf"` の `AuthenticationConfiguration` をテナントごとに登録する必要があります。
 
-### 外部FIDOサーバー
+FIDO-UAF認証は `interactions` ベースの設定構造を持ち、以下の6つのインタラクションを定義します。
 
-#### 設定項目（テンプレート定義）
+### トップレベル設定項目
 
-| 項目                    | 内容                    |
-|-----------------------|-----------------------|
-| `type`                | `external-authn` 固定   |
-| `device_id_param`     | 外部サービスのデバイスIDのパラメータ名  |
-| `oauth_authorization` | 外部APIへの認証情報（OAuth2設定） |
-| `executions`          | 外部サービスAPI定義           |
+| 項目            | 内容                           |
+|---------------|------------------------------|
+| `id`          | 設定ID（UUID形式）                  |
+| `type`        | `fido-uaf` 固定                 |
+| `attributes`  | 外部サービス設定（type, service_name） |
+| `interactions` | インタラクション定義（6つのFIDO操作）         |
 
-外部FIDOサーバーのAPI定義を6つ設定することができます。
+### attributes設定項目
 
-1. facets FIDO-UAFのメタデータ取得API用の設定
-2. registration-challenge 登録チャレンジ用のAPI設定
-3. registration 登録用のAPI設定
-4. authentication-challenge 認証チャレンジ用のAPI設定
-5. authentication 認証用のAPI設定
-6. delete-key 鍵の削除用のAPI設定
+| 項目                | 内容                              |
+|-------------------|-----------------------------------|
+| `type`            | `external` 固定（外部FIDOサーバー利用）      |
+| `service_name`    | サービス識別名（例：`mocky`）               |
 
-#### API定義項目
+---
 
-外部サービスのAPI仕様に応じて設定を行います。
+## インタラクション概要
 
-| 項目                  | 説明                                                   |
-|---------------------|------------------------------------------------------|
-| `url`               | 外部サービスAPIのURL。POSTで呼び出される。                           |
-| `method`            | HTTPメソッド（通常は `"POST"`）                               |
-| `headers`           | API呼び出し時のHTTPヘッダ（`Content-Type`, `Authorization` など） |
-| `dynamic_body_keys` | APIリクエストbodyに含める動的キー。ユーザー入力などから取得                    |
-| `static_body`       | APIリクエストbodyに含める固定キー（例：`{"service_code": "001"}`）    |
+FIDO-UAF認証では以下の6つのインタラクションを設定します。すべて `http_request` executorを使用して外部FIDOサーバーと連携します。
+
+### フロー別分類
+
+| フェーズ | インタラクション | 用途 | 呼び出し元 |
+|---------|----------------|------|-----------|
+| **初期設定** | `fido-uaf-facets` | Trusted Facetsメタデータ取得 | クライアントアプリ |
+| **デバイス登録** | `fido-uaf-registration-challenge` | 登録チャレンジ生成 | 管理API |
+| | `fido-uaf-registration` | デバイス登録・検証 | 管理API |
+| **認証** | `fido-uaf-authentication-challenge` | 認証チャレンジ生成 | 認可フロー |
+| | `fido-uaf-authentication` | 認証応答検証 | 認可フロー |
+| **登録解除** | `fido-uaf-deregistration` | デバイス登録削除 | 管理API |
+
+---
+
+## OAuth2認証設定
+
+各インタラクションの`oauth_authorization`で外部FIDOサーバーへの認証を設定します。
+
+| 項目                      | 説明                                |
+|-------------------------|-------------------------------------|
+| `type`                  | `password` (Resource Owner Password Credentials) |
+| `token_endpoint`        | トークンエンドポイントURL                     |
+| `client_id`             | クライアントID                           |
+| `username`              | ユーザー名                              |
+| `password`              | パスワード                              |
+| `scope`                 | スコープ                               |
+| `cache_enabled`         | トークンキャッシュ有効化（`true`/`false`）       |
+| `cache_ttl_seconds`     | キャッシュ有効期限（秒）                       |
+| `cache_buffer_seconds`  | キャッシュ更新バッファ時間（秒）                   |
+
+**キャッシング**: 外部FIDO APIへの認証トークン取得はコストが高いため、`cache_enabled: true`でトークンをキャッシュすることを推奨します。
+
+---
+
+## 設定例
+
+```json
+{
+  "id": "dd290cfa-e1f4-4a5f-88bf-e4958519ceac",
+  "type": "fido-uaf",
+  "attributes": {
+    "type": "external",
+    "service_name": "mocky"
+  },
+  "interactions": {
+    "fido-uaf-facets": {
+      "execution": {
+        "function": "http_request",
+        "http_request": {
+          "url": "http://localhost:4000/fido-uaf/facets",
+          "method": "GET",
+          "auth_type": "oauth2",
+          "oauth_authorization": {
+            "type": "password",
+            "token_endpoint": "http://localhost:4000/token",
+            "client_id": "your-client-id",
+            "username": "username",
+            "password": "password",
+            "scope": "application",
+            "cache_buffer_seconds": 10,
+            "cache_ttl_seconds": 1800,
+            "cache_enabled": true
+          },
+          "header_mapping_rules": [
+            {
+              "static_value": "application/json",
+              "to": "Content-Type"
+            }
+          ]
+        }
+      },
+      "response": {
+        "body_mapping_rules": [
+          {
+            "from": "$.execution_http_request.response_body",
+            "to": "*"
+          }
+        ]
+      }
+    },
+    "fido-uaf-registration-challenge": {
+      "execution": {
+        "function": "http_request",
+        "http_request": {
+          "url": "http://localhost:4000/fido-uaf/registration-challenge",
+          "method": "POST",
+          "auth_type": "oauth2",
+          "oauth_authorization": {
+            "type": "password",
+            "token_endpoint": "http://localhost:4000/token",
+            "client_id": "your-client-id",
+            "username": "username",
+            "password": "password",
+            "scope": "application",
+            "cache_buffer_seconds": 10,
+            "cache_ttl_seconds": 1800,
+            "cache_enabled": true
+          },
+          "header_mapping_rules": [
+            {
+              "static_value": "application/json",
+              "to": "Content-Type"
+            }
+          ],
+          "body_mapping_rules": [
+            {
+              "from": "$.request_body",
+              "to": "*"
+            }
+          ]
+        }
+      },
+      "response": {
+        "body_mapping_rules": [
+          {
+            "from": "$.execution_http_request.response_body",
+            "to": "*"
+          }
+        ]
+      }
+    },
+    "fido-uaf-registration": {
+      "execution": {
+        "function": "http_request",
+        "http_request": {
+          "url": "http://localhost:4000/fido-uaf/registration",
+          "method": "POST",
+          "auth_type": "oauth2",
+          "oauth_authorization": {
+            "type": "password",
+            "token_endpoint": "http://localhost:4000/token",
+            "client_id": "your-client-id",
+            "username": "username",
+            "password": "password",
+            "scope": "application",
+            "cache_buffer_seconds": 10,
+            "cache_ttl_seconds": 1800,
+            "cache_enabled": true
+          },
+          "header_mapping_rules": [
+            {
+              "static_value": "application/json",
+              "to": "Content-Type"
+            }
+          ],
+          "body_mapping_rules": [
+            {
+              "from": "$.request_body",
+              "to": "*"
+            }
+          ]
+        }
+      },
+      "response": {
+        "body_mapping_rules": [
+          {
+            "from": "$.execution_http_request.response_body",
+            "to": "*"
+          }
+        ]
+      }
+    },
+    "fido-uaf-authentication-challenge": {
+      "execution": {
+        "function": "http_request",
+        "http_request": {
+          "url": "http://localhost:4000/fido-uaf/authentication-challenge",
+          "method": "POST",
+          "auth_type": "oauth2",
+          "oauth_authorization": {
+            "type": "password",
+            "token_endpoint": "http://localhost:4000/token",
+            "client_id": "your-client-id",
+            "username": "username",
+            "password": "password",
+            "scope": "application",
+            "cache_buffer_seconds": 10,
+            "cache_ttl_seconds": 1800,
+            "cache_enabled": true
+          },
+          "header_mapping_rules": [
+            {
+              "static_value": "application/json",
+              "to": "Content-Type"
+            }
+          ],
+          "body_mapping_rules": [
+            {
+              "from": "$.request_body",
+              "to": "*"
+            }
+          ]
+        }
+      },
+      "response": {
+        "body_mapping_rules": [
+          {
+            "from": "$.execution_http_request.response_body",
+            "to": "*"
+          }
+        ]
+      }
+    },
+    "fido-uaf-authentication": {
+      "execution": {
+        "function": "http_request",
+        "http_request": {
+          "url": "http://localhost:4000/fido-uaf/authentication",
+          "method": "POST",
+          "auth_type": "oauth2",
+          "oauth_authorization": {
+            "type": "password",
+            "token_endpoint": "http://localhost:4000/token",
+            "client_id": "your-client-id",
+            "username": "username",
+            "password": "password",
+            "scope": "application",
+            "cache_buffer_seconds": 10,
+            "cache_ttl_seconds": 1800,
+            "cache_enabled": true
+          },
+          "header_mapping_rules": [
+            {
+              "static_value": "application/json",
+              "to": "Content-Type"
+            }
+          ],
+          "body_mapping_rules": [
+            {
+              "from": "$.request_body",
+              "to": "*"
+            }
+          ]
+        }
+      },
+      "response": {
+        "body_mapping_rules": [
+          {
+            "from": "$.execution_http_request.response_body",
+            "to": "*"
+          }
+        ]
+      }
+    },
+    "fido-uaf-deregistration": {
+      "execution": {
+        "function": "http_request",
+        "http_request": {
+          "url": "http://localhost:4000/fido-uaf/delete-key",
+          "method": "POST",
+          "auth_type": "oauth2",
+          "oauth_authorization": {
+            "type": "password",
+            "token_endpoint": "http://localhost:4000/token",
+            "client_id": "your-client-id",
+            "username": "username",
+            "password": "password",
+            "scope": "application",
+            "cache_buffer_seconds": 10,
+            "cache_ttl_seconds": 1800,
+            "cache_enabled": true
+          },
+          "header_mapping_rules": [
+            {
+              "static_value": "application/json",
+              "to": "Content-Type"
+            }
+          ],
+          "body_mapping_rules": [
+            {
+              "from": "$.request_body",
+              "to": "*"
+            }
+          ]
+        }
+      },
+      "response": {
+        "body_mapping_rules": [
+          {
+            "from": "$.execution_http_request.response_body",
+            "to": "*"
+          }
+        ]
+      }
+    }
+  }
+}
+```
 
 ---
 
 ## 利用方法
 
-### 事前準備
+### 全体フロー
 
-* テナントに `type = "fido-uaf"` の設定（`AuthenticationConfiguration`）を登録する
+FIDO-UAF認証は以下の4つのフェーズで構成されます：
 
-### 認証時の流れ
+1. **Facetsメタデータ取得**: クライアントアプリが信頼できるファセット情報を取得
+2. **デバイス登録**: 管理APIでユーザーの生体認証デバイスを登録
+3. **認証**: 認可フロー中で登録済みデバイスによる認証
+4. **デバイス登録解除**: 管理APIでデバイスの登録を削除
 
-1. クライアントが `/v1/authorizations/{id}/fido-uaf-authentication-challenge` にリクエストし、チャレンジを取得
-2. FIDO対応の認証器（デバイス）で認証を実行し、認証応答（signed assertion）を
-   `/v1/authorizations/{id}/fido-uaf-authentication` に送信
-3. サーバー側で応答を検証し、成功時に `Authentication` オブジェクトを生成して返却
+---
+
+### 1. Facetsメタデータ取得
+
+クライアントアプリケーションがFIDO-UAFの信頼できるファセット（Trusted Facets）情報を取得します。
+
+```http
+GET /{tenant-id}/fido-uaf/facets
+```
+
+**レスポンス**: FIDO-UAF仕様に準拠したTrusted Facets List
+
+---
+
+### 2. デバイス登録フロー（管理API）
+
+ユーザーが自分の生体認証デバイスを登録します。管理API経由で実行します。
+
+#### Step 1: 登録チャレンジ取得
+
+```http
+POST /v1/me/authentication-devices/fido-uaf/registration-challenge
+Authorization: Bearer {access_token}
+```
+
+**レスポンス**: FIDO-UAF登録チャレンジ（Registration Request）
+
+#### Step 2: デバイス登録
+
+クライアントアプリが生体認証デバイスで署名した登録応答をサーバーに送信します。
+
+```http
+POST /v1/me/authentication-devices/fido-uaf/registration
+Authorization: Bearer {access_token}
+Content-Type: application/json
+
+{
+  "uafResponse": "eyJ...（FIDO-UAF Registration Response）"
+}
+```
+
+**レスポンス**: 登録成功時のデバイス情報
+
+---
+
+### 3. 認証フロー（認可フロー中）
+
+認可リクエスト中にFIDO-UAF認証を実行します。
+
+#### Step 1: 認証チャレンジ取得
+
+```http
+POST /v1/authorizations/{authorization_id}/fido-uaf-authentication-challenge
+```
+
+**レスポンス**: FIDO-UAF認証チャレンジ（Authentication Request）
+
+#### Step 2: 認証
+
+クライアントアプリが生体認証デバイスで署名した認証応答をサーバーに送信します。
+
+```http
+POST /v1/authorizations/{authorization_id}/fido-uaf-authentication
+Content-Type: application/json
+
+{
+  "uafResponse": "eyJ...（FIDO-UAF Authentication Response）"
+}
+```
+
+**レスポンス**: 認証成功時の認証情報
+
+---
+
+### 4. デバイス登録解除フロー（管理API）
+
+登録済みデバイスを削除します。
+
+```http
+POST /v1/me/authentication-devices/fido-uaf/deregistration
+Authorization: Bearer {access_token}
+Content-Type: application/json
+
+{
+  "device_id": "device-uuid"
+}
+```
+
+**レスポンス**: 削除成功確認
 
 ---
 


### PR DESCRIPTION
## Summary

FIDO-UAF認証設定ドキュメント（`fido-uaf.md`）を初学者にも分かりやすい構成に再構築し、実装に一致させました。

## Changes

### 構成改善
- **インタラクション概要を追加**: 6つのインタラクションをフロー別に分類（初期設定/デバイス登録/認証/登録解除）
- **全体フローを明確化**: 4つのフェーズ（Facetsメタデータ取得/デバイス登録/認証/登録解除）に分けて説明
- **管理APIフローを追加**: デバイス登録・解除の管理API利用方法を追加
- **認可フローとの違いを明確化**: 呼び出し元（管理API vs 認可フロー）を表で整理

### 実装との整合性修正
- **未使用パラメータ削除**: `device_id_param`を削除（実装で参照されていない）
- **OAuth2キャッシュ設定を追加**: トークンキャッシュ設定の説明とベストプラクティス
- **完全な設定例を追加**: 実際の設定ファイル（`external.json`）に一致

### ドキュメント構造
```
設定
├─ トップレベル設定項目
├─ attributes設定項目
├─ インタラクション概要（フロー別分類表）
├─ OAuth2認証設定
└─ 設定例（完全な例）

利用方法
├─ 全体フロー（4フェーズ）
├─ 1. Facetsメタデータ取得
├─ 2. デバイス登録フロー（管理API）
├─ 3. 認証フロー（認可フロー）
└─ 4. デバイス登録解除（管理API）
```

## Test plan

- [x] 実装コードとの整合性確認（`FidoUafRegistrationInteractor.java`等）
- [x] 設定ファイルとの整合性確認（`config/examples/local/admin-tenant/authentication-config/fido-uaf/external.json`）
- [x] 未使用パラメータの確認（`device_id_param`が実装で参照されていないことを確認）
- [x] 6つのインタラクション定義の確認（`StandardAuthenticationInteraction.java`）

## Related Issue

Fixes #589

🤖 Generated with [Claude Code](https://claude.com/claude-code)