### PR TITLE
fix: Userinfoエンドポイントでユーザーステータス検証を追加 (Issue #901)

### DIFF
--- a/documentation/docs/content_06_developer-guide/03-application-plane/05-userinfo.md
+++ b/documentation/docs/content_06_developer-guide/03-application-plane/05-userinfo.md
@@ -294,6 +294,8 @@ UserInfoエンドポイントでは、以下を検証します：
 2. **有効期限チェック**: `exp`クレームが期限内か
 3. **失効チェック**: トークンが失効（revoke）されていないか
 4. **Audience検証**: トークンの用途が正しいか
+5. **ユーザー存在チェック**: ユーザーが存在するか
+6. **ユーザーステータスチェック**: ユーザーがアクティブな状態か（LOCKED, DISABLED, SUSPENDED, DEACTIVATED, DELETED_PENDING, DELETEDは拒否）
 
 ### 検証エラー
 
@@ -330,6 +332,30 @@ Authorization: Bearer eyJ...（失効済み）
 {
   "error": "invalid_token",
   "error_description": "The access token has been revoked"
+}
+```
+
+```bash
+# ユーザーが見つからない
+GET /{tenant-id}/v1/userinfo
+Authorization: Bearer eyJ...
+
+→ HTTP 401 Unauthorized
+{
+  "error": "invalid_token",
+  "error_description": "not found user"
+}
+```
+
+```bash
+# ユーザーがアクティブでない（LOCKED, DISABLED等）
+GET /{tenant-id}/v1/userinfo
+Authorization: Bearer eyJ...
+
+→ HTTP 401 Unauthorized
+{
+  "error": "invalid_token",
+  "error_description": "user is not active (id: xxx, status: LOCKED)"
 }
 ```
 
@@ -397,6 +423,12 @@ UserInfoレスポンス:
 // ✅ 正しい
 scope: 'openid profile email'  // profile, emailスコープ追加
 ```
+
+### エラー3: `invalid_token` - ユーザーがアクティブでない
+
+**原因**: ユーザーのステータスがLOCKED, DISABLED, SUSPENDED, DEACTIVATED, DELETED_PENDING, DELETEDのいずれか
+
+**解決策**: 管理者がユーザーステータスをアクティブな状態（INITIALIZED, FEDERATED, REGISTERED, IDENTITY_VERIFIED, IDENTITY_VERIFICATION_REQUIRED）に変更する
 
 ---
 

--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/identity/User.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/identity/User.java
@@ -941,7 +941,7 @@ public class User implements JsonReadable, Serializable, UuidConvertable {
   }
 
   public boolean isActive() {
-    return status.isActive();
+    return exists() && status.isActive();
   }
 
   public boolean enabledFidoUaf() {

--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/userinfo/verifier/UserinfoVerifier.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/userinfo/verifier/UserinfoVerifier.java
@@ -43,9 +43,21 @@ public class UserinfoVerifier {
   public void verify() {
     throwExceptionIfNotFoundToken();
     throwExceptionIfUnMatchClientCert();
-    // FIXME
+    throwExceptionIfNotFoundUser();
+    throwExceptionIfInactiveUser();
+  }
+
+  void throwExceptionIfNotFoundUser() {
     if (!user.exists()) {
       throw new TokenInvalidException("not found user");
+    }
+  }
+
+  void throwExceptionIfInactiveUser() {
+    if (!user.isActive()) {
+      throw new TokenInvalidException(
+          String.format(
+              "user is not active (id: %s, status: %s)", user.sub(), user.status().name()));
     }
   }
 


### PR DESCRIPTION
## Summary
- Userinfoエンドポイントでユーザーステータス検証を追加
- LOCKED, DISABLED, SUSPENDED, DEACTIVATED, DELETED_PENDING, DELETEDステータスのユーザーはアクセス拒否
- User.isActive()にexists()チェックを追加

## Changes
- `UserinfoVerifier.java`: `throwExceptionIfInactiveUser()`メソッド追加
- `User.java`: `isActive()`を`exists() && status.isActive()`に変更
- E2Eテスト追加
- ドキュメント更新

## Test plan
- [x] E2Eテスト通過（Userinfoステータス検証テスト）
- [ ] 手動確認：LOCKEDユーザーでUserinfo拒否確認

Closes #901

🤖 Generated with [Claude Code](https://claude.com/claude-code)