### PR TITLE
Make FunctionRegistry HashMap immutable using Collections.unmodifiableMap

### DIFF
--- a/libs/idp-server-platform/src/main/java/org/idp/server/platform/mapper/functions/FunctionRegistry.java
+++ b/libs/idp-server-platform/src/main/java/org/idp/server/platform/mapper/functions/FunctionRegistry.java
@@ -74,7 +74,6 @@ public class FunctionRegistry {
     // Collection operation functions
     MapFunction mapFunction = new MapFunction();
     temp.put(mapFunction.name(), mapFunction);
-    mapFunction.setFunctionRegistry(this);
 
     FilterFunction filterFunction = new FilterFunction();
     temp.put(filterFunction.name(), filterFunction);
@@ -85,7 +84,12 @@ public class FunctionRegistry {
     SplitFunction splitFunction = new SplitFunction();
     temp.put(splitFunction.name(), splitFunction);
 
+    // Initialize map field before calling setFunctionRegistry to prevent partial construction
+    // escape
     this.map = Collections.unmodifiableMap(temp);
+
+    // Set registry reference after map initialization to ensure thread-safety
+    mapFunction.setFunctionRegistry(this);
   }
 
   public ValueFunction get(String name) {


### PR DESCRIPTION
## Summary
- Convert mutable `HashMap` to immutable map using `Collections.unmodifiableMap()` pattern
- Remove public `register()` method (verified not used externally)
- Use `fn.name()` for all function registrations to ensure correct key mapping (snake_case)

## Implementation Details
- Created temporary `HashMap` in constructor
- Instantiate all functions and add using `fn.name()` as key
- Wrap with `Collections.unmodifiableMap()` before assigning to final field
- `MapFunction.setFunctionRegistry(this)` called after adding to temp map

## Testing
- All existing tests pass (`./gradlew test`)
- Full build successful (`./gradlew build`)

## Fixes
Closes #786

🤖 Generated with [Claude Code](https://claude.com/claude-code)