### PR TITLE
fix: Prevent transaction pollution in initial-registration error handling (Issue #965)

### DIFF
--- a/libs/idp-server-authentication-interactors/src/main/java/org/idp/server/authentication/interactors/initial_registration/InitialRegistrationInteractor.java
+++ b/libs/idp-server-authentication-interactors/src/main/java/org/idp/server/authentication/interactors/initial_registration/InitialRegistrationInteractor.java
@@ -106,14 +106,8 @@ public class InitialRegistrationInteractor implements AuthenticationInteractor {
       response.put("error", "invalid_request");
       response.put("error_description", "user is conflict with username and password");
 
-      return new AuthenticationInteractionRequestResult(
-          AuthenticationInteractionStatus.CLIENT_ERROR,
-          type,
-          operationType(),
-          method(),
-          existingUser,
-          response,
-          DefaultSecurityEventType.user_signup_conflict);
+      return AuthenticationInteractionRequestResult.clientError(
+          response, type, operationType(), method(), DefaultSecurityEventType.user_signup_conflict);
     }
 
     // Validate password against tenant password policy


### PR DESCRIPTION
## Summary

Fixes #965 - Initial-registration transaction bug where failed requests with email conflicts pollute the transaction, causing subsequent retry attempts to fail with "user not same" error.

## Problem

When a user attempts to register with a conflicting email address:
1. First request with existing email → Returns 400 error (expected behavior)
2. Second request with valid email → Returns 400 "user not same" error (BUG)

This prevented users from retrying registration after fixing their email address.

## Root Cause

`InitialRegistrationInteractor.java` (lines 103-117) was using the full constructor that included the `existingUser` parameter when handling email conflicts:

```java
// ❌ BEFORE: Pollutes transaction with existing user
return new AuthenticationInteractionRequestResult(
    AuthenticationInteractionStatus.CLIENT_ERROR,
    type,
    operationType(),
    method(),
    existingUser,  // ← BUG: Existing user attached to transaction
    response,
    DefaultSecurityEventType.user_signup_conflict);
```

This attached the existing user object to the authentication transaction, causing subsequent requests in the same flow to fail validation.

## Solution

Changed to use the static factory method `clientError()` which doesn't attach any user object:

```java
// ✅ AFTER: Transaction stays clean
return AuthenticationInteractionRequestResult.clientError(
    response, type, operationType(), method(), DefaultSecurityEventType.user_signup_conflict);
```

This matches the pattern used by other error handlers in the same class (password policy validation, schema validation).

## Changes

### Core Fix
- **InitialRegistrationInteractor.java**: Use `clientError()` static factory method for email conflict error

### Testing
- **standard-01-onboarding-and-audit.test.js**: Added comprehensive E2E regression test validating:
  - ✅ First request with conflicting email returns 400
  - ✅ Second request with valid email succeeds (was failing before fix)
  - ✅ Multiple failures don't cause "user not same" errors
  - ✅ Transaction state remains clean across retry attempts

## Test Results

```
PASS src/tests/usecase/standard/standard-01-onboarding-and-audit.test.js
  ✅ Created organization with existing user
  ✅ Authorization started
  ✅ First request correctly rejected with conflict error
  ✅ Second request succeeded: new-user@test.example.com
  ✅ Transaction was not polluted - registered NEW user, not existing user
  ✅ Attempt 1 failed with conflict
  ✅ Attempt 2 failed with conflict (not "user not same")
  ✅ Final attempt succeeded after multiple failures
```

## Impact

- **User Experience**: Users can now successfully retry registration after fixing email conflicts
- **Security**: No change - same validation logic, just proper error handling
- **Consistency**: Aligns with other error handlers in the same class

🤖 Generated with [Claude Code](https://claude.com/claude-code)