### PR TITLE
Fix user assignment bugs and add comprehensive test coverage

### DIFF
--- a/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/identity/user/handler/UserRolesUpdateService.java
+++ b/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/identity/user/handler/UserRolesUpdateService.java
@@ -110,8 +110,13 @@ public class UserRolesUpdateService implements UserManagementService<UserUpdateR
   }
 
   public User updateUser(UserRegistrationRequest request, User before) {
-    User newUser = JsonConverter.snakeCaseInstance().read(request.toMap(), User.class);
+    // Create deep copy to avoid mutating 'before' object
+    JsonConverter jsonConverter = JsonConverter.snakeCaseInstance();
+    User updated = jsonConverter.read(jsonConverter.write(before), User.class);
 
-    return before.setRoles(newUser.roles());
+    User newUser = jsonConverter.read(request.toMap(), User.class);
+    updated.setRoles(newUser.roles());
+
+    return updated;
   }
 }

--- a/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/identity/user/verifier/UserRegistrationRelatedDataVerifier.java
+++ b/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/identity/user/verifier/UserRegistrationRelatedDataVerifier.java
@@ -132,11 +132,13 @@ public class UserRegistrationRelatedDataVerifier {
         Optional.ofNullable(request.assignedOrganizations()).orElse(List.of());
 
     Set<String> allOrgIds = new LinkedHashSet<>(assignedOrganizations);
+    if (currentOrganizationId != null && !currentOrganizationId.trim().isEmpty()) {
+      allOrgIds.add(currentOrganizationId);
+    }
+
     if (allOrgIds.isEmpty()) {
       return;
     }
-
-    allOrgIds.add(currentOrganizationId);
 
     OrganizationQueries queries = OrganizationQueries.ids(allOrgIds);
     List<Organization> existingOrganizations = organizationRepository.findList(queries);

--- a/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/control_plane/organization_manager/OrgUserManagementEntryService.java
+++ b/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/control_plane/organization_manager/OrgUserManagementEntryService.java
@@ -129,7 +129,7 @@ public class OrgUserManagementEntryService implements OrgUserManagementApi {
       UserCommandRepository userCommandRepository,
       PasswordEncodeDelegation passwordEncodeDelegation,
       UserRegistrationVerifier verifier,
-      UserRegistrationRelatedDataVerifier updateVerifier,
+      UserRegistrationRelatedDataVerifier relatedDataVerifier,
       UserLifecycleEventPublisher userLifecycleEventPublisher,
       ManagementEventPublisher managementEventPublisher) {
 
@@ -163,13 +163,16 @@ public class OrgUserManagementEntryService implements OrgUserManagementApi {
     services.put("get", new UserFindService(userQueryRepository));
     services.put(
         "updateRoles",
-        new UserRolesUpdateService(userQueryRepository, userCommandRepository, updateVerifier));
+        new UserRolesUpdateService(
+            userQueryRepository, userCommandRepository, relatedDataVerifier));
     services.put(
         "updateTenantAssignments",
-        new UserTenantAssignmentsUpdateService(userQueryRepository, userCommandRepository));
+        new UserTenantAssignmentsUpdateService(
+            userQueryRepository, userCommandRepository, relatedDataVerifier));
     services.put(
         "updateOrganizationAssignments",
-        new UserOrganizationAssignmentsUpdateService(userQueryRepository, userCommandRepository));
+        new UserOrganizationAssignmentsUpdateService(
+            userQueryRepository, userCommandRepository, relatedDataVerifier));
 
     return new OrgUserManagementHandler(
         services, this, tenantQueryRepository, new OrganizationAccessVerifier());

--- a/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/control_plane/system_manager/UserManagementEntryService.java
+++ b/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/control_plane/system_manager/UserManagementEntryService.java
@@ -110,7 +110,7 @@ public class UserManagementEntryService implements UserManagementApi {
       UserLifecycleEventPublisher userLifecycleEventPublisher,
       ManagementEventPublisher managementEventPublisher) {
 
-    UserRegistrationRelatedDataVerifier updateVerifier =
+    UserRegistrationRelatedDataVerifier relatedDataVerifier =
         new UserRegistrationRelatedDataVerifier(
             roleQueryRepository, tenantQueryRepository, organizationRepository);
 
@@ -144,13 +144,16 @@ public class UserManagementEntryService implements UserManagementApi {
     services.put("get", new UserFindService(userQueryRepository));
     services.put(
         "updateRoles",
-        new UserRolesUpdateService(userQueryRepository, userCommandRepository, updateVerifier));
+        new UserRolesUpdateService(
+            userQueryRepository, userCommandRepository, relatedDataVerifier));
     services.put(
         "updateTenantAssignments",
-        new UserTenantAssignmentsUpdateService(userQueryRepository, userCommandRepository));
+        new UserTenantAssignmentsUpdateService(
+            userQueryRepository, userCommandRepository, relatedDataVerifier));
     services.put(
         "updateOrganizationAssignments",
-        new UserOrganizationAssignmentsUpdateService(userQueryRepository, userCommandRepository));
+        new UserOrganizationAssignmentsUpdateService(
+            userQueryRepository, userCommandRepository, relatedDataVerifier));
 
     return new UserManagementHandler(services, this, tenantQueryRepository);
   }


### PR DESCRIPTION
## Summary
- Add 12 comprehensive test patterns for organization/tenant assignment operations
- Fix UUID null validation bug in UserRegistrationRelatedDataVerifier
- Fix mutable object issue using JsonConverter deep copy pattern
- Add missing verifier calls in UserOrganizationAssignmentsUpdateService and UserTenantAssignmentsUpdateService
- Remove invalid test case that violated access control boundaries

## Bug Fixes

### 1. UUID Null Validation Error
**Location**: `UserRegistrationRelatedDataVerifier.verifyOrganizationAssignments():139`  
**Issue**: `currentOrganizationId` was being added to Set without null check, causing `invalid input syntax for type uuid: "null"` error  
**Fix**: Added null check before adding to Set, matching the pattern in `verifyTenantAssignments()`

### 2. Mutable Object Reference Problem
**Location**: `updateUser()` methods in UserOrganizationAssignmentsUpdateService, UserTenantAssignmentsUpdateService, UserRolesUpdateService  
**Issue**: `User updated = before` creates reference copy, causing `before` to be mutated and diff to always be empty  
**Fix**: Deep copy using `jsonConverter.read(jsonConverter.write(before), User.class)` pattern

### 3. Missing Verifier Calls
**Location**: UserOrganizationAssignmentsUpdateService, UserTenantAssignmentsUpdateService  
**Issue**: PostgreSQL foreign key constraint violation due to missing validation  
**Fix**: Added `UserRegistrationRelatedDataVerifier` dependency and verifier calls following UserRolesUpdateService pattern

## Test Coverage

Added 12 test patterns covering:
- Multiple tenant assignment updates
- Multiple organization assignment updates
- Assignment removal (empty array)
- Invalid ID error handling (non-UUID, non-existent)
- Creation-time assignments for both tenants and organizations

## Test Plan
- [x] Run organization user management E2E tests
- [x] Verify UUID null validation fix
- [x] Verify deep copy prevents before/after mutation
- [x] Verify verifier catches invalid organization/tenant IDs
- [ ] Execute full test suite: `cd e2e && npm test -- organization_user_management.test.js`

🤖 Generated with [Claude Code](https://claude.com/claude-code)