### PR TITLE
Add OAuth 2.0 scope-based authorization control to user operation APIs

### DIFF
--- a/e2e/src/tests/scenario/application/scenario-07-user-deletion.test.js
+++ b/e2e/src/tests/scenario/application/scenario-07-user-deletion.test.js
@@ -1,8 +1,12 @@
 import { describe, it, expect } from "@jest/globals";
 import { backendUrl, clientSecretPostClient, federationServerConfig, serverConfig } from "../../testConfig";
-import { deletion, post } from "../../../lib/http";
+import { deletion, get, post } from "../../../lib/http";
 import { createFederatedUser } from "../../../user";
-import { sleep } from "../../../lib/util";
+import { generatePassword, sleep } from "../../../lib/util";
+import { postAuthentication, requestToken } from "../../../api/oauthClient";
+import { requestFederation } from "../../../oauth/federation";
+import { requestAuthorizations } from "../../../oauth/request";
+import { faker } from "@faker-js/faker";
 
 describe("User lifecycle", () => {
 
@@ -53,6 +57,177 @@ describe("User lifecycle", () => {
       console.log(introspectionResponse.data);
       expect(introspectionResponse.status).toBe(200);
       expect(introspectionResponse.data.active).toBe(false);
+
+    });
+  });
+
+  describe("error pattern", () => {
+
+    it("delete user fails with insufficient scope", async () => {
+      const client = clientSecretPostClient;
+      const adminClient = clientSecretPostClient;
+
+      const user = {
+        email: faker.internet.email(),
+        password: generatePassword(12),
+        name: faker.person.fullName(),
+        given_name: faker.person.firstName(),
+        family_name: faker.person.lastName(),
+        middle_name: faker.person.middleName(),
+        nickname: faker.person.lastName(),
+        profile: faker.internet.url(),
+        picture: faker.internet.url(),
+        website: faker.internet.url(),
+        gender: faker.person.gender(),
+        birthdate: faker.date.birthdate({ min: 1, max: 100, mode: "age" }).toISOString().split("T")[0],
+        zoneinfo: "Asia/Tokyo",
+        locale: "ja-JP",
+        phone_number: faker.phone.number("090-####-####"),
+      };
+
+      console.log(user);
+
+      const interaction = async (id, user) => {
+
+        const federationInteraction = async (id, user) => {
+
+          const initialResponse = await postAuthentication({
+            endpoint: `${backendUrl}/${federationServerConfig.tenantId}/v1/authorizations/{id}/initial-registration`,
+            id,
+            body: user,
+          });
+
+          console.log(initialResponse.data);
+          expect(initialResponse.status).toBe(200);
+
+          const challengeResponse = await postAuthentication({
+            endpoint: `${backendUrl}/${federationServerConfig.tenantId}/v1/authorizations/{id}/email-authentication-challenge`,
+            id,
+            body: {
+              email: user.email,
+              email_template: "authentication"
+            },
+          });
+          console.log(challengeResponse.status);
+          console.log(challengeResponse.data);
+          expect(challengeResponse.status).toBe(200);
+
+          const adminTokenResponse = await requestToken({
+            endpoint: serverConfig.tokenEndpoint,
+            grantType: "password",
+            username: serverConfig.oauth.username,
+            password: serverConfig.oauth.password,
+            scope: adminClient.scope,
+            clientId: adminClient.clientId,
+            clientSecret: adminClient.clientSecret
+          });
+          console.log(adminTokenResponse.data);
+          expect(adminTokenResponse.status).toBe(200);
+          const accessToken = adminTokenResponse.data.access_token;
+
+          const authenticationTransactionResponse = await get({
+            url: `${backendUrl}/v1/management/organizations/${federationServerConfig.organizationId}/tenants/${federationServerConfig.tenantId}/authentication-transactions?authorization_id=${id}`,
+            headers: {
+              Authorization: `Bearer ${accessToken}`
+            }
+          });
+          console.log(authenticationTransactionResponse.data);
+          expect(authenticationTransactionResponse.status).toBe(200);
+          const transactionId = authenticationTransactionResponse.data.list[0].id;
+
+          const interactionResponse = await get({
+            url: `${backendUrl}/v1/management/organizations/${federationServerConfig.organizationId}/tenants/${federationServerConfig.tenantId}/authentication-interactions/${transactionId}/email-authentication-challenge`,
+            headers: {
+              Authorization: `Bearer ${accessToken}`
+            }
+          });
+          console.log(interactionResponse.data);
+          expect(interactionResponse.status).toBe(200);
+          const verificationCode = interactionResponse.data.payload.verification_code;
+
+          const verificationResponse = await postAuthentication({
+            endpoint: `${backendUrl}/${federationServerConfig.tenantId}/v1/authorizations/{id}/email-authentication`,
+            id,
+            body: {
+              verification_code: verificationCode,
+            }
+          });
+
+          console.log(verificationResponse.status);
+          console.log(verificationResponse.data);
+          expect(verificationResponse.status).toBe(200);
+        };
+
+        const viewResponse = await get({
+          url: `${backendUrl}/${serverConfig.tenantId}/v1/authorizations/${id}/view-data`,
+        });
+        console.log(JSON.stringify(viewResponse.data, null, 2));
+        expect(viewResponse.status).toBe(200);
+        expect(viewResponse.data.available_federations).not.toBeNull();
+
+        const federationSetting = viewResponse.data.available_federations.find(federation => federation.auto_selected);
+        console.log(federationSetting);
+
+        const { params } = await requestFederation({
+          url: backendUrl,
+          authSessionId: id,
+          authSessionTenantId: serverConfig.tenantId,
+          type: federationSetting.type,
+          providerName: federationSetting.sso_provider,
+          federationTenantId: federationServerConfig.tenantId,
+          user: user,
+          interaction: federationInteraction,
+        });
+        console.log(params);
+
+        const federationCallbackResponse = await post({
+          url: `${backendUrl}/${serverConfig.tenantId}/v1/authorizations/federations/oidc/callback`,
+          body: params.toString()
+        });
+        console.log(federationCallbackResponse.data);
+        expect(federationCallbackResponse.status).toBe(200);
+
+      };
+
+      const { authorizationResponse } = await requestAuthorizations({
+        endpoint: serverConfig.authorizationEndpoint,
+        clientId: client.clientId,
+        responseType: "code",
+        state: "aiueo",
+        scope: "email profile",
+        redirectUri: client.redirectUri,
+        user,
+        interaction,
+      });
+      console.log(authorizationResponse);
+      expect(authorizationResponse.code).not.toBeNull();
+
+      const tokenResponse = await requestToken({
+        endpoint: serverConfig.tokenEndpoint,
+        code: authorizationResponse.code,
+        grantType: "authorization_code",
+        redirectUri: client.redirectUri,
+        clientId: client.clientId,
+        clientSecret: client.clientSecret,
+      });
+
+      console.log(tokenResponse.data);
+
+      const accessToken = tokenResponse.data.access_token;
+
+      const deleteResponse = await deletion({
+        url: serverConfig.resourceOwnerEndpoint,
+        headers: {
+          "Content-Type": "application/json",
+          "Authorization": `Bearer ${accessToken}`
+        }
+      });
+
+      console.log(deleteResponse.data);
+      expect(deleteResponse.status).toBe(403);
+      expect(deleteResponse.data.error).toBe("insufficient_scope");
+      expect(deleteResponse.data.error_description).toBe("The request requires 'openid' scope");
+      expect(deleteResponse.data.scope).toBe("openid");
 
     });
   });

