### PR TITLE
[Security] リフレッシュトークン値のログ出力を削除 (Issue #824)

### DIFF
--- a/e2e/src/tests/scenario/application/scenario-09-token-refresh.test.js
+++ b/e2e/src/tests/scenario/application/scenario-09-token-refresh.test.js
@@ -73,7 +73,7 @@ describe("token refresh strategy", () => {
 
     expect(refreshTokenResponse.status).toBe(400);
     expect(refreshTokenResponse.data.error).toEqual("invalid_grant");
-
+    expect(refreshTokenResponse.data.error_description).toEqual("refresh token is expired");
   });
 
 

--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/token/verifier/RefreshTokenVerifier.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/token/verifier/RefreshTokenVerifier.java
@@ -48,9 +48,7 @@ public class RefreshTokenVerifier {
   void throwExceptionIfExpiredToken() {
     LocalDateTime now = SystemDateTime.now();
     if (oAuthToken.isExpiredRefreshToken(now)) {
-      throw new TokenBadRequestException(
-          "invalid_grant",
-          String.format("refresh token is expired (%s)", context.refreshToken().value()));
+      throw new TokenBadRequestException("invalid_grant", "refresh token is expired");
     }
   }
 }


### PR DESCRIPTION
## Summary
リフレッシュトークンの有効期限切れエラー時に、トークンの値が平文でログに出力される脆弱性を修正しました。

### 🔒 セキュリティ影響
- **深刻度**: 高
- **問題**: ログファイル漏洩時に攻撃者が有効なリフレッシュトークンを抽出可能
- **修正**: エラーメッセージからトークン値を完全に削除

### 📝 変更内容

#### 1. RefreshTokenVerifier.java
```java
// Before
throw new TokenBadRequestException(
    "invalid_grant",
    String.format("refresh token is expired (%s)", context.refreshToken().value()));

// After
throw new TokenBadRequestException("invalid_grant", "refresh token is expired");
```

#### 2. E2Eテスト更新
- `scenario-09-token-refresh.test.js`: エラーメッセージの期待値を更新

### 🎯 修正効果

**修正前のログ**:
```json
{"message":"Token request validation failed: error=invalid_grant, description=refresh token is expired (73mSYJT3RQOv2k7s7z7q5Kra2xke_3caKn9dgKnMJf4)"}
```

**修正後のログ**:
```json
{"message":"Token request validation failed: error=invalid_grant, description=refresh token is expired"}
```

## Test plan
- [x] RefreshTokenVerifier.javaのトークン値削除を確認
- [x] spotlessApplyでコードフォーマット適用
- [x] E2Eテストの期待値を更新 (scenario-09-token-refresh.test.js)
- [x] E2Eテスト実行で動作確認
- [x] ログ出力にトークン値が含まれないことを確認

### テスト実行コマンド
```bash
# E2Eテスト実行
cd e2e && npm test -- scenario-09-token-refresh.test.js

# ログ確認（トークン値が出力されないことを確認）
# アプリケーション起動後、有効期限切れリフレッシュトークンでリクエスト
```

Closes #824

🤖 Generated with [Claude Code](https://claude.com/claude-code)