### PR TITLE
Fix UserStatus.FEDERATED transition rules in UserLifecycleManager

### DIFF
--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/identity/UserLifecycleManager.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/identity/UserLifecycleManager.java
@@ -24,22 +24,41 @@ import org.idp.server.platform.exception.UnSupportedException;
 public class UserLifecycleManager {
 
   private static final Map<UserStatus, Set<UserStatus>> allowedTransitions =
-      Map.of(
-          UserStatus.INITIALIZED, EnumSet.of(UserStatus.REGISTERED),
-          UserStatus.REGISTERED, EnumSet.of(UserStatus.IDENTITY_VERIFIED, UserStatus.DELETED),
-          UserStatus.IDENTITY_VERIFIED,
+      Map.ofEntries(
+          Map.entry(UserStatus.INITIALIZED, EnumSet.of(UserStatus.REGISTERED)),
+          Map.entry(
+              UserStatus.FEDERATED,
+              EnumSet.of(
+                  UserStatus.REGISTERED,
+                  UserStatus.IDENTITY_VERIFIED,
+                  UserStatus.IDENTITY_VERIFICATION_REQUIRED,
+                  UserStatus.LOCKED,
+                  UserStatus.DISABLED,
+                  UserStatus.SUSPENDED)),
+          Map.entry(
+              UserStatus.REGISTERED, EnumSet.of(UserStatus.IDENTITY_VERIFIED, UserStatus.DELETED)),
+          Map.entry(
+              UserStatus.IDENTITY_VERIFIED,
               EnumSet.of(
                   UserStatus.IDENTITY_VERIFIED,
                   UserStatus.LOCKED,
                   UserStatus.DISABLED,
                   UserStatus.SUSPENDED,
-                  UserStatus.DEACTIVATED),
-          UserStatus.IDENTITY_VERIFICATION_REQUIRED, EnumSet.of(UserStatus.IDENTITY_VERIFIED),
-          UserStatus.LOCKED, EnumSet.of(UserStatus.IDENTITY_VERIFIED, UserStatus.REGISTERED),
-          UserStatus.DISABLED, EnumSet.of(UserStatus.IDENTITY_VERIFIED, UserStatus.REGISTERED),
-          UserStatus.SUSPENDED, EnumSet.of(UserStatus.IDENTITY_VERIFIED, UserStatus.REGISTERED),
-          UserStatus.DEACTIVATED, EnumSet.of(UserStatus.DELETED_PENDING, UserStatus.REGISTERED),
-          UserStatus.DELETED_PENDING, EnumSet.of(UserStatus.DELETED, UserStatus.REGISTERED));
+                  UserStatus.DEACTIVATED)),
+          Map.entry(
+              UserStatus.IDENTITY_VERIFICATION_REQUIRED, EnumSet.of(UserStatus.IDENTITY_VERIFIED)),
+          Map.entry(
+              UserStatus.LOCKED, EnumSet.of(UserStatus.IDENTITY_VERIFIED, UserStatus.REGISTERED)),
+          Map.entry(
+              UserStatus.DISABLED, EnumSet.of(UserStatus.IDENTITY_VERIFIED, UserStatus.REGISTERED)),
+          Map.entry(
+              UserStatus.SUSPENDED,
+              EnumSet.of(UserStatus.IDENTITY_VERIFIED, UserStatus.REGISTERED)),
+          Map.entry(
+              UserStatus.DEACTIVATED,
+              EnumSet.of(UserStatus.DELETED_PENDING, UserStatus.REGISTERED)),
+          Map.entry(
+              UserStatus.DELETED_PENDING, EnumSet.of(UserStatus.DELETED, UserStatus.REGISTERED)));
 
   public static boolean canTransit(UserStatus from, UserStatus to) {
     Set<UserStatus> nextStatuses = allowedTransitions.getOrDefault(from, Set.of());

--- a/libs/idp-server-core/src/test/java/org/idp/server/core/openid/identity/UserLifecycleManagerTest.java
+++ b/libs/idp-server-core/src/test/java/org/idp/server/core/openid/identity/UserLifecycleManagerTest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2025 Hirokazu Kobayashi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.idp.server.core.openid.identity;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.idp.server.platform.exception.UnSupportedException;
+import org.junit.jupiter.api.Test;
+
+class UserLifecycleManagerTest {
+
+  @Test
+  void testFederatedCanTransitToRegistered() {
+    assertTrue(UserLifecycleManager.canTransit(UserStatus.FEDERATED, UserStatus.REGISTERED));
+    assertEquals(
+        UserStatus.REGISTERED,
+        UserLifecycleManager.transit(UserStatus.FEDERATED, UserStatus.REGISTERED));
+  }
+
+  @Test
+  void testFederatedCanTransitToIdentityVerified() {
+    assertTrue(UserLifecycleManager.canTransit(UserStatus.FEDERATED, UserStatus.IDENTITY_VERIFIED));
+    assertEquals(
+        UserStatus.IDENTITY_VERIFIED,
+        UserLifecycleManager.transit(UserStatus.FEDERATED, UserStatus.IDENTITY_VERIFIED));
+  }
+
+  @Test
+  void testFederatedCanTransitToIdentityVerificationRequired() {
+    assertTrue(
+        UserLifecycleManager.canTransit(
+            UserStatus.FEDERATED, UserStatus.IDENTITY_VERIFICATION_REQUIRED));
+    assertEquals(
+        UserStatus.IDENTITY_VERIFICATION_REQUIRED,
+        UserLifecycleManager.transit(
+            UserStatus.FEDERATED, UserStatus.IDENTITY_VERIFICATION_REQUIRED));
+  }
+
+  @Test
+  void testFederatedCanTransitToLocked() {
+    assertTrue(UserLifecycleManager.canTransit(UserStatus.FEDERATED, UserStatus.LOCKED));
+    assertEquals(
+        UserStatus.LOCKED, UserLifecycleManager.transit(UserStatus.FEDERATED, UserStatus.LOCKED));
+  }
+
+  @Test
+  void testFederatedCanTransitToDisabled() {
+    assertTrue(UserLifecycleManager.canTransit(UserStatus.FEDERATED, UserStatus.DISABLED));
+    assertEquals(
+        UserStatus.DISABLED,
+        UserLifecycleManager.transit(UserStatus.FEDERATED, UserStatus.DISABLED));
+  }
+
+  @Test
+  void testFederatedCanTransitToSuspended() {
+    assertTrue(UserLifecycleManager.canTransit(UserStatus.FEDERATED, UserStatus.SUSPENDED));
+    assertEquals(
+        UserStatus.SUSPENDED,
+        UserLifecycleManager.transit(UserStatus.FEDERATED, UserStatus.SUSPENDED));
+  }
+
+  @Test
+  void testFederatedCannotTransitToDeleted() {
+    assertFalse(UserLifecycleManager.canTransit(UserStatus.FEDERATED, UserStatus.DELETED));
+    assertThrows(
+        UnSupportedException.class,
+        () -> UserLifecycleManager.transit(UserStatus.FEDERATED, UserStatus.DELETED));
+  }
+
+  @Test
+  void testFederatedCannotTransitToDeletedPending() {
+    assertFalse(UserLifecycleManager.canTransit(UserStatus.FEDERATED, UserStatus.DELETED_PENDING));
+    assertThrows(
+        UnSupportedException.class,
+        () -> UserLifecycleManager.transit(UserStatus.FEDERATED, UserStatus.DELETED_PENDING));
+  }
+
+  @Test
+  void testFederatedCannotTransitToDeactivated() {
+    assertFalse(UserLifecycleManager.canTransit(UserStatus.FEDERATED, UserStatus.DEACTIVATED));
+    assertThrows(
+        UnSupportedException.class,
+        () -> UserLifecycleManager.transit(UserStatus.FEDERATED, UserStatus.DEACTIVATED));
+  }
+
+  @Test
+  void testExistingTransitionsStillWork() {
+    assertTrue(UserLifecycleManager.canTransit(UserStatus.INITIALIZED, UserStatus.REGISTERED));
+    assertTrue(
+        UserLifecycleManager.canTransit(UserStatus.REGISTERED, UserStatus.IDENTITY_VERIFIED));
+    assertTrue(UserLifecycleManager.canTransit(UserStatus.LOCKED, UserStatus.IDENTITY_VERIFIED));
+  }
+}


### PR DESCRIPTION
## Summary
- Fix missing transition rules for `UserStatus.FEDERATED` in `UserLifecycleManager`
- Add comprehensive unit tests to verify all FEDERATED transitions
- Ensure external IdP federated users can properly transition to other states

## Problem
`UserStatus.FEDERATED` was defined in the enum and used in `OidcFederationInteractor.java:240`, but had no transition rules configured in `UserLifecycleManager.allowedTransitions`. This caused:
- `UserLifecycleManager.canTransit(UserStatus.FEDERATED, *)` → always `false`
- `UserLifecycleManager.transit(UserStatus.FEDERATED, *)` → always `UnSupportedException`

## Changes
### Implementation
- **UserLifecycleManager.java**: Add FEDERATED transition rules
  - `FEDERATED → REGISTERED` (formal registration in the system)
  - `FEDERATED → IDENTITY_VERIFIED` (trust external IdP verification)
  - `FEDERATED → IDENTITY_VERIFICATION_REQUIRED` (require additional verification)
  - `FEDERATED → LOCKED` (temporary lock)
  - `FEDERATED → DISABLED` (disable account)
  - `FEDERATED → SUSPENDED` (suspend account)

### Tests
- **UserLifecycleManagerTest.java** (new): 10 comprehensive test cases
  - 6 tests for allowed transitions
  - 3 tests for disallowed transitions (DELETED, DELETED_PENDING, DEACTIVATED)
  - 1 test to verify existing transitions still work

## Test Plan
- [x] Unit tests pass (UserLifecycleManagerTest)
- [x] All existing tests pass (./gradlew build)
- [x] Code formatting applied (spotlessApply)
- [x] No regressions (156 actionable tasks: 10 executed, 146 up-to-date)

## Impact
External IdP federated users (created via OIDC federation) can now properly transition to other user states as needed.

Fixes #782

🤖 Generated with [Claude Code](https://claude.com/claude-code)