### PR TITLE
fix: ユーザー登録中の2要素目認証失敗時にセキュリティイベントにユーザー情報を記録 (Issue #1042)

### DIFF
--- a/libs/idp-server-authentication-interactors/src/main/java/org/idp/server/authentication/interactors/initial_registration/InitialRegistrationInteractor.java
+++ b/libs/idp-server-authentication-interactors/src/main/java/org/idp/server/authentication/interactors/initial_registration/InitialRegistrationInteractor.java
@@ -156,6 +156,7 @@ public class InitialRegistrationInteractor implements AuthenticationInteractor {
     IdPUserCreator idPUserCreator =
         new IdPUserCreator(jsonSchemaDefinition, request, passwordEncodeDelegation);
     User user = idPUserCreator.create();
+    user.applyIdentityPolicy(tenant.identityPolicyConfig());
 
     Map<String, Object> response = new HashMap<>();
     response.put("user", user.toMap());


### PR DESCRIPTION
## Summary
- `InitialRegistrationInteractor`: `applyIdentityPolicy`追加でpreferred_username設定
- `EmailAuthenticationInteractor`: `transaction.hasUser()`を先にチェック + `applyIdentityPolicy`追加
- `SmsAuthenticationInteractor`: `transaction.hasUser()`を先にチェック + `applyIdentityPolicy`追加

## 問題
`initial-registration`でユーザー作成後、2要素目のEmail/SMS認証が失敗した場合、セキュリティイベントにユーザー情報が記録されなかった。

## 原因
`tryResolveUserForLogging`がデータベースからのみユーザーを検索していた。登録フローでは`initial-registration`で作成されたユーザーはまだデータベースに永続化されていない（トランザクション内にのみ存在）。

## 修正
1. `transaction.hasUser()`を先にチェックしてトランザクション内のユーザーを使用
2. `applyIdentityPolicy`を適用してpreferred_usernameを設定

## Test plan
- [x] E2Eテスト追加: `should record user info in security event when 2nd factor Email authentication fails during user registration`
- [x] E2Eテスト追加: `should record user info in security event when 2nd factor SMS authentication fails during user registration`
- [x] テスト全件パス確認

Closes #1042

🤖 Generated with [Claude Code](https://claude.com/claude-code)