### PR TITLE
Fix audit log type naming inconsistency - remove _management suffix

### DIFF
--- a/e2e/src/tests/usecase/standard/standard-01-onboarding-and-audit.test.js
+++ b/e2e/src/tests/usecase/standard/standard-01-onboarding-and-audit.test.js
@@ -227,7 +227,7 @@ describe("Standard Use Case: Onboarding Flow with Audit Log Tracking", () => {
 
     auditLogsResponse.data.list.forEach((log) => {
       console.log(JSON.stringify(log, null , 2));
-      if (log.type === "client_management" && log.target_resource_action === "POST" && log.outcome_result === "success") {
+      if (log.type === "client" && log.target_resource_action === "POST" && log.outcome_result === "success") {
         expectedOperations.client_create = true;
         console.log(`  ✓ Found client_create log: ${log.client_id}`);
       }
@@ -261,7 +261,7 @@ describe("Standard Use Case: Onboarding Flow with Audit Log Tracking", () => {
 
     // Test: Filter by type
     const clientLogsResponse = await get({
-      url: `${backendUrl}/v1/management/organizations/${organizationId}/tenants/${tenantId}/audit-logs?type=client_management&limit=20`,
+      url: `${backendUrl}/v1/management/organizations/${organizationId}/tenants/${tenantId}/audit-logs?type=client&limit=20`,
       headers: {
         Authorization: `Bearer ${orgAccessToken}`,
       },
@@ -270,7 +270,7 @@ describe("Standard Use Case: Onboarding Flow with Audit Log Tracking", () => {
     console.log(`✅ Client management logs: ${clientLogsResponse.data.list.length} entries`);
     expect(clientLogsResponse.status).toBe(200);
     clientLogsResponse.data.list.forEach((log) => {
-      expect(log.type).toBe("client_management");
+      expect(log.type).toBe("client");
     });
 
     // Test: Filter by target_tenant_id (Issue #913)
@@ -287,7 +287,7 @@ describe("Standard Use Case: Onboarding Flow with Audit Log Tracking", () => {
 
     // Verify expected operations are logged
     const hasCreateClientLog = targetTenantLogsResponse.data.list.some(
-      (log) => log.type === "client_management" && log.target_resource_action === "POST"
+      (log) => log.type === "client" && log.target_resource_action === "POST"
     );
     expect(hasCreateClientLog).toBe(true);
 
@@ -312,7 +312,7 @@ describe("Standard Use Case: Onboarding Flow with Audit Log Tracking", () => {
 
     // Test: Combined filters (type + outcome_result + dry_run + target_tenant_id)
     const combinedLogsResponse = await get({
-      url: `${backendUrl}/v1/management/organizations/${organizationId}/tenants/${tenantId}/audit-logs?type=client_management&outcome_result=success&dry_run=false&target_tenant_id=${tenantId}&limit=20`,
+      url: `${backendUrl}/v1/management/organizations/${organizationId}/tenants/${tenantId}/audit-logs?type=client&outcome_result=success&dry_run=false&target_tenant_id=${tenantId}&limit=20`,
       headers: {
         Authorization: `Bearer ${orgAccessToken}`,
       },
@@ -321,7 +321,7 @@ describe("Standard Use Case: Onboarding Flow with Audit Log Tracking", () => {
     console.log(`✅ Combined filter logs: ${combinedLogsResponse.data.list.length} entries`);
     expect(combinedLogsResponse.status).toBe(200);
     combinedLogsResponse.data.list.forEach((log) => {
-      expect(log.type).toBe("client_management");
+      expect(log.type).toBe("client");
       expect(log.outcome_result).toBe("success");
       expect(log.dry_run).toBe(false);
       expect(log.target_tenant_id).toBe(tenantId);

--- a/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/authentication/configuration/AuthenticationConfigManagementContext.java
+++ b/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/authentication/configuration/AuthenticationConfigManagementContext.java
@@ -95,7 +95,7 @@ public class AuthenticationConfigManagementContext implements AuditableContext {
 
   @Override
   public String type() {
-    return "authentication_config_management";
+    return "authentication_config";
   }
 
   @Override

--- a/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/oidc/client/ClientManagementContext.java
+++ b/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/oidc/client/ClientManagementContext.java
@@ -102,7 +102,7 @@ public class ClientManagementContext implements AuditableContext {
 
   @Override
   public String type() {
-    return "client_management";
+    return "client";
   }
 
   @Override

--- a/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/permission/PermissionManagementContext.java
+++ b/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/permission/PermissionManagementContext.java
@@ -102,7 +102,7 @@ public class PermissionManagementContext implements AuditableContext {
 
   @Override
   public String type() {
-    return "permission_management";
+    return "permission";
   }
 
   @Override

--- a/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/role/RoleManagementContext.java
+++ b/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/role/RoleManagementContext.java
@@ -102,7 +102,7 @@ public class RoleManagementContext implements AuditableContext {
 
   @Override
   public String type() {
-    return "role_management";
+    return "role";
   }
 
   @Override


### PR DESCRIPTION
## 概要
監査ログのtype命名に揺れがあった問題を修正しました。`_management`サフィックスを削除して命名規則を統一しました。

## 変更内容
### Javaコード
- `PermissionManagementContext.java`: `"permission_management"` → `"permission"`
- `AuthenticationConfigManagementContext.java`: `"authentication_config_management"` → `"authentication_config"`
- `ClientManagementContext.java`: `"client_management"` → `"client"`
- `RoleManagementContext.java`: `"role_management"` → `"role"`

### E2Eテスト
- `standard-01-onboarding-and-audit.test.js`: 新しいtype値に合わせてテスト期待値を更新

## 変更理由
- 監査ログtype名の不整合を解消
- 冗長な`_management`サフィックスを削除（コンテキストから自明）
- 監査ログフィルタリングの明確化
- DRY原則に準拠

## 影響範囲
- ✅ コンパイル確認済み
- ✅ E2Eテスト期待値更新済み
- ⚠️ 既存の監査ログデータには影響しない（新規ログのみ新type値を使用）

## テスト
- [x] `./gradlew spotlessApply` 実行済み
- [x] `./gradlew build -x test` 成功
- [ ] E2Eテスト実行（PR後に実施）

## 関連Issue
Fixes #923

🤖 Generated with [Claude Code](https://claude.com/claude-code)