### PR TITLE
fix: イベントリトライの回数制限を実装

### DIFF
--- a/documentation/docs/content_06_developer-guide/03-application-plane/09-events.md
+++ b/documentation/docs/content_06_developer-guide/03-application-plane/09-events.md
@@ -2,10 +2,10 @@
 
 ## このドキュメントの目的
 
-**SecurityEventとUserLifecycleEvent**の仕組みを理解することが目標です。
+**SecurityEventとUserLifecycleEvent**の概要を理解し、詳細ドキュメントへ誘導します。
 
 ### 所要時間
-⏱️ **約20分**
+⏱️ **約5分**（概要のみ）
 
 ### 前提知識
 - [04. Authentication実装](./04-authentication.md)
@@ -19,389 +19,93 @@ idp-serverの各種操作（認証・認可・ユーザー管理）で発生す�
 
 **2種類のイベント**:
 
-| イベントタイプ | 目的 | 例 |
-|--------------|------|---|
-| **SecurityEvent** | 「何が起きたか」を記録・通知 | 認証成功/失敗、トークン発行 |
-| **UserLifecycleEvent** | 「ユーザー状態を変更する」アクション | アカウントロック、ユーザー削除 |
+| イベントタイプ | 目的 | 例 | 詳細 |
+|--------------|------|---|------|
+| **SecurityEvent** | 「何が起きたか」を記録・通知 | 認証成功/失敗、トークン発行 | [詳細ガイド](./09-security-event.md) |
+| **UserLifecycleEvent** | 「ユーザー状態を変更する」アクション | アカウントロック、ユーザー削除 | [詳細ガイド](./09-user-lifecycle-event.md) |
 
 **使い分け**: SecurityEventは「監視」、UserLifecycleEventは「アクション」
 
 ---
 
-## アーキテクチャ全体像
+## アーキテクチャ概要
 
