### PR TITLE
Add UIConfiguration base_url support for external UI hosting

### DIFF
--- a/config/templates/tenant-template.json
+++ b/config/templates/tenant-template.json
@@ -6,6 +6,7 @@
     "authorization_provider": "idp-server",
     "database_type": "postgresql",
     "ui_config": {
+      "base_url": "",
       "signup_page": "/auth-views/signup/index.html",
       "signin_page": "/auth-views/signin/index.html"
     },

--- a/documentation/openapi/swagger-control-plane-en.yaml
+++ b/documentation/openapi/swagger-control-plane-en.yaml
@@ -7108,6 +7108,10 @@ components:
     UIConfiguration:
       type: object
       properties:
+        base_url:
+          type: string
+          description: Base URL for UI hosting (optional). When configured, authentication screens are served from this URL instead of the tenant domain. Enables cross-origin UI scenarios (e.g., localhost:3000 for development).
+          example: http://localhost:3000
         signup_page:
           type: string
           default: /auth-views/signup/index.html

--- a/documentation/openapi/swagger-control-plane-ja.yaml
+++ b/documentation/openapi/swagger-control-plane-ja.yaml
@@ -6826,6 +6826,10 @@ components:
     UIConfiguration:
       type: object
       properties:
+        base_url:
+          type: string
+          description: UIホスティング用のベースURL（オプション）。設定すると、認証画面はテナントドメインではなくこのURLから提供されます。クロスオリジンUIシナリオ（開発用のlocalhost:3000など）に対応します。
+          example: http://localhost:3000
         signup_page:
           type: string
           default: /auth-views/signup/index.html

