### PR TITLE
feat: 認証キャンセルのセキュリティイベントをユーザーに紐づけ

### DIFF
--- a/e2e/src/tests/scenario/control_plane/system/role-management.test.js
+++ b/e2e/src/tests/scenario/control_plane/system/role-management.test.js
@@ -86,7 +86,7 @@ describe("role management api", () => {
           ]
         }
       });
-      console.log(updateResponse.data);
+      console.log(JSON.stringify(updateResponse.data, null, 2));
       expect(updateResponse.status).toBe(200);
       expect(updateResponse.data).toHaveProperty("result");
       expect(updateResponse.data).toHaveProperty("diff");
@@ -100,10 +100,9 @@ describe("role management api", () => {
       });
       expect(afterUpdateDetail.status).toBe(200);
       expect(afterUpdateDetail.data.permissions).toHaveLength(2);
-      expect(afterUpdateDetail.data.permissions.map(p => p.id)).toEqual([
-        permissionListResponse.data.list[2].id,
-        permissionListResponse.data.list[3].id
-      ]);
+      expect(afterUpdateDetail.data.permissions.map(p => p.id)).toContain(permissionListResponse.data.list[2].id);
+      expect(afterUpdateDetail.data.permissions.map(p => p.id)).toContain(permissionListResponse.data.list[3].id);
+
       // Original permissions should be removed
       expect(afterUpdateDetail.data.permissions.map(p => p.id)).not.toContain(
         permissionListResponse.data.list[0].id

--- a/libs/idp-server-authentication-interactors/src/main/java/org/idp/server/authentication/interactors/cancel/AuthenticationCancelInteractor.java
+++ b/libs/idp-server-authentication-interactors/src/main/java/org/idp/server/authentication/interactors/cancel/AuthenticationCancelInteractor.java
@@ -18,6 +18,7 @@ package org.idp.server.authentication.interactors.cancel;
 
 import java.util.Map;
 import org.idp.server.core.openid.authentication.*;
+import org.idp.server.core.openid.identity.User;
 import org.idp.server.core.openid.identity.repository.UserQueryRepository;
 import org.idp.server.platform.multi_tenancy.tenant.Tenant;
 import org.idp.server.platform.security.event.DefaultSecurityEventType;
@@ -49,10 +50,11 @@ public class AuthenticationCancelInteractor implements AuthenticationInteractor 
       RequestAttributes requestAttributes,
       UserQueryRepository userQueryRepository) {
 
+    User user = transaction.user();
     AuthenticationInteractionStatus status = AuthenticationInteractionStatus.SUCCESS;
     Map<String, Object> response = Map.of();
     DefaultSecurityEventType eventType = DefaultSecurityEventType.authentication_cancel_success;
     return new AuthenticationInteractionRequestResult(
-        status, type, operationType(), method(), response, eventType);
+        status, type, operationType(), method(), user, response, eventType);
   }
 }

--- a/libs/idp-server-authentication-interactors/src/main/java/org/idp/server/authentication/interactors/fidouaf/FidoUafCancelInteractor.java
+++ b/libs/idp-server-authentication-interactors/src/main/java/org/idp/server/authentication/interactors/fidouaf/FidoUafCancelInteractor.java
@@ -18,6 +18,7 @@ package org.idp.server.authentication.interactors.fidouaf;
 
 import java.util.Map;
 import org.idp.server.core.openid.authentication.*;
+import org.idp.server.core.openid.identity.User;
 import org.idp.server.core.openid.identity.repository.UserQueryRepository;
 import org.idp.server.platform.log.LoggerWrapper;
 import org.idp.server.platform.multi_tenancy.tenant.Tenant;
@@ -54,10 +55,11 @@ public class FidoUafCancelInteractor implements AuthenticationInteractor {
 
     log.debug("FidoUafCancelInteractor called");
 
+    User user = transaction.user();
     AuthenticationInteractionStatus status = AuthenticationInteractionStatus.SUCCESS;
     Map<String, Object> response = Map.of();
     DefaultSecurityEventType eventType = DefaultSecurityEventType.authentication_cancel_success;
     return new AuthenticationInteractionRequestResult(
-        status, type, operationType(), method(), response, eventType);
+        status, type, operationType(), method(), user, response, eventType);
   }
 }


### PR DESCRIPTION
## Summary

- AuthenticationCancelInteractorでtransaction.user()を取得しセキュリティイベントに設定
- FidoUafCancelInteractorも同様に修正
- E2Eテスト(role-management.test.js)の検証ロジックを安定化（配列順序に依存しない検証に変更）

## 背景

認証キャンセル時のセキュリティイベントにユーザー情報が紐づいていなかった問題を修正。
`OAuthFlowEntryService`と`CibaFlowEntryService`で`result.user()`がイベントに渡されるため、
ユーザーを含むコンストラクタを使用するように変更。

## Test plan

- [x] DBで `authentication_cancel_success` イベントにユーザーが紐づくことを確認済み
- [x] コンパイル確認

Closes #985

🤖 Generated with [Claude Code](https://claude.com/claude-code)