### PR TITLE
feat: support device hint in CIBA login_hint for targeted device authentication (Issue #870)

### DIFF
--- a/libs/idp-server-core-extension-ciba/src/main/java/org/idp/server/core/extension/ciba/DefaultCibaProtocol.java
+++ b/libs/idp-server-core-extension-ciba/src/main/java/org/idp/server/core/extension/ciba/DefaultCibaProtocol.java
@@ -36,6 +36,7 @@ import org.idp.server.platform.dependency.protocol.AuthorizationProvider;
 import org.idp.server.platform.dependency.protocol.DefaultAuthorizationProvider;
 import org.idp.server.platform.http.HttpRequestExecutor;
 import org.idp.server.platform.log.LoggerWrapper;
+import org.idp.server.platform.log.TenantLoggingContext;
 import org.idp.server.platform.multi_tenancy.tenant.Tenant;
 
 public class DefaultCibaProtocol implements CibaProtocol {
@@ -130,6 +131,7 @@ public class DefaultCibaProtocol implements CibaProtocol {
               cibaRequestContext.userHintRelatedParams(),
               userQueryRepository);
 
+      setUserContext(user);
       additionalVerifiers.verify(cibaRequestContext, user);
 
       CibaIssueResponse response =
@@ -141,6 +143,17 @@ public class DefaultCibaProtocol implements CibaProtocol {
     } catch (Exception exception) {
 
       return errorHandler.handle(exception);
+    }
+  }
+
+  private void setUserContext(User user) {
+
+    if (user.exists()) {
+      TenantLoggingContext.setUserId(user.sub());
+
+      if (user.hasExternalUserId()) {
+        TenantLoggingContext.setUserId(user.externalUserId());
+      }
     }
   }
 

--- a/libs/idp-server-core-extension-ciba/src/main/java/org/idp/server/core/extension/ciba/user/IdTokenHintResolver.java
+++ b/libs/idp-server-core-extension-ciba/src/main/java/org/idp/server/core/extension/ciba/user/IdTokenHintResolver.java
@@ -38,6 +38,7 @@ public class IdTokenHintResolver implements UserHintResolver {
       UserQueryRepository userQueryRepository) {
 
     try {
+      log.debug("Backchannel Authentication Resolving user hint idToken");
       String idToken = userHint.value();
       String serverJwks = userHintRelatedParams.optValueAsString("serverJwks", "");
       String clientSecret = userHintRelatedParams.optValueAsString("clientSecret", "");

--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/oauth/type/oidc/LoginHint.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/oauth/type/oidc/LoginHint.java
@@ -17,6 +17,8 @@
 package org.idp.server.core.openid.oauth.type.oidc;
 
 import java.util.Objects;
+import java.util.Optional;
+import org.idp.server.core.openid.identity.device.AuthenticationDeviceIdentifier;
 
 /**
  * login_hint OPTIONAL.
@@ -28,8 +30,85 @@ import java.util.Objects;
  * This value MAY also be a phone number in the format specified for the phone_number Claim. The use
  * of this parameter is left to the OP's discretion.
  *
+ * <h2>Supported Formats</h2>
+ *
+ * <p>This implementation supports the following prefixed login hint formats:
+ *
+ * <table border="1">
+ *   <caption>Login Hint Formats</caption>
+ *   <tr>
+ *     <th>Format</th>
+ *     <th>Description</th>
+ *     <th>Example</th>
+ *   </tr>
+ *   <tr>
+ *     <td><code>device:{deviceId}</code></td>
+ *     <td>Device identifier for CIBA authentication</td>
+ *     <td><code>device:550e8400-e29b-41d4-a716-446655440000</code></td>
+ *   </tr>
+ *   <tr>
+ *     <td><code>sub:{subject}</code></td>
+ *     <td>Subject identifier (user ID)</td>
+ *     <td><code>sub:1234567890</code></td>
+ *   </tr>
+ *   <tr>
+ *     <td><code>ex-sub:{subject}</code></td>
+ *     <td>External IdP subject identifier</td>
+ *     <td><code>ex-sub:google-user-123</code></td>
+ *   </tr>
+ *   <tr>
+ *     <td><code>email:{email}</code></td>
+ *     <td>Email address</td>
+ *     <td><code>email:user@example.com</code></td>
+ *   </tr>
+ *   <tr>
+ *     <td><code>phone:{phoneNumber}</code></td>
+ *     <td>Phone number</td>
+ *     <td><code>phone:+81-90-1234-5678</code></td>
+ *   </tr>
+ * </table>
+ *
+ * <h2>Additional Provider Hint</h2>
+ *
+ * <p>All formats support an optional IdP provider hint using comma separation:
+ *
+ * <pre>{@code
+ * device:{deviceId},idp:{providerId}
+ * email:{email},idp:{providerId}
+ * }</pre>
+ *
+ * <p>Examples:
+ *
+ * <ul>
+ *   <li><code>device:550e8400-e29b-41d4-a716-446655440000,idp:google</code>
+ *   <li><code>email:user@example.com,idp:azure-ad</code>
+ * </ul>
+ *
+ * <h2>Usage Examples</h2>
+ *
+ * <pre>{@code
+ * LoginHint loginHint = new LoginHint("device:550e8400-e29b-41d4-a716-446655440000");
+ *
+ * // Type-safe extraction
+ * Optional<AuthenticationDeviceIdentifier> deviceId = loginHint.asDeviceIdentifier();
+ * deviceId.ifPresent(id -> {
+ *   // Use device identifier for CIBA authentication
+ *   AuthenticationDevice device = user.findAuthenticationDevice(id.value());
+ * });
+ *
+ * // Type checking
+ * LoginHintType type = loginHint.getType(); // Returns LoginHintType.DEVICE
+ *
+ * // String-based extraction
+ * if (loginHint.hasPrefix("device:")) {
+ *   String deviceIdStr = loginHint.extractPrefixValue("device:");
+ * }
+ * }</pre>
+ *
  * @see <a href="https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest">3.1.2.1.
  *     Authentication Request</a>
+ * @see LoginHintType
+ * @see org.idp.server.core.openid.identity.device.AuthenticationDeviceIdentifier
  */
 public class LoginHint {
   String value;
@@ -46,6 +125,100 @@ public class LoginHint {
 
   public boolean exists() {
     return Objects.nonNull(value) && !value.isEmpty();
+  }
+
+  /**
+   * Checks if the login hint starts with the specified prefix.
+   *
+   * @param prefix the prefix to check (e.g., "device:", "email:", "sub:")
+   * @return true if the login hint starts with the prefix
+   */
+  public boolean hasPrefix(String prefix) {
+    return Objects.nonNull(value) && value.startsWith(prefix);
+  }
+
+  /**
+   * Extracts the value after the specified prefix from the login hint.
+   *
+   * <p>Supports formats like:
+   *
+   * <ul>
+   *   <li>"prefix:value" → returns "value"
+   *   <li>"prefix:value,idp:providerId" → returns "value" (ignores additional hints)
+   * </ul>
+   *
+   * @param prefix the prefix to extract from (e.g., "device:", "email:", "sub:")
+   * @return the extracted value, or empty string if prefix not found
+   */
+  public String extractPrefixValue(String prefix) {
+    if (!hasPrefix(prefix)) {
+      return "";
+    }
+    // Handle "prefix:value" or "prefix:value,idp:providerId"
+    String[] parts = value.split(",");
+    return parts[0].substring(prefix.length());
+  }
+
+  /**
+   * Checks if the login hint specifies a device ID.
+   *
+   * @return true if the login hint starts with "device:"
+   */
+  public boolean isDeviceHint() {
+    return hasPrefix("device:");
+  }
+
+  /**
+   * Extracts the device ID from the login hint.
+   *
+   * <p>Supports formats like:
+   *
+   * <ul>
+   *   <li>"device:{deviceId}" → returns "{deviceId}"
+   *   <li>"device:{deviceId},idp:{providerId}" → returns "{deviceId}"
+   * </ul>
+   *
+   * @return the device ID, or empty string if not a device hint
+   */
+  public String extractDeviceId() {
+    return extractPrefixValue("device:");
+  }
+
+  /**
+   * Returns the type of this login hint based on its prefix.
+   *
+   * @return the login hint type
+   */
+  public LoginHintType getType() {
+    if (hasPrefix("device:")) return LoginHintType.DEVICE;
+    if (hasPrefix("sub:")) return LoginHintType.SUBJECT;
+    if (hasPrefix("ex-sub:")) return LoginHintType.EXTERNAL_SUBJECT;
+    if (hasPrefix("email:")) return LoginHintType.EMAIL;
+    if (hasPrefix("phone:")) return LoginHintType.PHONE;
+    return LoginHintType.UNKNOWN;
+  }
+
+  /**
+   * Extracts device identifier if this is a device hint.
+   *
+   * <p>Returns empty if:
+   *
+   * <ul>
+   *   <li>Login hint is not a device hint (doesn't start with "device:")
+   *   <li>Device ID is empty after extraction
+   * </ul>
+   *
+   * @return AuthenticationDeviceIdentifier wrapped in Optional, or empty if not a device hint
+   */
+  public Optional<AuthenticationDeviceIdentifier> asDeviceIdentifier() {
+    if (!isDeviceHint()) {
+      return Optional.empty();
+    }
+    String deviceId = extractDeviceId();
+    if (deviceId.isEmpty()) {
+      return Optional.empty();
+    }
+    return Optional.of(new AuthenticationDeviceIdentifier(deviceId));
   }
 
   @Override

--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/oauth/type/oidc/LoginHintType.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/oauth/type/oidc/LoginHintType.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2025 Hirokazu Kobayashi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.idp.server.core.openid.oauth.type.oidc;
+
+/**
+ * Represents the type of login hint based on its prefix.
+ *
+ * <p>Login hints can specify different types of user identifiers:
+ *
+ * <ul>
+ *   <li>DEVICE - Device ID hint (format: "device:{deviceId}")
+ *   <li>SUBJECT - Subject identifier hint (format: "sub:{sub}")
+ *   <li>EXTERNAL_SUBJECT - External IdP subject hint (format: "ex-sub:{sub}")
+ *   <li>EMAIL - Email address hint (format: "email:{email}")
+ *   <li>PHONE - Phone number hint (format: "phone:{phoneNumber}")
+ *   <li>UNKNOWN - Unrecognized format or no prefix
+ * </ul>
+ */
+public enum LoginHintType {
+  /** Device ID hint (format: "device:{deviceId}") */
+  DEVICE,
+
+  /** Subject identifier hint (format: "sub:{sub}") */
+  SUBJECT,
+
+  /** External IdP subject hint (format: "ex-sub:{sub}") */
+  EXTERNAL_SUBJECT,
+
+  /** Email address hint (format: "email:{email}") */
+  EMAIL,
+
+  /** Phone number hint (format: "phone:{phoneNumber}") */
+  PHONE,
+
+  /** Unrecognized format or no prefix */
+  UNKNOWN
+}


### PR DESCRIPTION
## Summary
Implements support for `device:{deviceId}` format in CIBA `login_hint` parameter to allow clients to specify which authentication device should be used for backchannel authentication.

## Changes

### Core Implementation
- **LoginHintType enum**: Type-safe classification of login hint formats (DEVICE, SUBJECT, EXTERNAL_SUBJECT, EMAIL, PHONE, UNKNOWN)
- **LoginHint API enhancements**:
  - `asDeviceIdentifier()`: Type-safe Optional-based device ID extraction
  - `getType()`: Returns LoginHintType for hint classification
  - `isDeviceHint()`, `extractDeviceId()`: Convenience methods for device hints
  - Comprehensive Javadoc with supported formats table and usage examples

### CIBA Device Selection
- **CibaAuthenticationTransactionCreator**: Refactored to use device specified in login_hint
  - Falls back to primary device if specified device not found
  - Supports `device:{deviceId}` and `device:{deviceId},idp:{providerId}` formats
  - Type-safe implementation using Optional API

### Logging Improvements
- **User resolution logging**:
  - Debug logs for each login hint type resolution (sub, ex-sub, device, phone, email, idToken)
  - Warn logs for unsupported login_hint formats
  - Warn logs when user not found for valid login_hint
- **User context tracking**:
  - TenantLoggingContext populated with user ID and external user ID
  - Improved traceability in CIBA authentication flows

### Testing
- **E2E test**: FIDO UAF multi-device scenario
  - Registers 2 FIDO UAF devices
  - Specifies device_1 via `login_hint`
  - Verifies authentication transaction created for specified device
  - Confirms successful token issuance

## Behavior

### Before
```java
// Always used primary authentication device
AuthenticationDevice authenticationDevice = user.findPrimaryAuthenticationDevice();
```

### After
```java
// Uses device specified in login_hint, falls back to primary if not found
return request
    .loginHint()
    .asDeviceIdentifier()
    .map(deviceId -> user.findAuthenticationDevice(deviceId.value()))
    .filter(AuthenticationDevice::exists)
    .orElseGet(user::findPrimaryAuthenticationDevice);
```

## Supported Login Hint Formats

| Format | Description | Example |
|--------|-------------|---------|
| `device:{deviceId}` | Device identifier for CIBA | `device:550e8400-e29b-41d4-a716-446655440000` |
| `sub:{subject}` | Subject identifier | `sub:1234567890` |
| `ex-sub:{subject}` | External IdP subject | `ex-sub:google-user-123` |
| `email:{email}` | Email address | `email:user@example.com` |
| `phone:{phoneNumber}` | Phone number | `phone:+81-90-1234-5678` |

All formats support optional IdP provider hint: `{format},idp:{providerId}`

## Impact
- ✅ **No breaking changes**: Existing behavior preserved (defaults to primary device)
- ✅ **Type-safe API**: Reduced string manipulation, improved maintainability
- ✅ **Better observability**: Enhanced logging for troubleshooting
- ✅ **CIBA spec compliance**: Proper device hint support per OpenID CIBA specification

## Test Plan
- [x] E2E test: FIDO UAF multi-device scenario with device hint
- [x] Existing CIBA tests pass (device hint is optional)
- [x] Javadoc generation successful
- [x] Code formatting applied

Closes #870

🤖 Generated with [Claude Code](https://claude.com/claude-code)