### PR TITLE
fix: セッション管理脆弱性の修正 (Issue #947)

### DIFF
--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/oauth/DefaultOAuthProtocol.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/oauth/DefaultOAuthProtocol.java
@@ -134,9 +134,10 @@ public class DefaultOAuthProtocol implements OAuthProtocol {
     }
   }
 
-  public OAuthViewDataResponse getViewData(OAuthViewDataRequest request) {
+  public OAuthViewDataResponse getViewData(
+      OAuthViewDataRequest request, OAuthUserDelegate oAuthUserDelegate) {
 
-    return oAuthHandler.handleViewData(request, oAuthSessionDelegate);
+    return oAuthHandler.handleViewData(request, oAuthSessionDelegate, oAuthUserDelegate);
   }
 
   public AuthorizationRequest get(Tenant tenant, AuthorizationRequestIdentifier identifier) {

--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/oauth/OAuthProtocol.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/oauth/OAuthProtocol.java
@@ -30,7 +30,7 @@ public interface OAuthProtocol {
 
   OAuthRequestResponse request(OAuthRequest oAuthRequest);
 
-  OAuthViewDataResponse getViewData(OAuthViewDataRequest request);
+  OAuthViewDataResponse getViewData(OAuthViewDataRequest request, OAuthUserDelegate delegate);
 
   AuthorizationRequest get(
       Tenant tenant, AuthorizationRequestIdentifier authorizationRequestIdentifier);

--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/oauth/OAuthUserDelegate.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/oauth/OAuthUserDelegate.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2025 Hirokazu Kobayashi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.idp.server.core.openid.oauth;
+
+import org.idp.server.core.openid.identity.UserIdentifier;
+import org.idp.server.platform.multi_tenancy.tenant.Tenant;
+
+public interface OAuthUserDelegate {
+
+  boolean userExists(Tenant tenant, UserIdentifier userIdentifier);
+}

--- a/sample-web/src/app/(authenticated)/home/page.tsx
+++ b/sample-web/src/app/(authenticated)/home/page.tsx
@@ -1,11 +1,11 @@
-import { Button, Container, Stack, Typography, Grid } from "@mui/material";
+import { Container, Stack, Typography, Grid } from "@mui/material";
 import { auth } from "@/app/auth";
 import { redirect } from "next/navigation";
 import UserInfo from "@/components/UserInfo";
 import TokenViewer from "@/components/TokenViewer";
 import PasswordChange from "@/components/PasswordChange";
 import UserDelete from "@/components/UserDelete";
-import LogoutIcon from "@mui/icons-material/Logout";
+import LogoutButton from "@/components/LogoutButton";
 
 const Home = async () => {
   const session = await auth();
@@ -22,22 +22,7 @@ const Home = async () => {
           <Typography variant="h4" component="h1">
             ダッシュボード
           </Typography>
-          <form
-            action={async () => {
-              "use server";
-              const { signOut } = await import("@/app/auth");
-              await signOut();
-            }}
-          >
-            <Button
-              type="submit"
-              variant="outlined"
-              color="error"
-              startIcon={<LogoutIcon />}
-            >
-              ログアウト
-            </Button>
-          </form>
+          <LogoutButton idToken={session.idToken} />
         </Stack>
 
         {/* User Info */}

--- a/sample-web/src/app/api/auth/logout/route.ts
+++ b/sample-web/src/app/api/auth/logout/route.ts
@@ -1,0 +1,28 @@
+import { NextResponse } from "next/server";
+
+/**
+ * RP-Initiated Logout Callback
+ *
+ * IDP server の /v1/logout からリダイレクトされた後に呼ばれる。
+ * NextAuth のセッション Cookie を削除してホームページにリダイレクトする。
+ */
+export async function GET() {
+  const frontendUrl = process.env.NEXT_PUBLIC_FRONTEND_URL || "http://localhost:3000";
+
+  // NextAuth v5 のデフォルト Cookie 名
+  const sessionCookieNames = [
+    "authjs.session-token",
+    "__Secure-authjs.session-token",
+    "authjs.callback-url",
+    "authjs.csrf-token",
+  ];
+
+  const response = NextResponse.redirect(new URL("/", frontendUrl));
+
+  // Cookie を削除（Max-Age=0 で即時削除）
+  for (const name of sessionCookieNames) {
+    response.cookies.delete(name);
+  }
+
+  return response;
+}

--- a/sample-web/src/app/auth.ts
+++ b/sample-web/src/app/auth.ts
@@ -142,21 +142,9 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
   events: {
     async signOut() {
       console.log("------------- signOut event -----------------");
-
-      // RP-Initiated Logout: バックエンドのログアウトAPIを呼び出し
-      // Note: eventsハンドラーではsessionにアクセスできないため、client_idのみで呼び出し
-      const params = new URLSearchParams({
-        client_id: process.env.NEXT_PUBLIC_IDP_CLIENT_ID as string,
-        post_logout_redirect_uri: `${frontendUrl}/logout`,
-      });
-
-      await fetch(
-        `${internalIssuer}/v1/logout?${params.toString()}`,
-        {
-          method: "GET",
-          credentials: "include",
-        },
-      );
+      // Note: RP-Initiated Logout はブラウザリダイレクト方式に変更
+      // LogoutButton コンポーネントから直接 IDP server の /v1/logout にリダイレクトする
+      // これにより Cookie が正しく送信され、セッションが確実に削除される
     },
   },
   session: {

--- a/sample-web/src/components/LogoutButton.tsx
+++ b/sample-web/src/components/LogoutButton.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import { useState } from "react";
+import { Button, CircularProgress } from "@mui/material";
+import LogoutIcon from "@mui/icons-material/Logout";
+
+const issuer = process.env.NEXT_PUBLIC_IDP_SERVER_ISSUER;
+const clientId = process.env.NEXT_PUBLIC_IDP_CLIENT_ID;
+const frontendUrl = process.env.NEXT_PUBLIC_FRONTEND_URL;
+
+interface LogoutButtonProps {
+  idToken?: string;
+}
+
+/**
+ * RP-Initiated Logout Button
+ *
+ * OpenID Connect RP-Initiated Logout 1.0 に準拠したログアウトボタン。
+ * ブラウザから fetch で IDP server の /v1/logout を呼び出し、
+ * Cookie を送信してセッションを削除する。
+ *
+ * フロー:
+ * 1. ボタンクリック → ブラウザから fetch で /v1/logout を呼び出し（Cookie 送信）
+ * 2. IDP server がセッションを削除
+ * 3. NextAuth の Cookie を削除するためにコールバックAPIへリダイレクト
+ *
+ * @see https://openid.net/specs/openid-connect-rpinitiated-1_0.html
+ */
+const LogoutButton = ({ idToken }: LogoutButtonProps) => {
+  const [isLoading, setIsLoading] = useState(false);
+
+  const handleLogout = async () => {
+    setIsLoading(true);
+
+    try {
+      const params = new URLSearchParams({
+        client_id: clientId || "",
+      });
+
+      // id_token_hint を追加（RFC推奨: セッション特定の精度向上）
+      if (idToken) {
+        params.set("id_token_hint", idToken);
+      }
+
+      // ブラウザから fetch で IDP server の logout を呼び出し（Cookie が送信される）
+      await fetch(`${issuer}/v1/logout?${params.toString()}`, {
+        method: "GET",
+        credentials: "include",
+      });
+
+      // NextAuth の Cookie を削除してホームへリダイレクト
+      window.location.href = `${frontendUrl}/api/auth/logout`;
+    } catch (error) {
+      console.error("Logout error:", error);
+      // エラーでも NextAuth のセッションは削除
+      window.location.href = `${frontendUrl}/api/auth/logout`;
+    }
+  };
+
+  return (
+    <Button
+      onClick={handleLogout}
+      variant="outlined"
+      color="error"
+      startIcon={isLoading ? <CircularProgress size={20} /> : <LogoutIcon />}
+      disabled={isLoading}
+    >
+      {isLoading ? "ログアウト中..." : "ログアウト"}
+    </Button>
+  );
+};
+
+export default LogoutButton;


### PR DESCRIPTION
## Summary

- 認証フロー途中離脱時のセッション確立バグを修正
  - 認証ステップ成功時のみセッションID再生成（セッション固定攻撃対策）
  - 最終的な認証情報付きセッションはauthorizeで作成

- ViewData取得時にセッションユーザーのDB存在確認を追加
  - OAuthUserDelegate インターフェース追加（UserinfoDelegate同様のパターン）
  - ユーザー削除後のセッション無効化

- sample-web: RP-Initiated Logout をブラウザfetch方式に変更
  - サーバーサイドfetchではCookieが送信されない問題を修正

## Test plan

- [x] Webアプリから意図した動作を確認
- [x] E2Eテスト成功

Closes #947

🤖 Generated with [Claude Code](https://claude.com/claude-code)