### PR TITLE
docs: CIBA binding_message の20文字制限をドキュメントとテストに反映

### DIFF
--- a/documentation/docs/content_05_how-to/how-to-12-ciba-flow-fido-uaf.md
+++ b/documentation/docs/content_05_how-to/how-to-12-ciba-flow-fido-uaf.md
@@ -81,7 +81,7 @@ client_id=...&client_secret=...&scope=openid profile phone email&login_hint=...&
 | `scope`                 | `string`        | ✅    | `openid` を含める必要がある。例：`openid profile email`                        |
 | `login_hint`            | `string`        | 条件付き | ユーザーを識別するヒント。例：sub:ユーザーID `login_hint` または `id_token_hint` のいずれか必須 |
 | `id_token_hint`         | `string`        | 条件付き | 過去のID Token。`login_hint` または `id_token_hint` のいずれか必須               |
-| `binding_message`       | `string`        | -    | ユーザー端末に表示されるメッセージ（ランダムな数字など）                                       |
+| `binding_message`       | `string`        | -    | ユーザー端末に表示されるメッセージ（最大20文字）                                            |
 | `requested_expiry`      | `integer`       | -    | `auth_req_id` の有効期限（秒）                                             |
 | `request_context`       | `string`        | -    | 認証時に使う追加情報。ユーザー通知に含めることも可                                          |
 | `acr_values`            | `string`        | -    | 要求する認証強度（ACR値）                                                     |

--- a/documentation/openapi/swagger-rp-ja.yaml
+++ b/documentation/openapi/swagger-rp-ja.yaml
@@ -2344,7 +2344,8 @@ components:
           description: "過去の ID Token を用いたユーザー識別 ※login_hintまたはid_token_hintの指定が必要"
         binding_message:
           type: string
-          description: "ユーザー端末に表示される文言"
+          maxLength: 20
+          description: "ユーザー端末に表示される文言（最大20文字）"
         requested_expiry:
           type: integer
           description: "auth_req_id の有効期限（秒）"

--- a/e2e/src/tests/monkey/ciba-monkey.test.js
+++ b/e2e/src/tests/monkey/ciba-monkey.test.js
@@ -158,7 +158,7 @@ describe("Monkey test CIBA Flow", () => {
       ["scope", 123, 400, "invalid_scope"],
       ["scope", null, 400, "invalid_scope"],
       ["loginHint", ["array"], 400, "unknown_user_id"],
-      ["bindingMessage", {}, 400, ""],
+      ["bindingMessage", "123456789012345678901", 400, ""],
       ["clientId", null, 400, "invalid_request"],
       ["clientSecret", ["a", "b"], 401, "invalid_client"],
       ["acrValues", undefined, 200, undefined],


### PR DESCRIPTION
## Summary

Issue #988 の修正に対応するドキュメント更新とテスト修正です。

- **how-to-12-ciba-flow-fido-uaf.md**: `binding_message`パラメータの説明に「最大20文字」を追記
- **swagger-rp-ja.yaml**: `maxLength: 20`を追加し、説明に「最大20文字」を追記
- **ciba-monkey.test.js**: 21文字の文字列でバリデーションエラーになることを検証するテストケースに修正

## 背景

#988 で `binding_message` の文字数制限が6文字から20文字に拡大されましたが、ドキュメントとテストが未更新でした。

## Test plan

- [x] ドキュメントの記載確認
- [x] OpenAPI仕様の更新確認

Closes #988

🤖 Generated with [Claude Code](https://claude.com/claude-code)