### PR TITLE
feat: adjust log levels in MappingRuleObjectMapper and JsonPathWrapper (Issue #882)

### DIFF
--- a/libs/idp-server-platform/src/main/java/org/idp/server/platform/json/path/JsonPathWrapper.java
+++ b/libs/idp-server-platform/src/main/java/org/idp/server/platform/json/path/JsonPathWrapper.java
@@ -35,7 +35,7 @@ public class JsonPathWrapper {
       return JsonPath.read(document, path);
     } catch (PathNotFoundException e) {
 
-      log.warn(e.getMessage());
+      log.info(e.getMessage());
       return null;
     }
   }
@@ -45,7 +45,7 @@ public class JsonPathWrapper {
       return JsonPath.read(document, path);
     } catch (PathNotFoundException e) {
 
-      log.warn(e.getMessage());
+      log.info(e.getMessage());
       return null;
     }
   }
@@ -55,7 +55,7 @@ public class JsonPathWrapper {
       return JsonPath.read(document, path);
     } catch (PathNotFoundException e) {
 
-      log.warn(e.getMessage());
+      log.info(e.getMessage());
       return null;
     }
   }
@@ -65,7 +65,7 @@ public class JsonPathWrapper {
       return JsonPath.read(document, path);
     } catch (PathNotFoundException e) {
 
-      log.warn(e.getMessage());
+      log.info(e.getMessage());
       return null;
     }
   }
@@ -75,7 +75,7 @@ public class JsonPathWrapper {
       return JsonPath.read(document, path);
     } catch (PathNotFoundException e) {
 
-      log.warn(e.getMessage());
+      log.info(e.getMessage());
       return null;
     }
   }
@@ -85,7 +85,7 @@ public class JsonPathWrapper {
       return JsonPath.read(document, path);
     } catch (PathNotFoundException e) {
 
-      log.warn(e.getMessage());
+      log.info(e.getMessage());
       return null;
     }
   }
@@ -95,7 +95,7 @@ public class JsonPathWrapper {
       return JsonPath.read(document, path);
     } catch (PathNotFoundException e) {
 
-      log.warn(e.getMessage());
+      log.info(e.getMessage());
       return null;
     }
   }
@@ -105,7 +105,7 @@ public class JsonPathWrapper {
       return JsonPath.read(document, path);
     } catch (PathNotFoundException e) {
 
-      log.warn(e.getMessage());
+      log.info(e.getMessage());
       return null;
     }
   }

--- a/libs/idp-server-platform/src/main/java/org/idp/server/platform/mapper/MappingRuleObjectMapper.java
+++ b/libs/idp-server-platform/src/main/java/org/idp/server/platform/mapper/MappingRuleObjectMapper.java
@@ -72,7 +72,7 @@ public class MappingRuleObjectMapper {
     for (FunctionSpec spec : rule.functions()) {
       ValueFunction fn = functionRegistry.get(spec.name());
       if (fn == null) {
-        log.warn("Function not found: name={}, to={}", spec.name(), rule.to());
+        log.error("Function not found: name={}, to={}", spec.name(), rule.to());
         continue;
       }
       v = fn.apply(v, spec.args());
@@ -90,10 +90,10 @@ public class MappingRuleObjectMapper {
           }
         }
       } else if (value == null) {
-        log.warn(
+        log.debug(
             "'*' skipped: value is null (from=" + (rule.hasFrom() ? rule.from() : "n/a") + ")");
       } else {
-        log.warn("'*' requires Map but got: type={}", value.getClass().getSimpleName());
+        log.error("'*' requires Map but got: type={}", value.getClass().getSimpleName());
       }
     } else {
       flatMap.put(rule.to(), value);


### PR DESCRIPTION
## Summary
Adjust log levels for better operational visibility in mapping and JSON path operations.

## Changes

### MappingRuleObjectMapper
- **Function not found**: WARN → ERROR (configuration error)
- **'*' type mismatch**: WARN → ERROR (type mismatch error)
- **'*' null value**: WARN → DEBUG (normal behavior)

### JsonPathWrapper
- **PathNotFoundException**: WARN → INFO (optional fields are common)

## Rationale

**MappingRuleObjectMapper**:
Configuration errors (function not found, type mismatch) should be ERROR level as they prevent correct mapping behavior.

**JsonPathWrapper**:
Missing JSON paths are common for optional fields. Reduced from WARN to INFO to minimize log noise while maintaining visibility.

## Related Issue
Closes #882

🤖 Generated with [Claude Code](https://claude.com/claude-code)