### PR TITLE
fix: CIBA binding_message桁数制限拡大とDBマッピング順序修正

### DIFF
--- a/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/ciba/request/MysqlExecutor.java
+++ b/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/ciba/request/MysqlExecutor.java
@@ -108,13 +108,13 @@ public class MysqlExecutor implements BackchannelAuthenticationRequestSqlExecuto
     } else {
       params.add(null);
     }
-    if (request.hasBindingMessage()) {
-      params.add(request.bindingMessage().value());
+    if (request.hasClientNotificationToken()) {
+      params.add(request.clientNotificationToken().value());
     } else {
       params.add(null);
     }
-    if (request.hasClientNotificationToken()) {
-      params.add(request.clientNotificationToken().value());
+    if (request.hasBindingMessage()) {
+      params.add(request.bindingMessage().value());
     } else {
       params.add(null);
     }

--- a/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/ciba/request/PostgresqlExecutor.java
+++ b/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/ciba/request/PostgresqlExecutor.java
@@ -108,13 +108,13 @@ public class PostgresqlExecutor implements BackchannelAuthenticationRequestSqlEx
     } else {
       params.add(null);
     }
-    if (request.hasBindingMessage()) {
-      params.add(request.bindingMessage().value());
+    if (request.hasClientNotificationToken()) {
+      params.add(request.clientNotificationToken().value());
     } else {
       params.add(null);
     }
-    if (request.hasClientNotificationToken()) {
-      params.add(request.clientNotificationToken().value());
+    if (request.hasBindingMessage()) {
+      params.add(request.bindingMessage().value());
     } else {
       params.add(null);
     }

--- a/libs/idp-server-core-extension-ciba/src/main/java/org/idp/server/core/extension/ciba/verifier/CibaRequestBaseVerifier.java
+++ b/libs/idp-server-core-extension-ciba/src/main/java/org/idp/server/core/extension/ciba/verifier/CibaRequestBaseVerifier.java
@@ -30,8 +30,11 @@ public class CibaRequestBaseVerifier {
    * <p>Per CIBA Core Section 7.1, the binding_message SHOULD be relatively short and use a limited
    * set of plain text characters. This limit ensures the message can be displayed on authentication
    * devices with limited screen space.
+   *
+   * <p>This implementation allows up to 20 characters to support more descriptive transaction
+   * contexts while maintaining compatibility with typical mobile device displays.
    */
-  private static final int BINDING_MESSAGE_MAX_LENGTH = 6;
+  private static final int BINDING_MESSAGE_MAX_LENGTH = 20;
 
   public void verify(CibaRequestContext context) {
     throwExceptionIfUnSupportedGrantType(context);


### PR DESCRIPTION
## 概要
CIBA `binding_message`パラメータの桁数制限拡大と、重大なDBマッピング順序バグを修正します。

Fixes #988

## 🔧 修正内容

### 1. binding_message桁数制限の拡大（6文字 → 20文字）

**目的**: より詳細なトランザクションコンテキスト情報を提供

**変更**:
- `CibaRequestBaseVerifier.BINDING_MESSAGE_MAX_LENGTH`: 6 → 20
- Javadoc更新: 20文字制限の理由を明記

**例**:
```
Before: "TX-123" (6文字)
After:  "TX-12345: €500 ACME" (20文字)
```

**ファイル**:
- `libs/idp-server-core-extension-ciba/src/main/java/org/idp/server/core/extension/ciba/verifier/CibaRequestBaseVerifier.java`

### 2. DBマッピング順序の修正（🚨 重大バグ）

**問題**: `binding_message`と`client_notification_token`のパラメータ順序が逆転
**影響**: DBに保存されるデータが入れ替わる重大な不具合

#### SQL INSERT文の列順序
```sql
user_code,
client_notification_token,  -- 位置12
binding_message,            -- 位置13
```

#### 修正前（誤り）
```java
params.add(request.userCode().value());              // 位置11
params.add(request.bindingMessage().value());        // 位置12 ← 逆!
params.add(request.clientNotificationToken().value()); // 位置13 ← 逆!
```

#### 修正後（正解）
```java
params.add(request.userCode().value());              // 位置11
params.add(request.clientNotificationToken().value()); // 位置12 ✅
params.add(request.bindingMessage().value());        // 位置13 ✅
```

**ファイル**:
- `libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/ciba/request/PostgresqlExecutor.java`
- `libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/ciba/request/MysqlExecutor.java`

## 🔍 発見経緯

実際のDBデータを確認したところ、以下のような状態を発見：

```csv
...,client_notification_token,binding_message,...
...,$binding_message,,,,...
```

→ `binding_message`の値が`client_notification_token`カラムに保存されていた

## ✅ テスト

- [ ] CIBAテスト実行（`e2e/src/tests/spec/ciba_authentication_request.test.js`）
- [ ] 20文字までのbinding_messageが許可されることを確認
- [ ] DBマッピングが正しい順序で保存されることを確認

## 📚 参考
- **CIBA Core Section 7.1**: binding_message仕様
- **FAPI CIBA Profile 5.2.2.5**: binding_message要件
- **DB Schema**: `V0_9_0__init_lib.sql:494-517`

## 優先度
**High** - マッピングバグはデータ整合性に直接影響

🤖 Generated with [Claude Code](https://claude.com/claude-code)