### PR TITLE
fix: CIBA認証デバイスAPIをPrimary DBに変更 (Issue #1040)

### DIFF
--- a/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/application/enduser/AuthenticationTransactionEntryService.java
+++ b/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/application/enduser/AuthenticationTransactionEntryService.java
@@ -33,7 +33,19 @@ import org.idp.server.platform.multi_tenancy.tenant.TenantIdentifier;
 import org.idp.server.platform.multi_tenancy.tenant.TenantQueryRepository;
 import org.idp.server.platform.type.RequestAttributes;
 
-@Transaction(readOnly = true)
+/**
+ * AuthenticationTransactionEntryService handles authentication transaction queries for
+ * authentication devices.
+ *
+ * <p>This service uses Primary DB (readOnly = false) instead of Read Replica to avoid replication
+ * lag issues in CIBA flow. When a backchannel authentication request is created, the authentication
+ * device needs to retrieve the transaction immediately. Using Read Replica can cause data not found
+ * errors due to replication lag (100-500ms under normal load, several seconds under high load).
+ *
+ * @see <a href="https://github.com/hirokazu-kobayashi-koba-hiro/idp-server/issues/1040">Issue
+ *     #1040</a>
+ */
+@Transaction(readOnly = false)
 public class AuthenticationTransactionEntryService implements AuthenticationTransactionApi {
 
   TenantQueryRepository tenantQueryRepository;


### PR DESCRIPTION
## Summary

- CIBAフローで認証デバイスから認証トランザクションを取得するAPIをPrimary DB使用に変更
- Read Replicaのレプリケーションラグ（通常100-500ms、高負荷時は数秒）による「データ取得できない」問題を解決

## 変更内容

`AuthenticationTransactionEntryService`の`@Transaction(readOnly = true)`を`@Transaction(readOnly = false)`に変更

## 背景

```
1. Client → Backchannel Auth Request
   └─ Primary DB に AuthenticationTransaction 書き込み

2. 認証デバイス → Transaction取得API
   └─ Reader DB から読み取り
   └─ ❌ レプリケーションラグでデータ未到着
```

## Test plan

- [ ] CIBAフローのE2Eテストが通ること
- [ ] 高負荷時にも認証デバイスからトランザクション取得ができること

Closes #1040

🤖 Generated with [Claude Code](https://claude.com/claude-code)