### PR TITLE
fix: Return correct HTTP status code in Onboarding API

### DIFF
--- a/libs/idp-server-springboot-adapter/src/main/java/org/idp/server/adapters/springboot/control_plane/restapi/management/OnboardingV1Api.java
+++ b/libs/idp-server-springboot-adapter/src/main/java/org/idp/server/adapters/springboot/control_plane/restapi/management/OnboardingV1Api.java
@@ -62,6 +62,7 @@ public class OnboardingV1Api implements ParameterTransformable {
 
     HttpHeaders headers = new HttpHeaders();
     headers.add("Content-Type", "application/json");
-    return new ResponseEntity<>(response.contents(), headers, HttpStatus.OK);
+    return new ResponseEntity<>(
+        response.contents(), headers, HttpStatus.valueOf(response.statusCode()));
   }
 }


### PR DESCRIPTION
## Summary
Fix Onboarding API controller to return appropriate HTTP status codes instead of always returning 200 OK.

## Changes
- Modified `OnboardingV1Api.java` to use `HttpStatus.valueOf(response.statusCode())` instead of hardcoded `HttpStatus.OK`
- Now properly returns:
  - 201 Created for successful onboarding
  - 400 Bad Request for validation errors
  - 403 Forbidden for permission errors
  - 404 Not Found for missing resources
  - 409 Conflict for duplicate resources
  - 500 Internal Server Error for server errors

## Related Issue
Fixes #957

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>