### PR TITLE
fix: Email/SMS認証でテンプレート未設定時のNPEを修正

### DIFF
--- a/libs/idp-server-authentication-interactors/src/main/java/org/idp/server/authentication/interactors/email/EmailAuthenticationConfiguration.java
+++ b/libs/idp-server-authentication-interactors/src/main/java/org/idp/server/authentication/interactors/email/EmailAuthenticationConfiguration.java
@@ -50,7 +50,16 @@ public class EmailAuthenticationConfiguration implements JsonReadable {
   }
 
   public EmailVerificationTemplate findTemplate(String templateKey) {
-    return templates.getOrDefault(templateKey, new EmailVerificationTemplate());
+    if (templates == null) {
+      return defaultTemplate();
+    }
+    return templates.getOrDefault(templateKey, defaultTemplate());
+  }
+
+  private EmailVerificationTemplate defaultTemplate() {
+    return new EmailVerificationTemplate(
+        "Verification Code",
+        "Your verification code is: {VERIFICATION_CODE}\nThis code expires in {EXPIRE_SECONDS} seconds.");
   }
 
   public EmailSenderConfiguration senderConfig() {

--- a/libs/idp-server-authentication-interactors/src/main/java/org/idp/server/authentication/interactors/sms/SmsAuthenticationConfiguration.java
+++ b/libs/idp-server-authentication-interactors/src/main/java/org/idp/server/authentication/interactors/sms/SmsAuthenticationConfiguration.java
@@ -45,7 +45,16 @@ public class SmsAuthenticationConfiguration implements JsonReadable {
   }
 
   public SmslVerificationTemplate findTemplate(String templateKey) {
-    return templates.getOrDefault(templateKey, new SmslVerificationTemplate());
+    if (templates == null) {
+      return defaultTemplate();
+    }
+    return templates.getOrDefault(templateKey, defaultTemplate());
+  }
+
+  private SmslVerificationTemplate defaultTemplate() {
+    return new SmslVerificationTemplate(
+        "Verification Code",
+        "Your verification code is: {VERIFICATION_CODE}. Expires in {EXPIRE_SECONDS} seconds.");
   }
 
   public Map<String, Object> settings() {


### PR DESCRIPTION
## Summary

- Email/SMS認証でテンプレートが設定されていない場合にNullPointerExceptionが発生する問題を修正
- デフォルトテンプレートを追加し、設定がない場合も正常に動作するように

## 修正内容

| ファイル | 修正 |
|---------|------|
| `EmailAuthenticationConfiguration.java` | `findTemplate()` でデフォルトテンプレートを返すように修正 |
| `SmsAuthenticationConfiguration.java` | 同様の修正 |

## デフォルトメッセージ

```
Subject: Verification Code
Body: Your verification code is: {VERIFICATION_CODE}
      This code expires in {EXPIRE_SECONDS} seconds.
```

## Test plan

- [x] ビルド確認
- [ ] Email認証チャレンジでテンプレート未設定時にNPEが発生しないことを確認
- [ ] SMS認証チャレンジでテンプレート未設定時にNPEが発生しないことを確認

Closes #1152

🤖 Generated with [Claude Code](https://claude.com/claude-code)