### PR TITLE
docs: 設定ドキュメントに未記載の高度な機能を追加 (Issue #1091)

### DIFF
--- a/documentation/docs/content_06_developer-guide/04-implementation-guides/impl-16-http-request-executor.md
+++ b/documentation/docs/content_06_developer-guide/04-implementation-guides/impl-16-http-request-executor.md
@@ -319,6 +319,205 @@ OAuthAuthorizationResolver resolver = resolvers.get("client_credentials");
 
 ---
 
+## 🗺️ Mapping Rules（データマッピング）
+
+HTTPリクエストの動的な構築とレスポンスの変換を行うMapping Rulesについて説明します。
+
+### Mapping Rulesの種類
+
+| Mapping Rule | 用途 | 説明 |
+|-------------|------|------|
+| `path_mapping_rules` | URLパス | URLテンプレート内の変数を動的に置き換え |
+| `header_mapping_rules` | HTTPヘッダー | ヘッダーの動的設定 |
+| `body_mapping_rules` | リクエストボディ | JSONボディの動的構築 |
+| `query_mapping_rules` | クエリパラメータ | URLクエリパラメータの動的設定 |
+
+**詳細**: [Mapping Functions 開発ガイド](impl-20-mapping-functions.md)
+
+### path_mapping_rules
+
+URLパスパラメータを動的に設定する機能です。
+
+**設定例**:
+```json
+{
+  "http_request": {
+    "url": "https://api.example.com/v1/applications/{{application_id}}/documents/{{document_id}}",
+    "path_mapping_rules": [
+      {
+        "from": "$.application.id",
+        "to": "application_id"
+      },
+      {
+        "from": "$.document.id",
+        "to": "document_id"
+      }
+    ]
+  }
+}
+```
+
+**動作**:
+1. URLテンプレート内の`{{application_id}}`と`{{document_id}}`を検出
+2. `path_mapping_rules`に基づいて値を取得
+3. 最終的なURL: `https://api.example.com/v1/applications/12345/documents/67890`
+
+**使用シーン**:
+- RESTful APIのリソースIDをパスに埋め込む
+- 動的なエンドポイント構築（ユーザーID、テナントID等）
+
+### header_mapping_rules / body_mapping_rules
+
+ヘッダーとボディのマッピングについては、[Mapping Functions 開発ガイド](impl-20-mapping-functions.md)を参照してください。
+
+---
+
+## 🔍 Response Resolver（レスポンス解決）
+
+HTTPレスポンスをアプリケーションレベルのステータスコードにマッピングする機能です。
+
+### 目的
+
+外部APIのレスポンスは様々な形式があります：
+- HTTP 200でも、ボディ内に`"status": "error"`が含まれる場合
+- HTTP 503でも、再試行可能なエラーと不可能なエラーがある
+- ビジネスレベルの成功/失敗をHTTPステータスとボディで複合判定する必要がある
+
+Response Resolverは、これらの複雑なレスポンスを統一的に扱うための仕組みです。
+
+### 設定構造
+
+```json
+{
+  "http_request": {
+    "url": "https://api.example.com/verify",
+    "response_resolve_configs": {
+      "configs": [
+        {
+          "conditions": [
+            {"path": "$.httpStatusCode", "operation": "in", "value": [200, 201]},
+            {"path": "$.response_body.status", "operation": "eq", "value": "approved"}
+          ],
+          "match_mode": "all",
+          "mapped_status_code": 200
+        },
+        {
+          "conditions": [
+            {"path": "$.httpStatusCode", "operation": "eq", "value": 200},
+            {"path": "$.response_body.status", "operation": "eq", "value": "pending"}
+          ],
+          "match_mode": "all",
+          "mapped_status_code": 202
+        },
+        {
+          "conditions": [
+            {"path": "$.httpStatusCode", "operation": "eq", "value": 503}
+          ],
+          "match_mode": "all",
+          "mapped_status_code": 503,
+          "error_message_json_path": "$.response_body.message"
+        }
+      ]
+    }
+  }
+}
+```
+
+### フィールド説明
+
+| フィールド | 説明 |
+|-----------|------|
+| `conditions` | レスポンス判定条件の配列 |
+| `conditions[].path` | JSONPath（`$.httpStatusCode`、`$.response_body.*`） |
+| `conditions[].operation` | 演算子（`eq`, `in`, `ne`, `gte`, `lte`等） |
+| `conditions[].value` | 比較値 |
+| `match_mode` | マッチモード（`all`: AND条件、`any`: OR条件） |
+| `mapped_status_code` | マッピング先のステータスコード |
+| `error_message_json_path` | エラーメッセージ抽出用JSONPath（オプション） |
+
+### 動作
+
+1. レスポンスを受信
+2. `configs`を順番に評価
+3. 最初にマッチした設定の`mapped_status_code`を適用
+4. どれもマッチしない場合は、元のHTTPステータスコードを使用
+
+### 使用シーン
+
+**ケース1: HTTP 200でもエラーを検出**
+
+外部APIが常にHTTP 200を返すが、ボディで成功/失敗を区別する場合：
+
+```json
+{
+  "configs": [
+    {
+      "conditions": [
+        {"path": "$.response_body.result", "operation": "eq", "value": "success"}
+      ],
+      "match_mode": "all",
+      "mapped_status_code": 200
+    },
+    {
+      "conditions": [
+        {"path": "$.response_body.result", "operation": "eq", "value": "error"}
+      ],
+      "match_mode": "all",
+      "mapped_status_code": 400,
+      "error_message_json_path": "$.response_body.error_message"
+    }
+  ]
+}
+```
+
+**ケース2: ビジネスステータスによる判定**
+
+eKYCの審査結果を判定する場合：
+
+```json
+{
+  "configs": [
+    {
+      "conditions": [
+        {"path": "$.httpStatusCode", "operation": "eq", "value": 200},
+        {"path": "$.response_body.verification_status", "operation": "eq", "value": "approved"}
+      ],
+      "match_mode": "all",
+      "mapped_status_code": 200
+    },
+    {
+      "conditions": [
+        {"path": "$.httpStatusCode", "operation": "eq", "value": 200},
+        {"path": "$.response_body.verification_status", "operation": "eq", "value": "rejected"}
+      ],
+      "match_mode": "all",
+      "mapped_status_code": 400
+    }
+  ]
+}
+```
+
+**ケース3: 複数条件の組み合わせ**
+
+```json
+{
+  "conditions": [
+    {"path": "$.httpStatusCode", "operation": "in", "value": [200, 201, 204]},
+    {"path": "$.response_body.errors", "operation": "eq", "value": null}
+  ],
+  "match_mode": "all",
+  "mapped_status_code": 200
+}
+```
+
+### 評価順序
+
+- `configs`配列の**順番**が重要
+- 最初にマッチした設定が適用される
+- より具体的な条件を先に、一般的な条件を後に配置
+
+---
+
 ## 🔄 再試行メカニズム
 
 ### 再試行可能な条件

--- a/documentation/docs/content_06_developer-guide/05-configuration/client.md
+++ b/documentation/docs/content_06_developer-guide/05-configuration/client.md
@@ -331,6 +331,35 @@ CIBA（Client Initiated Backchannel Authentication）対応のクライアント
 
 **詳細**: [CIBA Flow実装ガイド](../03-application-plane/06-ciba-flow.md)
 
+#### CIBA RAR必須化
+
+CIBAリクエスト時に、authorization_details（RAR: Rich Authorization Requests）を必須とする設定：
+
+```json
+{
+  "extension": {
+    "ciba_require_rar": true
+  },
+  "authorization_details_types": ["transaction"]
+}
+```
+
+**フィールド説明**:
+- `ciba_require_rar`: CIBAリクエスト時に`authorization_details`パラメータを必須とするか
+- `authorization_details_types`: サポートするauthorization detailsのタイプ
+
+**動作**:
+- `ciba_require_rar: true`の場合、CIBAリクエストに`authorization_details`が含まれていないとエラー
+- トランザクション詳細（金額、送金先等）をユーザーに明示的に提示して承認を得る
+
+**使用シーン**:
+- 金融トランザクション（送金、振込等）の承認
+- 高リスク操作の詳細確認
+- FAPI準拠のトランザクション承認
+
+**参照仕様**:
+- [RFC 9396: OAuth 2.0 Rich Authorization Requests](https://www.rfc-editor.org/rfc/rfc9396.html)
+
 ---
 
 ### Federation設定

--- a/documentation/docs/content_06_developer-guide/05-configuration/identity-verification.md
+++ b/documentation/docs/content_06_developer-guide/05-configuration/identity-verification.md
@@ -391,6 +391,88 @@ POST /{tenant-id}/v1/me/identity-verification/applications/{type}/cancel
 
 ---
 
+### Result（結果設定）
+
+#### verified_claims_mapping_rules
+
+OIDC4IDA（OpenID Connect for Identity Assurance）準拠のverified_claims生成ルールです。
+
+**設定例**:
+```json
+{
+  "result": {
+    "verified_claims_mapping_rules": [
+      {
+        "static_value": "jp_aml",
+        "to": "verification.trust_framework"
+      },
+      {
+        "from": "$.response_body.user.family_name",
+        "to": "claims.family_name"
+      },
+      {
+        "from": "$.response_body.user.given_name",
+        "to": "claims.given_name"
+      },
+      {
+        "from": "$.response_body.user.birthdate",
+        "to": "claims.birthdate"
+      }
+    ]
+  }
+}
+```
+
+**フィールド構造**:
+- `verification.*`: 身元確認のメタデータ
+  - `trust_framework`: 信頼フレームワーク（例: `jp_aml`）
+  - `evidence`: 証拠情報（例: 本人確認書類の種類）
+- `claims.*`: 検証済みユーザー属性
+  - `family_name`: 姓
+  - `given_name`: 名
+  - `birthdate`: 生年月日
+  - `address`: 住所
+  - など
+
+**動作**:
+1. eKYC等の外部サービスから取得した情報を`verified_claims`形式にマッピング
+2. OIDCトークンに含めて発行
+3. クライアントアプリケーションが信頼できる身元確認済み情報として利用可能
+
+**使用シーン**:
+- eKYC連携（本人確認書類のスキャン等）
+- 身元確認済みIDの発行
+- Verified Credentialsの生成
+
+**参照仕様**:
+- [OpenID Connect for Identity Assurance 1.0](https://openid.net/specs/openid-connect-4-identity-assurance-1_0.html)
+
+---
+
+### Common（共通設定）
+
+複数プロセスに共通する設定項目です。
+
+**設定例**:
+```json
+{
+  "common": {
+    "external_service": "kyc-provider",
+    "callback_application_id_param": "application_id"
+  }
+}
+```
+
+**フィールド説明**:
+- `external_service`: 外部サービスの識別名（ログ・監査用）
+- `callback_application_id_param`: コールバック時に使用する申請ID識別パラメータ名
+
+**使用シーン**:
+- 複数プロセスで共通する外部サービス名の定義
+- コールバック処理での申請ID識別
+
+---
+
 ## Management APIで登録
 
 ### API エンドポイント


### PR DESCRIPTION
## 概要

設定ファイルカバレッジレポート分析により発見された、実装済みだがドキュメント未記載の高度な設定項目を追加しました。

## 追加した設定項目

### 🔴 優先度：高（6項目）

#### 1. step_definitions - authentication-policy.md
- **機能**: 多段階認証のステップ定義
- **追加内容**:
  - フィールド詳細（order, requires_user, allow_registration, user_identity_source）
  - 1st Factor / 2nd Factorの概念説明
  - Email → SMS 多段階認証の設定例
  - success_conditionsとの違い

#### 2. path_mapping_rules - impl-16-http-request-executor.md
- **機能**: URLパスパラメータの動的マッピング
- **追加内容**:
  - URLテンプレート（`{{変数名}}`）の置換
  - RESTful APIリソースID埋め込み
  - 実用的な設定例

#### 3. verified_claims_mapping_rules - identity-verification.md
- **機能**: OIDC4IDA準拠のverified_claims生成
- **追加内容**:
  - verification.* と claims.* の構造説明
  - eKYC結果のマッピング例
  - OpenID Connect for Identity Assurance 1.0準拠

#### 4. SSF events セクション - security-event-hook.md
- **機能**: イベント別のSSF実行設定
- **追加内容**:
  - eventsセクションの詳細構造
  - metadata（spec_version, stream_configuration）
  - security_event_token_additional_payload_mapping_rules
  - 完全な設定例とフロー説明

#### 5. ciba_require_rar - client.md
- **機能**: CIBA RAR（Rich Authorization Requests）必須化
- **追加内容**:
  - authorization_details_typesとの組み合わせ
  - 金融トランザクション承認のユースケース
  - RFC 9396準拠

#### 6. response_resolve_configs - impl-16-http-request-executor.md（新規発見）
- **機能**: HTTPレスポンスのステータスコード解決
- **追加内容**:
  - HTTPステータスとボディの複合判定
  - ビジネスレベルの成功/失敗判定
  - 3つの実用的なユースケース
  - 評価順序の重要性

### 🟡 優先度：中（1項目）

#### 7. common セクション - identity-verification.md
- **機能**: プロセス共通設定
- **追加内容**:
  - external_service、callback_application_id_param

## 変更統計

- **5ファイル修正**
- **470行追加**

## カバレッジ改善

| 項目 | 対応前 | 対応後 | 改善 |
|------|--------|--------|------|
| ドキュメントカバレッジ | 約90% | 約96%以上 | **+6%** |
| 優先度：高の未記載項目 | 5項目 | 0項目 | **全て対応** |

## テストプラン

- [ ] 追加したドキュメントの記載内容が実装と一致しているか確認
- [ ] 設定例が実際に動作するか確認
- [ ] リンク切れがないか確認

## 補足

**対応不要と判断した項目**:
- `authentication_policies`（tenant.json内）- 廃止された機能（Issue コメント参照）

Closes #1091

🤖 Generated with [Claude Code](https://claude.com/claude-code)