### PR TITLE
feat: 統計アクティブユーザーテーブルにuser_name追加 & Federation/External-TokenのIDポリシー適用

### DIFF
--- a/libs/idp-server-authentication-interactors/src/main/java/org/idp/server/authentication/interactors/external_token/ExternalTokenAuthenticationInteractor.java
+++ b/libs/idp-server-authentication-interactors/src/main/java/org/idp/server/authentication/interactors/external_token/ExternalTokenAuthenticationInteractor.java
@@ -127,6 +127,7 @@ public class ExternalTokenAuthenticationInteractor implements AuthenticationInte
       if (!user.hasStatus()) {
         user.setStatus(UserStatus.INITIALIZED);
       }
+      user.applyIdentityPolicy(tenant.identityPolicyConfig());
     }
 
     Map<String, Object> result = new HashMap<>();

--- a/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/statistics/command/daily/DailyActiveUserCommandDataSource.java
+++ b/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/statistics/command/daily/DailyActiveUserCommandDataSource.java
@@ -18,8 +18,8 @@ package org.idp.server.core.adapters.datasource.statistics.command.daily;
 
 import java.time.LocalDate;
 import org.idp.server.platform.multi_tenancy.tenant.TenantIdentifier;
+import org.idp.server.platform.security.event.SecurityEventUserIdentifier;
 import org.idp.server.platform.statistics.repository.DailyActiveUserCommandRepository;
-import org.idp.server.platform.user.UserIdentifier;
 
 public class DailyActiveUserCommandDataSource implements DailyActiveUserCommandRepository {
 
@@ -31,7 +31,10 @@ public class DailyActiveUserCommandDataSource implements DailyActiveUserCommandR
 
   @Override
   public boolean addActiveUserAndReturnIfNew(
-      TenantIdentifier tenantId, LocalDate date, UserIdentifier userId) {
-    return executor.addActiveUserAndReturnIfNew(tenantId, date, userId);
+      TenantIdentifier tenantId,
+      LocalDate date,
+      SecurityEventUserIdentifier userId,
+      String userName) {
+    return executor.addActiveUserAndReturnIfNew(tenantId, date, userId, userName);
   }
 }

--- a/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/statistics/command/daily/DailyActiveUserMysqlExecutor.java
+++ b/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/statistics/command/daily/DailyActiveUserMysqlExecutor.java
@@ -21,13 +21,16 @@ import java.util.ArrayList;
 import java.util.List;
 import org.idp.server.platform.datasource.SqlExecutor;
 import org.idp.server.platform.multi_tenancy.tenant.TenantIdentifier;
