### PR TITLE
Add defensive null check for User status field in admin initialization

### DIFF
--- a/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/admin/starter/IdpServerStarterContextCreator.java
+++ b/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/admin/starter/IdpServerStarterContextCreator.java
@@ -132,6 +132,12 @@ public class IdpServerStarterContextCreator {
     Organization updatedWithTenant = organization.updateWithTenant(assignedTenant);
 
     User user = jsonConverter.read(request.get("user"), User.class);
+
+    // Ensure status is initialized if not provided in JSON
+    if (user.status() == null) {
+      user.setStatus(UserStatus.INITIALIZED);
+    }
+
     String encode = passwordEncodeDelegation.encode(user.rawPassword());
 
     // Apply tenant identity policy to set preferred_username if not set


### PR DESCRIPTION
## 概要
Admin初期化API (`POST /v1/admin/initialization`) での User.status フィールドの null チェックを追加し、NullPointerException を防止します。

## 背景

### 問題
JSON デシリアライゼーション時に `User.status` フィールドが `null` の場合、以下のエラーが発生：

```
NullPointerException: Cannot invoke "Object.hashCode()" because "<parameter1>" is null
at UserLifecycleManager.canTransit:131
```

### 根本原因
```java
// UserLifecycleManager.java:130-131
public static boolean canTransit(UserStatus from, UserStatus to) {
  Set<UserStatus> nextStatuses = allowedTransitions.getOrDefault(from, Set.of());
  // from が null の場合、Map.getOrDefault() 内部で hashCode() 呼び出し時に NPE
}
```

### 設計背景
`User` クラスはフィールドにデフォルト値を設定していません。これは以下の理由によります：

- **PATCH API との整合性**: フィールドデフォルト値があると、PATCH 更新時に JSON に存在しないフィールドが初期値に戻ってしまう
- **明示的な初期化**: `User.initialized()` ファクトリメソッドで明示的に初期化すべき

## 変更内容

`IdpServerStarterContextCreator.create()` メソッドに防御的な null チェックを追加：

```java
User user = jsonConverter.read(request.get("user"), User.class);

// Ensure status is initialized if not provided in JSON
if (user.status() == null) {
  user.setStatus(UserStatus.INITIALIZED);
}
```

## 影響範囲
- ✅ Admin初期化APIのみ
- ✅ PATCH API には影響なし（既存の User オブジェクトから status が読み込まれる）
- ✅ 後方互換性維持（JSON に status がある場合はその値を優先）

## テスト
- [x] JSON に `status` フィールドがない場合でも正常に初期化される
- [x] JSON に `status` フィールドがある場合は JSON の値が優先される
- [x] 統合環境（trustid-idp）での検証完了

## 関連
- Fixes #955
- 統合環境PR: https://github.com/sbisecuritysolutions/trustid-idp/pull/147

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>