### PR TITLE
fix: application.yamlのログレベル設定typo修正 (emai.aws → email.aws)

### DIFF
--- a/app/src/main/resources/application.yaml
+++ b/app/src/main/resources/application.yaml
@@ -79,7 +79,7 @@ logging:
           core.oidc: "${LOGGING_LEVEL_IDP_SERVER_CORE_OIDC:info}"
           core.adapters: "${LOGGING_LEVEL_IDP_SERVER_CORE_ADAPTERS:info}"
           core.extension: "${LOGGING_LEVEL_IDP_SERVER_CORE_EXTENSION:info}"
-          emai.aws: "${LOGGING_LEVEL_IDP_SERVER_EMAIL_AWS:info}"
+          email.aws: "${LOGGING_LEVEL_IDP_SERVER_EMAIL_AWS:info}"
           federation:  "${LOGGING_LEVEL_IDP_SERVER_FEDERATION:info}"
           notification.push.fcm: "${LOGGING_LEVEL_IDP_SERVER_NOTIFICATION_PUSH_FCM:info}"
           security.event.hook.ssf: "${LOGGING_LEVEL_IDP_SERVER_SECURITY_EVENT_HOOK_SSF:info}"


### PR DESCRIPTION
## Summary

- `emai.aws` → `email.aws` のtypoを修正
- これにより環境変数 `LOGGING_LEVEL_IDP_SERVER_EMAIL_AWS` が正しく機能するようになる

## 変更内容

**ファイル**: `app/src/main/resources/application.yaml` (82行目)

```diff
- emai.aws: "${LOGGING_LEVEL_IDP_SERVER_EMAIL_AWS:info}"
+ email.aws: "${LOGGING_LEVEL_IDP_SERVER_EMAIL_AWS:info}"
```

## 影響

- AWS Email サービスのログレベルが環境変数で正しく制御可能になる

## Test plan

- [x] typo修正のみのため、ビルド確認で十分

Closes #1074

🤖 Generated with [Claude Code](https://claude.com/claude-code)