### PR TITLE
feat: 権限の名前空間とワイルドカードマッチング機能を追加

### DIFF
--- a/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/base/definition/AdminPermissions.java
+++ b/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/base/definition/AdminPermissions.java
@@ -18,6 +18,7 @@ package org.idp.server.control_plane.base.definition;
 
 import java.util.Set;
 import java.util.stream.Collectors;
+import org.idp.server.core.openid.identity.permission.PermissionMatcher;
 
 public class AdminPermissions {
   Set<DefaultAdminPermission> values;
@@ -34,7 +35,21 @@ public class AdminPermissions {
     return values.stream().map(DefaultAdminPermission::value).collect(Collectors.joining(","));
   }
 
+  /**
+   * Checks if user permissions include all required permissions.
+   *
+   * <p>Supports wildcard matching where user permissions like:
+   *
+   * <ul>
+   *   <li>{@code *} - matches all permissions
+   *   <li>{@code idp:*} - matches all control plane permissions
+   *   <li>{@code idp:user:*} - matches all user management permissions
+   * </ul>
+   *
+   * @param userPermissions set of permissions the user has
+   * @return true if user has all required permissions (considering wildcards)
+   */
   public boolean includesAll(Set<String> userPermissions) {
-    return userPermissions.containsAll(valuesAsSetString());
+    return PermissionMatcher.matchesAll(userPermissions, valuesAsSetString());
   }
 }

--- a/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/base/definition/DefaultAdminPermission.java
+++ b/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/base/definition/DefaultAdminPermission.java
@@ -22,114 +22,123 @@ import org.idp.server.core.openid.identity.permission.Permission;
 import org.idp.server.core.openid.identity.permission.Permissions;
 
 public enum DefaultAdminPermission {
-  ORGANIZATION_CREATE("organization:create", "Admin Create a organization"),
-  ORGANIZATION_READ("organization:read", "Admin Read organization information"),
-  ORGANIZATION_UPDATE("organization:update", "Admin Update organization"),
-  ORGANIZATION_DELETE("organization:delete", "Admin Delete organization"),
+  // Wildcard permissions
+  CONTROL_PLANE_ALL("idp:*", "All control plane permissions"),
 
-  TENANT_INVITATION_CREATE("tenant-invitation:create", "Admin Create a tenant-invitation"),
-  TENANT_INVITATION_READ("tenant-invitation:read", "Admin Read tenant-invitation information"),
-  TENANT_INVITATION_UPDATE("tenant-invitation:update", "Admin Update tenant-invitation"),
-  TENANT_INVITATION_DELETE("tenant-invitation:delete", "Admin Delete tenant-invitation"),
+  // Organization permissions
+  ORGANIZATION_CREATE("idp:organization:create", "Admin Create a organization"),
+  ORGANIZATION_READ("idp:organization:read", "Admin Read organization information"),
+  ORGANIZATION_UPDATE("idp:organization:update", "Admin Update organization"),
+  ORGANIZATION_DELETE("idp:organization:delete", "Admin Delete organization"),
 
-  TENANT_CREATE("tenant:create", "Admin Create a tenant"),
-  TENANT_READ("tenant:read", "Admin Read tenant information"),
-  TENANT_UPDATE("tenant:update", "Admin Update tenant"),
-  TENANT_DELETE("tenant:delete", "Admin Delete tenant"),
+  TENANT_INVITATION_CREATE("idp:tenant-invitation:create", "Admin Create a tenant-invitation"),
+  TENANT_INVITATION_READ("idp:tenant-invitation:read", "Admin Read tenant-invitation information"),
+  TENANT_INVITATION_UPDATE("idp:tenant-invitation:update", "Admin Update tenant-invitation"),
+  TENANT_INVITATION_DELETE("idp:tenant-invitation:delete", "Admin Delete tenant-invitation"),
 
-  AUTHORIZATION_SERVER_CREATE("authorization-server:create", "Admin Create a authorization-server"),
+  TENANT_CREATE("idp:tenant:create", "Admin Create a tenant"),
+  TENANT_READ("idp:tenant:read", "Admin Read tenant information"),
+  TENANT_UPDATE("idp:tenant:update", "Admin Update tenant"),
+  TENANT_DELETE("idp:tenant:delete", "Admin Delete tenant"),
+
+  AUTHORIZATION_SERVER_CREATE(
+      "idp:authorization-server:create", "Admin Create a authorization-server"),
   AUTHORIZATION_SERVER_READ(
-      "authorization-server:read", "Admin Read authorization-server information"),
-  AUTHORIZATION_SERVER_UPDATE("authorization-server:update", "Admin Update authorization-server"),
-  AUTHORIZATION_SERVER_DELETE("authorization-server:delete", "Admin Delete authorization-server"),
+      "idp:authorization-server:read", "Admin Read authorization-server information"),
+  AUTHORIZATION_SERVER_UPDATE(
+      "idp:authorization-server:update", "Admin Update authorization-server"),
+  AUTHORIZATION_SERVER_DELETE(
+      "idp:authorization-server:delete", "Admin Delete authorization-server"),
 
-  CLIENT_CREATE("client:create", "Admin Create a client"),
-  CLIENT_READ("client:read", "Admin Read client information"),
-  CLIENT_UPDATE("client:update", "Admin Update client"),
-  CLIENT_DELETE("client:delete", "Admin Delete client"),
+  CLIENT_CREATE("idp:client:create", "Admin Create a client"),
+  CLIENT_READ("idp:client:read", "Admin Read client information"),
+  CLIENT_UPDATE("idp:client:update", "Admin Update client"),
+  CLIENT_DELETE("idp:client:delete", "Admin Delete client"),
 
-  USER_CREATE("user:create", "Admin Create a user"),
-  USER_READ("user:read", "Admin Read user information"),
-  USER_UPDATE("user:update", "Admin Update user"),
-  USER_DELETE("user:delete", "Admin Delete user"),
-  USER_INVITE("user:invite", "Admin Invite a user"),
-  USER_SUSPEND("user:suspend", "Admin Suspend user account"),
+  USER_CREATE("idp:user:create", "Admin Create a user"),
+  USER_READ("idp:user:read", "Admin Read user information"),
+  USER_UPDATE("idp:user:update", "Admin Update user"),
+  USER_DELETE("idp:user:delete", "Admin Delete user"),
+  USER_INVITE("idp:user:invite", "Admin Invite a user"),
+  USER_SUSPEND("idp:user:suspend", "Admin Suspend user account"),
 
