### PR TITLE
Fix thread-safety issues in SystemDateTime

### DIFF
--- a/libs/idp-server-platform/src/main/java/org/idp/server/platform/date/SystemDateTime.java
+++ b/libs/idp-server-platform/src/main/java/org/idp/server/platform/date/SystemDateTime.java
@@ -20,15 +20,75 @@ import java.time.Clock;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 
+/**
+ * Thread-safe system date/time provider with configurable timezone.
+ *
+ * <p>This class provides a centralized clock for the application that can be configured once at
+ * startup. The clock field uses {@code volatile} to ensure visibility across threads, and the
+ * configure method is {@code synchronized} to prevent race conditions.
+ *
+ * <h3>Thread Safety Guarantees</h3>
+ *
+ * <ul>
+ *   <li><b>Visibility</b>: The {@code volatile} modifier on the clock field ensures that changes
+ *       made by one thread are immediately visible to all other threads (Java Memory Model
+ *       happens-before guarantee).
+ *   <li><b>Atomicity</b>: The {@code synchronized} modifier on configure() prevents multiple
+ *       threads from simultaneously modifying the clock, avoiding partial writes.
+ *   <li><b>Immutability</b>: Once configured, the clock cannot be reconfigured, preventing runtime
+ *       timezone changes that could cause timestamp inconsistencies.
+ * </ul>
+ *
+ * <h3>Usage</h3>
+ *
+ * <pre>{@code
+ * // At application startup (once):
+ * SystemDateTime.configure(ZoneId.of("Asia/Tokyo"));
+ *
+ * // Throughout the application:
+ * LocalDateTime now = SystemDateTime.now();
+ * long epochSecond = SystemDateTime.toEpochSecond(now);
+ * }</pre>
+ *
+ * @see java.time.Clock
+ * @see java.time.ZoneId
+ */
 public class SystemDateTime {
 
-  private static Clock clock = Clock.systemUTC();
+  /**
+   * The system clock instance. Declared volatile to ensure visibility of changes across threads
+   * without requiring synchronization on read operations.
+   */
+  private static volatile Clock clock = Clock.systemUTC();
 
-  public static void configure(ZoneId zone) {
+  /**
+   * Flag to prevent reconfiguration. Once configure() is called successfully, this flag is set to
+   * true and any subsequent calls will throw UnsupportedOperationException.
+   */
+  private static boolean configured = false;
+
+  /**
+   * Configures the system clock with the specified timezone. This method can only be called once
+   * during application initialization.
+   *
+   * <p>This method is synchronized to prevent race conditions when multiple threads attempt to
+   * configure the clock simultaneously. The configured flag ensures that once successfully
+   * configured, the clock cannot be changed.
+   *
+   * @param zone the timezone to use for the system clock
+   * @throws IllegalArgumentException if zone is null
+   * @throws UnsupportedOperationException if the clock has already been configured
+   */
+  public static synchronized void configure(ZoneId zone) {
+    if (configured) {
+      throw new UnsupportedOperationException(
+          "Clock is already configured (zone=" + clock.getZone() + ")");
+    }
     if (zone == null) {
       throw new IllegalArgumentException("Zone cannot be null");
     }
     clock = Clock.system(zone);
+    configured = true;
   }
 
   public static LocalDateTime now() {


### PR DESCRIPTION
## Summary
- Fix thread-safety issues in `SystemDateTime` by adding `volatile` and `synchronized`
- Prevent race conditions and visibility problems in multi-threaded environment
- Add comprehensive Javadoc explaining thread-safety guarantees

## Problem
`SystemDateTime` had non-volatile, non-synchronized static `Clock` field that could cause:
1. **Race conditions**: Multiple threads configuring clock simultaneously
2. **Visibility issues**: CPU cache inconsistencies causing threads to see stale clock values
3. **Data inconsistencies**: Incorrect timestamps in tokens, audit logs, and sessions

## Changes
### Thread Safety Fixes
- **`volatile Clock clock`**: Ensures visibility across threads (Java Memory Model happens-before guarantee)
- **`synchronized configure()`**: Prevents concurrent modifications during clock configuration
- **`configured` flag**: Ensures clock can only be configured once at startup

### Documentation
- Added comprehensive Javadoc explaining thread-safety guarantees
- Documented visibility, atomicity, and immutability properties
- Provided usage examples and references to Java Memory Model

## Test Plan
- [x] All existing tests pass (`./gradlew :libs:idp-server-platform:test`)
- [x] Code formatting applied (`./gradlew spotlessApply`)
- [x] Full build succeeds (`./gradlew build`)

## Impact
Prevents potential bugs in multi-threaded scenarios:
- Token expiration calculation errors (9-hour timezone shifts)
- Audit log timestamp inconsistencies
- Session validity judgment errors

Fixes #783

🤖 Generated with [Claude Code](https://claude.com/claude-code)