### PR TITLE
fix: TokenRequestResponseのContent-Typeヘッダーのtypo修正 (Issue #1150)

### DIFF
--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/token/handler/token/io/TokenRequestResponse.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/token/handler/token/io/TokenRequestResponse.java
@@ -59,7 +59,7 @@ public class TokenRequestResponse {
     this.tokenResponse = new TokenResponseBuilder().build();
     this.errorResponse = errorResponse;
     Map<String, String> values = new HashMap<>();
-    values.put("Content-Typee", "application/json");
+    values.put("Content-Type", "application/json");
     values.put("Cache-Control", "no-store");
     values.put("Pragma", "no-cache");
     this.headers = values;


### PR DESCRIPTION
## Summary

- トークンエンドポイントのエラーレスポンスで`Content-Type`ヘッダー名にtypoがあった問題を修正

## 変更内容

```java
// Before
values.put("Content-Typee", "application/json");

// After
values.put("Content-Type", "application/json");
```

## 影響

- トークンエンドポイントのエラーレスポンスで`Content-Type`ヘッダーが正しく設定されるようになる

Closes #1150

## Test plan

- [x] E2Eテスト通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)