-  ADMIN_USER_CREATE("admin_user:create", "Admin Create an admin user"),
-  ADMIN_USER_READ("admin_user:read", "Admin Read admin user information"),
-  ADMIN_USER_UPDATE("admin_user:update", "Admin Update admin user"),
-  ADMIN_USER_DELETE("admin_user:delete", "Admin Delete admin user"),
-  ADMIN_USER_INVITE("admin_user:invite", "Admin Invite an admin user"),
-  ADMIN_USER_SUSPEND("admin_user:suspend", "Admin Suspend admin user account"),
+  ADMIN_USER_CREATE("idp:admin-user:create", "Admin Create an admin user"),
+  ADMIN_USER_READ("idp:admin-user:read", "Admin Read admin user information"),
+  ADMIN_USER_UPDATE("idp:admin-user:update", "Admin Update admin user"),
+  ADMIN_USER_DELETE("idp:admin-user:delete", "Admin Delete admin user"),
+  ADMIN_USER_INVITE("idp:admin-user:invite", "Admin Invite an admin user"),
+  ADMIN_USER_SUSPEND("idp:admin-user:suspend", "Admin Suspend admin user account"),
 
-  PERMISSION_CREATE("permission:create", "Admin Create a permission"),
-  PERMISSION_READ("permission:read", "Admin Read permission information"),
-  PERMISSION_UPDATE("permission:update", "Admin Update permission"),
-  PERMISSION_DELETE("permission:delete", "Admin Delete permission"),
+  PERMISSION_CREATE("idp:permission:create", "Admin Create a permission"),
+  PERMISSION_READ("idp:permission:read", "Admin Read permission information"),
+  PERMISSION_UPDATE("idp:permission:update", "Admin Update permission"),
+  PERMISSION_DELETE("idp:permission:delete", "Admin Delete permission"),
 
-  ROLE_CREATE("role:create", "Admin Create a role"),
-  ROLE_READ("role:read", "Admin Read role information"),
-  ROLE_UPDATE("role:update", "Admin Update role"),
-  ROLE_DELETE("role:delete", "Admin Delete role"),
+  ROLE_CREATE("idp:role:create", "Admin Create a role"),
+  ROLE_READ("idp:role:read", "Admin Read role information"),
+  ROLE_UPDATE("idp:role:update", "Admin Update role"),
+  ROLE_DELETE("idp:role:delete", "Admin Delete role"),
 
   AUTHENTICATION_CONFIG_CREATE(
-      "authentication-config:create", "Admin Create a authentication-config"),
+      "idp:authentication-config:create", "Admin Create a authentication-config"),
   AUTHENTICATION_CONFIG_READ(
-      "authentication-config:read", "Admin Read authentication-config information"),
+      "idp:authentication-config:read", "Admin Read authentication-config information"),
   AUTHENTICATION_CONFIG_UPDATE(
-      "authentication-config:update", "Admin Update authentication-config"),
+      "idp:authentication-config:update", "Admin Update authentication-config"),
   AUTHENTICATION_CONFIG_DELETE(
-      "authentication-config:delete", "Admin Delete authentication-config"),
+      "idp:authentication-config:delete", "Admin Delete authentication-config"),
 
   AUTHENTICATION_POLICY_CONFIG_CREATE(
-      "authentication-policy-config:create", "Admin Create a authentication-policy-config"),
+      "idp:authentication-policy-config:create", "Admin Create a authentication-policy-config"),
   AUTHENTICATION_POLICY_CONFIG_READ(
-      "authentication-policy-config:read", "Admin Read authentication-policy-config information"),
+      "idp:authentication-policy-config:read",
+      "Admin Read authentication-policy-config information"),
   AUTHENTICATION_POLICY_CONFIG_UPDATE(
-      "authentication-policy-config:update", "Admin Update authentication-policy-config"),
+      "idp:authentication-policy-config:update", "Admin Update authentication-policy-config"),
   AUTHENTICATION_POLICY_CONFIG_DELETE(
-      "authentication-policy-config:delete", "Admin Delete authentication-policy-config"),
+      "idp:authentication-policy-config:delete", "Admin Delete authentication-policy-config"),
 
   IDENTITY_VERIFICATION_CONFIG_CREATE(
-      "identity-verification-config:create", "Admin Create a identity-verification-config"),
+      "idp:identity-verification-config:create", "Admin Create a identity-verification-config"),
   IDENTITY_VERIFICATION_CONFIG_READ(
-      "identity-verification-config:read", "Admin Read identity-verification-config information"),
+      "idp:identity-verification-config:read",
+      "Admin Read identity-verification-config information"),
   IDENTITY_VERIFICATION_CONFIG_UPDATE(
-      "identity-verification-config:update", "Admin Update identity-verification-config"),
+      "idp:identity-verification-config:update", "Admin Update identity-verification-config"),
   IDENTITY_VERIFICATION_CONFIG_DELETE(
-      "identity-verification-config:delete", "Admin Delete identity-verification-config"),
+      "idp:identity-verification-config:delete", "Admin Delete identity-verification-config"),
 
-  FEDERATION_CONFIG_CREATE("federation-config:create", "Admin Create a federation-config"),
-  FEDERATION_CONFIG_READ("federation-config:read", "Admin Read federation-config information"),
-  FEDERATION_CONFIG_UPDATE("federation-config:update", "Admin Update federation-config"),
-  FEDERATION_CONFIG_DELETE("federation-config:delete", "Admin Delete federation-config"),
+  FEDERATION_CONFIG_CREATE("idp:federation-config:create", "Admin Create a federation-config"),
+  FEDERATION_CONFIG_READ("idp:federation-config:read", "Admin Read federation-config information"),
+  FEDERATION_CONFIG_UPDATE("idp:federation-config:update", "Admin Update federation-config"),
+  FEDERATION_CONFIG_DELETE("idp:federation-config:delete", "Admin Delete federation-config"),
 
   SECURITY_EVENT_HOOK_CONFIG_CREATE(
-      "security-event-hook-config:create", "Admin Create a security-event-hook-config"),
+      "idp:security-event-hook-config:create", "Admin Create a security-event-hook-config"),
   SECURITY_EVENT_HOOK_CONFIG_READ(
-      "security-event-hook-config:read", "Admin Read security-event-hook-config information"),
+      "idp:security-event-hook-config:read", "Admin Read security-event-hook-config information"),
   SECURITY_EVENT_HOOK_CONFIG_UPDATE(
-      "security-event-hook-config:update", "Admin Update security-event-hook-config"),
+      "idp:security-event-hook-config:update", "Admin Update security-event-hook-config"),
   SECURITY_EVENT_HOOK_CONFIG_DELETE(
-      "security-event-hook-config:delete", "Admin Delete security-event-hook-config"),
+      "idp:security-event-hook-config:delete", "Admin Delete security-event-hook-config"),
 
   SECURITY_EVENT_HOOK_READ(
-      "security-event-hook:read", "Admin Read security-event-hook information"),
+      "idp:security-event-hook:read", "Admin Read security-event-hook information"),
   SECURITY_EVENT_HOOK_RETRY(
-      "security-event-hook:retry", "Admin Retry failed security-event-hook execution"),
+      "idp:security-event-hook:retry", "Admin Retry failed security-event-hook execution"),
 
