### PR TITLE
Fix security event hook result query status enum mismatch

### DIFF
--- a/libs/idp-server-control-plane/src/main/resources/schema/1.0/security-event-hook-result-query.json
+++ b/libs/idp-server-control-plane/src/main/resources/schema/1.0/security-event-hook-result-query.json
@@ -18,7 +18,7 @@
     },
     "status": {
       "type": "string",
-      "enum": ["pending", "success", "failure"],
+      "enum": ["SUCCESS", "FAILURE", "RETRY_SUCCESS", "RETRY_FAILURE", "UNKNOWN"],
       "description": "Execution status filter"
     },
     "from": {

--- a/libs/idp-server-control-plane/src/test/java/org/idp/server/control_plane/management/security/hook_result/validator/SecurityEventHookResultQueryValidatorTest.java
+++ b/libs/idp-server-control-plane/src/test/java/org/idp/server/control_plane/management/security/hook_result/validator/SecurityEventHookResultQueryValidatorTest.java
@@ -31,7 +31,7 @@ class SecurityEventHookResultQueryValidatorTest {
     Map<String, String> queryParams = new HashMap<>();
     queryParams.put("security_event_id", "123e4567-e89b-12d3-a456-426614174000");
     queryParams.put("event_type", "user_created");
-    queryParams.put("status", "success");
+    queryParams.put("status", "SUCCESS");
     queryParams.put("limit", "100");
     queryParams.put("offset", "0");
 
@@ -195,7 +195,7 @@ class SecurityEventHookResultQueryValidatorTest {
   @Test
   void testValidate_ValidStatus_Success() {
     Map<String, String> queryParams = new HashMap<>();
-    queryParams.put("status", "success");
+    queryParams.put("status", "SUCCESS");
 
     SecurityEventHookResultQueries queries = new SecurityEventHookResultQueries(queryParams);
     SecurityEventHookResultQueryValidator validator =
@@ -205,9 +205,9 @@ class SecurityEventHookResultQueryValidatorTest {
   }
 
   @Test
-  void testValidate_ValidStatusPending_Success() {
+  void testValidate_ValidStatusRetrySuccess_Success() {
     Map<String, String> queryParams = new HashMap<>();
-    queryParams.put("status", "pending");
+    queryParams.put("status", "RETRY_SUCCESS");
 
     SecurityEventHookResultQueries queries = new SecurityEventHookResultQueries(queryParams);
     SecurityEventHookResultQueryValidator validator =
@@ -219,7 +219,31 @@ class SecurityEventHookResultQueryValidatorTest {
   @Test
   void testValidate_ValidStatusFailure_Success() {
     Map<String, String> queryParams = new HashMap<>();
-    queryParams.put("status", "failure");
+    queryParams.put("status", "FAILURE");
+
+    SecurityEventHookResultQueries queries = new SecurityEventHookResultQueries(queryParams);
+    SecurityEventHookResultQueryValidator validator =
+        new SecurityEventHookResultQueryValidator(queries);
+
+    assertDoesNotThrow(() -> validator.validate());
+  }
+
+  @Test
+  void testValidate_ValidStatusRetryFailure_Success() {
+    Map<String, String> queryParams = new HashMap<>();
+    queryParams.put("status", "RETRY_FAILURE");
+
+    SecurityEventHookResultQueries queries = new SecurityEventHookResultQueries(queryParams);
+    SecurityEventHookResultQueryValidator validator =
+        new SecurityEventHookResultQueryValidator(queries);
+
+    assertDoesNotThrow(() -> validator.validate());
+  }
+
+  @Test
+  void testValidate_ValidStatusUnknown_Success() {
+    Map<String, String> queryParams = new HashMap<>();
+    queryParams.put("status", "UNKNOWN");
 
     SecurityEventHookResultQueries queries = new SecurityEventHookResultQueries(queryParams);
     SecurityEventHookResultQueryValidator validator =
@@ -262,7 +286,7 @@ class SecurityEventHookResultQueryValidatorTest {
     queryParams.put("security_event_id", "123e4567-e89b-12d3-a456-426614174000");
     queryParams.put("event_type", "user_created,user_updated");
     queryParams.put("hook_type", "webhook");
-    queryParams.put("status", "success");
+    queryParams.put("status", "SUCCESS");
     queryParams.put("from", "2025-01-01T00:00:00Z");
     queryParams.put("to", "2025-01-31T23:59:59Z");
     queryParams.put("limit", "100");


### PR DESCRIPTION
## 概要

Security event hook result query のステータス値検証エラーを修正。JSON スキーマと Java enum の不一致を解消。

## 問題

JSON スキーマ検証で以下のエラーが発生：
```
{
  "error_description": "Security event hook result query validation failed",
  "error": "invalid_request",
  "error_messages": ["status is not allowed enum value, input: SUCCESS, definition: pending,success,failure"]
}
```

## 原因

JSON スキーマと Java 実装で enum 値が不一致：

**JSON スキーマ** (`security-event-hook-result-query.json:21`):
```json
"status": {
  "type": "string",
  "enum": ["pending", "success", "failure"]
}
```

**Java 実装** (`SecurityEventHookStatus.java`):
```java
public enum SecurityEventHookStatus {
  SUCCESS,
  FAILURE,
  RETRY_SUCCESS,
  RETRY_FAILURE,
  UNKNOWN;
}
```

**不一致点**:
1. 大文字小文字: スキーマは小文字、Java は大文字
2. 値の過不足: スキーマに `RETRY_SUCCESS`, `RETRY_FAILURE`, `UNKNOWN` が欠落
3. 存在しない値: スキーマの `"pending"` は Java に存在しない

## 修正内容

### 1. JSON スキーマ修正
`security-event-hook-result-query.json` の status enum を Java 実装に完全一致：
```json
"status": {
  "type": "string",
  "enum": ["SUCCESS", "FAILURE", "RETRY_SUCCESS", "RETRY_FAILURE", "UNKNOWN"],
  "description": "Execution status filter"
}
```

### 2. テストコード修正
`SecurityEventHookResultQueryValidatorTest.java`:
- 小文字のステータス値（`"success"`, `"pending"`, `"failure"`）を大文字に修正
- `testValidate_ValidStatusPending_Success()` → `testValidate_ValidStatusRetrySuccess_Success()` にリネーム
- 新規テスト追加: `testValidate_ValidStatusRetryFailure_Success()`, `testValidate_ValidStatusUnknown_Success()`

## 検証

✅ 全テストケース通過:
```bash
./gradlew :libs:idp-server-control-plane:test --tests SecurityEventHookResultQueryValidatorTest
# BUILD SUCCESSFUL
```

✅ 全体ビルド成功:
```bash
./gradlew build
# BUILD SUCCESSFUL in 53s
```

## 影響範囲

- `/libs/idp-server-control-plane/src/main/resources/schema/1.0/security-event-hook-result-query.json`
- `/libs/idp-server-control-plane/src/test/java/org/idp/server/control_plane/management/security/hook_result/validator/SecurityEventHookResultQueryValidatorTest.java`

Fixes #937

🤖 Generated with [Claude Code](https://claude.com/claude-code)