### PR TITLE
feat: add structured JSON logging for token introspection failures (Issue #877)

### DIFF
--- a/e2e/src/tests/scenario/resource_server/token_introspection_extensions.test.js
+++ b/e2e/src/tests/scenario/resource_server/token_introspection_extensions.test.js
@@ -700,7 +700,7 @@ describe("OAuth 2.0 Token Introspection Extensions", () => {
         clientId: selfSignedTlsAuthClient.clientId,
         clientCertFile: selfSignedTlsAuthClient.clientCertFile,
       });
-      console.log(introspectionResponse.data);
+      console.log(JSON.stringify(introspectionResponse.data, null, 2));
       expect(introspectionResponse.status).toBe(200);
       expect(introspectionResponse.data.active).toEqual(false);
       expect(introspectionResponse.data.error).toEqual("invalid_token");
@@ -780,7 +780,7 @@ describe("OAuth 2.0 Token Introspection Extensions", () => {
         clientCert: selfSignedTlsAuthClient.clientCertFile,
         clientCertFile: selfSignedTlsAuthClient.clientCertFile,
       });
-      console.log(introspectionResponse.data);
+      console.log(JSON.stringify(introspectionResponse.data, null, 2));
       expect(introspectionResponse.status).toBe(200);
       expect(introspectionResponse.data.status_code).toBe(401);
       expect(introspectionResponse.data.error).toEqual("invalid_token");
@@ -937,7 +937,7 @@ describe("OAuth 2.0 Token Introspection Extensions", () => {
         clientId: selfSignedTlsAuthClient.clientId,
         clientCertFile: selfSignedTlsAuthClient.clientCertFile,
       });
-      console.log(introspectionResponse.data);
+      console.log(JSON.stringify(introspectionResponse.data, null, 2));
       expect(introspectionResponse.status).toBe(200);
       expect(introspectionResponse.data.active).toEqual(false);
       expect(introspectionResponse.data.error).toEqual("invalid_token");

--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/token/handler/tokenintrospection/TokenIntrospectionErrorHandler.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/token/handler/tokenintrospection/TokenIntrospectionErrorHandler.java
@@ -36,7 +36,7 @@ public class TokenIntrospectionErrorHandler {
 
   public TokenIntrospectionResponse handle(Exception exception) {
     if (exception instanceof TokenIntrospectionBadRequestException badRequest) {
-      log.warn(exception.getMessage());
+      logTokenIntrospectionError("bad_request", badRequest.error().value(), exception.getMessage());
 
       Map<String, Object> contents = new HashMap<>();
       contents.put("active", false);
@@ -48,7 +48,7 @@ public class TokenIntrospectionErrorHandler {
     }
 
     if (exception instanceof TokenInvalidException tokenInvalid) {
-      log.warn(exception.getMessage());
+      logTokenIntrospectionError("invalid_token", "invalid_token", exception.getMessage());
 
       Map<String, Object> contents = new HashMap<>();
       contents.put("active", false);
@@ -60,7 +60,7 @@ public class TokenIntrospectionErrorHandler {
     }
 
     if (exception instanceof TokenCertificationBindingInvalidException bindingInvalidException) {
-      log.warn(exception.getMessage());
+      logTokenIntrospectionError("invalid_client_cert", "invalid_token", exception.getMessage());
 
       Map<String, Object> contents = new HashMap<>();
       contents.put("active", false);
@@ -72,7 +72,8 @@ public class TokenIntrospectionErrorHandler {
     }
 
     if (exception instanceof TokenInsufficientScopeException insufficientScopeException) {
-      log.warn(exception.getMessage());
+      logTokenIntrospectionError(
+          "insufficient_scope", "insufficient_scope", exception.getMessage());
 
       Map<String, Object> contents = new HashMap<>();
       contents.put("active", false);
@@ -84,6 +85,8 @@ public class TokenIntrospectionErrorHandler {
     }
 
     if (exception instanceof ClientUnAuthorizedException) {
+      logTokenIntrospectionError("invalid_client", "invalid_client", exception.getMessage());
+
       Map<String, Object> contents = new HashMap<>();
       contents.put("active", false);
       contents.put("error", "invalid_client");
@@ -94,7 +97,7 @@ public class TokenIntrospectionErrorHandler {
     }
 
     if (exception instanceof ClientConfigurationNotFoundException) {
-      log.warn(exception.getMessage());
+      logTokenIntrospectionError("invalid_client", "invalid_client", exception.getMessage());
 
       Map<String, Object> contents = new HashMap<>();
       contents.put("active", false);
@@ -106,7 +109,9 @@ public class TokenIntrospectionErrorHandler {
     }
 
     if (exception instanceof ServerConfigurationNotFoundException) {
-      log.warn(exception.getMessage());
+      logTokenIntrospectionError(
+          "server_config_not_found", "invalid_client", exception.getMessage());
+
       Map<String, Object> contents = new HashMap<>();
       contents.put("active", false);
       contents.put("error", "invalid_client");
@@ -124,5 +129,15 @@ public class TokenIntrospectionErrorHandler {
     contents.put("status_code", 500);
 
     return new TokenIntrospectionResponse(SERVER_ERROR, contents);
+  }
+
+  private void logTokenIntrospectionError(
+      String status, String errorCode, String errorDescription) {
+    Map<String, Object> logData = new HashMap<>();
+    logData.put("status", status);
+    logData.put("error", errorCode);
+    logData.put("error_description", errorDescription);
+
+    log.warnJson("Token introspection failed", logData);
   }
 }

--- a/libs/idp-server-platform/src/main/java/org/idp/server/platform/log/LoggerWrapper.java
+++ b/libs/idp-server-platform/src/main/java/org/idp/server/platform/log/LoggerWrapper.java
@@ -16,12 +16,16 @@
 
 package org.idp.server.platform.log;
 
+import java.util.HashMap;
+import java.util.Map;
+import org.idp.server.platform.json.JsonConverter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class LoggerWrapper {
 
   Logger logger;
+  JsonConverter jsonConverter = JsonConverter.snakeCaseInstance();
 
   public static LoggerWrapper getLogger(Class<?> clazz) {
     return new LoggerWrapper(clazz);
@@ -81,5 +85,85 @@ public class LoggerWrapper {
 
   public void error(String message, Throwable throwable) {
     logger.error(message, throwable);
+  }
+
+  /**
+   * Logs a message with structured data as JSON at TRACE level. The data is serialized as JSON
+   * string and appended to the message. Logback JsonEncoder will parse this JSON and make fields
+   * searchable in Datadog (e.g., @status:INVALID_TOKEN).
+   *
+   * @param message The message to log
+   * @param data Structured data to be serialized as JSON
+   */
+  public void traceJson(String message, Map<String, Object> data) {
+    if (logger.isTraceEnabled()) {
+      logger.trace("{} {}", message, jsonConverter.write(data));
+    }
+  }
+
+  /**
+   * Logs a message with structured data as JSON at DEBUG level. The data is serialized as JSON
+   * string and appended to the message. Logback JsonEncoder will parse this JSON and make fields
+   * searchable in Datadog (e.g., @status:INVALID_TOKEN).
+   *
+   * @param message The message to log
+   * @param data Structured data to be serialized as JSON
+   */
+  public void debugJson(String message, Map<String, Object> data) {
+    if (logger.isDebugEnabled()) {
+      logger.debug("{} {}", message, jsonConverter.write(data));
+    }
+  }
+
+  /**
+   * Logs a message with structured data as JSON at INFO level. The data is serialized as JSON
+   * string and appended to the message. Logback JsonEncoder will parse this JSON and make fields
+   * searchable in Datadog (e.g., @status:INVALID_TOKEN).
+   *
+   * @param message The message to log
+   * @param data Structured data to be serialized as JSON
+   */
+  public void infoJson(String message, Map<String, Object> data) {
+    logger.info("{} {}", message, jsonConverter.write(data));
+  }
+
+  /**
+   * Logs a message with structured data as JSON at WARN level. The data is serialized as JSON
+   * string and appended to the message. Logback JsonEncoder will parse this JSON and make fields
+   * searchable in Datadog (e.g., @status:INVALID_TOKEN).
+   *
+   * @param message The message to log
+   * @param data Structured data to be serialized as JSON
+   */
+  public void warnJson(String message, Map<String, Object> data) {
+    logger.warn("{} {}", message, jsonConverter.write(data));
+  }
+
+  /**
+   * Logs a message with structured data as JSON at ERROR level. The data is serialized as JSON
+   * string and appended to the message. Logback JsonEncoder will parse this JSON and make fields
+   * searchable in Datadog (e.g., @status:INVALID_TOKEN).
+   *
+   * @param message The message to log
+   * @param data Structured data to be serialized as JSON
+   */
+  public void errorJson(String message, Map<String, Object> data) {
+    logger.error("{} {}", message, jsonConverter.write(data));
+  }
+
+  /**
+   * Logs a message with structured data and exception as JSON at ERROR level. The data is
+   * serialized as JSON string and appended to the message. Logback JsonEncoder will parse this JSON
+   * and make fields searchable in Datadog (e.g., @status:INVALID_TOKEN).
+   *
+   * @param message The message to log
+   * @param data Structured data to be serialized as JSON
+   * @param throwable The exception to log
+   */
+  public void errorJson(String message, Map<String, Object> data, Throwable throwable) {
+    Map<String, Object> enrichedData = new HashMap<>(data);
+    enrichedData.put("exception", throwable.getClass().getName());
+    enrichedData.put("exception_message", throwable.getMessage());
+    logger.error("{} {}", message, jsonConverter.write(enrichedData), throwable);
   }
 }


### PR DESCRIPTION
## Summary
Add JSON-formatted structured logging for token introspection error cases to improve traceability in monitoring systems like Datadog.

## Changes

### 1. LoggerWrapper Enhancement
- Added `*Json()` methods for all log levels (trace/debug/info/warn/error)
- JSON strings are appended to messages and parsed by Logback JsonEncoder
- Enables powerful Datadog searches: `@status:invalid_token`, `@error:insufficient_scope`

### 2. TokenIntrospectionErrorHandler
- Added `logTokenIntrospectionError()` for consistent JSON logging
- Structured logging for all exception types:
  - TokenInvalidException
  - TokenCertificationBindingInvalidException
  - TokenInsufficientScopeException
  - ClientUnAuthorizedException
  - ClientConfigurationNotFoundException
  - ServerConfigurationNotFoundException

### 3. E2E Test Improvements
- Enhanced console.log formatting for better debugging output

## Log Output Example
```json
Token introspection failed {"status":"invalid_token","error":"invalid_token","error_description":"Token not found or invalid."}
```

## Benefits
- **Searchability**: Fields are automatically indexed in Datadog
- **Consistency**: Unified JSON format across all error cases
- **Context**: tenant_id and client_id automatically added via MDC
- **Traceability**: Easy to track down specific error patterns

## Test Plan
- [x] Build successful
- [ ] E2E tests pass
- [ ] Verify JSON logs in actual deployment
- [ ] Confirm Datadog field indexing

## Related Issue
Closes #877

🤖 Generated with [Claude Code](https://claude.com/claude-code)