-  SECURITY_EVENT_READ("security-event:read", "Admin Read security-event information"),
-  AUDIT_LOG_READ("audit-log:read", "Admin Read audit-log information"),
+  SECURITY_EVENT_READ("idp:security-event:read", "Admin Read security-event information"),
+  AUDIT_LOG_READ("idp:audit-log:read", "Admin Read audit-log information"),
   AUTHENTICATION_TRANSACTION_READ(
-      "authentication-transaction:read", "Admin Read authentication-transaction information"),
+      "idp:authentication-transaction:read", "Admin Read authentication-transaction information"),
   AUTHENTICATION_INTERACTION_READ(
-      "authentication-interaction:read", "Admin Read authentication-interaction information"),
+      "idp:authentication-interaction:read", "Admin Read authentication-interaction information"),
 
-  SESSION_READ("session:read", "Admin Read user session information"),
-  SESSION_DELETE("session:delete", "Admin Delete user session"),
+  SESSION_READ("idp:session:read", "Admin Read user session information"),
+  SESSION_DELETE("idp:session:delete", "Admin Delete user session"),
 
-  SYSTEM_READ("system:read", "Admin Read system configuration"),
-  SYSTEM_WRITE("system:write", "Admin Write system configuration");
+  SYSTEM_READ("idp:system:read", "Admin Read system configuration"),
+  SYSTEM_WRITE("idp:system:write", "Admin Write system configuration");
 
   private final String value;
   private final String description;
