### PR TITLE
refactor: Change shouldNotVerify() to shouldVerify() for better readability

### DIFF
--- a/libs/idp-server-core-extension-ciba/src/main/java/org/idp/server/core/extension/ciba/verifier/CibaAuthorizationDetailsVerifier.java
+++ b/libs/idp-server-core-extension-ciba/src/main/java/org/idp/server/core/extension/ciba/verifier/CibaAuthorizationDetailsVerifier.java
@@ -52,8 +52,8 @@ import org.idp.server.core.openid.oauth.verifier.extension.AuthorizationDetailsV
 public class CibaAuthorizationDetailsVerifier implements CibaExtensionVerifier {
 
   @Override
-  public boolean shouldNotVerify(CibaRequestContext context) {
-    return !context.hasAuthorizationDetails();
+  public boolean shouldVerify(CibaRequestContext context) {
+    return context.hasAuthorizationDetails();
   }
 
   @Override

--- a/libs/idp-server-core-extension-ciba/src/main/java/org/idp/server/core/extension/ciba/verifier/CibaExtensionVerifier.java
+++ b/libs/idp-server-core-extension-ciba/src/main/java/org/idp/server/core/extension/ciba/verifier/CibaExtensionVerifier.java
@@ -20,8 +20,8 @@ import org.idp.server.core.extension.ciba.CibaRequestContext;
 
 public interface CibaExtensionVerifier {
 
-  default boolean shouldNotVerify(CibaRequestContext context) {
-    return false;
+  default boolean shouldVerify(CibaRequestContext context) {
+    return true;
   }
 
   void verify(CibaRequestContext context);

--- a/libs/idp-server-core-extension-ciba/src/main/java/org/idp/server/core/extension/ciba/verifier/CibaRequestObjectVerifier.java
+++ b/libs/idp-server-core-extension-ciba/src/main/java/org/idp/server/core/extension/ciba/verifier/CibaRequestObjectVerifier.java
@@ -24,8 +24,8 @@ import org.idp.server.core.openid.oauth.verifier.extension.RequestObjectVerifyab
 public class CibaRequestObjectVerifier implements CibaExtensionVerifier, RequestObjectVerifyable {
 
   @Override
-  public boolean shouldNotVerify(CibaRequestContext context) {
-    return !context.isRequestObjectPattern();
+  public boolean shouldVerify(CibaRequestContext context) {
+    return context.isRequestObjectPattern();
   }
 
   public void verify(CibaRequestContext context) {

--- a/libs/idp-server-core-extension-ciba/src/main/java/org/idp/server/core/extension/ciba/verifier/CibaRequestVerifier.java
+++ b/libs/idp-server-core-extension-ciba/src/main/java/org/idp/server/core/extension/ciba/verifier/CibaRequestVerifier.java
@@ -67,7 +67,7 @@ public class CibaRequestVerifier {
     // 2. Common extension verifications
     extensionVerifiers.forEach(
         extensionVerifier -> {
-          if (extensionVerifier.shouldNotVerify(context)) {
+          if (!extensionVerifier.shouldVerify(context)) {
             return;
           }
           extensionVerifier.verify(context);

--- a/libs/idp-server-core-extension-ciba/src/main/java/org/idp/server/core/extension/ciba/verifier/CibaRequiredRarVerifier.java
+++ b/libs/idp-server-core-extension-ciba/src/main/java/org/idp/server/core/extension/ciba/verifier/CibaRequiredRarVerifier.java
@@ -77,8 +77,8 @@ import org.idp.server.core.extension.ciba.exception.BackchannelAuthenticationBad
 public class CibaRequiredRarVerifier implements CibaExtensionVerifier {
 
   @Override
-  public boolean shouldNotVerify(CibaRequestContext context) {
-    return !context.clientConfiguration().isCibaRequireRar();
+  public boolean shouldVerify(CibaRequestContext context) {
+    return context.clientConfiguration().isCibaRequireRar();
   }
 
   @Override


### PR DESCRIPTION
## Summary

This PR refactors `CibaExtensionVerifier` interface to replace the double-negative method `shouldNotVerify()` with the positive `shouldVerify()` for improved code readability.

## Issue #958: Refactor CIBA Extension Verifier Interface

### Problem

The current implementation uses double negatives which reduce code readability:

```java
// Confusing: double negative
if (extensionVerifier.shouldNotVerify(context)) {
  return; // Skip verification
}
```

### Solution

Replace with positive logic:

```java
// Clear: single negative
if (!extensionVerifier.shouldVerify(context)) {
  return; // Skip verification
}
```

## Changes

### Interface Change

**CibaExtensionVerifier.java:**
```java
// Before
default boolean shouldNotVerify(CibaRequestContext context) {
  return false;
}

// After
default boolean shouldVerify(CibaRequestContext context) {
  return true;
}
```

### Implementation Updates

All implementations updated with inverted logic:

**1. CibaRequestObjectVerifier:**
```java
// Before
public boolean shouldNotVerify(CibaRequestContext context) {
  return !context.isRequestObjectPattern();
}

// After
public boolean shouldVerify(CibaRequestContext context) {
  return context.isRequestObjectPattern();
}
```

**2. CibaAuthorizationDetailsVerifier:**
```java
// Before
public boolean shouldNotVerify(CibaRequestContext context) {
  return !context.hasAuthorizationDetails();
}

// After
public boolean shouldVerify(CibaRequestContext context) {
  return context.hasAuthorizationDetails();
}
```

**3. CibaRequiredRarVerifier:**
```java
// Before
public boolean shouldNotVerify(CibaRequestContext context) {
  return !context.clientConfiguration().isCibaRequireRar();
}

// After
public boolean shouldVerify(CibaRequestContext context) {
  return context.clientConfiguration().isCibaRequireRar();
}
```

### Caller Update

**CibaRequestVerifier.java:**
```java
// Before
extensionVerifiers.forEach(extensionVerifier -> {
  if (extensionVerifier.shouldNotVerify(context)) {
    return;
  }
  extensionVerifier.verify(context);
});

// After
extensionVerifiers.forEach(extensionVerifier -> {
  if (!extensionVerifier.shouldVerify(context)) {
    return;
  }
  extensionVerifier.verify(context);
});
```

## Benefits

1. **Improved Readability**: Eliminates double negatives
2. **Consistency**: Aligns with existing OAuth/OIDC verifier interfaces
   - `AuthorizationRequestExtensionVerifier` uses `shouldVerify()`
   - `AuthorizationCodeGrantExtensionVerifierInterface` uses `shouldVerify()`
3. **Maintainability**: Easier to understand verification logic at a glance

## Testing

### Build Status
```bash
./gradlew spotlessApply
./gradlew build -x test
# ✅ BUILD SUCCESSFUL
```

### Behavior Verification
- All logic is inverted correctly (NOT removed from conditions)
- Default behavior unchanged (verifiers run when conditions are met)
- No functional changes, only readability improvement

## Impact

- **Scope**: CIBA extension verifiers only
- **Breaking Changes**: None (internal refactoring)
- **Risk Level**: Low (pure refactoring with logic inversion)

## Files Modified

- `CibaExtensionVerifier.java`: Interface method signature
- `CibaRequestObjectVerifier.java`: Implementation + logic inversion
- `CibaAuthorizationDetailsVerifier.java`: Implementation + logic inversion
- `CibaRequiredRarVerifier.java`: Implementation + logic inversion
- `CibaRequestVerifier.java`: Caller logic inversion

## Related Issues

- Closes #958
- Improves code from PR #960

## Checklist

- [x] Code follows naming conventions (positive over negative)
- [x] Applied spotless formatting
- [x] Build passes without test execution
- [x] Logic correctly inverted (NOT added/removed appropriately)
- [x] Consistent with other verifier interfaces
- [x] No functional behavior changes