### PR TITLE
feat: implement external service password authentication with user mapping (Issue #898)

### DIFF
--- a/config/examples/e2e/test-tenant/authentication-config/password/standard.json
+++ b/config/examples/e2e/test-tenant/authentication-config/password/standard.json
@@ -1,0 +1,50 @@
+{
+  "id": "a1b2c3d4-5678-90ab-cdef-1234567890ab",
+  "type": "password",
+  "attributes": {},
+  "metadata": {
+    "type": "password",
+    "description": "Standard password authentication"
+  },
+  "interactions": {
+    "password-authentication": {
+      "request": {
+        "schema": {
+          "type": "object",
+          "properties": {
+            "username": {
+              "type": "string",
+              "description": "Username (preferred_username)"
+            },
+            "password": {
+              "type": "string",
+              "description": "Password"
+            },
+            "provider_id": {
+              "type": "string",
+              "description": "Provider ID (default: idp-server)"
+            }
+          },
+          "required": ["username", "password"]
+        }
+      },
+      "pre_hook": {},
+      "execution": {
+        "function": "password_verification"
+      },
+      "post_hook": {},
+      "response": {
+        "body_mapping_rules": [
+          {
+            "from": "$.user_id",
+            "to": "user_id"
+          },
+          {
+            "from": "$.username",
+            "to": "username"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/docker/mockoon/config.json
+++ b/docker/mockoon/config.json
@@ -133,6 +133,42 @@
       "streamingInterval": 0
     },
     {
+      "uuid": "a1b2c3d4-5678-90ab-cdef-password-auth",
+      "type": "http",
+      "documentation": "External password authentication service for Issue #898",
+      "method": "post",
+      "endpoint": "auth/password",
+      "responses": [
+        {
+          "uuid": "response-password-auth-success",
+          "body": "{\n  \"user_id\": \"{{ body 'username' }}\",\n  \"email\": \"{{ body 'username' }}\",\n  \"name\": \"Test User\",\n  \"authenticated\": true\n}",
+          "latency": 0,
+          "statusCode": 200,
+          "label": "Success",
+          "headers": [
+            {
+              "key": "Content-Type",
+              "value": "application/json"
+            }
+          ],
+          "bodyType": "INLINE",
+          "filePath": "",
+          "databucketID": "",
+          "sendFileAsBody": false,
+          "rules": [],
+          "rulesOperator": "OR",
+          "disableTemplating": false,
+          "fallbackTo404": false,
+          "default": true,
+          "crudKey": "id",
+          "callbacks": []
+        }
+      ],
+      "responseMode": null,
+      "streamingMode": null,
+      "streamingInterval": 0
+    },
+    {
       "uuid": "7cd7a5c2-403d-4381-88cf-552b0206a1d7",
       "type": "http",
       "documentation": "",

--- a/documentation/docs/content_05_how-to/how-to-03-tenant-setup.md
+++ b/documentation/docs/content_05_how-to/how-to-03-tenant-setup.md
@@ -311,6 +311,8 @@ POST /v1/management/organizations/{organization-id}/tenants
 | `grant_types_supported` | array | ✅ | サポートするグラントタイプ |
 | `token_endpoint_auth_methods_supported` | array | ✅ | サポートするクライアント認証方式 |
 | `subject_types_supported` | array | - | サポートするsubject識別子タイプ |
+| `claims_supported` | array | - | サポートするクレーム（`sub`, `name`, `email`等） |
+| `claim_types_supported` | array | - | サポートするクレームタイプ（`normal`等） |
 
 ---
 
@@ -424,6 +426,8 @@ OAuth/OIDC認証を動かすために、以下の4つのカテゴリのパラメ
 | `response_types_supported` | 認可レスポンス形式 |
 | `grant_types_supported` | トークン取得方法 |
 | `token_endpoint_auth_methods_supported` | クライアント認証方式 |
+| `claims_supported` | 利用可能なクレーム（ユーザー情報項目） |
+| `claim_types_supported` | クレームの種別（現状は`normal`のみサポート） |
 
 ### 🔑 4. JWKS（署名鍵）
 

--- a/documentation/openapi/swagger-rp-ja.yaml
+++ b/documentation/openapi/swagger-rp-ja.yaml
@@ -634,6 +634,11 @@ paths:
       description: |
         認証されたエンドユーザーのプロフィール情報を返す。
         OpenID Connect Core 1.0 Section 5 に準拠。
+
+        **返却可能なクレーム（ユーザー情報項目）**:
+        - OpenID Connect Discovery（`/.well-known/openid-configuration`）の `claims_supported` で確認できます
+        - 標準クレーム例: `sub`, `name`, `email`, `email_verified`, `preferred_username`, `phone_number` など
+        - 実際に返却されるクレームは、`scope` パラメータまたは `claims` パラメータでの要求内容に依存します
       security:
         - bearerAuth: [ ]
       responses:
@@ -667,6 +672,11 @@ paths:
       description: |
         認証されたエンドユーザーのプロフィール情報を返す。
         OpenID Connect Core 1.0 Section 5 に準拠。
+
+        **返却可能なクレーム（ユーザー情報項目）**:
+        - OpenID Connect Discovery（`/.well-known/openid-configuration`）の `claims_supported` で確認できます
+        - 標準クレーム例: `sub`, `name`, `email`, `email_verified`, `preferred_username`, `phone_number` など
+        - 実際に返却されるクレームは、`scope` パラメータまたは `claims` パラメータでの要求内容に依存します
       security:
         - bearerAuth: [ ]
       responses:

--- a/e2e/.env.local
+++ b/e2e/.env.local
@@ -18,3 +18,6 @@ CIBA_USER_EMAIL=ito.ichiro@gmail.com
 CIBA_USER_DEVICE_ID=7736a252-60b4-45f5-b817-65ea9a540860
 CIBA_USERNAME=ito.ichiro@gmail.com
 CIBA_PASSWORD=successUserCode001
+
+# MOCK_API_BASE_URL="http://localhost:4000"
+# MOCK_API_BASE_URL="http://host.docker.internal:4000"

--- a/e2e/src/tests/scenario/application/scenario-11-password-policy-full-flow.test.js
+++ b/e2e/src/tests/scenario/application/scenario-11-password-policy-full-flow.test.js
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "@jest/globals";
 import { requestToken, postAuthentication } from "../../../api/oauthClient";
-import { backendUrl, clientSecretPostClient, serverConfig } from "../../testConfig";
+import { backendUrl, clientSecretPostClient, mockApiBaseUrl, serverConfig } from "../../testConfig";
 import { post, postWithJson, get } from "../../../lib/http";
 import { faker } from "@faker-js/faker";
 import { v4 as uuidv4 } from "uuid";
@@ -101,6 +101,7 @@ describe("Issue #741: Password Policy Full Flow", () => {
           grant_types_supported: ["authorization_code", "password"],
           token_endpoint_auth_methods_supported: ["client_secret_post", "client_secret_basic"],
           id_token_signing_alg_values_supported: ["RS256"],
+          claims_supported: ["sub", "name", "email", "email_verified", "preferred_username"],
           extension: {
             access_token_type: "JWT",
             access_token_duration: 3600,
@@ -260,8 +261,251 @@ describe("Issue #741: Password Policy Full Flow", () => {
       expect(oldPasswordTokenResponse.data.error).toEqual("invalid_grant");
       console.log("✓ Old password correctly rejected\n");
 
+      // Step 9: Verify user info includes mapped data from external service
+      console.log("Step 7: Verifying user info from external service mapping...");
+      const userInfoResponse = await get({
+        url: `${backendUrl}/${tenantId}/v1/userinfo`,
+        headers: {
+          Authorization: `Bearer ${tokenResponse.data.access_token}`,
+        },
+      });
+
+      console.log("UserInfo response:", userInfoResponse.status, userInfoResponse.data);
+      expect(userInfoResponse.status).toBe(200);
+      expect(userInfoResponse.data).toHaveProperty("sub");
+      expect(userInfoResponse.data).toHaveProperty("email", userEmail);
+      console.log("✓ User info verified (mapped from external service)\n");
+
       console.log("=== Password Policy Full Flow Test Complete ===\n");
     }, 90000); // Extended timeout for full flow with tenant creation
+
+  });
+
+  describe("External Service Password Authentication (Issue #898)", () => {
+
+    it("should authenticate via external service and map user with http_request", async () => {
+      console.log("\n=== Starting External Service Password Authentication Test ===\n");
+
+      // Step 1: Get admin access token
+      console.log("Step 1: Getting admin access token...");
+      const adminTokenResponse = await requestToken({
+        endpoint: serverConfig.tokenEndpoint,
+        grantType: "password",
+        username: serverConfig.oauth.username,
+        password: serverConfig.oauth.password,
+        scope: clientSecretPostClient.scope,
+        clientId: clientSecretPostClient.clientId,
+        clientSecret: clientSecretPostClient.clientSecret
+      });
+      expect(adminTokenResponse.status).toBe(200);
+      const adminAccessToken = adminTokenResponse.data.access_token;
+      console.log("✓ Admin access token obtained\n");
+
+      // Step 2: Create new tenant
+      console.log("Step 2: Creating new tenant...");
+      const tenantId = uuidv4();
+      const { jwks } = await generateRS256KeyPair();
+
+      const tenantData = {
+        tenant: {
+          id: tenantId,
+          name: "External Auth Test Tenant",
+          domain: "http://localhost:8080",
+          description: "Test tenant for external password authentication",
+          authorization_provider: "idp-server",
+          tenant_type: "BUSINESS"
+        },
+        authorization_server: {
+          issuer: `${backendUrl}/${tenantId}`,
+          authorization_endpoint: `${backendUrl}/${tenantId}/v1/authorizations`,
+          token_endpoint: `${backendUrl}/${tenantId}/v1/tokens`,
+          userinfo_endpoint: `${backendUrl}/${tenantId}/v1/userinfo`,
+          jwks_uri: `${backendUrl}/${tenantId}/.well-known/jwks.json`,
+          jwks: jwks,
+          scopes_supported: ["openid", "profile", "email"],
+          response_types_supported: ["code"],
+          response_modes_supported: ["query"],
+          subject_types_supported: ["public"],
+          grant_types_supported: ["authorization_code", "password"],
+          token_endpoint_auth_methods_supported: ["client_secret_post"],
+          id_token_signing_alg_values_supported: ["RS256"],
+          claims_supported: ["sub", "name", "email", "email_verified", "preferred_username"],
+          claim_types_supported: ["normal"],
+          extension: {
+            access_token_type: "JWT",
+            access_token_duration: 3600,
+            id_token_duration: 3600
+          }
+        }
+      };
+
+      const createTenantResponse = await postWithJson({
+        url: `${backendUrl}/v1/management/organizations/${serverConfig.organizationId}/tenants`,
+        headers: {
+          Authorization: `Bearer ${adminAccessToken}`,
+        },
+        body: tenantData
+      });
+
+      expect(createTenantResponse.status).toBe(201);
+      console.log(`✓ Tenant created: ${tenantId}\n`);
+
+      // Step 3: Register client
+      console.log("Step 3: Registering client...");
+      const clientId = uuidv4();
+      const clientSecret = uuidv4();
+      const redirectUri = "http://localhost:8080/callback";
+
+      const clientData = {
+        client_id: clientId,
+        client_secret: clientSecret,
+        redirect_uris: [redirectUri],
+        grant_types: ["authorization_code", "password"],
+        response_types: ["code"],
+        scope: "openid profile email",
+        token_endpoint_auth_method: "client_secret_post"
+      };
+
+      const createClientResponse = await postWithJson({
+        url: `${backendUrl}/v1/management/organizations/${serverConfig.organizationId}/tenants/${tenantId}/clients`,
+        headers: {
+          Authorization: `Bearer ${adminAccessToken}`,
+        },
+        body: clientData
+      });
+
+      expect(createClientResponse.status).toBe(201);
+      console.log(`✓ Client registered: ${clientId}\n`);
+
+      // Step 4: Configure external password authentication with http_request (Issue #898)
+      console.log("Step 4: Configuring external password authentication...");
+      const authConfigId = uuidv4();
+
+      const authenticationConfig = {
+        id: authConfigId,
+        type: "password",
+        attributes: {},
+        metadata: {
+          description: "External password authentication via Mockoon for Issue #898"
+        },
+        interactions: {
+          "password-authentication": {
+            execution: {
+              function: "http_request",
+              http_request: {
+                url: `${mockApiBaseUrl}/auth/password`,
+                method: "POST",
+                header_mapping_rules: [
+                  { "static_value": "application/json", "to": "Content-Type" }
+                ],
+                body_mapping_rules: [
+                  { "from": "$.request_body.username", "to": "username" },
+                  { "from": "$.request_body.password", "to": "password" }
+                ]
+              }
+            },
+            user_resolve: {
+              user_mapping_rules: [
+                { "from": "$.execution_http_request.response_body.user_id", "to": "external_user_id" },
+                { "from": "$.execution_http_request.response_body.email", "to": "email" },
+                { "from": "$.execution_http_request.response_body.name", "to": "name" },
+                { "static_value": "mockoon", "to": "provider_id" }
+              ]
+            },
+            response: {
+              body_mapping_rules: [
+                { "from": "$.execution_http_request.response_body.user_id", "to": "user_id" },
+                { "from": "$.execution_http_request.response_body.email", "to": "email" }
+              ]
+            }
+          }
+        }
+      };
+
+      const createAuthConfigResponse = await postWithJson({
+        url: `${backendUrl}/v1/management/organizations/${serverConfig.organizationId}/tenants/${tenantId}/authentication-configurations`,
+        headers: {
+          Authorization: `Bearer ${adminAccessToken}`,
+        },
+        body: authenticationConfig
+      });
+
+      console.log("Authentication config response:", createAuthConfigResponse.status);
+      console.log(JSON.stringify( createAuthConfigResponse.data, null, 2));
+      expect(createAuthConfigResponse.status).toBe(201);
+      console.log(`✓ Authentication configuration created: ${authConfigId}\n`);
+
+      // Step 5: Password authentication via external service (Authorization Flow)
+      console.log("Step 5: Password authentication via external service...");
+      const userEmail = faker.internet.email();
+      const testPassword = "ExternalPass123!";
+
+      const interaction = async (id, user) => {
+        const passwordAuthResponse = await postWithJson({
+          url: `${backendUrl}/${tenantId}/v1/authorizations/${id}/password-authentication`,
+          body: {
+            username: user.email,
+            password: user.password
+          }
+        });
+
+        console.log("Password authentication response:", passwordAuthResponse.status, passwordAuthResponse.data);
+        expect(passwordAuthResponse.status).toBe(200);
+      };
+
+      const { authorizationResponse } = await requestAuthorizations({
+        endpoint: `${backendUrl}/${tenantId}/v1/authorizations`,
+        authorizeEndpoint: `${backendUrl}/${tenantId}/v1/authorizations/{id}/authorize`,
+        denyEndpoint: `${backendUrl}/${tenantId}/v1/authorizations/{id}/deny`,
+        clientId: clientId,
+        responseType: "code",
+        state: `state_${Date.now()}`,
+        scope: "openid profile email",
+        redirectUri: redirectUri,
+        user: {
+          email: userEmail,
+          password: testPassword
+        },
+        interaction,
+      });
+
+      expect(authorizationResponse.code).not.toBeNull();
+      console.log("✓ Password authentication via external service successful\n");
+
+      // Step 6: Exchange authorization code for token
+      console.log("Step 6: Exchanging authorization code for token...");
+      const tokenResponse = await requestToken({
+        endpoint: `${backendUrl}/${tenantId}/v1/tokens`,
+        code: authorizationResponse.code,
+        grantType: "authorization_code",
+        redirectUri: redirectUri,
+        clientId: clientId,
+        clientSecret: clientSecret,
+      });
+
+      console.log(JSON.stringify(tokenResponse.data, null, 2));
+      expect(tokenResponse.status).toBe(200);
+      expect(tokenResponse.data).toHaveProperty("access_token");
+      expect(tokenResponse.data).toHaveProperty("id_token");
+      console.log("✓ Token obtained\n");
+
+      // Step 7: Verify user info includes mapped data from external service
+      console.log("Step 7: Verifying user info from external service mapping...");
+      const userInfoResponse = await get({
+        url: `${backendUrl}/${tenantId}/v1/userinfo`,
+        headers: {
+          Authorization: `Bearer ${tokenResponse.data.access_token}`,
+        },
+      });
+
+      console.log("UserInfo response:", userInfoResponse.status, userInfoResponse.data);
+      expect(userInfoResponse.status).toBe(200);
+      expect(userInfoResponse.data).toHaveProperty("sub");
+      expect(userInfoResponse.data).toHaveProperty("email", userEmail);
+      console.log("✓ User info verified (mapped from external service)\n");
+
+      console.log("=== External Service Password Authentication Test Complete ===\n");
+    }, 90000);
 
   });
 

--- a/libs/idp-server-authentication-interactors/src/main/java/org/idp/server/authentication/interactors/password/PasswordAuthenticationInteractorFactory.java
+++ b/libs/idp-server-authentication-interactors/src/main/java/org/idp/server/authentication/interactors/password/PasswordAuthenticationInteractorFactory.java
@@ -17,17 +17,21 @@
 package org.idp.server.authentication.interactors.password;
 
 import org.idp.server.core.openid.authentication.AuthenticationInteractor;
+import org.idp.server.core.openid.authentication.interaction.execution.AuthenticationExecutors;
 import org.idp.server.core.openid.authentication.plugin.AuthenticationDependencyContainer;
 import org.idp.server.core.openid.authentication.plugin.AuthenticationInteractorFactory;
-import org.idp.server.core.openid.identity.authentication.PasswordVerificationDelegation;
+import org.idp.server.core.openid.authentication.repository.AuthenticationConfigurationQueryRepository;
 
 public class PasswordAuthenticationInteractorFactory implements AuthenticationInteractorFactory {
 
   @Override
   public AuthenticationInteractor create(AuthenticationDependencyContainer container) {
 
-    PasswordVerificationDelegation passwordVerificationDelegation =
-        container.resolve(PasswordVerificationDelegation.class);
-    return new PasswordAuthenticationInteractor(passwordVerificationDelegation);
+    AuthenticationExecutors authenticationExecutors =
+        container.resolve(AuthenticationExecutors.class);
+    AuthenticationConfigurationQueryRepository configurationQueryRepository =
+        container.resolve(AuthenticationConfigurationQueryRepository.class);
+    return new PasswordAuthenticationInteractor(
+        authenticationExecutors, configurationQueryRepository);
   }
 }

--- a/libs/idp-server-authentication-interactors/src/main/java/org/idp/server/authentication/interactors/password/executor/PasswordAuthenticationExecutor.java
+++ b/libs/idp-server-authentication-interactors/src/main/java/org/idp/server/authentication/interactors/password/executor/PasswordAuthenticationExecutor.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2025 Hirokazu Kobayashi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.idp.server.authentication.interactors.password.executor;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.idp.server.core.openid.authentication.AuthenticationTransactionIdentifier;
+import org.idp.server.core.openid.authentication.config.AuthenticationExecutionConfig;
+import org.idp.server.core.openid.authentication.interaction.execution.AuthenticationExecutionRequest;
+import org.idp.server.core.openid.authentication.interaction.execution.AuthenticationExecutionResult;
+import org.idp.server.core.openid.authentication.interaction.execution.AuthenticationExecutor;
+import org.idp.server.core.openid.identity.User;
+import org.idp.server.core.openid.identity.authentication.PasswordVerificationDelegation;
+import org.idp.server.core.openid.identity.repository.UserQueryRepository;
+import org.idp.server.platform.log.LoggerWrapper;
+import org.idp.server.platform.multi_tenancy.tenant.Tenant;
+import org.idp.server.platform.type.RequestAttributes;
+
+/**
+ * Password authentication executor that validates username and password credentials.
+ *
+ * <p>This executor implements the AuthenticationExecutor pattern for password authentication,
+ * providing configuration-based and testable password verification.
+ *
+ * <p><b>Issue #898:</b> Refactored from direct implementation in PasswordAuthenticationInteractor
+ * to follow EmailAuthenticationInteractor pattern.
+ *
+ * <p><b>Issue #897:</b> Uses preferred_username for user lookup instead of email.
+ *
+ * <p><b>Execution Logic:</b>
+ *
+ * <ol>
+ *   <li>Extract username, password, provider_id from request
+ *   <li>Search user by preferred_username (Issue #897)
+ *   <li>Verify password using PasswordVerificationDelegation
+ *   <li>Return success with user_id and username, or client error
+ * </ol>
+ *
+ * @see org.idp.server.authentication.interactors.password.PasswordAuthenticationInteractor
+ * @see org.idp.server.authentication.interactors.email.EmailAuthenticationInteractor
+ */
+public class PasswordAuthenticationExecutor implements AuthenticationExecutor {
+
+  UserQueryRepository userQueryRepository;
+  PasswordVerificationDelegation passwordVerificationDelegation;
+  LoggerWrapper log = LoggerWrapper.getLogger(PasswordAuthenticationExecutor.class);
+
+  public PasswordAuthenticationExecutor(
+      UserQueryRepository userQueryRepository,
+      PasswordVerificationDelegation passwordVerificationDelegation) {
+    this.userQueryRepository = userQueryRepository;
+    this.passwordVerificationDelegation = passwordVerificationDelegation;
+  }
+
+  @Override
+  public String function() {
+    return "password_verification";
+  }
+
+  @Override
+  public AuthenticationExecutionResult execute(
+      Tenant tenant,
+      AuthenticationTransactionIdentifier identifier,
+      AuthenticationExecutionRequest request,
+      RequestAttributes requestAttributes,
+      AuthenticationExecutionConfig configuration) {
+
+    String username = request.optValueAsString("username", "");
+    String password = request.optValueAsString("password", "");
+    String providerId = request.optValueAsString("provider_id", "idp-server");
+
+    log.debug(
+        "Password authentication executor called. username={}, providerId={}",
+        username,
+        providerId);
+
+    // Issue #897: Search by preferred_username instead of email
+    User user = userQueryRepository.findByPreferredUsername(tenant, providerId, username);
+
+    if (!user.exists()) {
+      log.warn("User not found. username={}, providerId={}", username, providerId);
+
+      Map<String, Object> errorContents = new HashMap<>();
+      errorContents.put("error", "invalid_credentials");
+      errorContents.put("error_description", "Invalid username or password");
+
+      return AuthenticationExecutionResult.clientError(errorContents);
+    }
+
+    if (!passwordVerificationDelegation.verify(password, user.hashedPassword())) {
+      log.warn(
+          "Password verification failed. username={}, providerId={}, sub={}",
+          username,
+          providerId,
+          user.sub());
+
+      Map<String, Object> errorContents = new HashMap<>();
+      errorContents.put("error", "invalid_credentials");
+      errorContents.put("error_description", "Invalid username or password");
+
+      return AuthenticationExecutionResult.clientError(errorContents);
+    }
+
+    log.debug("Password authentication succeeded. username={}, sub={}", username, user.sub());
+
+    Map<String, Object> successContents = new HashMap<>();
+    successContents.put("user_id", user.sub());
+    successContents.put("username", username);
+
+    return AuthenticationExecutionResult.success(successContents);
+  }
+}

--- a/libs/idp-server-authentication-interactors/src/main/java/org/idp/server/authentication/interactors/password/executor/PasswordAuthenticationExecutorFactory.java
+++ b/libs/idp-server-authentication-interactors/src/main/java/org/idp/server/authentication/interactors/password/executor/PasswordAuthenticationExecutorFactory.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2025 Hirokazu Kobayashi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.idp.server.authentication.interactors.password.executor;
+
+import org.idp.server.core.openid.authentication.interaction.execution.AuthenticationExecutor;
+import org.idp.server.core.openid.authentication.interaction.execution.AuthenticationExecutorFactory;
+import org.idp.server.core.openid.authentication.plugin.AuthenticationDependencyContainer;
+import org.idp.server.core.openid.identity.authentication.PasswordVerificationDelegation;
+import org.idp.server.core.openid.identity.repository.UserQueryRepository;
+
+public class PasswordAuthenticationExecutorFactory implements AuthenticationExecutorFactory {
+
+  @Override
+  public AuthenticationExecutor create(AuthenticationDependencyContainer container) {
+
+    UserQueryRepository userQueryRepository = container.resolve(UserQueryRepository.class);
+    PasswordVerificationDelegation passwordVerificationDelegation =
+        container.resolve(PasswordVerificationDelegation.class);
+
+    return new PasswordAuthenticationExecutor(userQueryRepository, passwordVerificationDelegation);
+  }
+}

--- a/libs/idp-server-authentication-interactors/src/main/resources/META-INF/services/org.idp.server.core.openid.authentication.interaction.execution.AuthenticationExecutorFactory
+++ b/libs/idp-server-authentication-interactors/src/main/resources/META-INF/services/org.idp.server.core.openid.authentication.interaction.execution.AuthenticationExecutorFactory
@@ -4,3 +4,4 @@ org.idp.server.authentication.interactors.sms.executor.SmsChallengeAuthenticatio
 org.idp.server.authentication.interactors.sms.executor.SmsAuthenticationExecutorFactory
 org.idp.server.authentication.interactors.email.executor.EmailChallengeAuthenticationExecutorFactory
 org.idp.server.authentication.interactors.email.executor.EmailAuthenticationExecutorFactory
+org.idp.server.authentication.interactors.password.executor.PasswordAuthenticationExecutorFactory

--- a/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/identity/UserQueryDataSourceProvider.java
+++ b/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/identity/UserQueryDataSourceProvider.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2025 Hirokazu Kobayashi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.idp.server.core.adapters.datasource.identity;
+
+import org.idp.server.core.openid.authentication.plugin.AuthenticationDependencyProvider;
+import org.idp.server.core.openid.identity.repository.UserQueryRepository;
+import org.idp.server.platform.datasource.ApplicationDatabaseTypeProvider;
+import org.idp.server.platform.dependency.ApplicationComponentDependencyContainer;
+import org.idp.server.platform.dependency.ApplicationComponentProvider;
+
+public class UserQueryDataSourceProvider
+    implements AuthenticationDependencyProvider<UserQueryRepository>,
+        ApplicationComponentProvider<UserQueryRepository> {
+
+  @Override
+  public Class<UserQueryRepository> type() {
+    return UserQueryRepository.class;
+  }
+
+  @Override
+  public UserQueryRepository provide(ApplicationComponentDependencyContainer container) {
+    ApplicationDatabaseTypeProvider databaseTypeProvider =
+        container.resolve(ApplicationDatabaseTypeProvider.class);
+    UserSqlExecutors executors = new UserSqlExecutors();
+    UserSqlExecutor executor = executors.get(databaseTypeProvider.provide());
+    return new UserQueryDataSource(executor);
+  }
+
+  @Override
+  public UserQueryRepository provide() {
+    throw new UnsupportedOperationException(
+        "Default provide() method is not supported. Use provide(ApplicationComponentDependencyContainer) instead.");
+  }
+}

--- a/libs/idp-server-core-adapter/src/main/resources/META-INF/services/org.idp.server.core.openid.authentication.plugin.AuthenticationDependencyProvider
+++ b/libs/idp-server-core-adapter/src/main/resources/META-INF/services/org.idp.server.core.openid.authentication.plugin.AuthenticationDependencyProvider
@@ -1,3 +1,4 @@
 org.idp.server.core.adapters.datasource.authentication.config.query.AuthenticationConfigurationDataSourceProvider
 org.idp.server.core.adapters.datasource.authentication.interaction.command.AuthenticationInteractionCommandDataSourceProvider
 org.idp.server.core.adapters.datasource.authentication.interaction.query.AuthenticationInteractionQueryDataSourceProvider
+org.idp.server.core.adapters.datasource.identity.UserQueryDataSourceProvider


### PR DESCRIPTION
## Summary

外部サービスによるパスワード認証とユーザーマッピング機能を実装しました（Issue #898対応）。

### 主な変更点

#### 1. AuthenticationExecutorパターン実装
- `PasswordAuthenticationExecutor`を実装（`EmailAuthenticationInteractor`パターンに準拠）
- `http_request` function経由で外部サービス連携をサポート
- `password_verification` executorをSPI登録

#### 2. ユーザー解決パターン
- 外部認証サービスからのレスポンスを`user_resolve` mapping rulesでUserオブジェクトにマッピング
- provider + externalUserIdで既存ユーザーを検索
- 既存ユーザーが見つかった場合はsubとstatusを再利用
- 新規ユーザーの場合は新しいUUIDを割り当て
- `ExternalTokenAuthenticationInteractor`と同じパターンを採用

#### 3. 依存性注入修正
- `UserQueryDataSourceProvider`を作成してSPI登録
- `AuthenticationDependencyContainer`経由で`UserQueryRepository`を提供
- 起動時の`AuthenticationDependencyMissionException`を解決

#### 4. E2Eテスト追加
- `scenario-11-password-policy-full-flow.test.js`に外部サービスパスワード認証テストを追加
- Mockoonで`/auth/password`エンドポイントを追加
- JsonPathマッピング（`$.execution_http_request.response_body.*`）を検証

## Documentation Enhancements

### Claims設定ドキュメント追加

#### `claims_supported` / `claim_types_supported`
- OIDC Discovery仕様に基づくクレーム設定の詳細説明を追加
- 標準クレーム15種類の一覧表と説明
- `claim_types_supported`の実装状況（現状は`normal`のみサポート）を明記
- OIDC Core仕様への参照リンク

#### UserInfo API強化
- `swagger-rp-ja.yaml`に`claims_supported`への参照を追加
- Discoveryメタデータとの関係を明記

#### `id_token_strict_mode`詳細説明
- IDトークンクレーム制御の詳細な挙動説明を追加
- 厳密モード（true）と非厳密モード（false）の違いを表形式で説明
- OIDC仕様への準拠に基づく判断基準
- 実装コードの引用と実際の動作例

### ドキュメント更新ファイル
- `documentation/docs/content_05_how-to/how-to-03-tenant-setup.md`
- `documentation/docs/content_06_developer-guide/05-configuration/tenant.md`
- `documentation/openapi/swagger-rp-ja.yaml`

## Test Plan

- [x] アプリケーション起動確認（UserQueryRepository依存性解決）
- [x] E2Eテスト実行（外部サービスパスワード認証）
- [x] ビルド成功確認

## Related Issues

Closes #898

🤖 Generated with [Claude Code](https://claude.com/claude-code)