### PR TITLE
fix: prevent NullPointerException in Role.permissionsAsMap()

### DIFF
--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/identity/role/Role.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/identity/role/Role.java
@@ -57,6 +57,9 @@ public class Role implements Serializable, UuidConvertable {
   }
 
   public List<Map<String, Object>> permissionsAsMap() {
+    if (permissions == null) {
+      return List.of();
+    }
     return permissions.stream().map(Permission::toMap).toList();
   }
 


### PR DESCRIPTION
Add null check to prevent NPE when permissions field is null. This occurs when deleting a role via DELETE /v1/management/tenants/{tenantId}/roles/{roleId}

Fixes #TBD