### PR TITLE
Fix CIBA login_hint validation to return 400 instead of 500 for invalid UUIDs (Issue #818)

### DIFF
--- a/libs/idp-server-core-extension-ciba/src/main/java/org/idp/server/core/extension/ciba/handler/CibaRequestErrorHandler.java
+++ b/libs/idp-server-core-extension-ciba/src/main/java/org/idp/server/core/extension/ciba/handler/CibaRequestErrorHandler.java
@@ -26,6 +26,7 @@ import org.idp.server.core.openid.oauth.configuration.exception.ClientConfigurat
 import org.idp.server.core.openid.oauth.configuration.exception.ServerConfigurationNotFoundException;
 import org.idp.server.core.openid.oauth.type.oauth.Error;
 import org.idp.server.core.openid.oauth.type.oauth.ErrorDescription;
+import org.idp.server.platform.exception.BadRequestException;
 import org.idp.server.platform.log.LoggerWrapper;
 
 public class CibaRequestErrorHandler {
@@ -55,6 +56,14 @@ public class CibaRequestErrorHandler {
           CibaRequestStatus.FORBIDDEN,
           new BackchannelAuthenticationErrorResponse(
               forbidden.error(), forbidden.errorDescription()));
+    }
+
+    if (exception instanceof BadRequestException badRequest) {
+      log.warn(exception.getMessage());
+      return new CibaIssueResponse(
+          CibaRequestStatus.BAD_REQUEST,
+          new BackchannelAuthenticationErrorResponse(
+              new Error("invalid_request"), new ErrorDescription(badRequest.getMessage())));
     }
 
     if (exception instanceof ClientConfigurationNotFoundException) {


### PR DESCRIPTION
## 概要
CIBA backchannel authentication endpointで不正なUUID形式のlogin_hintを指定した際に、500 Internal Server Errorを返す問題を修正しました。

Fixes #818

## 問題
- login_hintに不正なUUID（例: `sub:not-a-valid-uuid`）を指定
- `UuidConvertable.convertUuid()`が`BadRequestException`をthrow
- この例外が`CibaRequestErrorHandler`で処理されず500エラーを返却

## 解決策
### 1. CibaRequestErrorHandlerにBadRequestException処理を追加
```java
if (exception instanceof BadRequestException badRequest) {
  log.warn(exception.getMessage());
  return new CibaIssueResponse(
      CibaRequestStatus.BAD_REQUEST,
      new BackchannelAuthenticationErrorResponse(
          new Error("invalid_request"), 
          new ErrorDescription(badRequest.getMessage())));
}
```

### 2. モンキーテストを追加
- 不正なlogin_hint形式のテストケースを`ciba-monkey.test.js`に追加
- `sub:not-a-valid-uuid`のテストケースを有効化

## 変更ファイル
- `libs/idp-server-core-extension-ciba/src/main/java/org/idp/server/core/extension/ciba/handler/CibaRequestErrorHandler.java`
- `e2e/src/tests/monkey/ciba-monkey.test.js`

## テスト計画
- [x] モンキーテストで不正なlogin_hint形式を検証
- [x] 既存のCIBAテストがパスすることを確認

## 今後の改善
Issue #819で`CibaRequestValidator`でのより適切な検証層での実装を提案済み。本修正は応急処置として機能します。

## Test plan
- [x] モンキーテストを追加してinvalid login_hint形式を検証
- [x] 全CIBAテストを実行して既存機能に影響がないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)