@@ -152,11 +161,11 @@ public enum DefaultAdminPermission {
   }
 
   public boolean isAdminUserPermission() {
-    return value.startsWith("admin_user:");
+    return value.startsWith("idp:admin-user:");
   }
 
   public boolean isPublicUserPermission() {
-    return value.startsWith("user:") && !value.startsWith("admin_user:");
+    return value.startsWith("idp:user:");
   }
 
   public static Set<DefaultAdminPermission> getAll() {
@@ -188,8 +197,9 @@ public enum DefaultAdminPermission {
   }
 
   public static Set<DefaultAdminPermission> findByResource(String resource) {
+    String prefix = "idp:" + resource + ":";
     return Arrays.stream(values())
-        .filter(p -> p.value.startsWith(resource + ":"))
+        .filter(p -> p.value.startsWith(prefix))
         .collect(Collectors.toSet());
   }
 
@@ -232,6 +242,24 @@ public enum DefaultAdminPermission {
    * @return true if system permission
    */
   public boolean isSystemPermission() {
-    return value.startsWith("system:");
+    return value.startsWith("idp:system:");
+  }
+
+  /**
+   * Returns true if this is a wildcard permission.
+   *
+   * @return true if wildcard permission
+   */
+  public boolean isWildcard() {
+    return value.endsWith(":*") || value.equals("*");
+  }
+
+  /**
+   * Returns only the wildcard permission for control plane.
+   *
+   * @return set containing only CONTROL_PLANE_ALL
+   */
+  public static Set<DefaultAdminPermission> getWildcard() {
+    return Set.of(CONTROL_PLANE_ALL);
   }
 }

--- a/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/base/definition/DefaultAdminRole.java
+++ b/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/base/definition/DefaultAdminRole.java
@@ -24,7 +24,9 @@ import org.idp.server.core.openid.identity.role.Roles;
 
 public enum DefaultAdminRole {
   ADMINISTRATOR(
-      "administrator", "administrator has all permissions", DefaultAdminPermission.getAll());
+      "administrator",
+      "Administrator with full control plane access via wildcard permission",
+      DefaultAdminPermission.getWildcard());
 
   private final String name;
   private final String description;

--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/identity/permission/Permission.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/identity/permission/Permission.java
@@ -65,6 +65,42 @@ public class Permission implements Serializable, UuidConvertable {
     return this.name.equals(permission.name());
   }
 
+  /**
+   * Checks if this permission matches the required permission using wildcard matching.
+   *
+   * <p>Supports patterns like:
+   *
+   * <ul>
+   *   <li>{@code *} - matches all permissions
+   *   <li>{@code idp:*} - matches all control plane permissions
+   *   <li>{@code idp:user:*} - matches all user management permissions
+   * </ul>
+   *
+   * @param requiredPermission the permission required for the operation
+   * @return true if this permission covers the required permission
+   */
+  public boolean matchWithWildcard(Permission requiredPermission) {
+    if (!exists() || requiredPermission == null || !requiredPermission.exists()) {
+      return false;
+    }
+
+    return PermissionMatcher.matches(this.name, requiredPermission.name());
+  }
+
+  /**
+   * Checks if this permission matches the required permission name using wildcard matching.
+   *
+   * @param requiredPermissionName the permission name required for the operation
+   * @return true if this permission covers the required permission
+   */
+  public boolean matchWithWildcard(String requiredPermissionName) {
+    if (!exists() || requiredPermissionName == null || requiredPermissionName.isEmpty()) {
+      return false;
+    }
+
+    return PermissionMatcher.matches(this.name, requiredPermissionName);
+  }
+
   public Map<String, Object> toMap() {
     Map<String, Object> map = new HashMap<>();
     map.put("id", id);

--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/identity/permission/PermissionMatcher.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/identity/permission/PermissionMatcher.java
@@ -1,0 +1,239 @@
+/*
+ * Copyright 2025 Hirokazu Kobayashi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.idp.server.core.openid.identity.permission;
+
+import java.util.Set;
+
+/**
+ * Utility class for permission wildcard matching.
+ *
+ * <p>Supports AWS IAM-style wildcard patterns:
+ *
+ * <ul>
+ *   <li>{@code *} - matches all permissions
+ *   <li>{@code idp:*} - matches all control plane permissions (idp:user:create,
+ *       idp:organization:delete, etc.)
+ *   <li>{@code idp:user:*} - matches all user management permissions (idp:user:create,
+ *       idp:user:read, etc.)
+ * </ul>
+ *
+ * <p>The wildcard character {@code *} only works at the end of a permission pattern.
+ */
+public class PermissionMatcher {
+
+  private static final String WILDCARD = "*";
+  private static final String NAMESPACE_SEPARATOR = ":";
+  public static final String CONTROL_PLANE_NAMESPACE = "idp";
+  private static final String CONTROL_PLANE_PREFIX = CONTROL_PLANE_NAMESPACE + NAMESPACE_SEPARATOR;
+
+  private PermissionMatcher() {}
+
+  /**
+   * Checks if the user permission matches the required permission.
+   *
+   * <p>This method normalizes both permissions for backward compatibility, converting legacy format
+   * (e.g., "organization:create") to new format (e.g., "idp:organization:create").
+   *
+   * @param userPermission the permission that the user has (may contain wildcards)
+   * @param requiredPermission the permission required for the operation
+   * @return true if user permission covers the required permission
+   */
+  public static boolean matches(String userPermission, String requiredPermission) {
+    if (userPermission == null || requiredPermission == null) {
+      return false;
+    }
+
+    // Normalize both permissions for backward compatibility
+    String normalizedUser = normalize(userPermission);
+    String normalizedRequired = normalize(requiredPermission);
+
+    // Exact match
+    if (normalizedUser.equals(normalizedRequired)) {
+      return true;
+    }
+
+    // Global wildcard matches everything
+    if (WILDCARD.equals(normalizedUser)) {
+      return true;
+    }
+
+    // Pattern wildcard matching (e.g., "idp:*", "idp:user:*")
+    if (normalizedUser.endsWith(NAMESPACE_SEPARATOR + WILDCARD)) {
+      String prefix = normalizedUser.substring(0, normalizedUser.length() - 1);
+      return normalizedRequired.startsWith(prefix);
+    }
+
+    return false;
+  }
+
+  /**
+   * Normalizes a permission string for backward compatibility.
+   *
+   * <p>Converts legacy format permissions (without "idp:" prefix) to the new namespaced format. For
+   * example:
+   *
+   * <ul>
+   *   <li>"organization:create" → "idp:organization:create"
+   *   <li>"user:read" → "idp:user:read"
+   *   <li>"idp:user:read" → "idp:user:read" (unchanged)
+   *   <li>"custom:feature:admin" → "custom:feature:admin" (unchanged, different namespace)
+   * </ul>
+   *
+   * @param permission the permission to normalize
+   * @return normalized permission string
+   */
+  public static String normalize(String permission) {
+    if (permission == null || permission.isEmpty()) {
+      return permission;
+    }
+
+    // Already has a namespace prefix
+    if (permission.startsWith(CONTROL_PLANE_PREFIX)) {
+      return permission;
+    }
+
+    // Global wildcard - no normalization needed
+    if (WILDCARD.equals(permission)) {
+      return permission;
+    }
+
+    // Check if it looks like a legacy control plane permission (resource:action format)
+    // Legacy format: "organization:create", "user:read", etc.
+    // Non-legacy format: "custom:feature:admin" (has its own namespace)
+    if (isLegacyControlPlanePermission(permission)) {
+      // Also normalize underscore to hyphen (admin_user -> admin-user)
+      String normalized = permission.replace("_", "-");
+      return CONTROL_PLANE_PREFIX + normalized;
+    }
+
+    return permission;
+  }
+
+  /**
+   * Checks if the permission appears to be a legacy control plane permission.
+   *
+   * <p>Legacy permissions have format "resource:action" without a namespace prefix. This method
+   * checks against known control plane resource names.
+   *
+   * @param permission the permission to check
+   * @return true if it appears to be a legacy control plane permission
+   */
+  private static boolean isLegacyControlPlanePermission(String permission) {
+    if (!permission.contains(NAMESPACE_SEPARATOR)) {
+      return false;
+    }
+
+    // Known legacy resource prefixes
+    String[] legacyResources = {
+      "organization:",
+      "tenant:",
+      "tenant-invitation:",
+      "authorization-server:",
+      "client:",
+      "user:",
+      "admin_user:", // legacy format used underscore
+      "admin-user:",
+      "permission:",
+      "role:",
+      "authentication-config:",
+      "authentication-policy-config:",
+      "identity-verification-config:",
+      "federation-config:",
+      "security-event-hook-config:",
+      "security-event-hook:",
+      "security-event:",
+      "audit-log:",
+      "authentication-transaction:",
+      "authentication-interaction:",
+      "session:",
+      "system:"
+    };
+
+    for (String resource : legacyResources) {
+      if (permission.startsWith(resource)) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  /**
+   * Checks if any of the user's permissions match the required permission.
+   *
+   * @param userPermissions set of permissions the user has
+   * @param requiredPermission the permission required for the operation
+   * @return true if any user permission covers the required permission
+   */
+  public static boolean matchesAny(Set<String> userPermissions, String requiredPermission) {
+    if (userPermissions == null || userPermissions.isEmpty()) {
+      return false;
+    }
+
+    for (String userPermission : userPermissions) {
+      if (matches(userPermission, requiredPermission)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Checks if user has all required permissions (considering wildcards).
+   *
+   * @param userPermissions set of permissions the user has
+   * @param requiredPermissions set of permissions required for the operation
+   * @return true if user permissions cover all required permissions
+   */
+  public static boolean matchesAll(Set<String> userPermissions, Set<String> requiredPermissions) {
+    if (requiredPermissions == null || requiredPermissions.isEmpty()) {
+      return true;
+    }
+
+    if (userPermissions == null || userPermissions.isEmpty()) {
+      return false;
+    }
+
+    for (String required : requiredPermissions) {
+      if (!matchesAny(userPermissions, required)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /**
+   * Checks if the permission is a wildcard permission.
+   *
+   * @param permission the permission to check
+   * @return true if the permission contains a wildcard
+   */
+  public static boolean isWildcard(String permission) {
+    return permission != null && permission.contains(WILDCARD);
+  }
+
+  /**
+   * Checks if the permission belongs to the control plane namespace.
+   *
+   * @param permission the permission to check
+   * @return true if the permission starts with "idp:"
+   */
+  public static boolean isControlPlanePermission(String permission) {
+    return permission != null
+        && permission.startsWith(CONTROL_PLANE_NAMESPACE + NAMESPACE_SEPARATOR);
+  }
+}

--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/identity/permission/PermissionNamespaceValidator.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/identity/permission/PermissionNamespaceValidator.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2025 Hirokazu Kobayashi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.idp.server.core.openid.identity.permission;
+
+import java.util.Set;
+
+/**
+ * Validates permission names against reserved namespaces.
+ *
+ * <p>Prevents custom permissions from using system-reserved prefixes like {@code idp:}.
+ *
+ * <p>Reserved namespaces:
+ *
+ * <ul>
+ *   <li>{@code idp:} - Control plane permissions (organization, tenant, user management, etc.)
+ * </ul>
+ *
+ * <p>Custom permissions should use their own namespace like:
+ *
+ * <ul>
+ *   <li>{@code myapp:document:read}
+ *   <li>{@code custom:feature:admin}
+ * </ul>
+ */
+public class PermissionNamespaceValidator {
+
+  private static final Set<String> RESERVED_NAMESPACES = Set.of("idp");
+  private static final String NAMESPACE_SEPARATOR = ":";
+
+  private PermissionNamespaceValidator() {}
+
+  /**
+   * Validates that the permission name does not use reserved namespaces.
+   *
+   * @param permissionName the permission name to validate
+   * @throws ReservedNamespaceException if the permission uses a reserved namespace
+   */
+  public static void validate(String permissionName) {
+    if (permissionName == null || permissionName.isEmpty()) {
+      return;
+    }
+
+    String namespace = extractNamespace(permissionName);
+    if (RESERVED_NAMESPACES.contains(namespace)) {
+      throw new ReservedNamespaceException(permissionName, namespace);
+    }
+  }
+
+  /**
+   * Checks if the permission name uses a reserved namespace.
+   *
+   * @param permissionName the permission name to check
+   * @return true if the permission uses a reserved namespace
+   */
+  public static boolean usesReservedNamespace(String permissionName) {
+    if (permissionName == null || permissionName.isEmpty()) {
+      return false;
+    }
+
+    String namespace = extractNamespace(permissionName);
+    return RESERVED_NAMESPACES.contains(namespace);
+  }
+
+  /**
+   * Extracts the namespace from a permission name.
+   *
+   * @param permissionName the permission name (e.g., "idp:user:create")
+   * @return the namespace (e.g., "idp"), or empty string if no namespace
+   */
+  public static String extractNamespace(String permissionName) {
+    if (permissionName == null || !permissionName.contains(NAMESPACE_SEPARATOR)) {
+      return "";
+    }
+
+    int firstSeparator = permissionName.indexOf(NAMESPACE_SEPARATOR);
+    return permissionName.substring(0, firstSeparator);
+  }
+
+  /**
+   * Returns the set of reserved namespaces.
+   *
+   * @return immutable set of reserved namespace names
+   */
+  public static Set<String> reservedNamespaces() {
+    return RESERVED_NAMESPACES;
+  }
+}

--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/identity/permission/ReservedNamespaceException.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/identity/permission/ReservedNamespaceException.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2025 Hirokazu Kobayashi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.idp.server.core.openid.identity.permission;
+
+/**
+ * Thrown when attempting to create a permission with a reserved namespace.
+ *
+ * <p>Reserved namespaces like {@code idp:} are controlled by the system and cannot be used for
+ * custom permissions.
+ */
+public class ReservedNamespaceException extends RuntimeException {
+
+  private final String permissionName;
+  private final String namespace;
+
+  public ReservedNamespaceException(String permissionName, String namespace) {
+    super(
+        String.format(
+            "Permission name '%s' uses reserved namespace '%s'. "
+                + "Custom permissions cannot use reserved namespaces.",
+            permissionName, namespace));
+    this.permissionName = permissionName;
+    this.namespace = namespace;
+  }
+
+  public String permissionName() {
+    return permissionName;
+  }
+
+  public String namespace() {
+    return namespace;
+  }
+}

--- a/libs/idp-server-core/src/test/java/org/idp/server/core/openid/identity/permission/PermissionMatcherTest.java
+++ b/libs/idp-server-core/src/test/java/org/idp/server/core/openid/identity/permission/PermissionMatcherTest.java
@@ -1,0 +1,293 @@
+/*
+ * Copyright 2025 Hirokazu Kobayashi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.idp.server.core.openid.identity.permission;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.Set;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class PermissionMatcherTest {
+
+  @Nested
+  @DisplayName("matches() - Single permission matching")
+  class MatchesTests {
+
+    @Test
+    @DisplayName("Should match exact permission")
+    void shouldMatchExact() {
+      assertTrue(PermissionMatcher.matches("idp:user:create", "idp:user:create"));
+      assertTrue(PermissionMatcher.matches("idp:organization:read", "idp:organization:read"));
+    }
+
+    @Test
+    @DisplayName("Should not match different permission")
+    void shouldNotMatchDifferent() {
+      assertFalse(PermissionMatcher.matches("idp:user:create", "idp:user:delete"));
+      assertFalse(PermissionMatcher.matches("idp:user:read", "idp:organization:read"));
+    }
+
+    @Test
+    @DisplayName("Global wildcard should match everything")
+    void globalWildcardShouldMatchEverything() {
+      assertTrue(PermissionMatcher.matches("*", "idp:user:create"));
+      assertTrue(PermissionMatcher.matches("*", "idp:organization:delete"));
+      assertTrue(PermissionMatcher.matches("*", "custom:feature:admin"));
+      assertTrue(PermissionMatcher.matches("*", "anything"));
+    }
+
+    @Test
+    @DisplayName("Namespace wildcard should match all permissions in namespace")
+    void namespaceWildcardShouldMatchNamespace() {
+      assertTrue(PermissionMatcher.matches("idp:*", "idp:user:create"));
+      assertTrue(PermissionMatcher.matches("idp:*", "idp:organization:delete"));
+      assertTrue(PermissionMatcher.matches("idp:*", "idp:tenant:read"));
+      assertTrue(PermissionMatcher.matches("idp:*", "idp:system:write"));
+    }
+
+    @Test
+    @DisplayName("Namespace wildcard should not match other namespaces")
+    void namespaceWildcardShouldNotMatchOther() {
+      assertFalse(PermissionMatcher.matches("idp:*", "custom:feature:admin"));
+      assertFalse(PermissionMatcher.matches("idp:*", "myapp:document:read"));
+    }
+
+    @Test
+    @DisplayName("Resource wildcard should match all actions for resource")
+    void resourceWildcardShouldMatchResource() {
+      assertTrue(PermissionMatcher.matches("idp:user:*", "idp:user:create"));
+      assertTrue(PermissionMatcher.matches("idp:user:*", "idp:user:read"));
+      assertTrue(PermissionMatcher.matches("idp:user:*", "idp:user:update"));
+      assertTrue(PermissionMatcher.matches("idp:user:*", "idp:user:delete"));
+    }
+
+    @Test
+    @DisplayName("Resource wildcard should not match other resources")
+    void resourceWildcardShouldNotMatchOtherResource() {
+      assertFalse(PermissionMatcher.matches("idp:user:*", "idp:organization:create"));
+      assertFalse(PermissionMatcher.matches("idp:user:*", "idp:tenant:read"));
+    }
+
+    @Test
+    @DisplayName("Should handle null values")
+    void shouldHandleNull() {
+      assertFalse(PermissionMatcher.matches(null, "idp:user:create"));
+      assertFalse(PermissionMatcher.matches("idp:user:create", null));
+      assertFalse(PermissionMatcher.matches(null, null));
+    }
+  }
+
+  @Nested
+  @DisplayName("matchesAny() - Multiple user permissions")
+  class MatchesAnyTests {
+
+    @Test
+    @DisplayName("Should match when one permission matches exactly")
+    void shouldMatchWhenOneMatches() {
+      Set<String> userPermissions = Set.of("idp:user:read", "idp:user:create");
+      assertTrue(PermissionMatcher.matchesAny(userPermissions, "idp:user:create"));
+    }
+
+    @Test
+    @DisplayName("Should match when wildcard covers required permission")
+    void shouldMatchWithWildcard() {
+      Set<String> userPermissions = Set.of("idp:user:*");
+      assertTrue(PermissionMatcher.matchesAny(userPermissions, "idp:user:create"));
+      assertTrue(PermissionMatcher.matchesAny(userPermissions, "idp:user:delete"));
+    }
+
+    @Test
+    @DisplayName("Should match when global wildcard is present")
+    void shouldMatchWithGlobalWildcard() {
+      Set<String> userPermissions = Set.of("*");
+      assertTrue(PermissionMatcher.matchesAny(userPermissions, "idp:user:create"));
+      assertTrue(PermissionMatcher.matchesAny(userPermissions, "custom:feature:admin"));
+    }
+
+    @Test
+    @DisplayName("Should not match when no permission covers required")
+    void shouldNotMatchWhenNone() {
+      Set<String> userPermissions = Set.of("idp:user:read", "idp:organization:read");
+      assertFalse(PermissionMatcher.matchesAny(userPermissions, "idp:user:create"));
+    }
+
+    @Test
+    @DisplayName("Should handle empty user permissions")
+    void shouldHandleEmptyPermissions() {
+      assertFalse(PermissionMatcher.matchesAny(Set.of(), "idp:user:create"));
+      assertFalse(PermissionMatcher.matchesAny(null, "idp:user:create"));
+    }
+  }
+
+  @Nested
+  @DisplayName("matchesAll() - Multiple required permissions")
+  class MatchesAllTests {
+
+    @Test
+    @DisplayName("Should match when all required permissions are covered")
+    void shouldMatchAll() {
+      Set<String> userPermissions = Set.of("idp:user:create", "idp:user:read");
+      Set<String> required = Set.of("idp:user:create", "idp:user:read");
+      assertTrue(PermissionMatcher.matchesAll(userPermissions, required));
+    }
+
+    @Test
+    @DisplayName("Should match when wildcard covers all required permissions")
+    void shouldMatchAllWithWildcard() {
+      Set<String> userPermissions = Set.of("idp:user:*");
+      Set<String> required = Set.of("idp:user:create", "idp:user:read", "idp:user:delete");
+      assertTrue(PermissionMatcher.matchesAll(userPermissions, required));
+    }
+
+    @Test
+    @DisplayName("Should match when global wildcard is present")
+    void shouldMatchAllWithGlobalWildcard() {
+      Set<String> userPermissions = Set.of("*");
+      Set<String> required =
+          Set.of("idp:user:create", "idp:organization:delete", "custom:feature:admin");
+      assertTrue(PermissionMatcher.matchesAll(userPermissions, required));
+    }
+
+    @Test
+    @DisplayName("Should not match when missing required permission")
+    void shouldNotMatchWhenMissing() {
+      Set<String> userPermissions = Set.of("idp:user:read");
+      Set<String> required = Set.of("idp:user:create", "idp:user:read");
+      assertFalse(PermissionMatcher.matchesAll(userPermissions, required));
+    }
+
+    @Test
+    @DisplayName("Should match when required is empty")
+    void shouldMatchEmptyRequired() {
+      Set<String> userPermissions = Set.of("idp:user:read");
+      assertTrue(PermissionMatcher.matchesAll(userPermissions, Set.of()));
+      assertTrue(PermissionMatcher.matchesAll(userPermissions, null));
+    }
+
+    @Test
+    @DisplayName("Should not match when user has no permissions")
+    void shouldNotMatchEmptyUser() {
+      Set<String> required = Set.of("idp:user:create");
+      assertFalse(PermissionMatcher.matchesAll(Set.of(), required));
+      assertFalse(PermissionMatcher.matchesAll(null, required));
+    }
+
+    @Test
+    @DisplayName("Should handle mixed wildcards and exact permissions")
+    void shouldHandleMixedPermissions() {
+      Set<String> userPermissions = Set.of("idp:user:*", "idp:organization:read");
+      Set<String> required = Set.of("idp:user:create", "idp:user:delete", "idp:organization:read");
+      assertTrue(PermissionMatcher.matchesAll(userPermissions, required));
+    }
+  }
+
+  @Nested
+  @DisplayName("Utility methods")
+  class UtilityTests {
+
+    @Test
+    @DisplayName("isWildcard should detect wildcard permissions")
+    void isWildcardShouldDetect() {
+      assertTrue(PermissionMatcher.isWildcard("*"));
+      assertTrue(PermissionMatcher.isWildcard("idp:*"));
+      assertTrue(PermissionMatcher.isWildcard("idp:user:*"));
+      assertFalse(PermissionMatcher.isWildcard("idp:user:create"));
+      assertFalse(PermissionMatcher.isWildcard(null));
+    }
+
+    @Test
+    @DisplayName("isControlPlanePermission should detect idp namespace")
+    void isControlPlanePermissionShouldDetect() {
+      assertTrue(PermissionMatcher.isControlPlanePermission("idp:user:create"));
+      assertTrue(PermissionMatcher.isControlPlanePermission("idp:organization:read"));
+      assertFalse(PermissionMatcher.isControlPlanePermission("custom:feature:admin"));
+      assertFalse(PermissionMatcher.isControlPlanePermission(null));
+    }
+  }
+
+  @Nested
+  @DisplayName("Backward compatibility - Legacy format support")
+  class BackwardCompatibilityTests {
+
+    @Test
+    @DisplayName("Should normalize legacy permission to new format")
+    void shouldNormalizeLegacyPermission() {
+      assertEquals("idp:organization:create", PermissionMatcher.normalize("organization:create"));
+      assertEquals("idp:user:read", PermissionMatcher.normalize("user:read"));
+      assertEquals("idp:tenant:delete", PermissionMatcher.normalize("tenant:delete"));
+      // admin_user is normalized to admin-user (underscore to hyphen)
+      assertEquals("idp:admin-user:create", PermissionMatcher.normalize("admin_user:create"));
+    }
+
+    @Test
+    @DisplayName("Should not normalize already namespaced permission")
+    void shouldNotNormalizeNamespacedPermission() {
+      assertEquals("idp:user:create", PermissionMatcher.normalize("idp:user:create"));
+      assertEquals("custom:feature:admin", PermissionMatcher.normalize("custom:feature:admin"));
+    }
+
+    @Test
+    @DisplayName("Legacy user permission should match new format required permission")
+    void legacyUserShouldMatchNewRequired() {
+      // User has legacy format, API requires new format
+      assertTrue(PermissionMatcher.matches("organization:create", "idp:organization:create"));
+      assertTrue(PermissionMatcher.matches("user:read", "idp:user:read"));
+    }
+
+    @Test
+    @DisplayName("New format user permission should match legacy required permission")
+    void newUserShouldMatchLegacyRequired() {
+      // User has new format, required permission is legacy (edge case)
+      assertTrue(PermissionMatcher.matches("idp:organization:create", "organization:create"));
+      assertTrue(PermissionMatcher.matches("idp:user:read", "user:read"));
+    }
+
+    @Test
+    @DisplayName("Wildcard should match legacy format permissions")
+    void wildcardShouldMatchLegacy() {
+      assertTrue(PermissionMatcher.matches("idp:*", "organization:create"));
+      assertTrue(PermissionMatcher.matches("idp:*", "user:read"));
+      assertTrue(PermissionMatcher.matches("idp:user:*", "user:create"));
+    }
+
+    @Test
+    @DisplayName("Legacy wildcard-like permission should work")
+    void legacyWildcardShouldWork() {
+      // If someone stored "user:*" as legacy format
+      assertTrue(PermissionMatcher.matches("user:*", "idp:user:create"));
+      assertTrue(PermissionMatcher.matches("user:*", "user:read"));
+    }
+
+    @Test
+    @DisplayName("matchesAll should work with mixed legacy and new format")
+    void matchesAllWithMixedFormats() {
+      Set<String> userPermissions = Set.of("organization:create", "idp:user:read");
+      Set<String> required = Set.of("idp:organization:create", "user:read");
+      assertTrue(PermissionMatcher.matchesAll(userPermissions, required));
+    }
+
+    @Test
+    @DisplayName("Should not normalize custom namespace permissions")
+    void shouldNotNormalizeCustomNamespace() {
+      // Custom permissions should remain unchanged
+      assertEquals("myapp:document:read", PermissionMatcher.normalize("myapp:document:read"));
+      assertFalse(PermissionMatcher.matches("idp:*", "myapp:document:read"));
+    }
+  }
+}

--- a/libs/idp-server-core/src/test/java/org/idp/server/core/openid/identity/permission/PermissionNamespaceValidatorTest.java
+++ b/libs/idp-server-core/src/test/java/org/idp/server/core/openid/identity/permission/PermissionNamespaceValidatorTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2025 Hirokazu Kobayashi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.idp.server.core.openid.identity.permission;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class PermissionNamespaceValidatorTest {
+
+  @Nested
+  @DisplayName("validate() - Permission name validation")
+  class ValidateTests {
+
+    @Test
+    @DisplayName("Should throw exception for reserved namespace 'idp'")
+    void shouldThrowForReservedNamespace() {
+      ReservedNamespaceException ex =
+          assertThrows(
+              ReservedNamespaceException.class,
+              () -> PermissionNamespaceValidator.validate("idp:custom:action"));
+
+      assertEquals("idp:custom:action", ex.permissionName());
+      assertEquals("idp", ex.namespace());
+    }
+
+    @Test
+    @DisplayName("Should not throw for custom namespace")
+    void shouldNotThrowForCustomNamespace() {
+      assertDoesNotThrow(() -> PermissionNamespaceValidator.validate("myapp:document:read"));
+      assertDoesNotThrow(() -> PermissionNamespaceValidator.validate("custom:feature:admin"));
+      assertDoesNotThrow(() -> PermissionNamespaceValidator.validate("org:project:manage"));
+    }
+
+    @Test
+    @DisplayName("Should not throw for permission without namespace")
+    void shouldNotThrowWithoutNamespace() {
+      assertDoesNotThrow(() -> PermissionNamespaceValidator.validate("simplePermission"));
+    }
+
+    @Test
+    @DisplayName("Should handle null and empty values")
+    void shouldHandleNullAndEmpty() {
+      assertDoesNotThrow(() -> PermissionNamespaceValidator.validate(null));
+      assertDoesNotThrow(() -> PermissionNamespaceValidator.validate(""));
+    }
+  }
+
+  @Nested
+  @DisplayName("usesReservedNamespace() - Check reserved namespace usage")
+  class UsesReservedNamespaceTests {
+
+    @Test
+    @DisplayName("Should return true for reserved namespace")
+    void shouldReturnTrueForReserved() {
+      assertTrue(PermissionNamespaceValidator.usesReservedNamespace("idp:user:create"));
+      assertTrue(PermissionNamespaceValidator.usesReservedNamespace("idp:organization:read"));
+    }
+
+    @Test
+    @DisplayName("Should return false for custom namespace")
+    void shouldReturnFalseForCustom() {
+      assertFalse(PermissionNamespaceValidator.usesReservedNamespace("custom:feature:admin"));
+      assertFalse(PermissionNamespaceValidator.usesReservedNamespace("myapp:document:read"));
+    }
+
+    @Test
+    @DisplayName("Should return false for null and empty")
+    void shouldReturnFalseForNullAndEmpty() {
+      assertFalse(PermissionNamespaceValidator.usesReservedNamespace(null));
+      assertFalse(PermissionNamespaceValidator.usesReservedNamespace(""));
+    }
+  }
+
+  @Nested
+  @DisplayName("extractNamespace() - Extract namespace from permission name")
+  class ExtractNamespaceTests {
+
+    @Test
+    @DisplayName("Should extract namespace correctly")
+    void shouldExtractNamespace() {
+      assertEquals("idp", PermissionNamespaceValidator.extractNamespace("idp:user:create"));
+      assertEquals("custom", PermissionNamespaceValidator.extractNamespace("custom:feature:admin"));
+      assertEquals("myapp", PermissionNamespaceValidator.extractNamespace("myapp:document:read"));
+    }
+
+    @Test
+    @DisplayName("Should return empty for permission without namespace")
+    void shouldReturnEmptyWithoutNamespace() {
+      assertEquals("", PermissionNamespaceValidator.extractNamespace("simplePermission"));
+      assertEquals("", PermissionNamespaceValidator.extractNamespace(null));
+    }
+  }
+
+  @Nested
+  @DisplayName("reservedNamespaces() - Get reserved namespaces")
+  class ReservedNamespacesTests {
+
+    @Test
+    @DisplayName("Should contain 'idp' namespace")
+    void shouldContainIdpNamespace() {
+      assertTrue(PermissionNamespaceValidator.reservedNamespaces().contains("idp"));
+    }
+  }
+}

--- a/libs/idp-server-database/mysql/_V0_9_27__permission_namespace_migration.mysql.sql
+++ b/libs/idp-server-database/mysql/_V0_9_27__permission_namespace_migration.mysql.sql
@@ -1,0 +1,66 @@
+-- Migration: Permission Namespace and Wildcard Support
+-- Version: 0.9.27
+-- Description: Adds 'idp:' namespace prefix to control plane permissions and
+--              introduces wildcard permission (idp:*) for administrator role.
+--
+-- This migration:
+-- 1. Updates existing permission names to use 'idp:' prefix
+-- 2. Adds wildcard permission 'idp:*' for each tenant
+-- 3. Updates administrator role to use wildcard permission instead of individual permissions
+--
+-- Backward compatibility is maintained at the application level through PermissionMatcher.normalize()
+
+-- Step 1: Update existing permission names to use 'idp:' prefix
+-- Only update permissions that don't already have a namespace prefix
+UPDATE permission
+SET name = CONCAT('idp:', name),
+    updated_at = NOW()
+WHERE name NOT LIKE '%:%'
+   OR (name LIKE '%:%' AND name NOT LIKE 'idp:%' AND name NOT LIKE 'custom:%');
+
+-- Handle legacy admin_user permissions (convert underscore to hyphen)
+UPDATE permission
+SET name = REPLACE(name, 'idp:admin_user:', 'idp:admin-user:'),
+    updated_at = NOW()
+WHERE name LIKE 'idp:admin_user:%';
+
+-- Step 2: Add wildcard permission 'idp:*' for each tenant that doesn't have it
+INSERT INTO permission (id, tenant_id, name, description, created_at, updated_at)
+SELECT
+    UUID(),
+    t.id,
+    'idp:*',
+    'All control plane permissions',
+    NOW(),
+    NOW()
+FROM tenant t
+WHERE NOT EXISTS (
+    SELECT 1 FROM permission p
+    WHERE p.tenant_id = t.id AND p.name = 'idp:*'
+);
+
+-- Step 3: Update administrator role to use wildcard permission
+-- First, find the wildcard permission ID and administrator role ID for each tenant
+-- Then, add the wildcard permission to the administrator role if not already present
+INSERT INTO role_permission (id, tenant_id, role_id, permission_id, created_at)
+SELECT
+    UUID(),
+    r.tenant_id,
+    r.id,
+    p.id,
+    NOW()
+FROM role r
+JOIN permission p ON r.tenant_id = p.tenant_id AND p.name = 'idp:*'
+WHERE r.name = 'administrator'
+  AND NOT EXISTS (
+      SELECT 1 FROM role_permission rp
+      WHERE rp.role_id = r.id AND rp.permission_id = p.id
+  );
+
+-- Step 4: Optionally remove individual permissions from administrator role
+-- (keeping them won't hurt since wildcard covers everything, but cleanup is cleaner)
+-- Uncomment below if you want to remove individual permissions:
+--
+-- DELETE FROM role_permission
+-- WHERE role_id IN (SELECT id FROM role WHERE name = 'administrator')
+--   AND permission_id IN (SELECT id FROM permission WHERE name != 'idp:*');

--- a/libs/idp-server-database/postgresql/_V0_9_27__permission_namespace_migration.sql
+++ b/libs/idp-server-database/postgresql/_V0_9_27__permission_namespace_migration.sql
@@ -1,0 +1,66 @@
+-- Migration: Permission Namespace and Wildcard Support
+-- Version: 0.9.27
+-- Description: Adds 'idp:' namespace prefix to control plane permissions and
+--              introduces wildcard permission (idp:*) for administrator role.
+--
+-- This migration:
+-- 1. Updates existing permission names to use 'idp:' prefix
+-- 2. Adds wildcard permission 'idp:*' for each tenant
+-- 3. Updates administrator role to use wildcard permission instead of individual permissions
+--
+-- Backward compatibility is maintained at the application level through PermissionMatcher.normalize()
+
+-- Step 1: Update existing permission names to use 'idp:' prefix
+-- Only update permissions that don't already have a namespace prefix
+UPDATE permission
+SET name = 'idp:' || name,
+    updated_at = NOW()
+WHERE name NOT LIKE '%:%'
+   OR (name LIKE '%:%' AND name NOT LIKE 'idp:%' AND name NOT LIKE 'custom:%');
+
+-- Handle legacy admin_user permissions (convert underscore to hyphen)
+UPDATE permission
+SET name = REPLACE(name, 'idp:admin_user:', 'idp:admin-user:'),
+    updated_at = NOW()
+WHERE name LIKE 'idp:admin_user:%';
+
+-- Step 2: Add wildcard permission 'idp:*' for each tenant that doesn't have it
+INSERT INTO permission (id, tenant_id, name, description, created_at, updated_at)
+SELECT
+    gen_random_uuid(),
+    t.id,
+    'idp:*',
+    'All control plane permissions',
+    NOW(),
+    NOW()
+FROM tenant t
+WHERE NOT EXISTS (
+    SELECT 1 FROM permission p
+    WHERE p.tenant_id = t.id AND p.name = 'idp:*'
+);
+
+-- Step 3: Update administrator role to use wildcard permission
+-- First, find the wildcard permission ID and administrator role ID for each tenant
+-- Then, add the wildcard permission to the administrator role if not already present
+INSERT INTO role_permission (id, tenant_id, role_id, permission_id, created_at)
+SELECT
+    gen_random_uuid(),
+    r.tenant_id,
+    r.id,
+    p.id,
+    NOW()
+FROM role r
+JOIN permission p ON r.tenant_id = p.tenant_id AND p.name = 'idp:*'
+WHERE r.name = 'administrator'
+  AND NOT EXISTS (
+      SELECT 1 FROM role_permission rp
+      WHERE rp.role_id = r.id AND rp.permission_id = p.id
+  );
+
+-- Step 4: Optionally remove individual permissions from administrator role
+-- (keeping them won't hurt since wildcard covers everything, but cleanup is cleaner)
+-- Uncomment below if you want to remove individual permissions:
+--
+-- DELETE FROM role_permission
+-- WHERE role_id IN (SELECT id FROM role WHERE name = 'administrator')
+--   AND permission_id IN (SELECT id FROM permission WHERE name != 'idp:*');


### PR DESCRIPTION
## 概要
- AWS IAM形式のワイルドカード権限マッチング (`*`, `idp:*`, `idp:user:*`) を追加
- 全コントロールプレーン権限に `idp:` 名前空間プレフィックスを追加
- ADMINISTRATORロールが `idp:*` ワイルドカードを使用してデッドロック問題を解決 (#1075)
- `PermissionMatcher.normalize()` による後方互換性維持 - DBマイグレーション不要

## 変更内容
- **PermissionMatcher**: ワイルドカードマッチングとレガシー形式の正規化
- **PermissionNamespaceValidator**: 予約済み `idp:` 名前空間の使用を防止
- **DefaultAdminPermission**: 全権限が `idp:` プレフィックスを使用
- **DefaultAdminRole**: ADMINISTRATORが60以上の個別権限ではなくワイルドカードを使用
- **マイグレーションSQL**: オプションのDBクリーンアップスクリプト（アンダースコアで無効化）

## テスト
- [x] PermissionMatcherTest - ワイルドカードマッチングと後方互換性
- [x] PermissionNamespaceValidatorTest - 予約名前空間の検証
- [x] E2Eテスト - オールグリーン

🤖 Generated with [Claude Code](https://claude.com/claude-code)