### PR TITLE
Implement unified release script and fix version handling (Issue #815)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -58,41 +58,18 @@ jobs:
       - name: Run tests
         run: ./gradlew test
 
-      - name: Build all modules (app bootJar + libs jars)
-        run: ./gradlew build -x test -PreleaseVersion=${{ steps.version.outputs.version_number }}
-
-      - name: Collect and package library modules
+      - name: Create release artifacts
         run: |
-          mkdir -p release-artifacts
-          echo "Collecting library modules..."
-          find libs -name '*.jar' -path '*/build/libs/*' -not -name '*-plain.jar' -exec cp {} release-artifacts/ \;
+          chmod +x scripts/release.sh
+          ./scripts/release.sh ${{ steps.version.outputs.version_number }}
 
-          # Check if any JARs were found
-          JAR_COUNT=$(ls release-artifacts/*.jar 2>/dev/null | wc -l)
-          if [ $JAR_COUNT -eq 0 ]; then
-            echo "Error: No library JARs found to package"
-            exit 1
-          fi
-
-          echo "Found $JAR_COUNT library JARs:"
-          ls -la release-artifacts/
-          echo "Creating libraries zip archive..."
-          cd release-artifacts
-          zip -r "../idp-server-libs-${{ steps.version.outputs.version_number }}.zip" *.jar
-          cd ..
-          ls -la idp-server-libs-*.zip
-
-      - name: Generate checksums
+      - name: Verify release artifacts
         run: |
-          echo "Generating SHA256 checksums..."
-          # Use dynamic JAR detection
-          APP_JAR=$(ls app/build/libs/idp-server-*.jar)
-          LIBS_ZIP=$(ls idp-server-libs-*.zip)
-
-          sha256sum "$APP_JAR" > checksums.txt
-          sha256sum "$LIBS_ZIP" >> checksums.txt
-          echo "Generated checksums:"
-          cat checksums.txt
+          echo "📋 リリース成果物:"
+          cat build/release/manifest.txt
+          echo ""
+          echo "🔐 チェックサム:"
+          cat build/release/checksums.txt
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
@@ -105,7 +82,9 @@ jobs:
             ### 📦 Assets
             - **idp-server-${{ steps.version.outputs.version_number }}.jar**: Main application jar
             - **idp-server-libs-${{ steps.version.outputs.version_number }}.zip**: Library modules archive
+            - **idp-server-database-${{ steps.version.outputs.version_number }}.zip**: MySQL/PostgreSQL DDL scripts
             - **checksums.txt**: SHA256 checksums for verification
+            - **manifest.txt**: List of included files
 
             ### 📋 Changes
             This release includes all changes from the latest commits. See commit history for detailed changes.
@@ -116,9 +95,11 @@ jobs:
             3. Verify integrity using the provided checksums
 
           files: |
-            app/build/libs/idp-server-${{ steps.version.outputs.version_number }}.jar
-            idp-server-libs-${{ steps.version.outputs.version_number }}.zip
-            checksums.txt
+            build/release/idp-server-${{ steps.version.outputs.version_number }}.jar
+            build/release/idp-server-libs-${{ steps.version.outputs.version_number }}.zip
+            build/release/idp-server-database-${{ steps.version.outputs.version_number }}.zip
+            build/release/checksums.txt
+            build/release/manifest.txt
           generate_release_notes: true
           draft: false
           prerelease: ${{ contains(steps.version.outputs.version, '-') }}
@@ -127,7 +108,9 @@ jobs:
         run: |
           echo "✅ Release ${{ steps.version.outputs.version }} created successfully!"
           echo "📦 Artifacts uploaded:"
-          echo "  - Main application: app/build/libs/idp-server-*.jar"
-          echo "  - Library modules: idp-server-libs-${{ steps.version.outputs.version_number }}.zip"
-          echo "  - Checksums: checksums.txt"
+          echo "  - Main application: build/release/idp-server-${{ steps.version.outputs.version_number }}.jar"
+          echo "  - Library modules: build/release/idp-server-libs-${{ steps.version.outputs.version_number }}.zip"
+          echo "  - Database scripts: build/release/idp-server-database-${{ steps.version.outputs.version_number }}.zip"
+          echo "  - Checksums: build/release/checksums.txt"
+          echo "  - Manifest: build/release/manifest.txt"
           echo "🔗 Release URL: https://github.com/${{ github.repository }}/releases/tag/${{ steps.version.outputs.version }}"

--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,4 @@ config/generated/
 
 # Temporary files from scripts
 config/tmp/
+build/release/

--- a/libs/idp-server-core-extension-fapi/build.gradle
+++ b/libs/idp-server-core-extension-fapi/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 group = 'org.idp.server'
-version = '1.0,0'
+version = project.hasProperty('releaseVersion') ? project.releaseVersion : '0.9.0-SNAPSHOT'
 
 repositories {
 	mavenCentral()

--- a/libs/idp-server-core-extension-pkce/build.gradle
+++ b/libs/idp-server-core-extension-pkce/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 group = 'org.idp.server'
-version = '1.0,0'
+version = project.hasProperty('releaseVersion') ? project.releaseVersion : '0.9.0-SNAPSHOT'
 
 repositories {
 	mavenCentral()

--- a/libs/idp-server-core-extension-verifiable-credentials/build.gradle
+++ b/libs/idp-server-core-extension-verifiable-credentials/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 group = 'org.idp.server'
-version = '1.0,0'
+version = project.hasProperty('releaseVersion') ? project.releaseVersion : '0.9.0-SNAPSHOT'
 
 repositories {
 	mavenCentral()

--- a/libs/idp-server-core/build.gradle
+++ b/libs/idp-server-core/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 group 'org.idp.server'
-version '1.0.0'
+version = project.hasProperty('releaseVersion') ? project.releaseVersion : '0.9.0-SNAPSHOT'
 
 repositories {
 	mavenCentral()

--- a/libs/idp-server-security-event-framework/build.gradle
+++ b/libs/idp-server-security-event-framework/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 group = 'org.idp.server'
-version = '1.0,0'
+version = project.hasProperty('releaseVersion') ? project.releaseVersion : '0.9.0-SNAPSHOT'
 
 repositories {
 	mavenCentral()

--- a/libs/idp-server-security-event-hooks/build.gradle
+++ b/libs/idp-server-security-event-hooks/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 group = 'org.idp.server'
-version = '1.0,0'
+version = project.hasProperty('releaseVersion') ? project.releaseVersion : '0.9.0-SNAPSHOT'
 
 repositories {
 	mavenCentral()

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,146 @@
+#!/bin/bash
+# scripts/release.sh
+# Unified release script for idp-server
+# Usage: ./scripts/release.sh <version>
+# Example: ./scripts/release.sh 0.9.0
+
+set -e
+
+VERSION=$1
+if [ -z "$VERSION" ]; then
+  echo "使用方法: $0 <version>"
+  echo "例: $0 0.9.0"
+  exit 1
+fi
+
+# バージョン形式の検証
+if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9]+)?$ ]]; then
+  echo "エラー: 無効なバージョン形式。X.Y.Z または X.Y.Z-qualifier を使用してください"
+  exit 1
+fi
+
+echo "🚀 バージョン $VERSION のリリースプロセスを開始"
+
+# クリーンとビルド
+echo "🔨 プロジェクトをビルド中..."
+./gradlew clean build -x test -PreleaseVersion=$VERSION
+
+# リリースディレクトリ作成
+RELEASE_DIR="build/release"
+RELEASE_ARTIFACTS_DIR="$RELEASE_DIR/artifacts"
+rm -rf $RELEASE_DIR
+mkdir -p $RELEASE_ARTIFACTS_DIR
+
+# メインアプリケーションJARの収集
+echo ""
+echo "📦 メインアプリケーションを収集中..."
+MAIN_JAR="app/build/libs/idp-server-$VERSION.jar"
+if [ -f "$MAIN_JAR" ]; then
+  # artifacts ディレクトリとリリースディレクトリ両方にコピー
+  cp "$MAIN_JAR" $RELEASE_ARTIFACTS_DIR/
+  cp "$MAIN_JAR" $RELEASE_DIR/
+  echo "  ✓ idp-server-$VERSION.jar"
+else
+  echo "  ❌ エラー: メインアプリケーションJARが見つかりません: $MAIN_JAR"
+  exit 1
+fi
+
+# ライブラリJARの収集（バージョン一致のみ）
+echo ""
+echo "📚 ライブラリモジュールを収集中..."
+COLLECTED_COUNT=0
+SKIPPED_COUNT=0
+
+find libs -name "*.jar" -path "*/build/libs/*" -not -name "*-plain.jar" | sort | while read jar; do
+  JAR_NAME=$(basename "$jar")
+  # JARファイル名からバージョンを抽出
+  if [[ "$jar" =~ -${VERSION}\.jar$ ]]; then
+    cp "$jar" $RELEASE_ARTIFACTS_DIR/
+    echo "  ✓ $JAR_NAME"
+    COLLECTED_COUNT=$((COLLECTED_COUNT + 1))
+  else
+    echo "  ⊗ スキップ $JAR_NAME (バージョン不一致)"
+    SKIPPED_COUNT=$((SKIPPED_COUNT + 1))
+  fi
+done
+
+# 収集されたJARの検証
+JAR_COUNT=$(ls $RELEASE_ARTIFACTS_DIR/*.jar 2>/dev/null | wc -l | tr -d ' ')
+if [ "$JAR_COUNT" -eq 0 ]; then
+  echo ""
+  echo "❌ エラー: バージョン $VERSION に一致するJARが見つかりません"
+  echo "ヒント: 各モジュールの build.gradle で releaseVersion プロパティが正しく設定されているか確認してください"
+  exit 1
+fi
+
+# DDLスクリプトの収集
+echo ""
+echo "📜 データベーススクリプトを収集中..."
+DB_DIR="$RELEASE_DIR/database"
+mkdir -p $DB_DIR
+
+if [ -d "libs/idp-server-database/mysql" ]; then
+  cp -r libs/idp-server-database/mysql $DB_DIR/
+  echo "  ✓ MySQL DDL scripts"
+fi
+
+if [ -d "libs/idp-server-database/postgresql" ]; then
+  cp -r libs/idp-server-database/postgresql $DB_DIR/
+  echo "  ✓ PostgreSQL DDL scripts"
+fi
+
+# ZIPアーカイブの作成
+echo ""
+echo "📦 ライブラリアーカイブを作成中..."
+cd $RELEASE_ARTIFACTS_DIR
+zip -q -r "../idp-server-libs-$VERSION.zip" *.jar
+cd - > /dev/null
+echo "  ✓ idp-server-libs-$VERSION.zip"
+
+# データベーススクリプトのZIP作成
+echo ""
+echo "📦 データベーススクリプトアーカイブを作成中..."
+cd $DB_DIR
+zip -q -r "../idp-server-database-$VERSION.zip" mysql postgresql
+cd - > /dev/null
+echo "  ✓ idp-server-database-$VERSION.zip"
+
+# チェックサムの生成
+echo ""
+echo "🔐 チェックサムを生成中..."
+sha256sum "$RELEASE_DIR/idp-server-$VERSION.jar" > $RELEASE_DIR/checksums.txt
+sha256sum "$RELEASE_DIR/idp-server-libs-$VERSION.zip" >> $RELEASE_DIR/checksums.txt
+sha256sum "$RELEASE_DIR/idp-server-database-$VERSION.zip" >> $RELEASE_DIR/checksums.txt
+echo "  ✓ checksums.txt"
+
+# マニフェストの生成
+echo ""
+echo "📋 マニフェストを生成中..."
+{
+  echo "Release Version: $VERSION"
+  echo "Build Date: $(date -u +"%Y-%m-%d %H:%M:%S UTC")"
+  echo "Build Host: $(hostname)"
+  echo ""
+  echo "Included JARs ($JAR_COUNT files):"
+  echo "================================"
+  ls -1 $RELEASE_ARTIFACTS_DIR/*.jar | xargs -n1 basename
+} > $RELEASE_DIR/manifest.txt
+echo "  ✓ manifest.txt"
+
+echo ""
+echo "✅ リリース成果物の作成が完了しました！"
+echo ""
+echo "📂 出力先: $RELEASE_DIR"
+echo "  - idp-server-$VERSION.jar (メインアプリケーション)"
+echo "  - idp-server-libs-$VERSION.zip ($JAR_COUNT ライブラリJARs)"
+echo "  - idp-server-database-$VERSION.zip (MySQL/PostgreSQL DDLスクリプト)"
+echo "  - checksums.txt (SHA256チェックサム)"
+echo "  - manifest.txt (含まれるファイル一覧)"
+echo "  - artifacts/ ディレクトリ (全JARファイル)"
+echo "  - database/ ディレクトリ (mysql/, postgresql/)"
+echo ""
+echo "🔍 マニフェスト内容:"
+cat $RELEASE_DIR/manifest.txt
+echo ""
+echo "🔐 チェックサム:"
+cat $RELEASE_DIR/checksums.txt


### PR DESCRIPTION
## 📋 概要

リリースプロセスを改善するため、ローカルとGitHub Actionsの両方で実行可能な統一リリーススクリプトを作成し、バージョン不整合の問題を解決しました。

Closes #815

## 🔧 主要な変更

### 1. 統一リリーススクリプト (`scripts/release.sh`)

```bash
./scripts/release.sh 0.9.0
```

**機能:**
- ✅ バージョン形式検証（X.Y.Z）
- ✅ `-PreleaseVersion` でバージョン統一ビルド
- ✅ バージョン一致JARのみ収集（不一致はスキップ）
- ✅ 3種類のアーカイブ作成:
  - `idp-server-{version}.jar` (メインアプリケーション)
  - `idp-server-libs-{version}.zip` (19 ライブラリJAR)
  - `idp-server-database-{version}.zip` (MySQL/PostgreSQL DDL)
- ✅ SHA256チェックサム生成
- ✅ マニフェスト生成（含まれる全ファイルリスト）
- ✅ 成果物を `build/release/` に集約

### 2. バージョン管理の修正

**問題:** 無効なバージョン形式 `1.0,0`（カンマ含む）

**修正:** 全モジュールを `releaseVersion` プロパティに対応
- `idp-server-core`: `1.0.0` → `0.9.0-SNAPSHOT` (デフォルト)
- `idp-server-core-extension-*`: `1.0,0` → `0.9.0-SNAPSHOT`
- `idp-server-security-event-*`: `1.0,0` → `0.9.0-SNAPSHOT`

### 3. GitHub Actions ワークフロー簡素化

**Before:**
```yaml
- name: Build all modules
  run: ./gradlew build -x test -PreleaseVersion=$VERSION
- name: Collect and package library modules
  run: |
    find libs -name '*.jar' ... # 複雑な収集ロジック
```

**After:**
```yaml
- name: Create release artifacts
  run: ./scripts/release.sh $VERSION
```

## 📦 リリース成果物構造

```
build/release/
├── idp-server-0.9.0.jar              # メインアプリケーション (108MB)
├── idp-server-libs-0.9.0.zip         # ライブラリ19個 (100MB)
├── idp-server-database-0.9.0.zip     # DDLスクリプト (17KB)
├── checksums.txt                      # SHA256ハッシュ
├── manifest.txt                       # ファイル一覧
├── artifacts/                         # 全JARファイル
│   ├── idp-server-0.9.0.jar
│   ├── idp-server-core-0.9.0.jar
│   └── ...
└── database/                          # DDLスクリプト
    ├── mysql/
    └── postgresql/
```

## 🎯 解決した問題

### ❌ Before: バージョン不整合
```
idp-server-libs-v0.9.0.zip 内容:
  - idp-server-core-1.0.0.jar          ← 異なるバージョン
  - idp-server-platform-0.9.0-SNAPSHOT.jar
  - idp-server-security-event-1.0,0.jar ← 無効な形式
```

### ✅ After: バージョン一貫性
```
idp-server-libs-v0.9.0.zip 内容:
  - idp-server-core-0.9.0.jar          ← 統一
  - idp-server-platform-0.9.0.jar      ← 統一
  - idp-server-security-event-0.9.0.jar ← 修正済み
```

## 🧪 テスト結果

### ローカルテスト
```bash
$ ./scripts/release.sh 0.9.0-test4

🚀 バージョン 0.9.0-test4 のリリースプロセスを開始
🔨 プロジェクトをビルド中...
📦 メインアプリケーションを収集中...
  ✓ idp-server-0.9.0-test4.jar
📚 ライブラリモジュールを収集中...
  ✓ idp-server-core-0.9.0-test4.jar
  ⊗ スキップ idp-server-database.jar (バージョン不一致)
  ...
✅ リリース成果物の作成が完了しました！
```

### マニフェスト検証
```
Release Version: 0.9.0-test4
Build Date: 2025-10-27 03:50:47 UTC
Included JARs (19 files):
================================
idp-server-0.9.0-test4.jar
idp-server-core-0.9.0-test4.jar
...
```

### チェックサム検証
```
9cc461f40304ba53...  idp-server-0.9.0-test4.jar
7b5bdfb432be8138...  idp-server-libs-0.9.0-test4.zip
3edcd81e3c02db44...  idp-server-database-0.9.0-test4.zip
```

## 📚 メリット

| 項目 | Before | After |
|------|--------|-------|
| **バージョン一貫性** | ❌ 混在 (`0.9.0-SNAPSHOT`, `1.0.0`, `1.0,0`) | ✅ 統一 (全て同じバージョン) |
| **ローカルテスト** | ❌ 不可能（GitHub Actions専用） | ✅ 可能（`./scripts/release.sh`） |
| **再現性** | ❌ 環境依存 | ✅ 同じスクリプト、同じ結果 |
| **透明性** | ❌ 含まれるファイル不明 | ✅ manifest.txt で追跡 |
| **データベース** | ❌ 別途配布 | ✅ リリースに含む |

## 🔗 関連ファイル

- `scripts/release.sh` (新規作成)
- `.github/workflows/release.yaml` (簡素化)
- 6モジュールの `build.gradle` (バージョン修正)
- `.gitignore` (`build/release/` 追加)

## ✅ チェックリスト

- [x] 統一リリーススクリプト作成
- [x] 無効なバージョン形式修正
- [x] 全モジュールを `releaseVersion` 対応
- [x] GitHub Actions ワークフロー更新
- [x] ローカルテスト実行・検証
- [x] バージョン一貫性確認
- [x] データベーススクリプト同梱

🤖 Generated with [Claude Code](https://claude.com/claude-code)