### PR TITLE
fix: remove content-available from APNs notifications for CIBA

### DIFF
--- a/libs/idp-server-notification-apns-adapter/src/main/java/org/idp/server/notification/push/apns/ApnsNotifier.java
+++ b/libs/idp-server-notification-apns-adapter/src/main/java/org/idp/server/notification/push/apns/ApnsNotifier.java
@@ -169,7 +169,6 @@ public class ApnsNotifier implements AuthenticationDeviceNotifier {
       alert.put("title", title);
       alert.put("body", body);
       aps.put("alert", alert);
-      aps.put("content-available", 1);
 
       Map<String, Object> payload = new HashMap<>();
       payload.put("aps", aps);

--- a/libs/idp-server-notification-apns-adapter/src/test/java/org/idp/server/notification/push/apns/ApnsNotifierTest.java
+++ b/libs/idp-server-notification-apns-adapter/src/test/java/org/idp/server/notification/push/apns/ApnsNotifierTest.java
@@ -84,13 +84,12 @@ class ApnsNotifierTest {
 
     JsonNodeWrapper aps = payloadJson.getNode("aps");
     assertTrue(aps.contains("alert"));
-    assertTrue(aps.contains("content-available"));
+    assertFalse(aps.contains("content-available"));
 
     JsonNodeWrapper alert = aps.getNode("alert");
     assertTrue(alert.contains("title"));
     assertTrue(alert.contains("body"));
 
-    assertEquals(1, aps.getValueAsInt("content-available"));
     assertEquals("Test Title", alert.getValueOrEmptyAsString("title"));
     assertEquals("Test Body", alert.getValueOrEmptyAsString("body"));
     assertEquals("Test Sender", payloadJson.getValueOrEmptyAsString("sender"));


### PR DESCRIPTION
Issue #866: APNs notifications were using content-available:1 which caused background activation instead of user-tap activation.

Changes:
- Remove content-available flag from APNs payload
- Use alert-only notifications (aligned with FCM implementation)
- Keep apns-push-type as "alert" and apns-priority as "10"

Rationale:
- CIBA authentication requires user interaction (tap notification)
- Silent/background push is unnecessary for authentication flows
- Aligns APNs behavior with existing FCM implementation
- Follows Apple's recommendation to not mix alert with content-available

🤖 Generated with [Claude Code](https://claude.com/claude-code)