### PR TITLE
feat: implement response config and comprehensive logging for FIDO-UAF authentication (Issue #887)

### DIFF
--- a/libs/idp-server-authentication-interactors/src/main/java/org/idp/server/authentication/interactors/fidouaf/FidoUafCancelInteractor.java
+++ b/libs/idp-server-authentication-interactors/src/main/java/org/idp/server/authentication/interactors/fidouaf/FidoUafCancelInteractor.java
@@ -52,7 +52,7 @@ public class FidoUafCancelInteractor implements AuthenticationInteractor {
       RequestAttributes requestAttributes,
       UserQueryRepository userQueryRepository) {
 
-    log.info("FidoUafCancelInteractor called");
+    log.debug("FidoUafCancelInteractor called");
 
     AuthenticationInteractionStatus status = AuthenticationInteractionStatus.SUCCESS;
     Map<String, Object> response = Map.of();

--- a/libs/idp-server-authentication-interactors/src/main/java/org/idp/server/authentication/interactors/fidouaf/FidoUafDeRegistrationInteractor.java
+++ b/libs/idp-server-authentication-interactors/src/main/java/org/idp/server/authentication/interactors/fidouaf/FidoUafDeRegistrationInteractor.java
@@ -110,6 +110,9 @@ public class FidoUafDeRegistrationInteractor implements AuthenticationInteractor
         MappingRuleObjectMapper.execute(responseConfig.bodyMappingRules(), jsonPathWrapper);
 
     if (executionResult.isClientError()) {
+
+      log.warn("FIDO-UAF deregistration failed. Client error: {}", executionResult.contents());
+
       return AuthenticationInteractionRequestResult.clientError(
           contents,
           type,
@@ -119,6 +122,9 @@ public class FidoUafDeRegistrationInteractor implements AuthenticationInteractor
     }
 
     if (executionResult.isServerError()) {
+
+      log.warn("FIDO-UAF deregistration failed. Server error: {}", executionResult.contents());
+
       return AuthenticationInteractionRequestResult.serverError(
           contents,
           type,
@@ -131,6 +137,11 @@ public class FidoUafDeRegistrationInteractor implements AuthenticationInteractor
     User user = transaction.user();
 
     User removedDeviceUser = user.removeAuthenticationDevice(deviceId);
+
+    log.debug(
+        "FIDO-UAF deregistration succeeded for user: {}, device: {}",
+        removedDeviceUser.sub(),
+        deviceId);
 
     return new AuthenticationInteractionRequestResult(
         AuthenticationInteractionStatus.SUCCESS,

--- a/libs/idp-server-authentication-interactors/src/main/java/org/idp/server/authentication/interactors/fidouaf/FidoUafRegistrationChallengeInteractor.java
+++ b/libs/idp-server-authentication-interactors/src/main/java/org/idp/server/authentication/interactors/fidouaf/FidoUafRegistrationChallengeInteractor.java
@@ -118,6 +118,10 @@ public class FidoUafRegistrationChallengeInteractor implements AuthenticationInt
         MappingRuleObjectMapper.execute(responseConfig.bodyMappingRules(), jsonPathWrapper);
 
     if (executionResult.isClientError()) {
+
+      log.warn(
+          "FIDO-UAF registration challenge failed. Client error: {}", executionResult.contents());
+
       return AuthenticationInteractionRequestResult.clientError(
           contents,
           type,
@@ -127,6 +131,10 @@ public class FidoUafRegistrationChallengeInteractor implements AuthenticationInt
     }
 
     if (executionResult.isServerError()) {
+
+      log.warn(
+          "FIDO-UAF registration challenge failed. Server error: {}", executionResult.contents());
+
       return AuthenticationInteractionRequestResult.serverError(
           contents,
           type,


### PR DESCRIPTION
## Summary
- Apply response configuration mapping to FIDO-UAF authentication operations
- Implement comprehensive debug logging consistent with FIDO2 authentication
- Add device ID extraction tracing for improved troubleshooting

## Changes

### Response Configuration Support
Applied `AuthenticationResponseConfig` to map execution results:
- **FidoUafAuthenticationInteractor**: Maps response body using configured mapping rules
- **FidoUafRegistrationInteractor**: Maps response body using configured mapping rules

### Debug Logging Enhancements
Unified logging pattern with FIDO2:
- Changed `log.info()` → `log.debug()` for normal processing flow
- Added `log.warn()` for client/server errors with detailed execution results
- Added success debug logs with user/device identifiers

### Device ID Extraction Tracing
Added trace logs in `extractDeviceId()` to identify source:
- Request body (`device_id` parameter)
- Request attributes (`x-device-id` header)
- Transaction authentication device
- Not found case

## Modified Files (6)
1. `FidoUafAuthenticationInteractor.java` - responseConfig + logs
2. `FidoUafAuthenticationChallengeInteractor.java` - error logs + device ID tracing
3. `FidoUafRegistrationInteractor.java` - responseConfig + logs
4. `FidoUafRegistrationChallengeInteractor.java` - error logs
5. `FidoUafDeRegistrationInteractor.java` - error logs
6. `FidoUafCancelInteractor.java` - log level adjustment

## Test Plan
- [x] Build successful: `./gradlew build`
- [x] All unit tests pass
- [x] Code formatting applied: `./gradlew spotlessApply`

## Benefits
✅ Consistent logging pattern across all FIDO-UAF operations
✅ Response mapping configuration now applied correctly
✅ Improved troubleshooting with detailed error context
✅ Better device ID resolution tracking for debugging

Fixes #887

🤖 Generated with [Claude Code](https://claude.com/claude-code)