### PR TITLE
fix: serialize FunctionSpec objects properly in MappingRule.toMap() (Issue #983)

### DIFF
--- a/libs/idp-server-platform/src/main/java/org/idp/server/platform/mapper/MappingRule.java
+++ b/libs/idp-server-platform/src/main/java/org/idp/server/platform/mapper/MappingRule.java
@@ -141,7 +141,9 @@ public class MappingRule implements JsonReadable {
     map.put("from", from);
     map.put("static_value", staticValue);
     map.put("to", to);
-    map.put("functions", functions());
+    map.put(
+        "functions",
+        functions != null ? functions.stream().map(FunctionSpec::toMap).toList() : null);
     map.put("condition", condition != null ? condition.toMap() : null);
     return map;
   }


### PR DESCRIPTION
## Summary
- Fixed `MappingRule.toMap()` to properly serialize `FunctionSpec` objects
- The `functions` array was being placed directly into the map without calling `toMap()` on individual elements
- This caused Jackson serialization to return empty objects `[{}]` instead of the expected data with `name` and `args` fields

## Root Cause
`FunctionSpec` fields are package-private and use record-style accessors (`name()`, `args()`) instead of JavaBean conventions (`getName()`, `getArgs()`), so Jackson couldn't serialize them directly.

## Fix
Convert `List<FunctionSpec>` to `List<Map>` by calling `toMap()` on each element, consistent with how `ConditionSpec` is already handled in the same method.

## Test Plan
- [x] Unit tests for `MappingRule` related classes pass
- [x] Build succeeds with `./gradlew build -x test`
- [x] Code formatted with `./gradlew spotlessApply`

Closes #983

🤖 Generated with [Claude Code](https://claude.ai/code)