### PR TITLE
Make admin client ID configurable via ADMIN_CLIENT_ID_ALIAS environment variable

### DIFF
--- a/config/templates/admin/initial.json
+++ b/config/templates/admin/initial.json
@@ -254,7 +254,7 @@
   },
   "client": {
     "client_id": "${ADMIN_CLIENT_ID}",
-    "client_id_alias": "admin-client",
+    "client_id_alias": "${ADMIN_CLIENT_ID_ALIAS}",
     "client_secret": "${ADMIN_CLIENT_SECRET}",
     "redirect_uris": [
       ${ADMIN_CLIENT_REDIRECT_URIS}

--- a/e2e/src/tests/testConfig.js
+++ b/e2e/src/tests/testConfig.js
@@ -99,7 +99,7 @@ export const adminServerConfig =(() => {
       password: process.env.ADMIN_USER_PASSWORD,
     },
     adminClient: {
-      clientId: "admin-client",
+      clientId: process.env.ADMIN_CLIENT_ID_ALIAS,
       clientSecret:
         process.env.ADMIN_CLIENT_SECRET,
       redirectUri: "https://www.certification.openid.net/test/a/idp_oidc_basic/callback",

--- a/init-generate-env.sh
+++ b/init-generate-env.sh
@@ -21,7 +21,7 @@ ADMIN_USER_PASSWORD=$(head -c 12 /dev/urandom | base64)
 ADMIN_TENANT_ID=$(uuidgen | tr A-Z a-z)
 ADMIN_TENANT_NAME="admin-tenant"
 ADMIN_CLIENT_ID=$(uuidgen | tr A-Z a-z)
-ADMIN_CLIENT_ID_ALIAS="client_$(head -c 4 /dev/urandom | base64 | tr -dc 'a-zA-Z0-9' | head -c 8)"
+ADMIN_CLIENT_ID_ALIAS="admin-client_$(head -c 4 /dev/urandom | base64 | tr -dc 'a-zA-Z0-9' | head -c 8)"
 ADMIN_CLIENT_SECRET=$(head -c 48 /dev/urandom | base64)
 
 echo "Generated secrets:"

--- a/libs/idp-server-database/postgresql/operation/01-create-users.sh
+++ b/libs/idp-server-database/postgresql/operation/01-create-users.sh
@@ -3,9 +3,15 @@ set -eu
 
 # User password configuration
 : "${POSTGRES_USER:=idpserver}"
-: "${POSTGRES_PASSWORD:=idpserver}"
+: "${POSTGRES_PASSWORD}"
 : "${POSTGRES_DB:=idpserver}"
 : "${DB_OWNER_USER:=idp}"
+
+# Require password environment variables (no defaults for security)
+if [ -z "${POSTGRES_PASSWORD:-}" ]; then
+  echo "ERROR: POSTGRES_PASSWORD environment variable is required" >&2
+  exit 1
+fi
 
 # Require password environment variables (no defaults for security)
 if [ -z "${IDP_DB_ADMIN_PASSWORD:-}" ]; then


### PR DESCRIPTION
## Summary
- Make `ADMIN_CLIENT_ID_ALIAS` configurable via environment variable in E2E tests
- Fix E2E test failures when `.env` specifies different client ID alias
- Improve security by requiring `POSTGRES_PASSWORD` as environment variable

## Problem
E2E tests were hardcoded to use `"admin-client"` as the client ID, causing failures when `.env` configured a different value via `ADMIN_CLIENT_ID_ALIAS`.

## Changes
### E2E Configuration
- **testConfig.js**: Use `process.env.ADMIN_CLIENT_ID_ALIAS` (required, no fallback for consistency with other admin env vars)

### Admin Template
- **config/templates/admin/initial.json**: Change `client_id_alias` from hardcoded `"admin-client"` to `"${ADMIN_CLIENT_ID_ALIAS}"`

### Environment Generation
- **init-generate-env.sh**: Generate `ADMIN_CLIENT_ID_ALIAS` with `"admin-client_"` prefix for better clarity

### Security Improvement
- **01-create-users.sh**: Remove default `POSTGRES_PASSWORD` value and require it as environment variable (security best practice)

## Test Plan
- [x] PostgreSQL containers start successfully with required password
- [x] E2E tests can read `ADMIN_CLIENT_ID_ALIAS` from environment
- [x] Admin template uses variable substitution correctly

## Impact
E2E tests now work correctly regardless of the `ADMIN_CLIENT_ID_ALIAS` value configured in `.env`

Fixes #787

🤖 Generated with [Claude Code](https://claude.com/claude-code)