### PR TITLE
fix: unify response structure and add response mapping to authentication interactors (Issue #889)

### DIFF
--- a/libs/idp-server-authentication-interactors/src/main/java/org/idp/server/authentication/interactors/sms/SmsAuthenticationInteractor.java
+++ b/libs/idp-server-authentication-interactors/src/main/java/org/idp/server/authentication/interactors/sms/SmsAuthenticationInteractor.java
@@ -23,6 +23,7 @@ import org.idp.server.core.openid.authentication.*;
 import org.idp.server.core.openid.authentication.config.AuthenticationConfiguration;
 import org.idp.server.core.openid.authentication.config.AuthenticationExecutionConfig;
 import org.idp.server.core.openid.authentication.config.AuthenticationInteractionConfig;
+import org.idp.server.core.openid.authentication.config.AuthenticationResponseConfig;
 import org.idp.server.core.openid.authentication.interaction.execution.AuthenticationExecutionRequest;
 import org.idp.server.core.openid.authentication.interaction.execution.AuthenticationExecutionResult;
 import org.idp.server.core.openid.authentication.interaction.execution.AuthenticationExecutor;
@@ -32,7 +33,10 @@ import org.idp.server.core.openid.authentication.repository.AuthenticationConfig
 import org.idp.server.core.openid.authentication.repository.AuthenticationInteractionQueryRepository;
 import org.idp.server.core.openid.identity.User;
 import org.idp.server.core.openid.identity.repository.UserQueryRepository;
+import org.idp.server.platform.json.JsonNodeWrapper;
+import org.idp.server.platform.json.path.JsonPathWrapper;
 import org.idp.server.platform.log.LoggerWrapper;
+import org.idp.server.platform.mapper.MappingRuleObjectMapper;
 import org.idp.server.platform.multi_tenancy.tenant.Tenant;
 import org.idp.server.platform.security.event.DefaultSecurityEventType;
 import org.idp.server.platform.type.RequestAttributes;
@@ -86,9 +90,18 @@ public class SmsAuthenticationInteractor implements AuthenticationInteractor {
         executor.execute(
             tenant, transaction.identifier(), executionRequest, requestAttributes, execution);
 
+    AuthenticationResponseConfig responseConfig = authenticationInteractionConfig.response();
+    JsonNodeWrapper jsonNodeWrapper = JsonNodeWrapper.fromObject(executionResult.contents());
+    JsonPathWrapper jsonPathWrapper = new JsonPathWrapper(jsonNodeWrapper.toJson());
+    Map<String, Object> contents =
+        MappingRuleObjectMapper.execute(responseConfig.bodyMappingRules(), jsonPathWrapper);
+
     if (executionResult.isClientError()) {
+
+      log.warn("SMS authentication failed. Client error: {}", executionResult.contents());
+
       return AuthenticationInteractionRequestResult.clientError(
-          executionResult.contents(),
+          contents,
           type,
           operationType(),
           method(),
@@ -96,8 +109,11 @@ public class SmsAuthenticationInteractor implements AuthenticationInteractor {
     }
 
     if (executionResult.isServerError()) {
+
+      log.warn("SMS authentication failed. Server error: {}", executionResult.contents());
+
       return AuthenticationInteractionRequestResult.serverError(
-          executionResult.contents(),
+          contents,
           type,
           operationType(),
           method(),
@@ -141,8 +157,10 @@ public class SmsAuthenticationInteractor implements AuthenticationInteractor {
 
     verifiedUser.setPhoneNumberVerified(true);
 
-    Map<String, Object> contents = new HashMap<>();
-    contents.put("user", verifiedUser.toMap());
+    log.debug("SMS authentication succeeded for user: {}", verifiedUser.sub());
+
+    Map<String, Object> responseContents = new HashMap<>(contents);
+    responseContents.put("user", verifiedUser.toMap());
 
     return new AuthenticationInteractionRequestResult(
         AuthenticationInteractionStatus.SUCCESS,
@@ -150,7 +168,7 @@ public class SmsAuthenticationInteractor implements AuthenticationInteractor {
         operationType(),
         method(),
         verifiedUser,
-        contents,
+        responseContents,
         DefaultSecurityEventType.sms_verification_success);
   }
 


### PR DESCRIPTION
## Summary
- Unify response structure between success and error cases in HTTP executors
- Add response configuration mapping to Email and SMS authentication interactors
- Implement comprehensive debug logging for all authentication flows

## Changes

### 1. HTTP Executor Response Structure Unification (Issue #889)

**Problem**: Different response structures for success vs error cases made body mapping inconsistent and debugging difficult.

**Before**:
```json
// Success
{ "execution_http_request": { "statusCode": 200, "headers": {...}, "body": {...} } }

// Error (body only, missing statusCode and headers)
{ "error": "...", "error_description": "..." }
```

**After** (unified structure):
```json
// Both success and error
{ "execution_http_request": { "statusCode": XXX, "headers": {...}, "body": {...} } }
```

**Implementation**:
- **HttpRequestAuthenticationExecutor**: Added `createExecutionResult(HttpRequestResult)` helper
- **HttpRequestsAuthenticationExecutor**: Added `createExecutionResult(List<HttpRequestResult>, HttpRequestResult)` helper

### 2. Response Config Application & Logging

Applied to **EmailAuthenticationInteractor** and **SmsAuthenticationInteractor**:

```java
// Response mapping
AuthenticationResponseConfig responseConfig = authenticationInteractionConfig.response();
Map<String, Object> contents = MappingRuleObjectMapper.execute(
    responseConfig.bodyMappingRules(), jsonPathWrapper);

// Error logging
log.warn("Email/SMS authentication failed. Client/Server error: {}", executionResult.contents());

// Success logging
log.debug("Email/SMS authentication succeeded for user: {}", verifiedUser.sub());
```

## Modified Files (4)

1. **HttpRequestAuthenticationExecutor.java**
   - Helper method for consistent response structure
   - Store configuration only applied on success

2. **HttpRequestsAuthenticationExecutor.java**
   - Helper method for consistent response structure  
   - Preserves all results even on mid-execution error

3. **EmailAuthenticationInteractor.java**
   - Response config mapping added
   - Error and success logging added

4. **SmsAuthenticationInteractor.java**
   - Response config mapping added
   - Error and success logging added

## Benefits

✅ **Unified Structure**: Same response format for success and error cases
✅ **Complete Information**: Full HTTP details (status, headers, body) preserved in errors
✅ **Consistent Mapping**: Same mapping rules work for both success and error
✅ **Better Debugging**: Comprehensive logging with error context
✅ **DRY Principle**: Helper methods eliminate code duplication

## Test Plan

- [x] Build successful: `./gradlew build`
- [x] All unit tests pass
- [x] Code formatting applied: `./gradlew spotlessApply`
- [x] Consistent pattern across all authentication interactors

## Breaking Changes

⚠️ **HTTP Executor Error Response Structure Changed**

Applications using error response mapping rules may need updates:

**Before**:
```json
"mappingRules": {
  "error": "$.error"
}
```

**After**:
```json
"mappingRules": {
  "error": "$.execution_http_request.body.error"
}
```

Fixes #889

🤖 Generated with [Claude Code](https://claude.com/claude-code)