### PR TITLE
feat: 認証デバイスログをセキュリティイベントと統合 (Issue #1154)

### DIFF
--- a/documentation/openapi/swagger-authentication-device-ja.yaml
+++ b/documentation/openapi/swagger-authentication-device-ja.yaml
@@ -106,16 +106,52 @@ paths:
         - 認証
       summary: 認証デバイスのログ
       description: |
-       認証デバイスのFIDO-UAFなどの実行っ結果のログをアプリケーションのログとして出力する。
+        認証デバイス（モバイルアプリ等）からのFIDO認証などの実行結果ログを受信し、アプリケーションログとして出力する。
+
+        **セキュリティイベント連携**:
+        - リクエストに `device_id` または `user_id` が含まれる場合、該当ユーザーを検索
+        - ユーザーが見つかった場合、セキュリティイベント `authentication_device_log` を発行
+        - ユーザーが見つからない場合、セキュリティイベントは発行されない（ノイズ防止）
+        - リクエストボディ全体が `execution_result` としてセキュリティイベントの詳細に保存される
       parameters:
         - in: path
           name: tenant-id
           required: true
           schema:
             type: string
+          description: テナント識別子
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AuthenticationDeviceLogRequest'
+            examples:
+              fido2_success:
+                summary: FIDO2認証成功
+                value:
+                  device_id: "device-12345-abcde"
+                  event: "fido2_authentication"
+                  status: "success"
+                  timestamp: "2025-12-26T10:00:00Z"
+                  details:
+                    authenticator_type: "platform"
+                    user_verification: true
+              fido_uaf_failure:
+                summary: FIDO-UAF認証失敗
+                value:
+                  user_id: "550e8400-e29b-41d4-a716-446655440000"
+                  event: "fido_uaf_authentication"
+                  status: "failure"
+                  timestamp: "2025-12-26T10:05:00Z"
+                  details:
+                    error_code: "USER_CANCELLED"
+                    error_message: "User cancelled the authentication"
       responses:
         '200':
-          description: 200 OK
+          description: |
+            ログ受信成功。
+            セキュリティイベントの発行有無に関わらず200を返却する。
         '400':
           $ref: '#/components/responses/BadRequest'
         '500':
@@ -513,6 +549,47 @@ components:
                 example: "internal server error"
 
   schemas:
+    AuthenticationDeviceLogRequest:
+      type: object
+      description: |
+        認証デバイスログのリクエストボディ。
+        `device_id` または `user_id` のいずれかを含めることで、セキュリティイベントがユーザーに紐づけられる。
+      properties:
+        device_id:
+          type: string
+          description: |
+            認証デバイスの識別子。
+            この値でユーザーを検索し、セキュリティイベントに紐づける。
+          example: "device-12345-abcde"
+        user_id:
+          type: string
+          format: uuid
+          description: |
+            ユーザーの識別子（UUID）。
+            `device_id` でユーザーが見つからない場合、この値で検索する。
+          example: "550e8400-e29b-41d4-a716-446655440000"
+        event:
+          type: string
+          description: イベント種別（例：fido2_authentication, fido_uaf_registration）
+          example: "fido2_authentication"
+        status:
+          type: string
+          enum: [success, failure, cancelled]
+          description: 実行結果のステータス
+          example: "success"
+        timestamp:
+          type: string
+          format: date-time
+          description: イベント発生日時（ISO-8601形式）
+          example: "2025-12-26T10:00:00Z"
+        details:
+          type: object
+          description: イベントの詳細情報（任意のキー・バリュー）
+          additionalProperties: true
+          example:
+            authenticator_type: "platform"
+            user_verification: true
+
     AuthenticationTransactionListResponse:
       type: object
       properties:

--- a/e2e/src/tests/usecase/financial-grade/financial-grade-03-multi-device-priority.test.js
+++ b/e2e/src/tests/usecase/financial-grade/financial-grade-03-multi-device-priority.test.js
@@ -537,6 +537,23 @@ describe("Financial Grade: Multi-Device Priority - Later Registration Wins (Issu
     firstDeviceId = interactionResponse.data.device_id;
     console.log(`  ✅ First device registered: ${firstDeviceId} (expected auto priority: 1)`);
 
+    // Send authentication device log for first device
+    await postWithJson({
+      url: `${backendUrl}/${testTenantId}/v1/authentication-devices/logs`,
+      body: {
+        device_id: firstDeviceId,
+        event: "fido_uaf_registration",
+        status: "success",
+        timestamp: new Date().toISOString(),
+        details: {
+          app_name: "First App",
+          platform: "Android",
+          model: "Device 1",
+        },
+      },
+    });
+    console.log(`  📝 Authentication device log sent for first device`);
+
     // Device 2 (Second registered - should get auto priority 2)
     console.log("  Registering second device...");
     mfaResponse = await mtlsPostWithJson({
@@ -574,6 +591,23 @@ describe("Financial Grade: Multi-Device Priority - Later Registration Wins (Issu
     secondDeviceId = interactionResponse.data.device_id;
     console.log(`  ✅ Second device registered: ${secondDeviceId} (expected auto priority: 2)`);
 
+    // Send authentication device log for second device
+    await postWithJson({
+      url: `${backendUrl}/${testTenantId}/v1/authentication-devices/logs`,
+      body: {
+        device_id: secondDeviceId,
+        event: "fido_uaf_registration",
+        status: "success",
+        timestamp: new Date().toISOString(),
+        details: {
+          app_name: "Second App",
+          platform: "iOS",
+          model: "Device 2",
+        },
+      },
+    });
+    console.log(`  📝 Authentication device log sent for second device`);
+
     // Device 3 (Third registered - should get auto priority 3)
     console.log("  Registering third device...");
     mfaResponse = await mtlsPostWithJson({
@@ -610,6 +644,23 @@ describe("Financial Grade: Multi-Device Priority - Later Registration Wins (Issu
     expect(interactionResponse.status).toBe(200);
     thirdDeviceId = interactionResponse.data.device_id;
     console.log(`  ✅ Third device registered: ${thirdDeviceId} (expected auto priority: 3)`);
+
+    // Send authentication device log for third device
+    await postWithJson({
+      url: `${backendUrl}/${testTenantId}/v1/authentication-devices/logs`,
+      body: {
+        device_id: thirdDeviceId,
+        event: "fido_uaf_registration",
+        status: "success",
+        timestamp: new Date().toISOString(),
+        details: {
+          app_name: "Third App",
+          platform: "Android",
+          model: "Device 3",
+        },
+      },
+    });
+    console.log(`  📝 Authentication device log sent for third device`);
 
     // Step 9: Send CIBA request via mTLS (using same client)
     console.log("\n=== Step 9: Sending CIBA Request via mTLS ===");

--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/identity/device/AuthenticationDeviceLogApi.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/identity/device/AuthenticationDeviceLogApi.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2025 Hirokazu Kobayashi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.idp.server.core.openid.identity.device;
+
+import org.idp.server.platform.multi_tenancy.tenant.TenantIdentifier;
+import org.idp.server.platform.type.RequestAttributes;
+
+public interface AuthenticationDeviceLogApi {
+
+  AuthenticationDeviceLogResponse log(
+      TenantIdentifier tenantIdentifier,
+      AuthenticationDeviceLogRequest request,
+      RequestAttributes requestAttributes);
+}

--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/identity/device/AuthenticationDeviceLogEventCreator.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/identity/device/AuthenticationDeviceLogEventCreator.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2025 Hirokazu Kobayashi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.idp.server.core.openid.identity.device;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.idp.server.core.openid.identity.SecurityEventUserCreatable;
+import org.idp.server.core.openid.identity.User;
+import org.idp.server.platform.multi_tenancy.tenant.Tenant;
+import org.idp.server.platform.security.SecurityEvent;
+import org.idp.server.platform.security.event.*;
+import org.idp.server.platform.type.RequestAttributes;
+
+public class AuthenticationDeviceLogEventCreator implements SecurityEventUserCreatable {
+
+  Tenant tenant;
+  User user;
+  SecurityEventType securityEventType;
+  SecurityEventDescription securityEventDescription;
+  AuthenticationDeviceLogRequest request;
+  RequestAttributes requestAttributes;
+
+  public AuthenticationDeviceLogEventCreator(
+      Tenant tenant,
+      User user,
+      SecurityEventType securityEventType,
+      AuthenticationDeviceLogRequest request,
+      RequestAttributes requestAttributes) {
+    this.tenant = tenant;
+    this.user = user;
+    this.securityEventType = securityEventType;
+    this.securityEventDescription = new SecurityEventDescription(securityEventType.value());
+    this.request = request;
+    this.requestAttributes = requestAttributes;
+  }
+
+  public SecurityEvent create() {
+    HashMap<String, Object> detailsMap = new HashMap<>();
+    SecurityEventBuilder builder = new SecurityEventBuilder();
+    builder.add(securityEventType);
+    builder.add(securityEventDescription);
+
+    SecurityEventTenant securityEventTenant =
+        new SecurityEventTenant(
+            tenant.identifier().value(), tenant.tokenIssuer(), tenant.name().value());
+    builder.add(securityEventTenant);
+
+    // Add client from request or use default for authentication device log
+    builder.add(
+        new SecurityEventClient(request.clientIdOrDefault(), request.clientNameOrDefault()));
+
+    if (user != null && user.exists()) {
+      SecurityEventUser securityEventUser = createSecurityEventUser(user);
+      builder.add(securityEventUser);
+      detailsMap.put("user", toDetailWithSensitiveData(user, tenant));
+    }
+
+    builder.add(requestAttributes.getIpAddress());
+    builder.add(requestAttributes.getUserAgent());
+    detailsMap.putAll(requestAttributes.toMap());
+
+    Map<String, Object> requestMap = request.toMap();
+    if (!requestMap.isEmpty()) {
+      detailsMap.put("execution_result", requestMap);
+    }
+
+    SecurityEventDetail securityEventDetail =
+        createSecurityEventDetailWithScrubbing(detailsMap, tenant);
+
+    builder.add(securityEventDetail);
+
+    return builder.build();
+  }
+}

--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/identity/device/AuthenticationDeviceLogEventPublisher.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/identity/device/AuthenticationDeviceLogEventPublisher.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2025 Hirokazu Kobayashi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.idp.server.core.openid.identity.device;
+
+import org.idp.server.core.openid.identity.User;
+import org.idp.server.platform.multi_tenancy.tenant.Tenant;
+import org.idp.server.platform.security.SecurityEvent;
+import org.idp.server.platform.security.SecurityEventPublisher;
+import org.idp.server.platform.security.event.SecurityEventType;
+import org.idp.server.platform.type.RequestAttributes;
+
+public class AuthenticationDeviceLogEventPublisher {
+
+  SecurityEventPublisher securityEventPublisher;
+
+  public AuthenticationDeviceLogEventPublisher(SecurityEventPublisher securityEventPublisher) {
+    this.securityEventPublisher = securityEventPublisher;
+  }
+
+  public void publish(
+      Tenant tenant,
+      User user,
+      SecurityEventType type,
+      AuthenticationDeviceLogRequest request,
+      RequestAttributes requestAttributes) {
+    AuthenticationDeviceLogEventCreator eventCreator =
+        new AuthenticationDeviceLogEventCreator(tenant, user, type, request, requestAttributes);
+    SecurityEvent securityEvent = eventCreator.create();
+    securityEventPublisher.publish(securityEvent);
+  }
+}

--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/identity/device/AuthenticationDeviceLogRequest.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/identity/device/AuthenticationDeviceLogRequest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2025 Hirokazu Kobayashi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.idp.server.core.openid.identity.device;
+
+import java.util.Map;
+
+public class AuthenticationDeviceLogRequest {
+
+  Map<String, Object> values;
+
+  public AuthenticationDeviceLogRequest(Map<String, Object> values) {
+    this.values = values != null ? values : Map.of();
+  }
+
+  public String deviceId() {
+    return extractString("device_id");
+  }
+
+  public String userId() {
+    return extractString("user_id");
+  }
+
+  public String clientId() {
+    return extractString("client_id");
+  }
+
+  public String clientName() {
+    return extractString("client_name");
+  }
+
+  public String clientIdOrDefault() {
+    String clientId = clientId();
+    return (clientId != null && !clientId.isEmpty()) ? clientId : "authentication-device";
+  }
+
+  public String clientNameOrDefault() {
+    String clientName = clientName();
+    return (clientName != null && !clientName.isEmpty()) ? clientName : "Authentication Device";
+  }
+
+  public boolean hasDeviceId() {
+    String deviceId = deviceId();
+    return deviceId != null && !deviceId.isEmpty();
+  }
+
+  public boolean hasUserId() {
+    String userId = userId();
+    return userId != null && !userId.isEmpty();
+  }
+
+  public Map<String, Object> toMap() {
+    return values;
+  }
+
+  private String extractString(String key) {
+    Object value = values.get(key);
+    if (value instanceof String) {
+      return (String) value;
+    }
+    return null;
+  }
+}

--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/identity/device/AuthenticationDeviceLogResponse.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/identity/device/AuthenticationDeviceLogResponse.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2025 Hirokazu Kobayashi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.idp.server.core.openid.identity.device;
+
+public class AuthenticationDeviceLogResponse {
+
+  int statusCode;
+
+  public AuthenticationDeviceLogResponse(int statusCode) {
+    this.statusCode = statusCode;
+  }
+
+  public static AuthenticationDeviceLogResponse ok() {
+    return new AuthenticationDeviceLogResponse(200);
+  }
+
+  public int statusCode() {
+    return statusCode;
+  }
+}

--- a/libs/idp-server-platform/src/main/java/org/idp/server/platform/security/event/DefaultSecurityEventType.java
+++ b/libs/idp-server-platform/src/main/java/org/idp/server/platform/security/event/DefaultSecurityEventType.java
@@ -100,6 +100,7 @@ public enum DefaultSecurityEventType {
   authentication_device_deregistration_failure("User failed to deregister a device"),
   authentication_device_registration_challenge_success(
       "User successfully challenge a device registration"),
+  authentication_device_log("Authentication device log from client"),
   backchannel_authentication_request_success(
       "User successfully authenticated with a backchannel authentication"),
   backchannel_authentication_request_failure(

--- a/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/IdpServerApplication.java
+++ b/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/IdpServerApplication.java
@@ -100,6 +100,8 @@ import org.idp.server.core.openid.identity.*;
 import org.idp.server.core.openid.identity.authentication.PasswordEncodeDelegation;
 import org.idp.server.core.openid.identity.authentication.PasswordVerificationDelegation;
 import org.idp.server.core.openid.identity.authentication.UserPasswordAuthenticator;
+import org.idp.server.core.openid.identity.device.AuthenticationDeviceLogApi;
+import org.idp.server.core.openid.identity.device.AuthenticationDeviceLogEventPublisher;
 import org.idp.server.core.openid.identity.event.*;
 import org.idp.server.core.openid.identity.permission.PermissionCommandRepository;
 import org.idp.server.core.openid.identity.permission.PermissionQueryRepository;
@@ -164,6 +166,7 @@ import org.idp.server.platform.statistics.repository.TenantYearlyStatisticsQuery
 import org.idp.server.platform.statistics.repository.YearlyActiveUserCommandRepository;
 import org.idp.server.security.event.hook.ssf.SharedSignalsFrameworkMetaDataApi;
 import org.idp.server.usecases.application.enduser.*;
+import org.idp.server.usecases.application.enduser.AuthenticationDeviceLogEntryService;
 import org.idp.server.usecases.application.identity_verification_service.IdentityVerificationCallbackEntryService;
 import org.idp.server.usecases.application.identity_verification_service.IdentityVerificationEntryService;
 import org.idp.server.usecases.application.relying_party.OidcMetaDataEntryService;
@@ -198,6 +201,7 @@ public class IdpServerApplication {
   TenantInvitationMetaDataApi tenantInvitationMetaDataApi;
   UserOperationApi userOperationApi;
   UserLifecycleEventApi userLifecycleEventApi;
+  AuthenticationDeviceLogApi authenticationDeviceLogApi;
   OnboardingApi onboardingApi;
   TenantManagementApi tenantManagementApi;
   TenantStatisticsApi tenantStatisticsApi;
@@ -725,6 +729,16 @@ public class IdpServerApplication {
             UserLifecycleEventApi.class,
             databaseTypeProvider);
 
+    AuthenticationDeviceLogEventPublisher authenticationDeviceLogEventPublisher =
+        new AuthenticationDeviceLogEventPublisher(securityEventPublisher);
+
+    this.authenticationDeviceLogApi =
+        TenantAwareEntryServiceProxy.createProxy(
+            new AuthenticationDeviceLogEntryService(
+                tenantQueryRepository, userQueryRepository, authenticationDeviceLogEventPublisher),
+            AuthenticationDeviceLogApi.class,
+            databaseTypeProvider);
+
     this.adminUserAuthenticationApi =
         TenantAwareEntryServiceProxy.createProxy(
             new AdminUserAuthenticationEntryService(
@@ -1223,6 +1237,10 @@ public class IdpServerApplication {
 
   public UserLifecycleEventApi userLifecycleEventApi() {
     return userLifecycleEventApi;
+  }
+
+  public AuthenticationDeviceLogApi authenticationDeviceLogApi() {
+    return authenticationDeviceLogApi;
   }
 
   public OnboardingApi onboardingApi() {

--- a/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/application/enduser/AuthenticationDeviceLogEntryService.java
+++ b/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/application/enduser/AuthenticationDeviceLogEntryService.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2025 Hirokazu Kobayashi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.idp.server.usecases.application.enduser;
+
+import org.idp.server.core.openid.identity.User;
+import org.idp.server.core.openid.identity.UserIdentifier;
+import org.idp.server.core.openid.identity.device.AuthenticationDeviceLogApi;
+import org.idp.server.core.openid.identity.device.AuthenticationDeviceLogEventPublisher;
+import org.idp.server.core.openid.identity.device.AuthenticationDeviceLogRequest;
+import org.idp.server.core.openid.identity.device.AuthenticationDeviceLogResponse;
+import org.idp.server.core.openid.identity.repository.UserQueryRepository;
+import org.idp.server.platform.datasource.Transaction;
+import org.idp.server.platform.log.LoggerWrapper;
+import org.idp.server.platform.multi_tenancy.tenant.Tenant;
+import org.idp.server.platform.multi_tenancy.tenant.TenantIdentifier;
+import org.idp.server.platform.multi_tenancy.tenant.TenantQueryRepository;
+import org.idp.server.platform.security.event.DefaultSecurityEventType;
+import org.idp.server.platform.type.RequestAttributes;
+
+@Transaction
+public class AuthenticationDeviceLogEntryService implements AuthenticationDeviceLogApi {
+
+  TenantQueryRepository tenantQueryRepository;
+  UserQueryRepository userQueryRepository;
+  AuthenticationDeviceLogEventPublisher eventPublisher;
+  LoggerWrapper log = LoggerWrapper.getLogger(AuthenticationDeviceLogEntryService.class);
+
+  public AuthenticationDeviceLogEntryService(
+      TenantQueryRepository tenantQueryRepository,
+      UserQueryRepository userQueryRepository,
+      AuthenticationDeviceLogEventPublisher eventPublisher) {
+    this.tenantQueryRepository = tenantQueryRepository;
+    this.userQueryRepository = userQueryRepository;
+    this.eventPublisher = eventPublisher;
+  }
+
+  @Override
+  public AuthenticationDeviceLogResponse log(
+      TenantIdentifier tenantIdentifier,
+      AuthenticationDeviceLogRequest request,
+      RequestAttributes requestAttributes) {
+
+    Tenant tenant = tenantQueryRepository.get(tenantIdentifier);
+
+    User user = findUser(tenant, request);
+
+    if (user == null || !user.exists()) {
+      log.debug(
+          "Skipping security event publish - no user found for tenant: {}",
+          tenantIdentifier.value());
+      return AuthenticationDeviceLogResponse.ok();
+    }
+
+    eventPublisher.publish(
+        tenant,
+        user,
+        DefaultSecurityEventType.authentication_device_log.toEventType(),
+        request,
+        requestAttributes);
+
+    return AuthenticationDeviceLogResponse.ok();
+  }
+
+  private User findUser(Tenant tenant, AuthenticationDeviceLogRequest request) {
+    if (request.hasDeviceId()) {
+      User user = userQueryRepository.findByAuthenticationDevice(tenant, request.deviceId());
+      if (user != null && user.exists()) {
+        return user;
+      }
+    }
+
+    if (request.hasUserId()) {
+      User user = userQueryRepository.findById(tenant, new UserIdentifier(request.userId()));
+      if (user != null && user.exists()) {
+        return user;
+      }
+    }
+
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary
- 認証デバイスログ (`/logs`) エンドポイントをセキュリティイベントシステムと統合
- `device_id` または `user_id` でユーザーを検索し、見つかった場合のみセキュリティイベントを発行
- リクエスト内容を `execution_result` としてイベント詳細に記録
- ユーザーが見つからない場合はノイズ防止のためイベント発行をスキップ

## 変更内容
### 新規ファイル (6件)
- `AuthenticationDeviceLogApi.java`: API契約定義
- `AuthenticationDeviceLogRequest.java`: リクエストボディのラッパークラス
- `AuthenticationDeviceLogResponse.java`: レスポンス定義
- `AuthenticationDeviceLogEventCreator.java`: セキュリティイベント作成
- `AuthenticationDeviceLogEventPublisher.java`: イベント発行
- `AuthenticationDeviceLogEntryService.java`: ユーザー検索とイベント発行のサービス

### 修正ファイル
- `DefaultSecurityEventType.java`: `authentication_device_log` イベントタイプ追加
- `AuthenticationDeviceV1Api.java`: APIにセキュリティイベント発行を統合
- `IdpServerApplication.java`: 新しいAPIの配線追加
- `09-security-event.md`: 開発者ドキュメント追加
- `swagger-authentication-device-ja.yaml`: Swagger仕様追加
- `financial-grade-03-multi-device-priority.test.js`: E2Eテストにログ記録を追加

## Test plan
- [x] E2Eテスト `financial-grade-03-multi-device-priority.test.js` でAPI呼び出し確認
- [x] セキュリティイベントテーブルへの記録確認済み

Closes #1154

🤖 Generated with [Claude Code](https://claude.com/claude-code)