-import org.idp.server.platform.user.UserIdentifier;
+import org.idp.server.platform.security.event.SecurityEventUserIdentifier;
 
 public class DailyActiveUserMysqlExecutor implements DailyActiveUserSqlExecutor {
 
   @Override
   public boolean addActiveUserAndReturnIfNew(
-      TenantIdentifier tenantId, LocalDate date, UserIdentifier userId) {
+      TenantIdentifier tenantId,
+      LocalDate date,
+      SecurityEventUserIdentifier userId,
+      String userName) {
     SqlExecutor sqlExecutor = new SqlExecutor();
 
     // MySQL: Use INSERT IGNORE + ROW_COUNT() to check if new row was inserted
@@ -37,14 +40,16 @@ public class DailyActiveUserMysqlExecutor implements DailyActiveUserSqlExecutor 
                     tenant_id,
                     stat_date,
                     user_id,
+                    user_name,
                     created_at
-                ) VALUES (?, ?, ?, NOW())
+                ) VALUES (?, ?, ?, ?, NOW())
                 """;
 
     List<Object> params = new ArrayList<>();
     params.add(tenantId.value());
     params.add(date);
     params.add(userId.value());
+    params.add(userName != null ? userName : "");
 
     return sqlExecutor.executeAndCheckReturned(sql, params);
   }

--- a/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/statistics/command/daily/DailyActiveUserPostgresqlExecutor.java
+++ b/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/statistics/command/daily/DailyActiveUserPostgresqlExecutor.java
@@ -21,13 +21,16 @@ import java.util.ArrayList;
 import java.util.List;
 import org.idp.server.platform.datasource.SqlExecutor;
 import org.idp.server.platform.multi_tenancy.tenant.TenantIdentifier;
-import org.idp.server.platform.user.UserIdentifier;
+import org.idp.server.platform.security.event.SecurityEventUserIdentifier;
 
 public class DailyActiveUserPostgresqlExecutor implements DailyActiveUserSqlExecutor {
 
   @Override
   public boolean addActiveUserAndReturnIfNew(
-      TenantIdentifier tenantId, LocalDate date, UserIdentifier userId) {
+      TenantIdentifier tenantId,
+      LocalDate date,
+      SecurityEventUserIdentifier userId,
+      String userName) {
     SqlExecutor sqlExecutor = new SqlExecutor();
 
     String sql =
@@ -36,11 +39,13 @@ public class DailyActiveUserPostgresqlExecutor implements DailyActiveUserSqlExec
                     tenant_id,
                     stat_date,
                     user_id,
+                    user_name,
                     created_at
                 ) VALUES (
                     ?::uuid,
                     ?,
                     ?::uuid,
+                    ?,
                     NOW()
                 )
                 ON CONFLICT (tenant_id, stat_date, user_id) DO NOTHING
@@ -51,6 +56,7 @@ public class DailyActiveUserPostgresqlExecutor implements DailyActiveUserSqlExec
     params.add(tenantId.value());
     params.add(date);
     params.add(userId.value());
+    params.add(userName != null ? userName : "");
 
     return sqlExecutor.executeAndCheckReturned(sql, params);
   }

--- a/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/statistics/command/daily/DailyActiveUserSqlExecutor.java
+++ b/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/statistics/command/daily/DailyActiveUserSqlExecutor.java
@@ -18,7 +18,7 @@ package org.idp.server.core.adapters.datasource.statistics.command.daily;
 
 import java.time.LocalDate;
 import org.idp.server.platform.multi_tenancy.tenant.TenantIdentifier;
-import org.idp.server.platform.user.UserIdentifier;
+import org.idp.server.platform.security.event.SecurityEventUserIdentifier;
 
 public interface DailyActiveUserSqlExecutor {
 
@@ -28,8 +28,12 @@ public interface DailyActiveUserSqlExecutor {
    * @param tenantId tenant identifier
    * @param date statistics date
    * @param userId user identifier
+   * @param userName user name to store
    * @return true if user was newly added (not a duplicate), false if already existed
    */
   boolean addActiveUserAndReturnIfNew(
-      TenantIdentifier tenantId, LocalDate date, UserIdentifier userId);
+      TenantIdentifier tenantId,
+      LocalDate date,
+      SecurityEventUserIdentifier userId,
+      String userName);
 }

--- a/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/statistics/command/monthly/MonthlyActiveUserCommandDataSource.java
+++ b/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/statistics/command/monthly/MonthlyActiveUserCommandDataSource.java
@@ -18,8 +18,8 @@ package org.idp.server.core.adapters.datasource.statistics.command.monthly;
 
 import java.time.LocalDate;
 import org.idp.server.platform.multi_tenancy.tenant.TenantIdentifier;
+import org.idp.server.platform.security.event.SecurityEventUserIdentifier;
 import org.idp.server.platform.statistics.repository.MonthlyActiveUserCommandRepository;
-import org.idp.server.platform.user.UserIdentifier;
 
 public class MonthlyActiveUserCommandDataSource implements MonthlyActiveUserCommandRepository {
 
@@ -31,7 +31,10 @@ public class MonthlyActiveUserCommandDataSource implements MonthlyActiveUserComm
 
   @Override
   public boolean addActiveUserAndReturnIfNew(
-      TenantIdentifier tenantId, LocalDate statMonth, UserIdentifier userId) {
-    return executor.addActiveUserAndReturnIfNew(tenantId, statMonth, userId);
+      TenantIdentifier tenantId,
+      LocalDate statMonth,
+      SecurityEventUserIdentifier userId,
+      String userName) {
+    return executor.addActiveUserAndReturnIfNew(tenantId, statMonth, userId, userName);
   }
 }

--- a/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/statistics/command/monthly/MonthlyActiveUserMysqlExecutor.java
+++ b/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/statistics/command/monthly/MonthlyActiveUserMysqlExecutor.java
@@ -21,13 +21,16 @@ import java.util.ArrayList;
 import java.util.List;
 import org.idp.server.platform.datasource.SqlExecutor;
 import org.idp.server.platform.multi_tenancy.tenant.TenantIdentifier;
-import org.idp.server.platform.user.UserIdentifier;
+import org.idp.server.platform.security.event.SecurityEventUserIdentifier;
 
 public class MonthlyActiveUserMysqlExecutor implements MonthlyActiveUserSqlExecutor {
 
   @Override
   public boolean addActiveUserAndReturnIfNew(
-      TenantIdentifier tenantId, LocalDate statMonth, UserIdentifier userId) {
+      TenantIdentifier tenantId,
+      LocalDate statMonth,
+      SecurityEventUserIdentifier userId,
+      String userName) {
     SqlExecutor sqlExecutor = new SqlExecutor();
 
     // MySQL: Use INSERT IGNORE + ROW_COUNT() to check if new row was inserted
@@ -37,14 +40,16 @@ public class MonthlyActiveUserMysqlExecutor implements MonthlyActiveUserSqlExecu
                     tenant_id,
                     stat_month,
                     user_id,
+                    user_name,
                     created_at
-                ) VALUES (?, ?, ?, NOW())
+                ) VALUES (?, ?, ?, ?, NOW())
                 """;
 
     List<Object> params = new ArrayList<>();
     params.add(tenantId.value());
     params.add(statMonth);
     params.add(userId.value());
