### PR TITLE
docs: OpenAPI仕様書更新 - 認可エンドポイントPOSTとパスワードリセットAPI追加

### DIFF
--- a/documentation/openapi/swagger-resource-owner-ja.yaml
+++ b/documentation/openapi/swagger-resource-owner-ja.yaml
@@ -258,6 +258,154 @@ paths:
         '500':
           $ref: '#/components/responses/InternalServerError'
 
+  /{tenant-id}/v1/me/password/reset:
+    post:
+      tags:
+        - ユーザー
+      summary: パスワードリセット
+      description: |
+        セルフサービスでパスワードをリセットします。
+
+        ## 認可フロー
+
+        このAPIは特別なスコープ `password:reset` が必要です。
+        通常のログインフローではなく、以下の手順で取得します：
+
+        1. Email認証フローで認可リクエスト開始（scope=password:reset）
+        2. Email認証チャレンジで検証コード送信
+        3. Email認証検証でユーザー認証
+        4. 認可コード取得
+        5. トークンエンドポイントで `password:reset` スコープ付きアクセストークン取得
+        6. このAPIでパスワードリセット実行
+
+        ## password/change との違い
+
+        | API | 必要なもの | スコープ | ユースケース |
+        |-----|----------|---------|-------------|
+        | `/v1/me/password/change` | 現在のパスワード | `openid` | ログイン中のパスワード変更 |
+        | `/v1/me/password/reset` | Email認証等 | `password:reset` | パスワードを忘れた場合 |
+
+        **重要**: このAPIは現在のパスワードを**必要としません**。代わりに、Email認証などの別の認証方式で取得した `password:reset` スコープ付きトークンを使用します。
+
+        ## パスワードポリシー
+
+        テナントごとに以下のポリシーを設定可能（`identity_policy_config.password_policy`）：
+        - `min_length`: 最小文字数（デフォルト: 8）
+        - `require_uppercase`: 大文字必須（デフォルト: false）
+        - `require_lowercase`: 小文字必須（デフォルト: false）
+        - `require_number`: 数字必須（デフォルト: false）
+        - `require_special_char`: 記号必須（デフォルト: false）
+
+        デフォルトポリシーはNIST SP 800-63Bの推奨に従い、最小8文字のみを要求します。
+
+        ## セキュリティイベント
+
+        パスワードリセットの成功・失敗時に以下のセキュリティイベントが発行されます：
+        - `password_reset_success`: パスワードリセット成功時
+        - `password_reset_failure`: パスワードリセット失敗時（ポリシー違反等）
+
+        ## 参考
+
+        - Issue #1002: Self-service password reset using email authentication
+        - [NIST SP 800-63B](https://pages.nist.gov/800-63-3/sp800-63b.html)
+      parameters:
+        - $ref: '#/components/parameters/TenantId'
+      security:
+        - OAuth2:
+            - password:reset
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - new_password
+              properties:
+                new_password:
+                  type: string
+                  description: 新しいパスワード
+                  minLength: 8
+                  maxLength: 72
+                  example: "NewSecurePassword456!"
+            example:
+              new_password: "NewSecurePassword456!"
+      responses:
+        '200':
+          description: パスワードリセット成功
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - message
+                properties:
+                  message:
+                    type: string
+                    description: 成功メッセージ
+                    example: "Password changed successfully."
+        '400':
+          description: |
+            バリデーションエラー
+            - 新しいパスワードが未入力
+            - 新しいパスワードがポリシー違反
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - error
+                  - error_description
+                properties:
+                  error:
+                    type: string
+                    enum:
+                      - invalid_request
+                      - invalid_new_password
+                    description: エラーコード
+                  error_description:
+                    type: string
+                    description: エラー詳細メッセージ
+              examples:
+                missing_new_password:
+                  value:
+                    error: "invalid_request"
+                    error_description: "New password is required."
+                password_too_short:
+                  value:
+                    error: "invalid_new_password"
+                    error_description: "Password must be at least 8 characters long."
+                password_policy_violation:
+                  value:
+                    error: "invalid_new_password"
+                    error_description: "Password must contain at least one uppercase letter, one lowercase letter, one digit, and one special character."
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          description: |
+            スコープ不足
+            - 必要スコープ: `password:reset`
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - error
+                  - error_description
+                  - scope
+                properties:
+                  error:
+                    type: string
+                    example: "insufficient_scope"
+                  error_description:
+                    type: string
+                    example: "The request requires 'password:reset' scope"
+                  scope:
+                    type: string
+                    example: "password:reset"
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
   /{tenant-id}/v1/me/identity-verification/applications/{verification-type}/{verification-process}:
     post:
       tags:

--- a/documentation/openapi/swagger-rp-ja.yaml
+++ b/documentation/openapi/swagger-rp-ja.yaml
@@ -348,6 +348,127 @@ paths:
       responses:
         '302':
           description: 認可画面のURL（リダイレクト）
+    post:
+      summary: 認可リクエスト（POST）
+      tags:
+        - 認可コードフロー
+      description: |
+        クライアントアプリケーションがエンドユーザーの認可を取得するためのエンドポイント（POSTメソッド）。
+
+        ## 仕様準拠
+
+        - **RFC 6749 Section 3.1**: Authorization ServerはGETメソッドをサポートしなければならず（MUST）、POSTメソッドもサポートしてもよい（MAY）
+        - **OIDC Core 1.0 Section 3.1.2.1**: Authorization ServerはGETとPOSTの両方をサポートしなければならない（MUST）
+
+        ## POSTメソッドの利点
+
+        1. **URLの長さ制限を回避**: `authorization_details` や `claims` などの長いパラメータに対応
+        2. **セキュリティ向上**: ブラウザ履歴やプロキシログにセンシティブなパラメータが残らない
+        3. **プライバシー保護**: `login_hint` などの個人情報がURLに含まれない
+
+        ## パラメータ
+
+        GETメソッドと同じパラメータを `application/x-www-form-urlencoded` 形式でリクエストボディに含めます。
+
+        ## 参考
+
+        - [RFC 6749 Section 3.1](https://datatracker.ietf.org/doc/html/rfc6749#section-3.1)
+        - [OIDC Core 1.0 Section 3.1.2.1](https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest)
+      requestBody:
+        required: true
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              required:
+                - response_type
+                - client_id
+                - redirect_uri
+                - scope
+              properties:
+                response_type:
+                  type: string
+                  description: レスポンスタイプ（code, id_token, token等）
+                  example: "code"
+                client_id:
+                  type: string
+                  description: クライアントID
+                  example: "client123"
+                redirect_uri:
+                  type: string
+                  format: uri
+                  description: リダイレクトURI
+                  example: "https://app.example.com/callback"
+                scope:
+                  type: string
+                  description: 要求するスコープ（スペース区切り）
+                  example: "openid profile email"
+                state:
+                  type: string
+                  description: CSRF対策用のstate値
+                  example: "xyz123"
+                nonce:
+                  type: string
+                  description: リプレイ攻撃防止用のnonce値
+                  example: "abc456"
+                display:
+                  type: string
+                  enum: [page, popup, touch, wap]
+                  description: 認証画面の表示形式
+                prompt:
+                  type: string
+                  enum: [none, login, consent, select_account]
+                  description: 認証プロンプトの動作
+                max_age:
+                  type: integer
+                  description: 最大認証経過時間（秒）
+                ui_locales:
+                  type: string
+                  description: UI表示言語（スペース区切り）
+                  example: "ja en"
+                id_token_hint:
+                  type: string
+                  description: IDトークンのヒント
+                login_hint:
+                  type: string
+                  description: ログインヒント（メールアドレス等）
+                  example: "user@example.com"
+                acr_values:
+                  type: string
+                  description: 要求する認証コンテキストクラス参照値
+                claims:
+                  type: string
+                  description: 要求するクレーム（JSON形式）
+                  example: '{"id_token":{"email":null}}'
+                request:
+                  type: string
+                  description: JWTリクエストオブジェクト
+                request_uri:
+                  type: string
+                  format: uri
+                  description: リクエストオブジェクトのURI
+                code_challenge:
+                  type: string
+                  description: PKCEコードチャレンジ
+                code_challenge_method:
+                  type: string
+                  enum: [plain, S256]
+                  description: コードチャレンジメソッド
+                  default: plain
+                authorization_details:
+                  type: string
+                  description: 認可詳細（JSON配列形式）
+                  example: '[{"type":"payment_initiation","locations":["https://example.com"]}]'
+      responses:
+        '302':
+          description: 認可画面のURL（リダイレクト）
+          headers:
+            Location:
+              schema:
+                type: string
+                format: uri
+              description: 認証画面のURL
+              example: "https://idp.example.com/{tenant-id}/v1/authorizations/authenticate?id={authorization-id}"
 
   /v1/tokens:
     post:


### PR DESCRIPTION
## swagger-rp-ja.yaml
- /v1/authorizations にPOSTメソッド追加
- RFC 6749 Section 3.1 および OIDC Core 1.0 Section 3.1.2.1 準拠
- POSTメソッドの利点（URL長制限回避、セキュリティ向上）を記載
- 全パラメータのスキーマ定義を追加

## swagger-resource-owner-ja.yaml
- /v1/me/password/reset エンドポイント追加
- password:reset スコープ要件を明記
- Email認証フローの手順を記載
- password/change との違いを表形式で説明
- パスワードポリシーとセキュリティイベントの説明追加

Closes #1006

🤖 Generated with [Claude Code](https://claude.com/claude-code)