### PR TITLE
docs: available_methodsがUIヒントであることを明確化 (Issue #1014)

### DIFF
--- a/documentation/docs/content_05_how-to/how-to-07-authentication-policy-basic.md
+++ b/documentation/docs/content_05_how-to/how-to-07-authentication-policy-basic.md
@@ -80,7 +80,7 @@ curl -X POST "http://localhost:8080/v1/management/organizations/${ORGANIZATION_I
 
 **設定内容**:
 - `flow: "oauth"` - OAuth/OIDC認証フローで使用
-- `available_methods: ["password"]` - パスワード認証のみ許可
+- `available_methods: ["password"]` - UIにパスワード認証を表示
 - `success_conditions.any_of` - 成功条件の配列（外側はOR、内側はAND）
 - `$.password-authentication.success_count >= 1` - パスワード認証が1回以上成功すれば完了
 
@@ -127,7 +127,7 @@ curl -X POST "http://localhost:8080/v1/management/organizations/${ORGANIZATION_I
 ```
 
 **設定内容**:
-- `available_methods: ["password", "sms"]` - 両方許可
+- `available_methods: ["password", "sms"]` - UIに両方の認証方式を表示
 - `any_of: [[ 条件1, 条件2 ]]` - **両方成功が必要**（内側の配列はAND条件）
 
 **認証フロー**:
@@ -568,7 +568,7 @@ ID Tokenに acr クレームとして含める
 2. **available_methodsとsuccess_conditionsの不一致**
    ```json
    // 間違い
-   "available_methods": ["password"],  // パスワードのみ許可
+   "available_methods": ["password"],  // UIにはパスワードのみ表示
    "success_conditions": {
      "any_of": [
        [
@@ -577,8 +577,10 @@ ID Tokenに acr クレームとして含める
        ]
      ]
    }
-   // → SMS認証ができない（available_methodsにない）
+   // → UIにSMS認証が表示されず、ユーザーが認証を完了できない
    ```
+
+   **注意**: `available_methods`はUIヒントです。`success_conditions`で必要な認証方式は必ず`available_methods`にも含めてください。
 
 3. **AND条件とOR条件の混同**
    ```json

--- a/documentation/docs/content_06_developer-guide/03-application-plane/04-authentication.md
+++ b/documentation/docs/content_06_developer-guide/03-application-plane/04-authentication.md
@@ -719,7 +719,7 @@ public class SmsAuthenticationInteractor implements AuthenticationInteractor {
 | フィールド | 型 | 説明 |
 |-----------|---|------|
 | `priority` | number | ポリシーの優先順位（複数ポリシー時、低い値が優先） |
-| `available_methods` | array | 使用可能な認証方式のリスト |
+| `available_methods` | array | UIに表示する認証方式のリスト（UIヒント） |
 | `success_conditions` | object | 認証成功の条件（`any_of`で複数パターン） |
 | `failure_conditions` | object | 認証失敗の条件 |
 | `lock_conditions` | object | アカウントロックの条件 |

--- a/documentation/docs/content_06_developer-guide/04-implementation-guides/impl-05-authentication-policy.md
+++ b/documentation/docs/content_06_developer-guide/04-implementation-guides/impl-05-authentication-policy.md
@@ -118,7 +118,7 @@
 | `description`                      | ポリシーの説明                                            | `"MFA required for high-value transactions"`                       |
 | `priority`                         | 優先度（数値が大きいほど優先）                                  | `1`                                                                 |
 | `conditions`                       | 適用条件。`scopes`, `acr_values`, `client_ids`等を指定       | `{"scopes": ["openid"], "acr_values": ["urn:mace:incommon:iap:gold"]}` |
-| `available_methods`                | 利用可能な認証方式のリスト                                     | `["password", "fido-uaf", "webauthn"]`                              |
+| `available_methods`                | UIに表示する認証方式のリスト（UIヒント）                           | `["password", "fido-uaf", "webauthn"]`                              |
 | `acr_mapping_rules`                | ACR値と認証方式のマッピング                                   | `{"urn:mace:incommon:iap:gold": ["fido-uaf", "webauthn"]}`          |
 | `level_of_authentication_scopes`   | スコープ別の必須認証レベル                                     | `{"transfers": ["fido-uaf", "webauthn"]}`                           |
 | `success_conditions`               | 認証成功とみなす条件（JSONPath + 演算子）                        | 下記参照                                                                |
@@ -156,7 +156,7 @@
 ## 🔁 評価フロー例
 
 1. `conditions` に一致するポリシーが選択される
-2. `available_methods` に定義された認証方式が提示・実行される
+2. `available_methods` に定義された認証方式がUIに提示される
 3. 各認証ステップの結果が収集される
 4. `success_conditions` を満たせば → ✅ 認証成功
 5. `failure_conditions` を満たせば → ⚠️ 警告や記録
@@ -168,7 +168,7 @@
 
 - 機密操作（例：送金）では厳格な `success_conditions` を設定
 - ブルートフォース攻撃対策に `lock_conditions` を活用
-- 信頼済み端末からのログインには `available_methods` を最小化
+- 信頼済み端末からのログインにはUIに表示する `available_methods` を最小化
 
 ---
 

--- a/documentation/docs/content_06_developer-guide/05-configuration/authentication-policy.md
+++ b/documentation/docs/content_06_developer-guide/05-configuration/authentication-policy.md
@@ -89,7 +89,7 @@
 | `description` | ❌ | ポリシー説明 |
 | `priority` | ✅ | 優先度（高い値が優先） |
 | `conditions` | ❌ | 適用条件 |
-| `available_methods` | ✅ | 利用可能な認証方式 |
+| `available_methods` | ✅ | UIに表示する認証方式（UIヒント） |
 | `acr_mapping_rules` | ❌ | ACRマッピング |
 | `success_conditions` | ✅ | 成功条件 |
 | `failure_conditions` | ❌ | 失敗条件 |
@@ -99,7 +99,7 @@
 
 ## Available Methods
 
-利用可能な認証方式を指定：
+UIに表示する認証方式を指定します。この設定は**UIヒント**として機能し、フロントエンドが認証画面で表示する認証方式を決定するために使用されます。
 
 ```json
 {
@@ -112,7 +112,10 @@
 }
 ```
 
-**注意**: Authentication Configuration で登録済みの認証方式のみ指定可能
+**重要**:
+- この設定はバックエンドでの認証方式の制限には使用されません
+- 認証の成功条件は `success_conditions` で制御してください
+- Authentication Configuration で登録済みの認証方式のみ指定可能
 
 ---
 


### PR DESCRIPTION
## Summary

- `available_methods`がバックエンドでの認証方式制限ではなく、**UIヒント**であることをドキュメントで明確化
- 誤解を招く「許可」という表現を「UIに表示」に修正

## 背景

Issue #1014 の検討結果として、`available_methods`のバックエンド検証は不要と判断しました。

理由:
1. 認証成功条件は`success_conditions`で制御可能
2. テナント設定で有効な認証方式は制限可能
3. バックエンド検証追加の効果は限定的（認証自体は正当に行われる）

## 変更内容

| ファイル | 変更内容 |
|---------|---------|
| `authentication-policy.md` | 説明を「UIヒント」に修正、重要な注意事項を追加 |
| `how-to-07-authentication-policy-basic.md` | 「許可」→「UIに表示」に表現修正 |
| `impl-05-authentication-policy.md` | テーブルと評価フローの説明を修正 |
| `04-authentication.md` | テーブルの説明を修正 |

## Test plan

- [ ] ドキュメントのビルド確認
- [ ] 記載内容の整合性確認

Closes #1014

🤖 Generated with [Claude Code](https://claude.com/claude-code)