+    params.add(userName != null ? userName : "");
 
     return sqlExecutor.executeAndCheckReturned(sql, params);
   }

--- a/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/statistics/command/monthly/MonthlyActiveUserPostgresqlExecutor.java
+++ b/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/statistics/command/monthly/MonthlyActiveUserPostgresqlExecutor.java
@@ -21,13 +21,16 @@ import java.util.ArrayList;
 import java.util.List;
 import org.idp.server.platform.datasource.SqlExecutor;
 import org.idp.server.platform.multi_tenancy.tenant.TenantIdentifier;
-import org.idp.server.platform.user.UserIdentifier;
+import org.idp.server.platform.security.event.SecurityEventUserIdentifier;
 
 public class MonthlyActiveUserPostgresqlExecutor implements MonthlyActiveUserSqlExecutor {
 
   @Override
   public boolean addActiveUserAndReturnIfNew(
-      TenantIdentifier tenantId, LocalDate statMonth, UserIdentifier userId) {
+      TenantIdentifier tenantId,
+      LocalDate statMonth,
+      SecurityEventUserIdentifier userId,
+      String userName) {
     SqlExecutor sqlExecutor = new SqlExecutor();
 
     String sql =
@@ -36,11 +39,13 @@ public class MonthlyActiveUserPostgresqlExecutor implements MonthlyActiveUserSql
                     tenant_id,
                     stat_month,
                     user_id,
+                    user_name,
                     created_at
                 ) VALUES (
                     ?::uuid,
                     ?::date,
                     ?::uuid,
+                    ?,
                     NOW()
                 )
                 ON CONFLICT (tenant_id, stat_month, user_id) DO NOTHING
@@ -51,6 +56,7 @@ public class MonthlyActiveUserPostgresqlExecutor implements MonthlyActiveUserSql
     params.add(tenantId.value());
     params.add(statMonth);
     params.add(userId.value());
+    params.add(userName != null ? userName : "");
 
     return sqlExecutor.executeAndCheckReturned(sql, params);
   }

--- a/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/statistics/command/monthly/MonthlyActiveUserSqlExecutor.java
+++ b/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/statistics/command/monthly/MonthlyActiveUserSqlExecutor.java
@@ -18,7 +18,7 @@ package org.idp.server.core.adapters.datasource.statistics.command.monthly;
 
 import java.time.LocalDate;
 import org.idp.server.platform.multi_tenancy.tenant.TenantIdentifier;
-import org.idp.server.platform.user.UserIdentifier;
+import org.idp.server.platform.security.event.SecurityEventUserIdentifier;
 
 public interface MonthlyActiveUserSqlExecutor {
 
@@ -28,8 +28,12 @@ public interface MonthlyActiveUserSqlExecutor {
    * @param tenantId tenant identifier
    * @param statMonth first day of month (e.g., 2025-01-01)
    * @param userId user identifier
+   * @param userName user name to store
    * @return true if user was newly added (not a duplicate), false if already existed
    */
   boolean addActiveUserAndReturnIfNew(
-      TenantIdentifier tenantId, LocalDate statMonth, UserIdentifier userId);
+      TenantIdentifier tenantId,
+      LocalDate statMonth,
+      SecurityEventUserIdentifier userId,
+      String userName);
 }

--- a/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/statistics/command/yearly/YearlyActiveUserCommandDataSource.java
+++ b/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/statistics/command/yearly/YearlyActiveUserCommandDataSource.java
@@ -18,8 +18,8 @@ package org.idp.server.core.adapters.datasource.statistics.command.yearly;
 
 import java.time.LocalDate;
 import org.idp.server.platform.multi_tenancy.tenant.TenantIdentifier;
+import org.idp.server.platform.security.event.SecurityEventUserIdentifier;
 import org.idp.server.platform.statistics.repository.YearlyActiveUserCommandRepository;
