### PR TITLE
Add authorization code expiration verification (Issue #695)

### DIFF
--- a/config/examples/e2e/test-tenant/authorization-server/idp-server.json
+++ b/config/examples/e2e/test-tenant/authorization-server/idp-server.json
@@ -200,6 +200,7 @@
     "access_token_type": "JWT",
     "token_signed_key_id": "id_token_nextauth",
     "id_token_signed_key_id": "id_token_nextauth",
+    "authorization_code_valid_duration": 10,
     "access_token_duration": 3600,
     "id_token_duration": 3600,
     "id_token_strict_mode": false,

--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/oauth/OAuthAuthorizeContext.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/oauth/OAuthAuthorizeContext.java
@@ -177,7 +177,7 @@ public class OAuthAuthorizeContext implements ResponseModeDecidable {
   public ExpiresAt authorizationCodeGrantExpiresDateTime() {
     LocalDateTime localDateTime = SystemDateTime.now();
     int duration = authorizationServerConfiguration.authorizationCodeValidDuration();
-    return new ExpiresAt(localDateTime.plusMinutes(duration));
+    return new ExpiresAt(localDateTime.plusSeconds(duration));
   }
 
   public RequestedIdTokenClaims idTokenClaims() {

--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/token/verifier/AuthorizationCodeGrantBaseVerifier.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/token/verifier/AuthorizationCodeGrantBaseVerifier.java
@@ -22,6 +22,7 @@ import org.idp.server.core.openid.oauth.request.AuthorizationRequest;
 import org.idp.server.core.openid.oauth.type.oauth.GrantType;
 import org.idp.server.core.openid.token.TokenRequestContext;
 import org.idp.server.core.openid.token.exception.TokenBadRequestException;
+import org.idp.server.platform.date.SystemDateTime;
 
 public class AuthorizationCodeGrantBaseVerifier {
 
@@ -34,6 +35,7 @@ public class AuthorizationCodeGrantBaseVerifier {
     throwExceptionIfUnSupportedGrantTypeWithClient(tokenRequestContext);
     throwExceptionIfNotFoundAuthorizationCode(
         tokenRequestContext, authorizationRequest, authorizationCodeGrant);
+    throwExceptionIfExpiredAuthorizationCode(authorizationCodeGrant);
     throwExceptionIfUnMatchRedirectUri(tokenRequestContext, authorizationRequest);
   }
 
@@ -90,6 +92,23 @@ public class AuthorizationCodeGrantBaseVerifier {
     }
     if (!authorizationCodeGrant.isGrantedClient(tokenRequestContext.clientIdentifier())) {
       throw new TokenBadRequestException("invalid_grant", "not found authorization code.");
+    }
+  }
+
+  /**
+   * 5.2. Error Response invalid_grant
+   *
+   * <p>The provided authorization grant (e.g., authorization code, resource owner credentials) or
+   * refresh token is invalid, expired, revoked, does not match the redirection URI used in the
+   * authorization request, or was issued to another client.
+   *
+   * <p>ensure that the authorization code has not expired
+   *
+   * @see <a href="https://www.rfc-editor.org/rfc/rfc6749#section-5.2">5.2. Error Response</a>
+   */
+  void throwExceptionIfExpiredAuthorizationCode(AuthorizationCodeGrant authorizationCodeGrant) {
+    if (authorizationCodeGrant.isExpire(SystemDateTime.now())) {
+      throw new TokenBadRequestException("invalid_grant", "authorization code is expired");
     }
   }
 


### PR DESCRIPTION
## Summary
- Add authorization code expiration verification during token requests
- Fix critical bug in authorization code expiration calculation (60x duration error)
- Add E2E test for expired authorization code scenario

## Changes
### 1. Authorization Code Expiration Verification
**File**: `libs/idp-server-core/src/main/java/org/idp/server/core/openid/token/verifier/AuthorizationCodeGrantBaseVerifier.java`
- Added `throwExceptionIfExpiredAuthorizationCode()` method
- Returns `invalid_grant` error with message "authorization code is expired"
- Uses `SystemDateTime.now()` for consistent time handling
- Follows existing verifier pattern (separate method per validation)

### 2. Bug Fix: Authorization Code Expiration Calculation
**File**: `libs/idp-server-core/src/main/java/org/idp/server/core/openid/oauth/OAuthAuthorizeContext.java:180`
- **Issue**: Used `plusMinutes(duration)` instead of `plusSeconds(duration)`
- **Impact**: Expiration time was 60x longer than intended (600 seconds → 600 minutes = 10 hours)
- **Fix**: Changed to `plusSeconds(duration)` for correct calculation

### 3. E2E Test
**File**: `e2e/src/tests/spec/rfc6749_4_1_code.test.js:683-713`
- Added test case for expired authorization code
- Test waits for code expiration and verifies proper error response
- Validates error format per RFC 6749 Section 5.2

### 4. Test Configuration
**File**: `config/examples/e2e/test-tenant/authorization-server/idp-server.json`
- Added `authorization_code_valid_duration: 10` for faster test execution

## Test Plan
- [x] Build succeeds (`./gradlew build -x test`)
- [x] Code formatting applied (`./gradlew spotlessApply`)
- [x] E2E test added for expired authorization code scenario
- [ ] Run E2E tests to verify expiration handling: `cd e2e && npm test -- rfc6749_4_1_code.test.js`
- [ ] Verify existing authorization code flow tests still pass

## Related Issue
Fixes #695

🤖 Generated with [Claude Code](https://claude.com/claude-code)