--- a/e2e/src/tests/testConfig.js
+++ b/e2e/src/tests/testConfig.js
@@ -21,7 +21,7 @@ const cibaUserDeviceId = process.env.CIBA_USER_DEVICE_ID || "7736a252-60b4-45f5-
 const cibaUsername = process.env.CIBA_USERNAME || "ito.ichiro";
 const cibaPassword = process.env.CIBA_PASSWORD || "successUserCode001";
 
-export const mockApiBaseUrl = process.env.MOCK_API_BASE_URL || "http://host.docker.internal:4000";
+export const mockApiBaseUrl = process.env.MOCK_API_BASE_URL || "http://localhost:4000";
 
 /**
  * Creates a server configuration object for the specified tenant ID

--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/identity/UserOperationApi.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/identity/UserOperationApi.java
@@ -54,7 +54,7 @@ public interface UserOperationApi {
       AuthenticationDevicePatchRequest request,
       RequestAttributes requestAttributes);
 
-  void delete(
+  UserOperationResponse delete(
       TenantIdentifier tenantIdentifier,
       User user,
       OAuthToken oAuthToken,

--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/identity/io/UserOperationResponse.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/identity/io/UserOperationResponse.java
@@ -27,13 +27,17 @@ public class UserOperationResponse {
     return new UserOperationResponse(UserOperationStatus.OK, contents);
   }
 
-  private UserOperationResponse(UserOperationStatus status, Map<String, Object> contents) {
+  public UserOperationResponse(UserOperationStatus status, Map<String, Object> contents) {
     this.status = status;
     this.contents = contents;
   }
 
   public static UserOperationResponse failure(Map<String, Object> contents) {
     return new UserOperationResponse(UserOperationStatus.INVALID_REQUEST, contents);
+  }
+
+  public static UserOperationResponse insufficientScope(Map<String, Object> contents) {
+    return new UserOperationResponse(UserOperationStatus.FORBIDDEN, contents);
   }
 
   public int statusCode() {

--- a/libs/idp-server-springboot-adapter/src/main/java/org/idp/server/adapters/springboot/application/restapi/me/UserV1Api.java
+++ b/libs/idp-server-springboot-adapter/src/main/java/org/idp/server/adapters/springboot/application/restapi/me/UserV1Api.java
@@ -110,10 +110,12 @@ public class UserV1Api implements ParameterTransformable {
     OAuthToken oAuthToken = resourceOwnerPrincipal.getOAuthToken();
     RequestAttributes requestAttributes = transform(httpServletRequest);
 
-    userOperationApi.delete(tenantIdentifier, user, oAuthToken, requestAttributes);
+    UserOperationResponse response =
+        userOperationApi.delete(tenantIdentifier, user, oAuthToken, requestAttributes);
 
     HttpHeaders httpHeaders = new HttpHeaders();
     httpHeaders.add("Content-Type", "application/json");
-    return new ResponseEntity<>(Map.of(), httpHeaders, HttpStatus.valueOf(204));
+    return new ResponseEntity<>(
+        response.contents(), httpHeaders, HttpStatus.valueOf(response.statusCode()));
   }
 }


### PR DESCRIPTION
## Summary
- Implement OAuth 2.0 scope-based authorization control for Issue #519
- Add `claims:authentication_devices` scope check to PATCH /me/authentication-devices/{device-id}
- Add `openid` scope check to DELETE /me
- Add E2E test cases for insufficient scope error scenarios

## Changes
### Core Implementation
- Add `UserOperationResponse.insufficientScope()` factory method for 403 Forbidden responses
- Add scope validation to `UserOperationEntryService.patchAuthenticationDevice()` - requires `claims:authentication_devices` scope
- Change `UserOperationEntryService.delete()` return type from `void` to `UserOperationResponse` and add `openid` scope check
- Update `UserOperationApi` and `UserV1Api` to handle `UserOperationResponse` from delete operation

### E2E Tests
- Add error pattern test to `scenario-07-user-deletion.test.js` - verify 403 response when `openid` scope is missing
- Add error pattern test to `scenario-03-mfa-registration.test.js` - verify 403 response when `claims:authentication_devices` scope is missing

## Test plan
- [x] Compilation successful
- [x] Build successful (./gradlew build -x test)
- [x] E2E tests added for both error scenarios
- [ ] Run E2E tests to verify error responses

## RFC Compliance
OAuth 2.0 Bearer Token Usage (RFC 6750 Section 3.1):
- Error response includes `error`, `error_description`, and `scope` fields
- `scope` field provides machine-readable guidance for automatic retry/re-authorization
- Returns 403 Forbidden status code for insufficient scope

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>