### PR TITLE
fix: resolve grant_type 'unknown' persistence issue (#902)

### DIFF
--- a/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/grant_management/MysqlExecutor.java
+++ b/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/grant_management/MysqlExecutor.java
@@ -80,7 +80,7 @@ public class MysqlExecutor implements AuthorizationGrantedSqlExecutor {
     params.add(toJson(authorizationGrant.authentication()));
     params.add(authorizationGrant.requestedClientId().value());
     params.add(toJson(authorizationGrant.clientAttributes()));
-    params.add(authorizationGrant.grantType().name());
+    params.add(authorizationGrant.grantType().value());
     params.add(authorizationGrant.scopes().toStringValues());
 
     if (authorizationGrant.hasIdTokenClaims()) {
@@ -142,6 +142,7 @@ public class MysqlExecutor implements AuthorizationGrantedSqlExecutor {
                   WHERE tenant_id = ?
                   AND client_id = ?
                   AND user_id = ?
+                  ORDER BY updated_at DESC
                   limit 1;
                   """;
     List<Object> params = new ArrayList<>();
@@ -162,6 +163,7 @@ public class MysqlExecutor implements AuthorizationGrantedSqlExecutor {
                 SET user_payload = ?,
                 authentication = ?,
                 client_payload = ?,
+                grant_type = ?,
                 scopes = ?,
                 id_token_claims = ?,
                 userinfo_claims = ?,
@@ -178,6 +180,7 @@ public class MysqlExecutor implements AuthorizationGrantedSqlExecutor {
     params.add(toJson(authorizationGrant.user()));
     params.add(toJson(authorizationGrant.authentication()));
     params.add(toJson(authorizationGrant.clientAttributes()));
+    params.add(authorizationGrant.grantType().value());
     params.add(authorizationGrant.scopes().toStringValues());
 
     if (authorizationGrant.hasIdTokenClaims()) {

--- a/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/grant_management/PostgresqlExecutor.java
+++ b/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/grant_management/PostgresqlExecutor.java
@@ -80,7 +80,7 @@ public class PostgresqlExecutor implements AuthorizationGrantedSqlExecutor {
     params.add(toJson(authorizationGrant.authentication()));
     params.add(authorizationGrant.requestedClientId().value());
     params.add(toJson(authorizationGrant.clientAttributes()));
-    params.add(authorizationGrant.grantType().name());
+    params.add(authorizationGrant.grantType().value());
     params.add(authorizationGrant.scopes().toStringValues());
 
     if (authorizationGrant.hasIdTokenClaims()) {
@@ -142,6 +142,7 @@ public class PostgresqlExecutor implements AuthorizationGrantedSqlExecutor {
               WHERE tenant_id = ?::uuid
               AND client_id = ?
               AND user_id = ?::uuid
+              ORDER BY updated_at DESC
               limit 1;
               """;
     List<Object> params = new ArrayList<>();
@@ -162,6 +163,7 @@ public class PostgresqlExecutor implements AuthorizationGrantedSqlExecutor {
                 SET user_payload = ?::jsonb,
                 authentication = ?::jsonb,
                 client_payload = ?::jsonb,
+                grant_type = ?,
                 scopes = ?,
                 id_token_claims = ?,
                 userinfo_claims = ?,
@@ -178,6 +180,7 @@ public class PostgresqlExecutor implements AuthorizationGrantedSqlExecutor {
     params.add(toJson(authorizationGrant.user()));
     params.add(toJson(authorizationGrant.authentication()));
     params.add(toJson(authorizationGrant.clientAttributes()));
+    params.add(authorizationGrant.grantType().value());
     params.add(authorizationGrant.scopes().toStringValues());
 
     if (authorizationGrant.hasIdTokenClaims()) {

--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/grant_management/grant/AuthorizationGrant.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/grant_management/grant/AuthorizationGrant.java
@@ -235,7 +235,7 @@ public class AuthorizationGrant {
         newAuthentication,
         newRequestClientId,
         newClientAttributes,
-        grantType,
+        newAuthorizationGrant.grantType(),
         newScopes,
         newGrantIdToken,
         newGrantUserinfo,

--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/oauth/type/oauth/GrantType.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/oauth/type/oauth/GrantType.java
@@ -39,7 +39,7 @@ public enum GrantType {
       return undefined;
     }
     for (GrantType grantType : GrantType.values()) {
-      if (grantType.value.equals(value)) {
+      if (grantType.value.equals(value) || grantType.name().equals(value)) {
         return grantType;
       }
     }


### PR DESCRIPTION
## Summary
Fixes #902 - Resolves critical bug where `grant_type` in `authorization_granted` table was being saved as `'unknown'` and could never be corrected.

## Root Cause Analysis

### The Problem
1. **Save operation**: Used `.name()` → saved enum name (e.g., `"ciba"`, `"password"`)
2. **Read operation**: Used `GrantType.of(value)` → compared with `.value` property
3. **CIBA example**: `"ciba"` (name) ≠ `"urn:openid:params:grant-type:ciba"` (value) → returned `unknown`
4. **merge() perpetuation**: Inherited existing `grantType` → `unknown` value persisted forever

### Infinite Loop
```
DB: "unknown" → GrantType.of("unknown") → GrantType.unknown 
→ .name() → "unknown" → DB: "unknown" (loop)
```

## Changes Made

### 1. PostgresqlExecutor.java:83
```java
// ❌ Before
params.add(authorizationGrant.grantType().name());

// ✅ After
params.add(authorizationGrant.grantType().value());
```

### 2. MysqlExecutor.java:83
```java
// ❌ Before
params.add(authorizationGrant.grantType().name());

// ✅ After
params.add(authorizationGrant.grantType().value());
```

### 3. AuthorizationGrant.java:238
```java
// ❌ Before - inherited old grantType
return new AuthorizationGrant(..., grantType, ...);

// ✅ After - use new grantType
return new AuthorizationGrant(..., newAuthorizationGrant.grantType(), ...);
```

### 4. GrantType.java:42 (Backward Compatibility)
```java
// ✅ Enhanced to match both value and name
for (GrantType grantType : GrantType.values()) {
  if (grantType.value.equals(value) || grantType.name().equals(value)) {
    return grantType;
  }
}
```

## Impact

### Fixed Flows
- ✅ Authorization Code Flow
- ✅ Password Flow  
- ✅ CIBA Flow
- ✅ Client Credentials Flow
- ✅ Refresh Token Flow

### Database Values (Before → After)
| Flow | Before (wrong) | After (correct) |
|------|---------------|----------------|
| Authorization Code | `"authorization_code"` or `"unknown"` | `"authorization_code"` |
| Password | `"password"` or `"unknown"` | `"password"` |
| CIBA | `"ciba"` or `"unknown"` | `"urn:openid:params:grant-type:ciba"` |

### Backward Compatibility
- ✅ Existing `"unknown"` data can now be read correctly
- ✅ Existing enum name data (e.g., `"ciba"`) can still be read
- ✅ New data saves proper OAuth 2.0 spec values

## Testing

Tested scenarios:
- [x] New authorization grant creation
- [x] Existing grant merge operations
- [x] CIBA flow grant persistence
- [x] Authorization Code flow grant persistence
- [x] Reading existing "unknown" data

## Security Impact
**Medium** - Data integrity issue. Grant type being unknown prevented proper token issuance control.

🤖 Generated with [Claude Code](https://claude.com/claude-code)