### PR TITLE
fix: MDXパースエラーを修正（URLのエスケープ）

### DIFF
--- a/documentation/docs/content_11_learning/15-networking/05-api-gateway-networking.md
+++ b/documentation/docs/content_11_learning/15-networking/05-api-gateway-networking.md
@@ -280,7 +280,7 @@ aws apigateway update-rest-api \
 
 ### 3.1 カスタムドメインの設定
 
-デフォルトのAPI Gatewayエンドポイント（例：https://api-id.execute-api.us-east-1.amazonaws.com）を、カスタムドメイン（例：https://api.example.com）に変更できます。
+デフォルトのAPI Gatewayエンドポイント（例：`https://api-id.execute-api.us-east-1.amazonaws.com`）を、カスタムドメイン（例：`https://api.example.com`）に変更できます。
 
 ```
 ┌─────────────────────────────────────────────────────────────┐


### PR DESCRIPTION
## Summary

- API Gateway NetworkingドキュメントのURLをバッククォートでエスケープ
- Docusaurusビルドエラーを修正

## 問題

```
Error: Can't parse URL https://api-id.execute-api.us-east-1.amazonaws.com）を、カスタムドメイン...
```

URLが括弧内にあり、Markdownパーサーがリンクとして誤解釈していた。

## 修正内容

```diff
- デフォルトのAPI Gatewayエンドポイント（例：https://api-id.execute-api.us-east-1.amazonaws.com）を...
+ デフォルトのAPI Gatewayエンドポイント（例：`https://api-id.execute-api.us-east-1.amazonaws.com`）を...
```

## Test plan

- [x] `npm run build` でビルドエラーが解消されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)