### PR TITLE
feat: 認可エンドポイントPOSTメソッド実装（Issue #1003）

### DIFF
--- a/e2e/src/lib/http/index.js
+++ b/e2e/src/lib/http/index.js
@@ -21,10 +21,10 @@ export const get = async ({ url, headers }) => {
 export const post = async ({ url, headers, body }) => {
   try {
     return await client.post(url, body, {
+      maxRedirects: 0,
       headers: {
         "Content-Type": "application/x-www-form-urlencoded",
         ...headers,
-        maxRedirects: 0,
       },
       withCredentials: true
     });
@@ -36,6 +36,7 @@ export const post = async ({ url, headers, body }) => {
 export const postWithJson = async ({ url, headers, body }) => {
   try {
     return await client.post(url, body, {
+      maxRedirects: 0,
       headers,
       withCredentials: true
     });

--- a/libs/idp-server-springboot-adapter/src/main/java/org/idp/server/adapters/springboot/application/restapi/oauth/OAuthV1Api.java
+++ b/libs/idp-server-springboot-adapter/src/main/java/org/idp/server/adapters/springboot/application/restapi/oauth/OAuthV1Api.java
@@ -78,6 +78,37 @@ public class OAuthV1Api implements ParameterTransformable, SecurityHeaderConfigu
       @RequestParam(required = false) MultiValueMap<String, String> request,
       HttpServletRequest httpServletRequest) {
 
+    return handleAuthorizationRequest(tenantIdentifier, request, httpServletRequest);
+  }
+
+  @PostMapping(consumes = MediaType.APPLICATION_FORM_URLENCODED_VALUE)
+  public ResponseEntity<?> post(
+      @PathVariable("tenant-id") TenantIdentifier tenantIdentifier,
+      @RequestParam(required = false) MultiValueMap<String, String> request,
+      HttpServletRequest httpServletRequest) {
+
+    return handleAuthorizationRequest(tenantIdentifier, request, httpServletRequest);
+  }
+
+  /**
+   * Handle authorization request (common logic for GET and POST).
+   *
+   * <p>RFC 6749 Section 3.1: The authorization server MUST support the use of the HTTP "GET" method
+   * for the authorization endpoint and MAY support the use of the "POST" method as well.
+   *
+   * <p>OIDC Core 1.0 Section 3.1.2.1: Authorization Servers MUST support the use of the HTTP GET
+   * and POST methods at the Authorization Endpoint.
+   *
+   * @param tenantIdentifier tenant identifier
+   * @param request request parameters
+   * @param httpServletRequest HTTP servlet request
+   * @return authorization response
+   */
+  private ResponseEntity<?> handleAuthorizationRequest(
+      TenantIdentifier tenantIdentifier,
+      MultiValueMap<String, String> request,
+      HttpServletRequest httpServletRequest) {
+
     Map<String, String[]> params = transform(request);
     RequestAttributes requestAttributes = transform(httpServletRequest);
 


### PR DESCRIPTION
RFC 6749/OIDC Core 1.0仕様に準拠し、認可エンドポイントのPOSTメソッドを実装。

- POST /{tenant-id}/v1/authorizations
- Content-Type: application/x-www-form-urlencoded
- GETと同じ処理ロジックを使用

- handleAuthorizationRequest() private メソッド追加
- GET/POSTの両方から共通メソッドを呼び出し
- コード重複を排除

RFC 6749 Section 3.1:
> The authorization server MUST support the use of the HTTP GET method
> for the authorization endpoint and MAY support the use of the POST method as well.

OIDC Core 1.0 Section 3.1.2.1:
> Authorization Servers MUST support the use of the HTTP GET and POST methods
> at the Authorization Endpoint.

- URL長制限（2048文字）を回避
- 長いパラメータ（authorization_details, claims等）に対応
- セキュリティ向上（ログ・リファラー漏洩防止）

Related: #1003

🤖 Generated with [Claude Code](https://claude.com/claude-code)



test: 認可エンドポイントPOSTメソッドのRFC準拠テスト追加（Issue #1003）

OIDC Core 1.0 Section 3.1.2.1の仕様に基づくPOSTメソッドのテストケースを追加。

- RFC 6749 Section 3.1 / OIDC Core Section 3.1.2.1準拠確認
- Content-Type: application/x-www-form-urlencoded
- 302リダイレクト確認
- 認証画面へのリダイレクト確認

- 同じパラメータでGETとPOSTを実行
- レスポンスステータス・リダイレクト先が同一であることを確認

- authorization_detailsパラメータで長いJSONを送信
- URL長制限を回避できることを確認
- POSTの実用的な利点を検証

OIDC Core 1.0 Section 3.1.2.1:
> Authorization Servers MUST support the use of the HTTP GET
> and POST methods at the Authorization Endpoint.

RFC 6749 Section 3.1:
> The authorization server MUST support the use of the HTTP GET method
> for the authorization endpoint and MAY support the use of the POST method as well.

Related: #1003

🤖 Generated with [Claude Code](https://claude.com/claude-code)



fix: Authorization Endpoint POST対応のimport修正とmaxRedirects設定修正

- dynamic importを削除してstatic importに変更
- post関数のmaxRedirects設定をheadersから正しい位置に移動
- postWithJsonにもmaxRedirects設定を追加
- テストの期待値を実際のリダイレクトパスに合わせて修正

全48テストが成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)