-import org.idp.server.platform.user.UserIdentifier;
 
 public class YearlyActiveUserCommandDataSource implements YearlyActiveUserCommandRepository {
 
@@ -31,7 +31,10 @@ public class YearlyActiveUserCommandDataSource implements YearlyActiveUserComman
 
   @Override
   public boolean addActiveUserAndReturnIfNew(
-      TenantIdentifier tenantId, LocalDate statYear, UserIdentifier userId) {
-    return executor.addActiveUserAndReturnIfNew(tenantId, statYear, userId);
+      TenantIdentifier tenantId,
+      LocalDate statYear,
+      SecurityEventUserIdentifier userId,
+      String userName) {
+    return executor.addActiveUserAndReturnIfNew(tenantId, statYear, userId, userName);
   }
 }

--- a/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/statistics/command/yearly/YearlyActiveUserMysqlExecutor.java
+++ b/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/statistics/command/yearly/YearlyActiveUserMysqlExecutor.java
@@ -22,13 +22,16 @@ import java.util.List;
 import java.util.Map;
 import org.idp.server.platform.datasource.SqlExecutor;
 import org.idp.server.platform.multi_tenancy.tenant.TenantIdentifier;
-import org.idp.server.platform.user.UserIdentifier;
+import org.idp.server.platform.security.event.SecurityEventUserIdentifier;
 
 public class YearlyActiveUserMysqlExecutor implements YearlyActiveUserSqlExecutor {
 
   @Override
   public boolean addActiveUserAndReturnIfNew(
-      TenantIdentifier tenantId, LocalDate statYear, UserIdentifier userId) {
+      TenantIdentifier tenantId,
+      LocalDate statYear,
+      SecurityEventUserIdentifier userId,
+      String userName) {
     SqlExecutor sqlExecutor = new SqlExecutor();
 
     // MySQL doesn't support RETURNING, so we check if the record exists first
@@ -53,9 +56,10 @@ public class YearlyActiveUserMysqlExecutor implements YearlyActiveUserSqlExecuto
                     tenant_id,
                     stat_year,
                     user_id,
+                    user_name,
                     last_used_at,
                     created_at
-                ) VALUES (?, ?, ?, NOW(), NOW())
+                ) VALUES (?, ?, ?, ?, NOW(), NOW())
                 ON DUPLICATE KEY UPDATE last_used_at = NOW()
                 """;
 
@@ -63,6 +67,7 @@ public class YearlyActiveUserMysqlExecutor implements YearlyActiveUserSqlExecuto
     params.add(tenantId.value());
     params.add(statYear);
     params.add(userId.value());
+    params.add(userName != null ? userName : "");
 
     sqlExecutor.execute(sql, params);
 

--- a/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/statistics/command/yearly/YearlyActiveUserPostgresqlExecutor.java
+++ b/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/statistics/command/yearly/YearlyActiveUserPostgresqlExecutor.java
@@ -21,13 +21,16 @@ import java.util.ArrayList;
 import java.util.List;
 import org.idp.server.platform.datasource.SqlExecutor;
 import org.idp.server.platform.multi_tenancy.tenant.TenantIdentifier;
-import org.idp.server.platform.user.UserIdentifier;
+import org.idp.server.platform.security.event.SecurityEventUserIdentifier;
 
 public class YearlyActiveUserPostgresqlExecutor implements YearlyActiveUserSqlExecutor {
 
   @Override
   public boolean addActiveUserAndReturnIfNew(
-      TenantIdentifier tenantId, LocalDate statYear, UserIdentifier userId) {
+      TenantIdentifier tenantId,
+      LocalDate statYear,
+      SecurityEventUserIdentifier userId,
+      String userName) {
     SqlExecutor sqlExecutor = new SqlExecutor();
 
     // Use ON CONFLICT DO NOTHING + RETURNING pattern (same as Daily/Monthly)
@@ -38,12 +41,14 @@ public class YearlyActiveUserPostgresqlExecutor implements YearlyActiveUserSqlEx
                     tenant_id,
                     stat_year,
                     user_id,
+                    user_name,
                     last_used_at,
                     created_at
                 ) VALUES (
                     ?::uuid,
                     ?::date,
                     ?::uuid,
+                    ?,
                     NOW(),
                     NOW()
                 )
@@ -55,6 +60,7 @@ public class YearlyActiveUserPostgresqlExecutor implements YearlyActiveUserSqlEx
     params.add(tenantId.value());
     params.add(statYear);
     params.add(userId.value());
+    params.add(userName != null ? userName : "");
 
     // If RETURNING returns a row, the insert succeeded (new user)
     // If RETURNING returns empty, the user already existed (conflict)

--- a/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/statistics/command/yearly/YearlyActiveUserSqlExecutor.java
+++ b/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/statistics/command/yearly/YearlyActiveUserSqlExecutor.java
@@ -18,7 +18,7 @@ package org.idp.server.core.adapters.datasource.statistics.command.yearly;
 
 import java.time.LocalDate;
 import org.idp.server.platform.multi_tenancy.tenant.TenantIdentifier;
-import org.idp.server.platform.user.UserIdentifier;
+import org.idp.server.platform.security.event.SecurityEventUserIdentifier;
 
 public interface YearlyActiveUserSqlExecutor {
 
@@ -28,8 +28,12 @@ public interface YearlyActiveUserSqlExecutor {
    * @param tenantId tenant identifier
    * @param statYear first day of year (e.g., 2025-01-01)
    * @param userId user identifier
+   * @param userName user name to store
    * @return true if user was newly added (not a duplicate), false if already existed
    */
   boolean addActiveUserAndReturnIfNew(
-      TenantIdentifier tenantId, LocalDate statYear, UserIdentifier userId);
+      TenantIdentifier tenantId,
+      LocalDate statYear,
+      SecurityEventUserIdentifier userId,
+      String userName);
 }

--- a/libs/idp-server-database/mysql/V0_9_21_2__statistics.mysql.sql
+++ b/libs/idp-server-database/mysql/V0_9_21_2__statistics.mysql.sql
@@ -1,4 +1,4 @@
--- V0_10_0__statistics.mysql.sql
+-- V0_9_21_2__statistics.mysql.sql
 -- Issue #441: Tenant statistics data collection (DAU/MAU/YAU) (MySQL version)
 
 -- =====================================================
@@ -74,6 +74,7 @@ CREATE TABLE statistics_daily_users (
     tenant_id CHAR(36) NOT NULL,
     stat_date DATE NOT NULL,
     user_id CHAR(36) NOT NULL,
+    user_name VARCHAR(255) NOT NULL DEFAULT '',
     last_used_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
     created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
 
@@ -91,6 +92,7 @@ CREATE TABLE statistics_monthly_users (
     tenant_id CHAR(36) NOT NULL,
     stat_month CHAR(7) NOT NULL COMMENT 'YYYY-MM format (e.g., 2025-01)',
     user_id CHAR(36) NOT NULL,
+    user_name VARCHAR(255) NOT NULL DEFAULT '',
     last_used_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
     created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
 
@@ -108,6 +110,7 @@ CREATE TABLE statistics_yearly_users (
     tenant_id CHAR(36) NOT NULL,
     stat_year CHAR(4) NOT NULL COMMENT 'YYYY format (e.g., 2025)',
     user_id CHAR(36) NOT NULL,
+    user_name VARCHAR(255) NOT NULL DEFAULT '',
     last_used_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
     created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
 

--- a/libs/idp-server-database/postgresql/V0_9_21_2__statistics.sql
+++ b/libs/idp-server-database/postgresql/V0_9_21_2__statistics.sql
@@ -36,6 +36,7 @@ CREATE TABLE statistics_daily_users (
     tenant_id UUID NOT NULL,
     stat_date DATE NOT NULL,
     user_id UUID NOT NULL,
+    user_name VARCHAR(255) NOT NULL DEFAULT '',
     last_used_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
     created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
 
@@ -84,6 +85,7 @@ CREATE TABLE statistics_monthly_users (
     tenant_id UUID NOT NULL,
     stat_month DATE NOT NULL,  -- First day of month (e.g., 2025-01-01)
     user_id UUID NOT NULL,
+    user_name VARCHAR(255) NOT NULL DEFAULT '',
     last_used_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
     created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
 
@@ -132,6 +134,7 @@ CREATE TABLE statistics_yearly_users (
     tenant_id UUID NOT NULL,
     stat_year DATE NOT NULL,  -- First day of year (e.g., 2025-01-01)
     user_id UUID NOT NULL,
+    user_name VARCHAR(255) NOT NULL DEFAULT '',
     last_used_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
     created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
 

--- a/libs/idp-server-federation-oidc/src/main/java/org/idp/server/federation/sso/oidc/OidcFederationInteractor.java
+++ b/libs/idp-server-federation-oidc/src/main/java/org/idp/server/federation/sso/oidc/OidcFederationInteractor.java
@@ -239,6 +239,7 @@ public class OidcFederationInteractor implements FederationInteractor {
     } else {
       user.setSub(UUID.randomUUID().toString());
       user.setStatus(UserStatus.FEDERATED);
+      user.applyIdentityPolicy(tenant.identityPolicyConfig());
     }
 
     return user;

--- a/libs/idp-server-platform/src/main/java/org/idp/server/platform/security/SecurityEvent.java
+++ b/libs/idp-server-platform/src/main/java/org/idp/server/platform/security/SecurityEvent.java
@@ -166,6 +166,10 @@ public class SecurityEvent {
     return tenant.id();
   }
 
+  public SecurityEventUserIdentifier securityEventUserIdentifier() {
+    return user.securityEventUserIdentifier();
+  }
+
   public String tokenIssuerValue() {
     return tenant.issuerAsString();
   }

--- a/libs/idp-server-platform/src/main/java/org/idp/server/platform/security/event/SecurityEventUser.java
+++ b/libs/idp-server-platform/src/main/java/org/idp/server/platform/security/event/SecurityEventUser.java
@@ -243,4 +243,8 @@ public class SecurityEventUser implements UuidConvertable, JsonReadable {
   public boolean exists() {
     return Objects.nonNull(sub) && !sub.isEmpty();
   }
+
+  public SecurityEventUserIdentifier securityEventUserIdentifier() {
+    return new SecurityEventUserIdentifier(subAsUuid());
+  }
 }

--- a/libs/idp-server-platform/src/main/java/org/idp/server/platform/security/event/SecurityEventUserIdentifier.java
+++ b/libs/idp-server-platform/src/main/java/org/idp/server/platform/security/event/SecurityEventUserIdentifier.java
@@ -14,24 +14,24 @@
  * limitations under the License.
  */
 
-package org.idp.server.platform.user;
+package org.idp.server.platform.security.event;
 
 import java.util.Objects;
 import java.util.UUID;
 import org.idp.server.platform.uuid.UuidConvertable;
 
-/** Identifier for User */
-public class UserIdentifier implements UuidConvertable {
+/** Identifier for Security Event User */
+public class SecurityEventUserIdentifier implements UuidConvertable {
 
   String value;
 
-  public UserIdentifier() {}
+  public SecurityEventUserIdentifier() {}
 
-  public UserIdentifier(String value) {
+  public SecurityEventUserIdentifier(String value) {
     this.value = value;
   }
 
-  public UserIdentifier(UUID value) {
+  public SecurityEventUserIdentifier(UUID value) {
     this.value = value.toString();
   }
 
@@ -46,7 +46,7 @@ public class UserIdentifier implements UuidConvertable {
   @Override
   public boolean equals(Object o) {
     if (o == null || getClass() != o.getClass()) return false;
-    UserIdentifier that = (UserIdentifier) o;
+    SecurityEventUserIdentifier that = (SecurityEventUserIdentifier) o;
     return Objects.equals(value, that.value);
   }
 

--- a/libs/idp-server-platform/src/main/java/org/idp/server/platform/security/handler/SecurityEventHandler.java
+++ b/libs/idp-server-platform/src/main/java/org/idp/server/platform/security/handler/SecurityEventHandler.java
@@ -25,6 +25,8 @@ import org.idp.server.platform.log.LoggerWrapper;
 import org.idp.server.platform.multi_tenancy.tenant.Tenant;
 import org.idp.server.platform.security.SecurityEvent;
 import org.idp.server.platform.security.event.DefaultSecurityEventType;
+import org.idp.server.platform.security.event.SecurityEventUser;
+import org.idp.server.platform.security.event.SecurityEventUserIdentifier;
 import org.idp.server.platform.security.hook.*;
 import org.idp.server.platform.security.hook.SecurityEventHook;
 import org.idp.server.platform.security.hook.SecurityEventHooks;
@@ -39,7 +41,6 @@ import org.idp.server.platform.statistics.repository.MonthlyActiveUserCommandRep
 import org.idp.server.platform.statistics.repository.TenantStatisticsCommandRepository;
 import org.idp.server.platform.statistics.repository.TenantYearlyStatisticsCommandRepository;
 import org.idp.server.platform.statistics.repository.YearlyActiveUserCommandRepository;
-import org.idp.server.platform.user.UserIdentifier;
 
 public class SecurityEventHandler {
 
@@ -145,12 +146,9 @@ public class SecurityEventHandler {
     DefaultSecurityEventType eventType = DefaultSecurityEventType.findByValue(eventTypeValue);
     String day = eventDate.format(DATE_FORMATTER);
 
-    if (eventType != null && eventType.isActiveUserEvent()) {
-      UserIdentifier userId =
-          securityEvent.hasUser()
-              ? new UserIdentifier(securityEvent.user().subAsUuid().toString())
-              : null;
-      handleActiveUserEvent(tenant, userId, eventDate, day, eventTypeValue);
+    if (eventType != null && eventType.isActiveUserEvent() && securityEvent.hasUser()) {
+
+      handleActiveUserEvent(tenant, securityEvent.user(), eventDate, day, eventTypeValue);
     } else {
       incrementMetric(tenant, eventDate, eventTypeValue);
     }
@@ -164,10 +162,14 @@ public class SecurityEventHandler {
    * {@link DefaultSecurityEventType#isActiveUserEvent()}.
    */
   private void handleActiveUserEvent(
-      Tenant tenant, UserIdentifier userId, LocalDate eventDate, String day, String eventType) {
-    if (userId == null) {
-      return;
-    }
+      Tenant tenant,
+      SecurityEventUser securityEventUser,
+      LocalDate eventDate,
+      String day,
+      String eventType) {
+
+    SecurityEventUserIdentifier userId = securityEventUser.securityEventUserIdentifier();
+    String userName = securityEventUser.name();
 
     // Derive month and year from eventDate for statistics grouping
     LocalDate monthStart = eventDate.withDayOfMonth(1);
@@ -179,7 +181,7 @@ public class SecurityEventHandler {
     // Track DAU - add user to daily active users table and increment DAU count if new
     boolean isNewDailyUser =
         dailyActiveUserRepository.addActiveUserAndReturnIfNew(
-            tenant.identifier(), eventDate, userId);
+            tenant.identifier(), eventDate, userId, userName);
 
     if (isNewDailyUser) {
       log.debug(
@@ -200,7 +202,7 @@ public class SecurityEventHandler {
     // Track MAU - add user to monthly active users table and increment MAU count if new
     boolean isNewMonthlyUser =
         monthlyActiveUserRepository.addActiveUserAndReturnIfNew(
-            tenant.identifier(), monthStart, userId);
+            tenant.identifier(), monthStart, userId, userName);
 
     if (isNewMonthlyUser) {
       log.debug(
@@ -221,7 +223,7 @@ public class SecurityEventHandler {
     // Track YAU - add user to yearly active users table and increment YAU count if new
     boolean isNewYearlyUser =
         yearlyActiveUserRepository.addActiveUserAndReturnIfNew(
-            tenant.identifier(), yearStart, userId);
+            tenant.identifier(), yearStart, userId, userName);
 
     if (isNewYearlyUser) {
       log.debug(

--- a/libs/idp-server-platform/src/main/java/org/idp/server/platform/statistics/repository/DailyActiveUserCommandRepository.java
+++ b/libs/idp-server-platform/src/main/java/org/idp/server/platform/statistics/repository/DailyActiveUserCommandRepository.java
@@ -18,7 +18,7 @@ package org.idp.server.platform.statistics.repository;
 
 import java.time.LocalDate;
 import org.idp.server.platform.multi_tenancy.tenant.TenantIdentifier;
-import org.idp.server.platform.user.UserIdentifier;
+import org.idp.server.platform.security.event.SecurityEventUserIdentifier;
 
 /**
  * Command repository for daily active users
@@ -31,7 +31,7 @@ import org.idp.server.platform.user.UserIdentifier;
  *
  * <pre>{@code
  * // Track user login for DAU
- * repository.addActiveUser(tenantId, LocalDate.now(), userId);
+ * repository.addActiveUser(tenantId, LocalDate.now(), userId, userName);
  * // Duplicate calls are automatically ignored (PRIMARY KEY constraint)
  * }</pre>
  */
@@ -48,8 +48,12 @@ public interface DailyActiveUserCommandRepository {
    * @param tenantId tenant identifier
    * @param date statistics date
    * @param userId user identifier to track
+   * @param userName user name to store
    * @return true if user was newly added, false if already existed
    */
   boolean addActiveUserAndReturnIfNew(
-      TenantIdentifier tenantId, LocalDate date, UserIdentifier userId);
+      TenantIdentifier tenantId,
+      LocalDate date,
+      SecurityEventUserIdentifier userId,
+      String userName);
 }

--- a/libs/idp-server-platform/src/main/java/org/idp/server/platform/statistics/repository/MonthlyActiveUserCommandRepository.java
+++ b/libs/idp-server-platform/src/main/java/org/idp/server/platform/statistics/repository/MonthlyActiveUserCommandRepository.java
@@ -18,7 +18,7 @@ package org.idp.server.platform.statistics.repository;
 
 import java.time.LocalDate;
 import org.idp.server.platform.multi_tenancy.tenant.TenantIdentifier;
-import org.idp.server.platform.user.UserIdentifier;
+import org.idp.server.platform.security.event.SecurityEventUserIdentifier;
 
 /**
  * Command repository for monthly active users (MAU)
@@ -32,7 +32,7 @@ import org.idp.server.platform.user.UserIdentifier;
  * <pre>{@code
  * // Track user login for MAU
  * LocalDate statMonth = eventDate.withDayOfMonth(1); // First day of month
- * repository.addActiveUserAndReturnIfNew(tenantId, statMonth, userId);
+ * repository.addActiveUserAndReturnIfNew(tenantId, statMonth, userId, userName);
  * // Duplicate calls are automatically ignored (PRIMARY KEY constraint)
  * }</pre>
  */
@@ -49,8 +49,12 @@ public interface MonthlyActiveUserCommandRepository {
    * @param tenantId tenant identifier
    * @param statMonth first day of month (e.g., 2025-01-01)
    * @param userId user identifier to track
+   * @param userName user name to store
    * @return true if user was newly added, false if already existed
    */
   boolean addActiveUserAndReturnIfNew(
-      TenantIdentifier tenantId, LocalDate statMonth, UserIdentifier userId);
+      TenantIdentifier tenantId,
+      LocalDate statMonth,
+      SecurityEventUserIdentifier userId,
+      String userName);
 }

--- a/libs/idp-server-platform/src/main/java/org/idp/server/platform/statistics/repository/YearlyActiveUserCommandRepository.java
+++ b/libs/idp-server-platform/src/main/java/org/idp/server/platform/statistics/repository/YearlyActiveUserCommandRepository.java
@@ -18,7 +18,7 @@ package org.idp.server.platform.statistics.repository;
 
 import java.time.LocalDate;
 import org.idp.server.platform.multi_tenancy.tenant.TenantIdentifier;
-import org.idp.server.platform.user.UserIdentifier;
+import org.idp.server.platform.security.event.SecurityEventUserIdentifier;
 
 /**
  * Command repository for yearly active users (YAU)
@@ -32,7 +32,7 @@ import org.idp.server.platform.user.UserIdentifier;
  * <pre>{@code
  * // Track user login for YAU
  * LocalDate statYear = eventDate.withDayOfYear(1); // First day of year
- * repository.addActiveUserAndReturnIfNew(tenantId, statYear, userId);
+ * repository.addActiveUserAndReturnIfNew(tenantId, statYear, userId, userName);
  * // Duplicate calls update last_used_at (ON CONFLICT DO UPDATE)
  * }</pre>
  */
@@ -51,8 +51,12 @@ public interface YearlyActiveUserCommandRepository {
    * @param tenantId tenant identifier
    * @param statYear first day of year (e.g., 2025-01-01)
    * @param userId user identifier to track
+   * @param userName user name to store
    * @return true if user was newly added, false if already existed
    */
   boolean addActiveUserAndReturnIfNew(
-      TenantIdentifier tenantId, LocalDate statYear, UserIdentifier userId);
+      TenantIdentifier tenantId,
+      LocalDate statYear,
+      SecurityEventUserIdentifier userId,
+      String userName);
 }


### PR DESCRIPTION
## Summary

- 統計アクティブユーザーテーブル（daily/monthly/yearly）に`user_name`カラムを追加
- Federation/External-Token認証の初回ユーザー作成時にIDポリシーを適用
- SecurityEventHandlerのロジック整理

## 変更内容

### Issue #1082: 統計user_name追加
- `statistics_daily_users`, `statistics_monthly_users`, `statistics_yearly_users`テーブルに`user_name`カラムを追加
- `UserIdentifier`を`SecurityEventUserIdentifier`にリネーム・移動（`platform.user` → `platform.security.event`）
- MySQLのDDLバージョンをPostgreSQLと統一 (V0_10_0 → V0_9_21_2)

### Issue #1084: Federation/External-TokenのIDポリシー適用
- `OidcFederationInteractor`: 初回ユーザー作成時に`applyIdentityPolicy()`を呼び出し
- `ExternalTokenAuthenticationInteractor`: 初回ユーザー作成時に`applyIdentityPolicy()`を呼び出し
- これにより`preferred_username`が設定され、統計の`user_name`も正しく記録される

### SecurityEventHandlerの改善
- クライアントクレデンシャル等のユーザーなしイベントでもメトリクスを記録するよう修正
- `SecurityEventUser`を直接渡すようにリファクタリング

## Test plan

- [x] ビルド成功
- [x] E2Eテスト通過

## Related Issues

- Closes #1082
- Closes #1084

🤖 Generated with [Claude Code](https://claude.com/claude-code)