### PR TITLE
fix: UserUpdateServiceでtenant.identityPolicyConfig()を使用 (Issue #1033)

### DIFF
--- a/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/identity/user/handler/UserUpdateService.java
+++ b/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/identity/user/handler/UserUpdateService.java
@@ -32,7 +32,6 @@ import org.idp.server.platform.json.JsonConverter;
 import org.idp.server.platform.json.JsonDiffCalculator;
 import org.idp.server.platform.json.JsonNodeWrapper;
 import org.idp.server.platform.multi_tenancy.tenant.Tenant;
-import org.idp.server.platform.multi_tenancy.tenant.policy.TenantIdentityPolicy;
 import org.idp.server.platform.security.event.DefaultSecurityEventType;
 import org.idp.server.platform.type.RequestAttributes;
 
@@ -136,8 +135,7 @@ public class UserUpdateService implements UserManagementService<UserUpdateReques
     // Always recalculate preferred_username based on tenant identity policy
     // OIDC Core: preferred_username is mutable and should reflect current user attributes
     // Issue #729: When email/phone/username changes, preferred_username must update accordingly
-    TenantIdentityPolicy policy = TenantIdentityPolicy.fromTenantAttributes(tenant.attributes());
-    newUser.applyIdentityPolicy(policy);
+    newUser.applyIdentityPolicy(tenant.identityPolicyConfig());
 
     return newUser;
   }


### PR DESCRIPTION
## Summary
- `TenantIdentityPolicy.fromTenantAttributes()`を毎回呼び出す代わりに、`tenant.identityPolicyConfig()`を直接使用
- 不要なimportを削除

## Changes
- `UserUpdateService.java`: `TenantIdentityPolicy.fromTenantAttributes(tenant.attributes())` → `tenant.identityPolicyConfig()`

Closes #1033

🤖 Generated with [Claude Code](https://claude.com/claude-code)