--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/oauth/view/OAuthViewUrlResolver.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/oauth/view/OAuthViewUrlResolver.java
@@ -29,7 +29,7 @@ public class OAuthViewUrlResolver {
   public static String resolve(OAuthRequestContext context) {
     Tenant tenant = context.tenant();
     UIConfiguration uiConfiguration = tenant.uiConfiguration();
-    String base = context.tenant().domain().value();
+    String base = tenant.baseUrl();
 
     if (context.isPromptCreate()) {
       String signupPage = uiConfiguration.signupPage();
@@ -41,7 +41,7 @@ public class OAuthViewUrlResolver {
   }
 
   public static String resolveError(Tenant tenant, Error error, ErrorDescription errorDescription) {
-    String base = tenant.domain().value();
+    String base = tenant.baseUrl();
     return String.format(
         "%s/error?error=%s&error_description=%s&tenant_id=%s",
         base, error.value(), errorDescription.value(), tenant.identifier().value());

--- a/libs/idp-server-platform/src/main/java/org/idp/server/platform/multi_tenancy/tenant/Tenant.java
+++ b/libs/idp-server-platform/src/main/java/org/idp/server/platform/multi_tenancy/tenant/Tenant.java
@@ -158,6 +158,22 @@ public class Tenant {
   }
 
   /**
+   * Returns base URL for UI hosting.
+   *
+   * <p>Prioritizes UIConfiguration base_url if configured, otherwise uses tenant domain. This
+   * enables hosting UI on separate domains (e.g., localhost:3000) for development and cross-origin
+   * scenarios.
+   *
+   * @return configured base URL or tenant domain value
+   */
+  public String baseUrl() {
+    if (uiConfiguration.hasBaseUrl()) {
+      return uiConfiguration.baseUrl();
+    }
+    return domain.value();
+  }
+
+  /**
    * Returns session cookie name with tenant ID suffix for default configuration.
    *
    * <p>For multi-tenant isolation, generates tenant-specific cookie name when no custom name is

--- a/libs/idp-server-platform/src/main/java/org/idp/server/platform/multi_tenancy/tenant/config/UIConfiguration.java
+++ b/libs/idp-server-platform/src/main/java/org/idp/server/platform/multi_tenancy/tenant/config/UIConfiguration.java
@@ -28,18 +28,39 @@ import java.util.Objects;
  */
 public class UIConfiguration {
 
+  private final String baseUrl;
   private final String signupPage;
   private final String signinPage;
 
   public UIConfiguration() {
+    this.baseUrl = null;
     this.signupPage = "/auth-views/signup/index.html";
     this.signinPage = "/auth-views/signin/index.html";
   }
 
   public UIConfiguration(Map<String, Object> values) {
     Map<String, Object> safeValues = Objects.requireNonNullElseGet(values, HashMap::new);
+    this.baseUrl = extractString(safeValues, "base_url", null);
     this.signupPage = extractString(safeValues, "signup_page", "/auth-views/signup/index.html");
     this.signinPage = extractString(safeValues, "signin_page", "/auth-views/signin/index.html");
+  }
+
+  /**
+   * Returns the base URL for UI hosting
+   *
+   * @return base URL or null if not configured
+   */
+  public String baseUrl() {
+    return baseUrl;
+  }
+
+  /**
+   * Checks if base URL is configured
+   *
+   * @return true if base URL is set and not empty
+   */
+  public boolean hasBaseUrl() {
+    return baseUrl != null && !baseUrl.isEmpty();
   }
 
   /**
@@ -67,6 +88,9 @@ public class UIConfiguration {
    */
   public Map<String, Object> toMap() {
     Map<String, Object> map = new HashMap<>();
+    if (baseUrl != null) {
+      map.put("base_url", baseUrl);
+    }
     map.put("signup_page", signupPage);
     map.put("signin_page", signinPage);
     return map;


### PR DESCRIPTION
## Summary

Adds `base_url` support to `UIConfiguration`, enabling authentication screens to be hosted on separate domains (e.g., `http://localhost:3000` for development). Maintains full backward compatibility.

## Changes

### 1. UIConfiguration Enhancement
- **Added**: `base_url` optional field (default: null)
- **Added**: `hasBaseUrl()` helper method
- **Updated**: `toMap()` to include `base_url` when configured
- **File**: `libs/idp-server-platform/.../UIConfiguration.java`

### 2. Tenant Encapsulation
- **Added**: `baseUrl()` method with domain fallback logic
- **Design**: Follows `sessionCookieName()` pattern
- **Benefits**: Encapsulates "base_url if configured, else domain" logic
- **File**: `libs/idp-server-platform/.../Tenant.java`

### 3. OAuthViewUrlResolver Simplification
- **Updated**: `resolve()` to use `tenant.baseUrl()`
- **Updated**: `resolveError()` to use `tenant.baseUrl()`
- **Removed**: Law of Demeter violations
- **File**: `libs/idp-server-core/.../OAuthViewUrlResolver.java`

### 4. Configuration & Documentation
- **Updated**: `tenant-template.json` with `base_url` field
- **Updated**: `swagger-control-plane-en.yaml` with parameter documentation
- **Updated**: `swagger-control-plane-ja.yaml` with Japanese documentation

## Behavior

### Before (Current)
```
Tenant Domain: https://tenant1.example.com
↓
Auth URL: https://tenant1.example.com/auth-views/signin/index.html
```

### After (With base_url configured)
```
UIConfig base_url: http://localhost:3000
Tenant Domain: https://tenant1.example.com
↓
Auth URL: http://localhost:3000/auth-views/signin/index.html
```

### Backward Compatibility
✅ When `base_url` is **not configured** → uses tenant domain (current behavior)  
✅ When `base_url` is **configured** → uses specified URL (new feature)

## Use Case

Supports **PR #743** (app-view Docker containerization) for CORS validation:
- Frontend: `http://localhost:3000` (app-view container)
- Backend: `http://localhost:8080` (idp-server)
- Enables testing cross-origin authentication flows

## Design Decisions

### Why `Tenant.baseUrl()` instead of direct access?
- **Encapsulation**: Hides fallback logic from consumers
- **Consistency**: Follows existing `sessionCookieName()` pattern
- **Law of Demeter**: Reduces coupling to UIConfiguration internals

### Why optional field?
- **Backward compatible**: Existing tenants work without changes
- **Flexible**: Development vs production scenarios
- **Default behavior**: Tenant domain remains the default

## Testing

- ✅ Build successful: `./gradlew build -x test`
- ✅ Formatting applied: `./gradlew spotlessApply`
- ⏳ E2E tests: To be added in follow-up (Issue checklist item)

## Checklist

- [x] UIConfiguration `base_url` field added
- [x] Tenant `baseUrl()` method implemented
- [x] OAuthViewUrlResolver updated
- [x] Context Creators verified (no changes needed)
- [x] DataSource persistence verified (no changes needed)
- [x] tenant-template.json updated
- [x] OpenAPI specs updated (EN/JA)
- [x] Build successful
- [ ] E2E tests (deferred)

## Related

- Closes #744
- Related: PR #743 (Docker containerization for app-view)
- Related: PR #739 (CORS origin validation fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)