-### SecurityEventのアーキテクチャ
+両イベントとも同じアーキテクチャパターンを採用：
 
 ```
-Application Plane API（認証・認可・トークン発行等）
-    ↓
 EntryService - eventPublisher.publish()
     ↓ (同期)
-┌─────────────────────────────────────────────────────┐
-│ SecurityEventPublisher（インターフェース）             │
-├─────────────────────────────────────────────────────┤
-│  SecurityEventPublisherService（Adapter層）          │
-│    → applicationEventPublisher.publishEvent()       │
-│       (Spring ApplicationEventPublisher)           │
-└─────────────────────────────────────────────────────┘
+Spring ApplicationEventPublisher
     ↓ (同期で即座に返却)
 EntryService処理完了 → HTTPレスポンス返却
     ↓
     ↓ (非同期 - Spring @EventListener)
     ↓
-┌─────────────────────────────────────────────────────┐
-│ SecurityEventListener（Spring Bean）                │
-├─────────────────────────────────────────────────────┤
-│  @EventListener                                     │
-│  handleSecurityEvent(SecurityEvent event)           │
-│    ↓                                                │
-│  SecurityEventRunnable作成                          │
-│    - TenantLoggingContext設定                       │
-│    - SecurityEventHandler呼び出し                    │
-│    ↓                                                │
-│  securityEventTaskExecutor.execute(runnable)        │
-│    → ThreadPoolに投入                                │
-└─────────────────────────────────────────────────────┘
-    ↓ (ThreadPoolで非同期実行)
-    ├─ 正常時: 別スレッドで実行
-    └─ ThreadPool満杯時: RejectedExecutionHandler
-        ↓
-    ┌─────────────────────────────────────────────────┐
-    │ RejectedExecutionHandler                        │
-    ├─────────────────────────────────────────────────┤
-    │  SecurityEventRetryScheduler.enqueue()          │
-    │    → retryQueueに追加                            │
-    └─────────────────────────────────────────────────┘
-    ↓ (別スレッド - 正常実行時)
-┌─────────────────────────────────────────────────────┐
-│ SecurityEventHandler（Platform層）                  │
-├─────────────────────────────────────────────────────┤
-│  1. SecurityEventLogService.logEvent()              │
-│     → security_event テーブルに記録                  │
-│                                                     │
-│  2. SecurityEventHookConfiguration取得               │
-│     → 設定されたHookを取得                            │
-│                                                     │
-│  3. SecurityEventHook.shouldExecute()               │
-│     → イベントタイプフィルタリング                      │
-│                                                     │
-│  4. SecurityEventHook.execute()                     │
-│     → 外部サービスに送信（Webhook/Slack/SIEM）        │
-│                                                     │
-│  5. SecurityEventHookResult保存                      │
-│     → security_event_hook_results テーブル           │
-└─────────────────────────────────────────────────────┘
-    ↓ (ThreadPool満杯でリトライキューに入った場合)
-┌─────────────────────────────────────────────────────┐
-│ SecurityEventRetryScheduler（Spring Scheduler）     │
-├─────────────────────────────────────────────────────┤
-│  @Scheduled(fixedDelay = 60_000)  ← 60秒ごと         │
-│  resendFailedEvents()                               │
-│    - retryQueueから取得                             │
-│    - securityEventApi.handle()で再実行               │
-│    - 失敗 → retryQueueに戻す                        │
-└─────────────────────────────────────────────────────┘
-```
-
-**実装**:
-- Publisher: [SecurityEventPublisherService.java](../../../../libs/idp-server-springboot-adapter/src/main/java/org/idp/server/adapters/springboot/application/event/SecurityEventPublisherService.java)
-- Runnable: [SecurityEventRunnable.java](../../../../libs/idp-server-springboot-adapter/src/main/java/org/idp/server/adapters/springboot/application/event/SecurityEventRunnable.java)
-- Handler: [SecurityEventHandler.java](../../../../libs/idp-server-platform/src/main/java/org/idp/server/platform/security/handler/SecurityEventHandler.java)
-- Retry Scheduler: [SecurityEventRetryScheduler.java](../../../../libs/idp-server-springboot-adapter/src/main/java/org/idp/server/adapters/springboot/application/event/SecurityEventRetryScheduler.java)
-- ThreadPool設定: [AsyncConfig.java:46-69](../../../../libs/idp-server-springboot-adapter/src/main/java/org/idp/server/adapters/springboot/AsyncConfig.java#L46-L69)
-
-**ThreadPool設定**:
-- **CorePoolSize**: 5スレッド
-- **MaxPoolSize**: 10スレッド
-- **QueueCapacity**: 50イベント
-- **RejectedExecutionHandler**: ThreadPool満杯時にSecurityEventRetryScheduler.enqueue()
-
-**重要**: SecurityEventRetrySchedulerは**Hook送信失敗時ではなく、ThreadPool満杯時**に使われる
-
----
-
-### UserLifecycleEventのアーキテクチャ
-
-SecurityEventと同じThreadPool + RejectedExecutionHandlerの仕組み：
-
-```
-EntryService - userLifecycleEventPublisher.publish()
-    ↓ (同期)
-┌─────────────────────────────────────────────────────┐
-│ UserLifecycleEventPublisher（インターフェース）       │
-├─────────────────────────────────────────────────────┤
-│  UserLifecycleEventPublisherService（Adapter層）    │
-│    → applicationEventPublisher.publishEvent()       │
-│       (Spring ApplicationEventPublisher)           │
-└─────────────────────────────────────────────────────┘
-    ↓ (同期で即座に返却)
-EntryService処理完了 → HTTPレスポンス返却
+EventListener → ThreadPool → EventHandler
     ↓
-    ↓ (非同期 - Spring @EventListener)
-    ↓
-┌─────────────────────────────────────────────────────┐
-│ UserLifecycleEventListener（Spring Bean）          │
-├─────────────────────────────────────────────────────┤
-│  @EventListener                                     │
-│  handleUserLifecycleEvent(UserLifecycleEvent event) │
-│    ↓                                                │
-│  UserLifecycleEventRunnable作成                     │
-│    - TenantLoggingContext設定                       │
-│    - UserLifecycleEventHandler呼び出し              │
-│    ↓                                                │
-│  userLifecycleEventTaskExecutor.execute(runnable)   │
-│    → ThreadPoolに投入                                │
-└─────────────────────────────────────────────────────┘
-    ↓ (ThreadPoolで非同期実行)
-    ├─ 正常時: 別スレッドで実行
-    └─ ThreadPool満杯時: RejectedExecutionHandler
-        ↓
-    ┌─────────────────────────────────────────────────┐
-    │ RejectedExecutionHandler                        │
-    ├─────────────────────────────────────────────────┤
-    │  UserLifecycleEventRetryScheduler.enqueue()     │
-    │    → retryQueueに追加                            │
-    └─────────────────────────────────────────────────┘
-    ↓ (別スレッド - 正常実行時)
-┌─────────────────────────────────────────────────────┐
-│ UserLifecycleEventHandler（Platform層）             │
-├─────────────────────────────────────────────────────┤
-│  UserLifecycleType.LOCK の場合:                      │
-│    1. User.status = LOCKED                          │
-│    2. 全OAuthToken削除                               │
-│    3. SecurityEvent(user_locked)発行                 │
-│                                                     │
-│  UserLifecycleType.DELETE の場合:                    │
-│    1. 関連データ削除（12ステップ）                     │
-│    2. 外部サービスに通知（FIDO/VC等）                  │
-│    3. SecurityEvent(user_deleted)発行                │
-└─────────────────────────────────────────────────────┘
-    ↓ (ThreadPool満杯でリトライキューに入った場合)
-┌─────────────────────────────────────────────────────┐
-│ UserLifecycleEventRetryScheduler（Spring Scheduler）│
-├─────────────────────────────────────────────────────┤
-│  @Scheduled(fixedDelay = 60_000)  ← 60秒ごと         │
-│  resendFailedEvents()                               │
-│    - retryQueueから取得                             │
-│    - userLifecycleEventApi.handle()で再実行          │
-│    - 失敗 → retryQueueに戻す                        │
-└─────────────────────────────────────────────────────┘
+    └─ ThreadPool満杯時: RetryScheduler.enqueue()
 ```
 
-**実装**:
-- Publisher: [UserLifecycleEventPublisherService.java](../../../../libs/idp-server-springboot-adapter/src/main/java/org/idp/server/adapters/springboot/application/event/UserLifecycleEventPublisherService.java)
-- Runnable: [UserLifecycleEventRunnable.java](../../../../libs/idp-server-springboot-adapter/src/main/java/org/idp/server/adapters/springboot/application/event/UserLifecycleEventRunnable.java)
-- Handler: Platform層（イベントタイプ別に処理）
-- Retry Scheduler: [UserLifecycleEventRetryScheduler.java](../../../../libs/idp-server-springboot-adapter/src/main/java/org/idp/server/adapters/springboot/application/event/UserLifecycleEventRetryScheduler.java)
-- ThreadPool設定: [AsyncConfig.java:71-94](../../../../libs/idp-server-springboot-adapter/src/main/java/org/idp/server/adapters/springboot/AsyncConfig.java#L71-L94)
+### 共通のThreadPool設定
 
-**ThreadPool設定**:
-- **CorePoolSize**: 5スレッド
-- **MaxPoolSize**: 10スレッド
-- **QueueCapacity**: 50イベント
-- **RejectedExecutionHandler**: ThreadPool満杯時にUserLifecycleEventRetryScheduler.enqueue()
+| 設定 | 値 | 説明 |
+|------|-----|------|
+| **CorePoolSize** | 5 | 常駐スレッド数 |
+| **MaxPoolSize** | 10 | 最大スレッド数 |
+| **QueueCapacity** | 50 | キュー待機数 |
+| **RejectedExecutionHandler** | カスタム | 満杯時にRetrySchedulerへ |
+
+### 共通のリトライ戦略
+
+| 設定 | 値 |
+|------|-----|
+| **最大リトライ** | 3回 |
+| **間隔** | 60秒 |
+| **超過時** | ログ出力して破棄 |
 
 ---
 
-### 主要クラスの責務
+## 詳細ドキュメント
 
-| クラス | 層 | 役割 | 実装 |
-|--------|---|------|------|
-| **SecurityEventPublisher** | Interface | イベント発行インターフェース | Platform |
-| **SecurityEventPublisherService** | Adapter | Spring ApplicationEventPublisherへの委譲 | [SecurityEventPublisherService.java](../../../../libs/idp-server-springboot-adapter/src/main/java/org/idp/server/adapters/springboot/application/event/SecurityEventPublisherService.java) |
-| **SecurityEventRunnable** | Adapter | TenantLoggingContext設定＋Handler実行 | [SecurityEventRunnable.java](../../../../libs/idp-server-springboot-adapter/src/main/java/org/idp/server/adapters/springboot/application/event/SecurityEventRunnable.java) |
-| **SecurityEventHandler** | Platform | イベント処理・Hook実行（5ステップ） | [SecurityEventHandler.java](../../../../libs/idp-server-platform/src/main/java/org/idp/server/platform/security/handler/SecurityEventHandler.java) |
-| **SecurityEventRetryScheduler** | Adapter | ThreadPool満杯時の再実行（60秒ごと） | [SecurityEventRetryScheduler.java](../../../../libs/idp-server-springboot-adapter/src/main/java/org/idp/server/adapters/springboot/application/event/SecurityEventRetryScheduler.java) |
-| **AsyncConfig** | Adapter | ThreadPool設定（5-10スレッド、Queue50） | [AsyncConfig.java](../../../../libs/idp-server-springboot-adapter/src/main/java/org/idp/server/adapters/springboot/AsyncConfig.java) |
-| **SecurityEventHook** | Plugin | 外部サービス送信（Webhook等） | Platform |
-| **UserLifecycleEventPublisher** | Interface | ライフサイクルイベント発行 | Core |
-| **UserLifecycleEventPublisherService** | Adapter | Spring ApplicationEventPublisherへの委譲 | [UserLifecycleEventPublisherService.java](../../../../libs/idp-server-springboot-adapter/src/main/java/org/idp/server/adapters/springboot/application/event/UserLifecycleEventPublisherService.java) |
-| **UserLifecycleEventRunnable** | Adapter | TenantLoggingContext設定＋Handler実行 | [UserLifecycleEventRunnable.java](../../../../libs/idp-server-springboot-adapter/src/main/java/org/idp/server/adapters/springboot/application/event/UserLifecycleEventRunnable.java) |
-| **UserLifecycleEventRetryScheduler** | Adapter | ThreadPool満杯時の再実行（60秒ごと） | [UserLifecycleEventRetryScheduler.java](../../../../libs/idp-server-springboot-adapter/src/main/java/org/idp/server/adapters/springboot/application/event/UserLifecycleEventRetryScheduler.java) |
+### SecurityEvent
 
----
-
-### Spring ApplicationEventPublisherの利用
-
-idp-serverは**Spring ApplicationEventPublisher**を活用して非同期イベント処理を実現：
-
-**Publisher側（同期）**:
-```java
-@Service
-public class SecurityEventPublisherService implements SecurityEventPublisher {
-  ApplicationEventPublisher applicationEventPublisher;
-
-  @Override
-  public void publish(SecurityEvent securityEvent) {
-    applicationEventPublisher.publishEvent(securityEvent);  // 同期で発行
-  }
-}
-```
-
-**Handler側（非同期）**:
-```java
-@Component
-public class SecurityEventListener {
-
-  @EventListener
-  @Async  // 非同期実行
-  public void handleSecurityEvent(SecurityEvent event) {
-    securityEventHandler.handle(event.tenant(), event);
-  }
-}
-```
-
-**メリット**:
-- ✅ EntryServiceはイベント発行後すぐに返却（パフォーマンス）
-- ✅ Hook送信失敗がAPI呼び出しに影響しない
-- ✅ Spring標準機能で非同期処理
-
----
-
-## SecurityEvent詳細
-
-### 特徴
-
-**目的**: 「何が起きたか」を記録・通知
+**目的**: 監視・監査（状態変更しない）
 
 ```
 認証成功 → SecurityEvent(password_success) → 監査ログに記録 → 外部サービスに通知
 ```
 
-**特徴**:
-- ✅ **記録中心**: security_eventテーブルに永久保存
-- ✅ **監視・通知**: Security Event Hooksで外部サービスに送信
-- ❌ **状態変更しない**: ユーザー・トークン等は変更しない
+**内容**:
+- 2層のリトライ戦略（イベント処理層 + HTTP層）
+- 主要なイベントタイプ
+- Security Event Hooks
+- データベーススキーマ
+
+👉 **[SecurityEvent実装ガイド](./09-security-event.md)**
 
 ---
 
-### 主要なイベントタイプ
+### UserLifecycleEvent
 
-Application Planeで発行されるSecurityEvent：
-
-| イベントタイプ | 発行タイミング | 実装箇所 |
-|--------------|--------------|---------|
-| `password_success` | パスワード認証成功 | [OAuthFlowEntryService.java:210](../../../../libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/application/enduser/OAuthFlowEntryService.java#L210) |
-| `password_failure` | パスワード認証失敗 | 同上 |
-| `oauth_authorize` | Authorization Code発行 | [OAuthFlowEntryService.java:330-335](../../../../libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/application/enduser/OAuthFlowEntryService.java#L330-L335) |
-| `token_request_success` | トークン発行成功 | TokenEntryService |
-| `userinfo_success` | UserInfo取得成功 | UserinfoEntryService |
-| `backchannel_authentication_request_success` | CIBA認証リクエスト成功 | CibaFlowEntryService |
-
-**完全なリスト**: [DefaultSecurityEventType.java](../../../../libs/idp-server-platform/src/main/java/org/idp/server/platform/security/event/DefaultSecurityEventType.java)
-
-### イベント発行の実装
-
-**04-authentication.mdで見た例**:
-
-```java
-// 10. イベント発行（Security Event）
-eventPublisher.publish(
-    tenant,
-    authorizationRequest,
-    result.user(),
-    result.eventType(),  // password_success or password_failure
-    requestAttributes);
-```
-
-### SecurityEventの保存先
-
-```sql
--- security_eventテーブル
-CREATE TABLE security_event (
-    id UUID PRIMARY KEY,
-    tenant_id UUID NOT NULL,
-    event_type VARCHAR(255) NOT NULL,  -- 'password_success' 等
-    user_id UUID,
-    client_id VARCHAR(255),
-    ip_address VARCHAR(45),
-    user_agent TEXT,
-    event_data JSONB,
-    created_at TIMESTAMP NOT NULL
-);
-```
-
-**用途**:
-- 監査ログとして永久保存
-- Security Event Hooksで外部サービスに通知
-- SIEM（Security Information and Event Management）連携
-
----
-
-## UserLifecycleEvent詳細
-
-### 特徴
-
-**目的**: 「ユーザー状態を変更する」アクション
+**目的**: ユーザー状態変更のトリガー
 
 ```
 認証失敗5回 → UserLifecycleEvent(LOCK) → User.status = LOCKED → トークン全削除
 ```
 
-**特徴**:
-- ✅ **状態変更**: ユーザーステータス・トークン・関連データを変更
-- ✅ **非同期処理**: 別スレッドでデータ削除・外部サービス連携
-- ✅ **副作用あり**: SecurityEvent(user_locked)等を再発行
+**内容**:
+- ライフサイクルタイプ（LOCK/UNLOCK/DELETE等）
+- アカウントロックフロー
+- ユーザー削除戦略（12ステップ）
+- SecurityEventとの連携
 
----
-
-### ライフサイクルタイプ
-
-| ライフサイクルタイプ | 発行タイミング | 用途 |
-|-----------------|--------------|------|
-| `LOCK` | アカウントロック | ユーザーステータス更新、トークン失効 |
-| `UNLOCK` | アカウントロック解除 | ユーザーステータス更新 |
-| `DELETE` | ユーザー削除 | 関連データ削除、外部サービス連携 |
-| `SUSPEND` | アカウント停止 | ユーザーステータス更新 |
-| `ACTIVATE` | アカウント有効化 | ユーザーステータス更新 |
-| `INVITE_COMPLETE` | 招待完了 | 招待ステータス更新 |
-
-### イベント発行の実装
-
-**04-authentication.mdで見た例**:
-
-```java
-// 9. ロック処理（失敗回数超過時）
-if (updatedTransaction.isLocked()) {
-  UserLifecycleEvent userLifecycleEvent =
-      new UserLifecycleEvent(tenant, updatedTransaction.user(), UserLifecycleType.LOCK);
-  userLifecycleEventPublisher.publish(userLifecycleEvent);
-}
-```
-
-### UserLifecycleEventの処理
-
-**非同期処理**: イベント発行後、別スレッドで処理
-
-```
-UserLifecycleEvent発行
-    ↓
-UserLifecycleEventHandler（非同期）
-    ↓
-┌─────────────────────────────────────────┐
-│ UserLifecycleType.LOCK                  │
-├─────────────────────────────────────────┤
-│  - User.status = LOCKED                 │
-│  - OAuthToken全削除                      │
-│  - SecurityEvent(user_locked)発行        │
-└─────────────────────────────────────────┘
-    ↓
-┌─────────────────────────────────────────┐
-│ UserLifecycleType.DELETE                │
-├─────────────────────────────────────────┤
-│  - 関連データ削除（12ステップ）            │
-│  - 外部サービスに通知（FIDO/VC等）         │
-│  - SecurityEvent(user_deleted)発行       │
-└─────────────────────────────────────────┘
-```
+👉 **[UserLifecycleEvent実装ガイド](./09-user-lifecycle-event.md)**
 
 ---
 
 ## 2種類のイベントの使い分け
 
-### パスワード認証失敗のフロー
-
-2つのイベントがどう連携するかの具体例：
+### パスワード認証失敗の例
 
 ```
 1. パスワード認証失敗
@@ -420,188 +124,6 @@ UserLifecycleEventHandler（非同期）
 - SecurityEvent: 監視・記録のみ（状態変更しない）
 - UserLifecycleEvent: 状態変更のトリガー
 - 1つのUserLifecycleEventが複数のSecurityEventを発生させることもある
-
----
-
-## アカウントロックフロー（詳細）
-
-認証失敗が一定回数を超えた場合の自動ロック：
-
-```
-[パスワード認証失敗 x5]
-    ↓
-AuthenticationTransaction.isLocked() = true
-    ↓
-UserLifecycleEvent(type=LOCK)発行
-    ↓
-UserLifecycleEventHandler（非同期処理）
-    ├─ User.status = LOCKED
-    ├─ 全OAuthToken削除
-    └─ SecurityEvent(user_locked)発行
-    ↓
-次回認証試行時
-    ↓
-{
-  "error": "account_locked",
-  "error_description": "Account has been locked due to too many failed attempts"
-}
-```
-
-**実装**: [OAuthFlowEntryService.java:204-208](../../../../libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/application/enduser/OAuthFlowEntryService.java#L204-L208)
-
----
-
-## ユーザー削除戦略
-
-### 削除方針
-
-| カテゴリ | ストラテジー | 対象テーブル |
-|----------|------------|------------|
-| **コアデータ** | 物理削除 | `idp_user`, `idp_user_roles`, `oauth_token`, `authorization_code_grant`, `authentication_transaction`, `ciba_grant`, `federation_sso_session` |
-| **ログ・履歴** | 論理削除/保持 | `authorization_granted`（revoked_at設定）, `identity_verification_application`（status=deleted）, `security_event`（保持） |
-| **外部サービス** | 非同期削除 | FIDO-UAFデバイス、Verifiable Credentials |
-
-### 削除シーケンス（推奨順序）
-
-```
-UserLifecycleEvent(type=DELETE)発行
-    ↓
-UserLifecycleEventHandler
-    ↓
-1. authentication_interactions 削除
-2. authentication_transaction 削除
-3. idp_user_roles 削除
-4. idp_user_permission_override 削除
-5. oauth_token 削除
-6. authorization_code_grant 削除
-7. ciba_grant 削除
-8. federation_sso_session 削除
-9. authorization_granted 論理削除（revoked_at設定）
-10. identity_verification_application 論理削除（status=deleted）
-11. idp_user 物理削除
-12. security_event 監査エントリ追加
-13. 外部サービスに delete_account イベント送信（非同期）
-```
-
-### 監査ログは削除しない
-
-**重要**: `security_event`テーブルは削除せず、永久保存
-
-**理由**:
-- 法的要件（監査証跡の保持義務）
-- セキュリティ分析（過去の不正アクセス調査）
-- コンプライアンス（GDPR等の例外規定）
-
-**対応**: ユーザー削除後も、security_eventは`user_id`を保持（または匿名化）
-
----
-
-## Security Event Hooks
-
-### Hooksとは
-
-SecurityEventを外部サービス（Webhook/Slack/SIEM等）に通知する仕組み。
-
-```
-SecurityEvent発行
-    ↓
-SecurityEventHookExecutor（非同期）
-    ↓
-┌─────────────────────────────────────────┐
-│ 設定されたHookエンドポイントに送信          │
-├─────────────────────────────────────────┤
-│  POST https://webhook.example.com/events │
-│  {                                       │
-│    "event_type": "password_failure",     │
-│    "user_id": "user-12345",              │
-│    "ip_address": "192.168.1.1",          │
-│    "timestamp": "2025-10-13T10:00:00Z"   │
-│  }                                       │
-└─────────────────────────────────────────┘
-    ↓
-外部サービス（Slack/SIEM/監視ツール）
-```
-
-### Hook設定
-
-**Management APIで設定**:
-
-```json
-{
-  "id": "uuid",
-  "event_types": ["password_failure", "user_locked", "token_request_success"],
-  "endpoint": "https://webhook.example.com/events",
-  "auth_type": "bearer",
-  "auth_token": "secret-token",
-  "enabled": true
-}
-```
-
-**設定API**:
-```
-POST /v1/management/tenants/{tenant-id}/security-event-hooks
-```
-
-### リトライ戦略
-
-Hook送信失敗時は自動リトライ：
-
-- **max_retries**: 3回（デフォルト）
-- **backoff**: 1秒 → 2秒 → 4秒
-- **retryable_status_codes**: 502, 503, 504
-
-**詳細**: [実装ガイド: Security Event Hooks](../04-implementation-guides/impl-15-security-event-hooks.md)
-
----
-
-## よくある質問
-
-### Q1: SecurityEventとUserLifecycleEventの使い分けは？
-
-**SecurityEvent**:
-- 監視・監査が目的
-- 外部サービスへの通知
-- ユーザー状態は変更しない
-
-**UserLifecycleEvent**:
-- ユーザー状態変更が目的
-- データ削除・更新
-- 内部処理のトリガー
-
-**例**: パスワード失敗
-```
-1. SecurityEvent(password_failure) → 監査ログに記録
-2. 5回失敗 → UserLifecycleEvent(LOCK) → ユーザーステータス更新
-3. SecurityEvent(user_locked) → 外部に通知
-```
-
----
-
-### Q2: イベントは同期？非同期？
-
-**SecurityEvent発行**: 同期（eventPublisher.publish()）
-**SecurityEvent保存**: 同期（DBに即座に記録）
-**Security Event Hooks送信**: 非同期（別スレッド）
-
-**UserLifecycleEvent発行**: 同期（userLifecycleEventPublisher.publish()）
-**UserLifecycleEvent処理**: 非同期（別スレッド）
-
-**理由**:
-- イベント記録は即座に完了（監査証跡）
-- 外部サービス通知は非同期（パフォーマンス影響を避ける）
-
----
-
-### Q3: イベント発行失敗時は？
-
-**SecurityEvent発行失敗**:
-- トランザクションロールバック
-- API呼び出し自体が失敗
-
-**Hook送信失敗**:
-- リトライ（3回）
-- 最終的に失敗 → security_event_hook_results テーブルに記録
-- API呼び出しは成功（非同期のため影響なし）
 
 ---
 
@@ -659,12 +181,10 @@ public class EventListener {
 
 ## 次のステップ
 
-✅ イベント処理の仕組みを理解した！
+イベント処理の概要を理解したら、詳細ドキュメントへ進んでください：
 
-### 📖 詳細情報
-
-- [実装ガイド: Security Event Hooks](../04-implementation-guides/impl-15-security-event-hooks.md) - Hook実装詳細
-- [AI開発者向け: Security Event](../../content_10_ai_developer/ai-51-notification-security-event.md#security-event)
+- 👉 **[SecurityEvent実装ガイド](./09-security-event.md)** - 監視・監査イベント
+- 👉 **[UserLifecycleEvent実装ガイド](./09-user-lifecycle-event.md)** - ユーザー状態変更イベント
 
 ---
 
@@ -673,4 +193,4 @@ public class EventListener {
 - [SecurityEventPublisher.java](../../../../libs/idp-server-platform/src/main/java/org/idp/server/platform/security/event/SecurityEventPublisher.java)
 - [UserLifecycleEventPublisher.java](../../../../libs/idp-server-core/src/main/java/org/idp/server/core/openid/identity/event/UserLifecycleEventPublisher.java)
 
-**最終更新**: 2025-10-13
+**最終更新**: 2025-12-13

--- a/documentation/docs/content_06_developer-guide/03-application-plane/09-security-event.md
+++ b/documentation/docs/content_06_developer-guide/03-application-plane/09-security-event.md
@@ -1,0 +1,460 @@
+# SecurityEvent 実装ガイド
+
+## このドキュメントの目的
+
+**SecurityEvent**の仕組みとリトライ戦略を理解することが目標です。
+
+### 所要時間
+⏱️ **約15分**
+
+### 前提知識
+- [04. Authentication実装](./04-authentication.md)
+- Spring Frameworkの`@EventListener`の基礎知識
+
+---
+
+## SecurityEventとは
+
+**目的**: 「何が起きたか」を記録・通知
+
+```
+認証成功 → SecurityEvent(password_success) → 監査ログに記録 → 外部サービスに通知
+```
+
+**特徴**:
+- ✅ **記録中心**: security_eventテーブルに永久保存
+- ✅ **監視・通知**: Security Event Hooksで外部サービスに送信
+- ❌ **状態変更しない**: ユーザー・トークン等は変更しない
+
+---
+
+## 処理フロー概要
+
+SecurityEventの処理は以下の流れで行われます：
+
+1. **イベント発行**: EntryServiceが `eventPublisher.publish()` で発行（同期）
+2. **非同期処理**: Spring `@EventListener` がイベントを受信し、ThreadPoolに投入
+3. **イベント処理**: `SecurityEventHandler` がDBへの記録とHook送信を実行
+4. **リトライ**: ThreadPool満杯時は `SecurityEventRetryScheduler` が後で再実行
+
+```
+EntryService → publish() → ThreadPool → SecurityEventHandler → DB記録 + Hook送信
+                              ↓ (満杯時)
+                     RetryScheduler → 60秒後に再実行（最大3回）
+```
+
+**ポイント**: イベント発行は同期だが、処理は非同期。API呼び出しはイベント処理完了を待たずに返却される。
+
+---
+
+## アーキテクチャ
+
+```
+Application Plane API（認証・認可・トークン発行等）
+    ↓
+EntryService - eventPublisher.publish()
+    ↓ (同期)
+┌─────────────────────────────────────────────────────┐
+│ SecurityEventPublisher（インターフェース）             │
+├─────────────────────────────────────────────────────┤
+│  SecurityEventPublisherService（Adapter層）          │
+│    → applicationEventPublisher.publishEvent()       │
+│       (Spring ApplicationEventPublisher)           │
+└─────────────────────────────────────────────────────┘
+    ↓ (同期で即座に返却)
+EntryService処理完了 → HTTPレスポンス返却
+    ↓
+    ↓ (非同期 - Spring @EventListener)
+    ↓
+┌─────────────────────────────────────────────────────┐
+│ SecurityEventListener（Spring Bean）                │
+├─────────────────────────────────────────────────────┤
+│  @EventListener                                     │
+│  handleSecurityEvent(SecurityEvent event)           │
+│    ↓                                                │
+│  SecurityEventRunnable作成                          │
+│    - TenantLoggingContext設定                       │
+│    - SecurityEventHandler呼び出し                    │
+│    ↓                                                │
+│  securityEventTaskExecutor.execute(runnable)        │
+│    → ThreadPoolに投入                                │
+└─────────────────────────────────────────────────────┘
+    ↓ (ThreadPoolで非同期実行)
+    ├─ 正常時: 別スレッドで実行
+    └─ ThreadPool満杯時: RejectedExecutionHandler
+        ↓
+    ┌─────────────────────────────────────────────────┐
+    │ RejectedExecutionHandler                        │
+    ├─────────────────────────────────────────────────┤
+    │  SecurityEventRetryScheduler.enqueue()          │
+    │    → retryQueueに追加                            │
+    └─────────────────────────────────────────────────┘
+    ↓ (別スレッド - 正常実行時)
+┌─────────────────────────────────────────────────────┐
+│ SecurityEventHandler（Platform層）                  │
+├─────────────────────────────────────────────────────┤
+│  1. SecurityEventLogService.logEvent()              │
+│     → security_event テーブルに記録                  │
+│                                                     │
+│  2. SecurityEventHookConfiguration取得               │
+│     → 設定されたHookを取得                            │
+│                                                     │
+│  3. SecurityEventHook.shouldExecute()               │
+│     → イベントタイプフィルタリング                      │
+│                                                     │
+│  4. SecurityEventHook.execute()                     │
+│     → 外部サービスに送信（Webhook/Slack/SIEM）        │
+│                                                     │
+│  5. SecurityEventHookResult保存                      │
+│     → security_event_hook_results テーブル           │
+└─────────────────────────────────────────────────────┘
+```
+
+**実装**:
+- Publisher: [SecurityEventPublisherService.java](../../../../libs/idp-server-springboot-adapter/src/main/java/org/idp/server/adapters/springboot/application/event/SecurityEventPublisherService.java)
+- Runnable: [SecurityEventRunnable.java](../../../../libs/idp-server-springboot-adapter/src/main/java/org/idp/server/adapters/springboot/application/event/SecurityEventRunnable.java)
+- Handler: [SecurityEventHandler.java](../../../../libs/idp-server-platform/src/main/java/org/idp/server/platform/security/handler/SecurityEventHandler.java)
+- Retry Scheduler: [SecurityEventRetryScheduler.java](../../../../libs/idp-server-springboot-adapter/src/main/java/org/idp/server/adapters/springboot/application/event/SecurityEventRetryScheduler.java)
+- ThreadPool設定: [AsyncConfig.java:46-69](../../../../libs/idp-server-springboot-adapter/src/main/java/org/idp/server/adapters/springboot/AsyncConfig.java#L46-L69)
+
+---
+
+## ThreadPool設定
+
+| 設定 | 値 | 説明 |
+|------|-----|------|
+| **CorePoolSize** | 5 | 常駐スレッド数 |
+| **MaxPoolSize** | 10 | 最大スレッド数 |
+| **QueueCapacity** | 50 | キュー待機数 |
+| **RejectedExecutionHandler** | カスタム | 満杯時にRetrySchedulerへ |
+
+### 処理の流れ
+
+```
+新規イベント到着
+    ↓
+┌─────────────────────────────────────────────────────────┐
+│ ThreadPool (securityEventTaskExecutor)                  │
+├─────────────────────────────────────────────────────────┤
+│                                                         │
+│  [Worker 1] [Worker 2] [Worker 3] [Worker 4] [Worker 5] │  ← CorePoolSize: 5
+│                                                         │
+│  ─────────────────────────────────────────────────────  │
+│  負荷増加時に追加                                        │
+│  [Worker 6] [Worker 7] [Worker 8] [Worker 9] [Worker 10]│  ← MaxPoolSize: 10
+│                                                         │
+│  ─────────────────────────────────────────────────────  │
+│  全Worker稼働中は待機                                    │
+│  [Queue: 最大50件まで待機可能]                            │  ← QueueCapacity: 50
+│                                                         │
+└─────────────────────────────────────────────────────────┘
+    ↓ (Queue も満杯の場合)
+┌─────────────────────────────────────────────────────────┐
+│ RejectedExecutionHandler                                │
+├─────────────────────────────────────────────────────────┤
+│  SecurityEventRetryScheduler.enqueue(event)             │
+│    → 60秒後にリトライ（最大3回）                          │
+└─────────────────────────────────────────────────────────┘
+```
+
+### 設定の意味
+
+- **CorePoolSize (5)**: 通常時に稼働するスレッド数。イベント処理の基本キャパシティ
+- **MaxPoolSize (10)**: 負荷が高い時に増加できる最大スレッド数
+- **QueueCapacity (50)**: 全スレッドが稼働中でも50件までキューで待機可能
+- **RejectedExecutionHandler**: キューも満杯になった場合の処理。RetrySchedulerに委譲
+
+### キャパシティ計算
+
+同時に処理可能なイベント数：
+- **即時処理**: 最大10件（MaxPoolSize）
+- **待機可能**: 50件（QueueCapacity）
+- **合計**: 60件まで受け入れ可能
+
+61件目以降は `RejectedExecutionHandler` → `RetryScheduler` へ
+
+### スレッド数設定の考え方
+
+#### スレッド数の上限制約
+
+スレッド数は以下のリソースによって制約されます：
+
+| 制約 | 説明 | 確認方法 |
+|------|------|---------|
+| **DB接続プール** | スレッド数 > DB接続数だと接続待ちが発生 | HikariCPの`maximumPoolSize` |
+| **メモリ（スタック）** | 1スレッドあたり約1MB消費（デフォルト） | `-Xss`オプション |
+| **OS制限** | プロセスあたりのスレッド数上限 | `ulimit -u` |
+| **外部API Rate Limit** | Hook送信先のレート制限 | 外部サービスの仕様 |
+
+```
+実効上限 = min(DB接続プール, 利用可能メモリ/スタックサイズ, OS制限, 外部API制限)
+```
+
+**例**: DB接続プール20、メモリ2GB、スタック1MBの場合
+- メモリ上限: 2048MB / 1MB = 約2000スレッド（理論値）
+- **実効上限: 20スレッド**（DB接続プールがボトルネック）
+
+#### I/O待ち時間を考慮
+
+SecurityEvent処理はI/Oバウンド（DB書き込み、HTTP送信）なので、CPUコア数より多めに設定可能。
+
+```
+推奨スレッド数 = CPUコア数 × (1 + I/O待ち時間 / CPU処理時間)
+```
+
+例：4コアCPU、I/O待ち時間がCPU処理時間の10倍の場合
+```
+4 × (1 + 10) = 44スレッド まで効果的
+```
+
+ただし、上記の上限制約を超えないこと。
+
+#### 現在の設定値の根拠
+
+| 設定 | 値 | 根拠 |
+|------|-----|------|
+| CorePoolSize | 5 | 通常負荷での安定動作。DB接続プールとのバランス |
+| MaxPoolSize | 10 | ピーク時の2倍対応。過度なリソース消費を防止 |
+| QueueCapacity | 50 | バースト的なイベント増加に対応。メモリ消費とのバランス |
+
+#### 調整が必要なケース
+
+| 状況 | 調整案 |
+|------|-------|
+| リトライが頻発する | MaxPoolSize / QueueCapacity を増加 |
+| メモリ使用量が高い | QueueCapacity を減少 |
+| DB接続エラーが発生 | CorePoolSize を DB接続プール以下に調整 |
+| Hook送信が遅い | MaxPoolSize を増加（I/O待ち対策） |
+
+#### 設定変更方法
+
+`AsyncConfig.java` で設定を変更：
+
+```java
+@Bean("securityEventTaskExecutor")
+public TaskExecutor securityEventTaskExecutor() {
+    ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+    executor.setCorePoolSize(5);    // 調整可能
+    executor.setMaxPoolSize(10);    // 調整可能
+    executor.setQueueCapacity(50);  // 調整可能
+    // ...
+}
+```
+
+将来的には `application.yml` からの設定読み込みを検討中。
+
+---
+
+## リトライ戦略
+
+ThreadPool満杯時のリトライは`SecurityEventRetryScheduler`が担当します。
+
+| 設定 | 値 |
+|------|-----|
+| **最大リトライ** | 3回 |
+| **間隔** | 60秒 |
+| **超過時** | ログ出力して破棄 |
+
+### リトライ実装
+
+**リトライ回数管理**: Mapでイベント別にカウント
+
+```java
+@Component
+public class SecurityEventRetryScheduler {
+
+  private static final int MAX_RETRIES = 3;
+
+  Queue<SecurityEvent> retryQueue = new ConcurrentLinkedQueue<>();
+  Map<String, Integer> retryCountMap = new ConcurrentHashMap<>();
+
+  public void enqueue(SecurityEvent event) {
+    retryQueue.add(event);
+    retryCountMap.putIfAbsent(event.id(), 0);
+  }
+
+  @Scheduled(fixedDelay = 60_000)
+  public void resendFailedEvents() {
+    while (!retryQueue.isEmpty()) {
+      SecurityEvent event = retryQueue.poll();
+      String eventId = event.id();
+
+      try {
+        log.info("retry event (attempt {}): {}",
+            retryCountMap.get(eventId) + 1, eventId);
+        securityEventApi.handle(event.tenantIdentifier(), event);
+        retryCountMap.remove(eventId);  // 成功時はクリア
+      } catch (Exception e) {
+        int count = retryCountMap.merge(eventId, 1, Integer::sum);
+        if (count < MAX_RETRIES) {
+          log.warn("retry scheduled ({}/{}): {}", count, MAX_RETRIES, eventId);
+          retryQueue.add(event);
+        } else {
+          log.error("max retries exceeded, dropping event: {}", event.toMap());
+          retryCountMap.remove(eventId);
+        }
+      }
+    }
+  }
+}
+```
+
+**ポイント**:
+- `retryCountMap`: イベントID → リトライ回数のマッピング
+- 成功時・上限到達時に`remove()`でメモリ解放
+- 最大3回リトライ後は破棄（ログに記録）
+
+---
+
+## 主要なイベントタイプ
+
+Application Planeで発行されるSecurityEvent：
+
+| イベントタイプ | 発行タイミング | 実装箇所 |
+|--------------|--------------|---------|
+| `password_success` | パスワード認証成功 | [OAuthFlowEntryService.java:210](../../../../libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/application/enduser/OAuthFlowEntryService.java#L210) |
+| `password_failure` | パスワード認証失敗 | 同上 |
+| `oauth_authorize` | Authorization Code発行 | [OAuthFlowEntryService.java:330-335](../../../../libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/application/enduser/OAuthFlowEntryService.java#L330-L335) |
+| `token_request_success` | トークン発行成功 | TokenEntryService |
+| `userinfo_success` | UserInfo取得成功 | UserinfoEntryService |
+| `backchannel_authentication_request_success` | CIBA認証リクエスト成功 | CibaFlowEntryService |
+
+**完全なリスト**: [DefaultSecurityEventType.java](../../../../libs/idp-server-platform/src/main/java/org/idp/server/platform/security/event/DefaultSecurityEventType.java)
+
+---
+
+## イベント発行の実装
+
+```java
+// 10. イベント発行（Security Event）
+eventPublisher.publish(
+    tenant,
+    authorizationRequest,
+    result.user(),
+    result.eventType(),  // password_success or password_failure
+    requestAttributes);
+```
+
+---
+
+## データベーススキーマ
+
+### security_event テーブル
+
+```sql
+CREATE TABLE security_event (
+    id UUID PRIMARY KEY,
+    tenant_id UUID NOT NULL,
+    event_type VARCHAR(255) NOT NULL,  -- 'password_success' 等
+    user_id UUID,
+    client_id VARCHAR(255),
+    ip_address VARCHAR(45),
+    user_agent TEXT,
+    event_data JSONB,
+    created_at TIMESTAMP NOT NULL
+);
+```
+
+**用途**:
+- 監査ログとして永久保存
+- Security Event Hooksで外部サービスに通知
+- SIEM（Security Information and Event Management）連携
+
+---
+
+## Security Event Hooks
+
+### Hooksとは
+
+SecurityEventを外部サービス（Webhook/Slack/SIEM等）に通知する仕組み。
+
+```
+SecurityEvent発行
+    ↓
+SecurityEventHookExecutor（非同期）
+    ↓
+┌─────────────────────────────────────────┐
+│ 設定されたHookエンドポイントに送信          │
+├─────────────────────────────────────────┤
+│  POST https://webhook.example.com/events │
+│  {                                       │
+│    "event_type": "password_failure",     │
+│    "user_id": "user-12345",              │
+│    "ip_address": "192.168.1.1",          │
+│    "timestamp": "2025-10-13T10:00:00Z"   │
+│  }                                       │
+└─────────────────────────────────────────┘
+    ↓
+外部サービス（Slack/SIEM/監視ツール）
+```
+
+### Hook設定
+
+**Management APIで設定**:
+
+```json
+{
+  "id": "uuid",
+  "event_types": ["password_failure", "user_locked", "token_request_success"],
+  "endpoint": "https://webhook.example.com/events",
+  "auth_type": "bearer",
+  "auth_token": "secret-token",
+  "enabled": true
+}
+```
+
+**設定API**:
+```
+POST /v1/management/tenants/{tenant-id}/security-event-hooks
+```
+
+---
+
+## よくある質問
+
+### Q1: イベントは同期？非同期？
+
+| 処理 | 同期/非同期 | 説明 |
+|------|-----------|------|
+| **イベント発行** | 同期 | `eventPublisher.publish()` |
+| **イベント保存** | 同期 | DBに即座に記録 |
+| **Hook送信** | 非同期 | 別スレッドで実行 |
+
+**理由**:
+- イベント記録は即座に完了（監査証跡）
+- 外部サービス通知は非同期（パフォーマンス影響を避ける）
+
+### Q2: イベント発行失敗時は？
+
+**SecurityEvent発行失敗**:
+- トランザクションロールバック
+- API呼び出し自体が失敗
+
+**Hook送信失敗**:
+- HTTP層でリトライ（3回）
+- 最終的に失敗 → security_event_hook_results テーブルに記録
+- API呼び出しは成功（非同期のため影響なし）
+
+### Q3: リトライ回数を変更するには？
+
+`SecurityEventRetryScheduler`の`MAX_RETRIES`定数を変更します。
+
+将来的には設定ファイル（`application.yml`）から読み込む形式への変更を検討中です。
+
+---
+
+## 関連ドキュメント
+
+- [UserLifecycleEvent実装ガイド](./09-user-lifecycle-event.md) - ユーザー状態変更イベント
+- [実装ガイド: Security Event Hooks](../04-implementation-guides/impl-15-security-event-hooks.md) - Hook実装詳細
+- [HTTP Request Executor](../04-implementation-guides/impl-16-http-request-executor.md) - HTTP層のリトライ機構
+- [AI開発者向け: Security Event](../../content_10_ai_developer/ai-50-notification-security-event.md)
+
+---
+
+**情報源**:
+- [OAuthFlowEntryService.java](../../../../libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/application/enduser/OAuthFlowEntryService.java)
+- [SecurityEventPublisher.java](../../../../libs/idp-server-platform/src/main/java/org/idp/server/platform/security/event/SecurityEventPublisher.java)
+- [SecurityEventRetryScheduler.java](../../../../libs/idp-server-springboot-adapter/src/main/java/org/idp/server/adapters/springboot/application/event/SecurityEventRetryScheduler.java)
+
+**最終更新**: 2025-12-13

--- a/documentation/docs/content_06_developer-guide/03-application-plane/09-user-lifecycle-event.md
+++ b/documentation/docs/content_06_developer-guide/03-application-plane/09-user-lifecycle-event.md
@@ -1,0 +1,310 @@
+# UserLifecycleEvent 実装ガイド
+
+## このドキュメントの目的
+
+**UserLifecycleEvent**の仕組みを理解することが目標です。
+
+### 所要時間
+⏱️ **約10分**
+
+### 前提知識
+- [04. Authentication実装](./04-authentication.md)
+- [SecurityEvent実装ガイド](./09-security-event.md)
+
+---
+
+## UserLifecycleEventとは
+
+**目的**: 「ユーザー状態を変更する」アクション
+
+```
+認証失敗5回 → UserLifecycleEvent(LOCK) → User.status = LOCKED → トークン全削除
+```
+
+**特徴**:
+- ✅ **状態変更**: ユーザーステータス・トークン・関連データを変更
+- ✅ **非同期処理**: 別スレッドでデータ削除・外部サービス連携
+- ✅ **副作用あり**: SecurityEvent(user_locked)等を再発行
+
+---
+
+## SecurityEventとの違い
+
+| 項目 | SecurityEvent | UserLifecycleEvent |
+|------|--------------|-------------------|
+| **目的** | 監視・監査 | 状態変更 |
+| **状態変更** | しない | する |
+| **用途** | ログ記録・外部通知 | ユーザー操作のトリガー |
+| **例** | `password_failure` | `LOCK` |
+
+**使い分け**: SecurityEventは「監視」、UserLifecycleEventは「アクション」
+
+---
+
+## アーキテクチャ
+
+```
+EntryService - userLifecycleEventPublisher.publish()
+    ↓ (同期)
+┌─────────────────────────────────────────────────────┐
+│ UserLifecycleEventPublisher（インターフェース）       │
+├─────────────────────────────────────────────────────┤
+│  UserLifecycleEventPublisherService（Adapter層）    │
+│    → applicationEventPublisher.publishEvent()       │
+│       (Spring ApplicationEventPublisher)           │
+└─────────────────────────────────────────────────────┘
+    ↓ (同期で即座に返却)
+EntryService処理完了 → HTTPレスポンス返却
+    ↓
+    ↓ (非同期 - Spring @EventListener)
+    ↓
+┌─────────────────────────────────────────────────────┐
+│ UserLifecycleEventListener（Spring Bean）          │
+├─────────────────────────────────────────────────────┤
+│  @EventListener                                     │
+│  handleUserLifecycleEvent(UserLifecycleEvent event) │
+│    ↓                                                │
+│  UserLifecycleEventRunnable作成                     │
+│    - TenantLoggingContext設定                       │
+│    - UserLifecycleEventHandler呼び出し              │
+│    ↓                                                │
+│  userLifecycleEventTaskExecutor.execute(runnable)   │
+│    → ThreadPoolに投入                                │
+└─────────────────────────────────────────────────────┘
+    ↓ (ThreadPoolで非同期実行)
+    ├─ 正常時: 別スレッドで実行
+    └─ ThreadPool満杯時: RejectedExecutionHandler
+        ↓
+    ┌─────────────────────────────────────────────────┐
+    │ RejectedExecutionHandler                        │
+    ├─────────────────────────────────────────────────┤
+    │  UserLifecycleEventRetryScheduler.enqueue()     │
+    │    → retryQueueに追加                            │
+    └─────────────────────────────────────────────────┘
+    ↓ (別スレッド - 正常実行時)
+┌─────────────────────────────────────────────────────┐
+│ UserLifecycleEventHandler（Platform層）             │
+├─────────────────────────────────────────────────────┤
+│  UserLifecycleType.LOCK の場合:                      │
+│    1. User.status = LOCKED                          │
+│    2. 全OAuthToken削除                               │
+│    3. SecurityEvent(user_locked)発行                 │
+│                                                     │
+│  UserLifecycleType.DELETE の場合:                    │
+│    1. 関連データ削除（12ステップ）                     │
+│    2. 外部サービスに通知（FIDO/VC等）                  │
+│    3. SecurityEvent(user_deleted)発行                │
+└─────────────────────────────────────────────────────┘
+    ↓ (ThreadPool満杯でリトライキューに入った場合)
+┌─────────────────────────────────────────────────────┐
+│ UserLifecycleEventRetryScheduler（Spring Scheduler）│
+├─────────────────────────────────────────────────────┤
+│  @Scheduled(fixedDelay = 60_000)  ← 60秒ごと         │
+│  resendFailedEvents()                               │
+│    - retryQueueから取得                             │
+│    - userLifecycleEventApi.handle()で再実行          │
+│    - 失敗 → retryQueueに戻す（最大3回）              │
+└─────────────────────────────────────────────────────┘
+```
+
+**実装**:
+- Publisher: [UserLifecycleEventPublisherService.java](../../../../libs/idp-server-springboot-adapter/src/main/java/org/idp/server/adapters/springboot/application/event/UserLifecycleEventPublisherService.java)
+- Runnable: [UserLifecycleEventRunnable.java](../../../../libs/idp-server-springboot-adapter/src/main/java/org/idp/server/adapters/springboot/application/event/UserLifecycleEventRunnable.java)
+- Handler: Platform層（イベントタイプ別に処理）
+- Retry Scheduler: [UserLifecycleEventRetryScheduler.java](../../../../libs/idp-server-springboot-adapter/src/main/java/org/idp/server/adapters/springboot/application/event/UserLifecycleEventRetryScheduler.java)
+- ThreadPool設定: [AsyncConfig.java:71-94](../../../../libs/idp-server-springboot-adapter/src/main/java/org/idp/server/adapters/springboot/AsyncConfig.java#L71-L94)
+
+---
+
+## ThreadPool設定
+
+| 設定 | 値 | 説明 |
+|------|-----|------|
+| **CorePoolSize** | 5 | 常駐スレッド数 |
+| **MaxPoolSize** | 10 | 最大スレッド数 |
+| **QueueCapacity** | 50 | キュー待機数 |
+| **RejectedExecutionHandler** | カスタム | 満杯時にRetrySchedulerへ |
+
+---
+
+## ライフサイクルタイプ
+
+| ライフサイクルタイプ | 発行タイミング | 用途 |
+|-----------------|--------------|------|
+| `LOCK` | アカウントロック | ユーザーステータス更新、トークン失効 |
+| `UNLOCK` | アカウントロック解除 | ユーザーステータス更新 |
+| `DELETE` | ユーザー削除 | 関連データ削除、外部サービス連携 |
+| `SUSPEND` | アカウント停止 | ユーザーステータス更新 |
+| `ACTIVATE` | アカウント有効化 | ユーザーステータス更新 |
+| `INVITE_COMPLETE` | 招待完了 | 招待ステータス更新 |
+
+---
+
+## イベント発行の実装
+
+```java
+// 9. ロック処理（失敗回数超過時）
+if (updatedTransaction.isLocked()) {
+  UserLifecycleEvent userLifecycleEvent =
+      new UserLifecycleEvent(tenant, updatedTransaction.user(), UserLifecycleType.LOCK);
+  userLifecycleEventPublisher.publish(userLifecycleEvent);
+}
+```
+
+---
+
+## 2種類のイベントの連携
+
+### パスワード認証失敗のフロー
+
+2つのイベントがどう連携するかの具体例：
+
+```
+1. パスワード認証失敗
+   → SecurityEvent(password_failure)発行  ← 監視・記録
+
+2. 失敗回数が5回に到達
+   → UserLifecycleEvent(LOCK)発行  ← 状態変更トリガー
+
+3. UserLifecycleEventHandler（非同期）
+   ├─ User.status = LOCKED  ← 状態変更
+   ├─ 全OAuthToken削除  ← 状態変更
+   └─ SecurityEvent(user_locked)発行  ← 記録・通知
+```
+
+**ポイント**:
+- SecurityEvent: 監視・記録のみ（状態変更しない）
+- UserLifecycleEvent: 状態変更のトリガー
+- 1つのUserLifecycleEventが複数のSecurityEventを発生させることもある
+
+---
+
+## アカウントロックフロー（詳細）
+
+認証失敗が一定回数を超えた場合の自動ロック：
+
+```
+[パスワード認証失敗 x5]
+    ↓
+AuthenticationTransaction.isLocked() = true
+    ↓
+UserLifecycleEvent(type=LOCK)発行
+    ↓
+UserLifecycleEventHandler（非同期処理）
+    ├─ User.status = LOCKED
+    ├─ 全OAuthToken削除
+    └─ SecurityEvent(user_locked)発行
+    ↓
+次回認証試行時
+    ↓
+{
+  "error": "account_locked",
+  "error_description": "Account has been locked due to too many failed attempts"
+}
+```
+
+**実装**: [OAuthFlowEntryService.java:204-208](../../../../libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/application/enduser/OAuthFlowEntryService.java#L204-L208)
+
+---
+
+## ユーザー削除戦略
+
+### 削除方針
+
+| カテゴリ | ストラテジー | 対象テーブル |
+|----------|------------|------------|
+| **コアデータ** | 物理削除 | `idp_user`, `idp_user_roles`, `oauth_token`, `authorization_code_grant`, `authentication_transaction`, `ciba_grant`, `federation_sso_session` |
+| **ログ・履歴** | 論理削除/保持 | `authorization_granted`（revoked_at設定）, `identity_verification_application`（status=deleted）, `security_event`（保持） |
+| **外部サービス** | 非同期削除 | FIDO-UAFデバイス、Verifiable Credentials |
+
+### 削除シーケンス（推奨順序）
+
+```
+UserLifecycleEvent(type=DELETE)発行
+    ↓
+UserLifecycleEventHandler
+    ↓
+1. authentication_interactions 削除
+2. authentication_transaction 削除
+3. idp_user_roles 削除
+4. idp_user_permission_override 削除
+5. oauth_token 削除
+6. authorization_code_grant 削除
+7. ciba_grant 削除
+8. federation_sso_session 削除
+9. authorization_granted 論理削除（revoked_at設定）
+10. identity_verification_application 論理削除（status=deleted）
+11. idp_user 物理削除
+12. security_event 監査エントリ追加
+13. 外部サービスに delete_account イベント送信（非同期）
+```
+
+### 監査ログは削除しない
+
+**重要**: `security_event`テーブルは削除せず、永久保存
+
+**理由**:
+- 法的要件（監査証跡の保持義務）
+- セキュリティ分析（過去の不正アクセス調査）
+- コンプライアンス（GDPR等の例外規定）
+
+**対応**: ユーザー削除後も、security_eventは`user_id`を保持（または匿名化）
+
+---
+
+## リトライ戦略
+
+UserLifecycleEventのリトライはSecurityEventと同じ仕組みです。
+
+| 設定 | 値 |
+|------|-----|
+| **最大リトライ** | 3回 |
+| **間隔** | 60秒 |
+| **超過時** | ログ出力して破棄 |
+
+詳細は[SecurityEvent実装ガイド - リトライ戦略](./09-security-event.md#リトライ戦略)を参照してください。
+
+---
+
+## よくある質問
+
+### Q1: UserLifecycleEvent処理失敗時は？
+
+- ThreadPool満杯時: RetrySchedulerで最大3回リトライ
+- 処理中エラー: ログ出力、イベントは破棄
+- **重要**: 状態変更が部分的に完了する可能性あり（要監視）
+
+### Q2: DELETEイベントが途中で失敗したら？
+
+削除は順序依存があるため、途中失敗時は不整合が発生する可能性があります。
+
+**対策**:
+- 監視ログで失敗検知
+- 手動での復旧対応
+- 将来的にはSagaパターンの導入を検討
+
+### Q3: SecurityEventとUserLifecycleEventどちらを使うべき？
+
+| ユースケース | 使うべきイベント |
+|-------------|----------------|
+| ログインイベントを記録したい | SecurityEvent |
+| ログイン失敗を外部に通知したい | SecurityEvent |
+| アカウントをロックしたい | UserLifecycleEvent |
+| ユーザーを削除したい | UserLifecycleEvent |
+| ロック完了を通知したい | SecurityEvent（UserLifecycleEventHandlerが発行） |
+
+---
+
+## 関連ドキュメント
+
+- [SecurityEvent実装ガイド](./09-security-event.md) - 監視・監査イベント
+- [04. Authentication実装](./04-authentication.md) - 認証フローでのイベント発行
+
+---
+
+**情報源**:
+- [UserLifecycleEventPublisher.java](../../../../libs/idp-server-core/src/main/java/org/idp/server/core/openid/identity/event/UserLifecycleEventPublisher.java)
+- [UserLifecycleEventRetryScheduler.java](../../../../libs/idp-server-springboot-adapter/src/main/java/org/idp/server/adapters/springboot/application/event/UserLifecycleEventRetryScheduler.java)
+- [OAuthFlowEntryService.java](../../../../libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/application/enduser/OAuthFlowEntryService.java)
+
+**最終更新**: 2025-12-13

--- a/libs/idp-server-springboot-adapter/src/main/java/org/idp/server/adapters/springboot/AsyncConfig.java
+++ b/libs/idp-server-springboot-adapter/src/main/java/org/idp/server/adapters/springboot/AsyncConfig.java
@@ -52,15 +52,21 @@ public class AsyncConfig {
     executor.setThreadNamePrefix("SecurityEvent-Async-");
 
     executor.setRejectedExecutionHandler(
-        (r, executor1) -> {
-          logger.warn("Rejected Execution Handler");
-
+        (r, executorRef) -> {
           if (r instanceof SecurityEventRunnable) {
             SecurityEvent securityEvent = ((SecurityEventRunnable) r).getEvent();
+            logger.warn(
+                "security event rejected, queuing for retry: id={}, type={}, pool=[active={}, queue={}, completed={}]",
+                securityEvent.identifier().value(),
+                securityEvent.type().value(),
+                executor.getActiveCount(),
+                executor.getThreadPoolExecutor().getQueue().size(),
+                executor.getThreadPoolExecutor().getCompletedTaskCount());
             securityEventRetryScheduler.enqueue(securityEvent);
           } else {
-
-            logger.error("unknown EventRunnable" + r.getClass().getName());
+            logger.error(
+                "unknown runnable rejected from security event executor: {}",
+                r.getClass().getName());
           }
         });
 
@@ -77,15 +83,21 @@ public class AsyncConfig {
     executor.setThreadNamePrefix("UserLifecycleEvent-Async-");
 
     executor.setRejectedExecutionHandler(
-        (r, executor1) -> {
-          logger.warn("Rejected Execution Handler");
-
+        (r, executorRef) -> {
           if (r instanceof UserLifecycleEventRunnable) {
             UserLifecycleEvent userLifecycleEvent = ((UserLifecycleEventRunnable) r).getEvent();
+            logger.warn(
+                "user lifecycle event rejected, queuing for retry: type={}, user={}, pool=[active={}, queue={}, completed={}]",
+                userLifecycleEvent.lifecycleType().name(),
+                userLifecycleEvent.user().sub(),
+                executor.getActiveCount(),
+                executor.getThreadPoolExecutor().getQueue().size(),
+                executor.getThreadPoolExecutor().getCompletedTaskCount());
             userLifecycleEventRetryScheduler.enqueue(userLifecycleEvent);
           } else {
-
-            logger.error("unknown EventRunnable" + r.getClass().getName());
+            logger.error(
+                "unknown runnable rejected from user lifecycle event executor: {}",
+                r.getClass().getName());
           }
         });
 
@@ -102,15 +114,20 @@ public class AsyncConfig {
     executor.setThreadNamePrefix("AuditLog-Async-");
 
     executor.setRejectedExecutionHandler(
-        (r, executor1) -> {
-          logger.warn("AuditLog Rejected Execution Handler");
-
+        (r, executorRef) -> {
           if (r instanceof AuditLogRunnable) {
             AuditLog auditLog = ((AuditLogRunnable) r).getAuditLog();
-            logger.error("Failed to process audit log asynchronously: {}", auditLog.id());
+            logger.warn(
+                "audit log rejected, queuing for retry: id={}, type={}, pool=[active={}, queue={}, completed={}]",
+                auditLog.id(),
+                auditLog.type(),
+                executor.getActiveCount(),
+                executor.getThreadPoolExecutor().getQueue().size(),
+                executor.getThreadPoolExecutor().getCompletedTaskCount());
             auditLogRetryScheduler.enqueue(auditLog);
           } else {
-            logger.error("unknown AuditLog EventRunnable: {}", r.getClass().getName());
+            logger.error(
+                "unknown runnable rejected from audit log executor: {}", r.getClass().getName());
           }
         });
 

--- a/libs/idp-server-springboot-adapter/src/main/java/org/idp/server/adapters/springboot/application/event/AuditLogRetryScheduler.java
+++ b/libs/idp-server-springboot-adapter/src/main/java/org/idp/server/adapters/springboot/application/event/AuditLogRetryScheduler.java
@@ -16,7 +16,9 @@
 
 package org.idp.server.adapters.springboot.application.event;
 
+import java.util.Map;
 import java.util.Queue;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import org.idp.server.platform.audit.AuditLog;
 import org.idp.server.platform.audit.AuditLogApi;
@@ -28,9 +30,12 @@ import org.springframework.stereotype.Component;
 @Component
 public class AuditLogRetryScheduler {
 
+  private static final int MAX_RETRIES = 3;
+
   LoggerWrapper log = LoggerWrapper.getLogger(AuditLogRetryScheduler.class);
 
   Queue<AuditLog> retryQueue = new ConcurrentLinkedQueue<>();
+  Map<String, Integer> retryCountMap = new ConcurrentHashMap<>();
 
   AuditLogApi auditLogApi;
 
@@ -40,18 +45,48 @@ public class AuditLogRetryScheduler {
 
   public void enqueue(AuditLog auditLog) {
     retryQueue.add(auditLog);
+    retryCountMap.putIfAbsent(auditLog.id(), 0);
   }
 
   @Scheduled(fixedDelay = 60_000)
   public void resendFailedEvents() {
+    int queueSize = retryQueue.size();
+    if (queueSize > 0) {
+      log.info("processing audit log retry queue: {} events", queueSize);
+    }
+
     while (!retryQueue.isEmpty()) {
       AuditLog auditLog = retryQueue.poll();
+      String auditLogId = auditLog.id();
+
       try {
-        log.info("retry audit log: {}", auditLog.type());
+        int currentAttempt = retryCountMap.getOrDefault(auditLogId, 0) + 1;
+        log.info(
+            "retry audit log (attempt {}/{}): id={}, type={}",
+            currentAttempt,
+            MAX_RETRIES,
+            auditLogId,
+            auditLog.type());
         auditLogApi.handle(auditLog.tenantIdentifier(), auditLog);
+        retryCountMap.remove(auditLogId);
       } catch (Exception e) {
-        log.error("retry audit log error: {}", auditLog.type());
-        retryQueue.add(auditLog);
+        int count = retryCountMap.merge(auditLogId, 1, Integer::sum);
+        if (count < MAX_RETRIES) {
+          log.warn(
+              "retry audit log scheduled ({}/{}): id={}, type={}",
+              count,
+              MAX_RETRIES,
+              auditLogId,
+              auditLog.type());
+          retryQueue.add(auditLog);
+        } else {
+          log.error(
+              "max retries exceeded, dropping audit log: id={}, type={}",
+              auditLogId,
+              auditLog.type(),
+              e);
+          retryCountMap.remove(auditLogId);
+        }
       }
     }
   }

--- a/libs/idp-server-springboot-adapter/src/main/java/org/idp/server/adapters/springboot/application/event/UserLifecycleEventRetryScheduler.java
+++ b/libs/idp-server-springboot-adapter/src/main/java/org/idp/server/adapters/springboot/application/event/UserLifecycleEventRetryScheduler.java
@@ -16,7 +16,9 @@
 
 package org.idp.server.adapters.springboot.application.event;
 
+import java.util.Map;
 import java.util.Queue;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import org.idp.server.core.openid.identity.event.UserLifecycleEvent;
 import org.idp.server.core.openid.identity.event.UserLifecycleEventApi;
@@ -28,9 +30,12 @@ import org.springframework.stereotype.Component;
 @Component
 public class UserLifecycleEventRetryScheduler {
 
+  private static final int MAX_RETRIES = 3;
+
   LoggerWrapper log = LoggerWrapper.getLogger(UserLifecycleEventRetryScheduler.class);
 
   Queue<UserLifecycleEvent> retryQueue = new ConcurrentLinkedQueue<>();
+  Map<String, Integer> retryCountMap = new ConcurrentHashMap<>();
 
   UserLifecycleEventApi userLifecycleEventApi;
 
@@ -40,19 +45,55 @@ public class UserLifecycleEventRetryScheduler {
 
   public void enqueue(UserLifecycleEvent userLifecycleEvent) {
     retryQueue.add(userLifecycleEvent);
+    retryCountMap.putIfAbsent(createEventKey(userLifecycleEvent), 0);
   }
 
   @Scheduled(fixedDelay = 60_000)
   public void resendFailedEvents() {
+    int queueSize = retryQueue.size();
+    if (queueSize > 0) {
+      log.info("processing user lifecycle event retry queue: {} events", queueSize);
+    }
+
     while (!retryQueue.isEmpty()) {
       UserLifecycleEvent userLifecycleEvent = retryQueue.poll();
+      String eventKey = createEventKey(userLifecycleEvent);
+
       try {
-        log.info("retry event: {}", userLifecycleEvent.lifecycleType().name());
+        int currentAttempt = retryCountMap.getOrDefault(eventKey, 0) + 1;
+        log.info(
+            "retry user lifecycle event (attempt {}/{}): type={}, user={}",
+            currentAttempt,
+            MAX_RETRIES,
+            userLifecycleEvent.lifecycleType().name(),
+            userLifecycleEvent.user().sub());
         userLifecycleEventApi.handle(userLifecycleEvent.tenantIdentifier(), userLifecycleEvent);
+        retryCountMap.remove(eventKey);
       } catch (Exception e) {
-        log.error("retry event error: {}", userLifecycleEvent.lifecycleType().name());
-        retryQueue.add(userLifecycleEvent);
+        int count = retryCountMap.merge(eventKey, 1, Integer::sum);
+        if (count < MAX_RETRIES) {
+          log.warn(
+              "retry user lifecycle event scheduled ({}/{}): type={}, user={}",
+              count,
+              MAX_RETRIES,
+              userLifecycleEvent.lifecycleType().name(),
+              userLifecycleEvent.user().sub());
+          retryQueue.add(userLifecycleEvent);
+        } else {
+          log.error(
+              "max retries exceeded, dropping user lifecycle event: type={}, user={}",
+              userLifecycleEvent.lifecycleType().name(),
+              userLifecycleEvent.user().sub(),
+              e);
+          retryCountMap.remove(eventKey);
+        }
       }
     }
+  }
+
+  private String createEventKey(UserLifecycleEvent event) {
+    return String.format(
+        "%s:%s:%s",
+        event.tenantIdentifier().value(), event.user().sub(), event.lifecycleType().name());
   }
 }


### PR DESCRIPTION
## Summary

- SecurityEvent/UserLifecycleEvent/AuditLogの各RetrySchedulerに最大3回のリトライ制限を追加
- ConcurrentHashMapによるスレッドセーフなリトライカウント管理
- AsyncConfigのRejectedExecutionHandlerログを改善（イベント情報・プール状態を出力）
- イベント処理ドキュメントを分割・整理

## 変更内容

### リトライ回数制限の実装
従来は無限リトライだったが、最大3回に制限。3回失敗後はエラーログを出力して破棄。

```java
private static final int MAX_RETRIES = 3;
Map<String, Integer> retryCountMap = new ConcurrentHashMap<>();
```

### ログ改善
RejectedExecutionHandler発動時のログにイベント情報とプール状態を追加：

```
security event rejected, queuing for retry: id=xxx, type=password_failure, pool=[active=10, queue=50, completed=1234]
```

### ドキュメント整理
- `09-events.md` → 概要ページ（両イベントへのリンク）
- `09-security-event.md` → SecurityEvent詳細（ThreadPool設定、リトライ戦略）
- `09-user-lifecycle-event.md` → UserLifecycleEvent詳細（ライフサイクルタイプ、削除戦略）

## Test plan
- [x] ビルド成功確認
- [x] 実際のログ出力でプール状態の可視化を確認

Closes #1051

🤖 Generated with [Claude Code](https://claude.com/claude-code)