### PR TITLE
fix: Email/SMS認証で送信先を認証ポリシーに基づく値に修正 (Issue #999)

### DIFF
--- a/libs/idp-server-authentication-interactors/src/main/java/org/idp/server/authentication/interactors/email/EmailAuthenticationChallengeInteractor.java
+++ b/libs/idp-server-authentication-interactors/src/main/java/org/idp/server/authentication/interactors/email/EmailAuthenticationChallengeInteractor.java
@@ -111,8 +111,10 @@ public class EmailAuthenticationChallengeInteractor implements AuthenticationInt
 
       AuthenticationExecutor executor = authenticationExecutors.get(execution.function());
 
+      Map<String, Object> executionRequestValues = new HashMap<>(request.toMap());
+      executionRequestValues.put("email", email);
       AuthenticationExecutionRequest executionRequest =
-          new AuthenticationExecutionRequest(request.toMap());
+          new AuthenticationExecutionRequest(executionRequestValues);
       AuthenticationExecutionResult executionResult =
           executor.execute(
               tenant, transaction.identifier(), executionRequest, requestAttributes, execution);

--- a/libs/idp-server-authentication-interactors/src/main/java/org/idp/server/authentication/interactors/sms/SmsAuthenticationChallengeInteractor.java
+++ b/libs/idp-server-authentication-interactors/src/main/java/org/idp/server/authentication/interactors/sms/SmsAuthenticationChallengeInteractor.java
@@ -110,8 +110,10 @@ public class SmsAuthenticationChallengeInteractor implements AuthenticationInter
 
       AuthenticationExecutor executor = executors.get(executionConfig.function());
 
+      Map<String, Object> executionRequestValues = new HashMap<>(request.toMap());
+      executionRequestValues.put("phone_number", phoneNumber);
       AuthenticationExecutionRequest executionRequest =
-          new AuthenticationExecutionRequest(request.toMap());
+          new AuthenticationExecutionRequest(executionRequestValues);
       AuthenticationExecutionResult executionResult =
           executor.execute(
               tenant,


### PR DESCRIPTION
## Summary

- Email認証とSMS認証で、送信先がリクエストの値をそのまま使用していた脆弱性を修正
- `resolveEmail()`/`resolvePhoneNumber()`で認証ポリシーに基づいて解決した値を`AuthenticationExecutionRequest`に設定するように変更

## 変更内容

| ファイル | 修正内容 |
|----------|----------|
| `EmailAuthenticationChallengeInteractor.java` | 解決した`email`値でリクエストを上書き |
| `SmsAuthenticationChallengeInteractor.java` | 解決した`phone_number`値でリクエストを上書き |

## セキュリティ影響

**修正前**: 攻撃者が任意のメールアドレス/電話番号を指定して認証コードを送信可能
**修正後**: 認証ポリシーに基づいて解決された値（認証済みユーザーの登録情報等）のみ使用

## Test plan

- [ ] 2nd factor認証時: ユーザー登録済みのメール/電話番号にのみ送信されることを確認
- [ ] 1st factor認証時: リクエストまたはトランザクションの値が正しく使用されることを確認

Closes #999

🤖 Generated with [Claude Code](https://claude.com/claude-code)