### PR TITLE
Fix CORS Origin validation vulnerability

### DIFF
--- a/libs/idp-server-springboot-adapter/src/main/java/org/idp/server/adapters/springboot/DynamicCorsFilter.java
+++ b/libs/idp-server-springboot-adapter/src/main/java/org/idp/server/adapters/springboot/DynamicCorsFilter.java
@@ -60,7 +60,7 @@ public class DynamicCorsFilter extends OncePerRequestFilter {
       String origin = request.getHeader("Origin") != null ? request.getHeader("Origin") : "";
       String allowOrigin =
           allowOrigins.stream()
-              .filter(allow -> allow.contains(origin))
+              .filter(allow -> allow.equals(origin))
               .findFirst()
               .orElse(tenant.domain().value());
       log.debug(


### PR DESCRIPTION
## Summary
CORS Origin検証の脆弱性を修正しました。部分一致（`contains()`）から完全一致（`equals()`）に変更。

## Security Vulnerability

**ファイル**: `libs/idp-server-springboot-adapter/src/main/java/org/idp/server/adapters/springboot/DynamicCorsFilter.java:63`

**問題**: `contains()`による部分一致検証

```java
// ❌ Before: 脆弱
allowOrigins.stream()
    .filter(allow -> allow.contains(origin))  // 部分一致
    .findFirst()
```

**攻撃例**:
```
設定: allow_origins = ["https://app.example.com"]

攻撃者のOrigin: https://app.example.com.evil.com
Before: ✅ 受け入れ（"https://app.example.com" が含まれる）
After:  ❌ 拒否（完全一致しない）
```

## Changes

```java
// ✅ After: 安全
allowOrigins.stream()
    .filter(allow -> allow.equals(origin))  // 完全一致
    .findFirst()
```

**変更行**: 1行（DynamicCorsFilter.java:63）

## Security Impact

### 防止される攻撃

1. **サブドメイン乗っ取り攻撃**
   - `https://app.example.com.attacker.com` からのアクセス拒否

2. **Origin Validation Bypass**
   - 部分文字列マッチングによるバイパス防止

3. **CORS Misconfiguration Exploit**
   - 意図しないオリジンからのクレデンシャル付きリクエスト防止

### CVSS評価
- **Before**: CVSS 7.5 (High) - Origin Validation Bypass
- **After**: 脆弱性解消

## Test Plan

- [x] ビルド成功（`./gradlew build -x test`）
- [x] Spotless適用済み
- [ ] E2Eテスト（CORS検証）
  - 許可オリジンからのリクエスト → 成功
  - 部分一致オリジンからのリクエスト → 失敗

## Testing Recommendation

```bash
# テストケース1: 正当なOrigin
curl -H "Origin: https://app.example.com" \
  https://idp.example.com/tenant-id/v1/userinfo

# テストケース2: 攻撃者のOrigin（防止すべき）
curl -H "Origin: https://app.example.com.evil.com" \
  https://idp.example.com/tenant-id/v1/userinfo
# → Access-Control-Allow-Origin にevilドメインが含まれないことを確認
```

## Related Issues

Fixes #710

Part of #641 (脆弱性診断_20251009) - High優先度修正

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)