### PR TITLE
docs: MFAと認証ポリシードキュメントを実装に合わせて修正

### DIFF
--- a/documentation/docs/content_05_how-to/phase-2-security/01-mfa-setup.md
+++ b/documentation/docs/content_05_how-to/phase-2-security/01-mfa-setup.md
@@ -5,19 +5,20 @@
 **SMS OTPによるMFA（多要素認証）** を設定し、パスワード認証に追加することが目標です。
 
 ### 所要時間
-⏱️ **約15分**
+⏱️ **約20分**
 
 ### 前提条件
 - [パスワード認証](../phase-1-foundation/05-user-registration.md)が設定済み
 - 管理者トークンを取得済み
 - 組織ID（organization-id）を取得済み
+- 外部SMS送信サービス（モックまたは実サービス）が稼働中
 
 ### Management API URL
 
 **組織レベルAPI**（このドキュメントでの表記）:
 ```
 POST /v1/management/organizations/{organization-id}/tenants/{tenant-id}/authentication-configurations
-PUT  /v1/management/organizations/{organization-id}/tenants/{tenant-id}/authentication-policies/{policy-id}
+POST /v1/management/organizations/{organization-id}/tenants/{tenant-id}/authentication-policies
 ```
 
 **注意**: システムレベルAPIとの違い
@@ -48,19 +49,117 @@ PUT  /v1/management/organizations/{organization-id}/tenants/{tenant-id}/authenti
 
 ## Step 1: SMS OTP認証設定を作成
 
-### Management APIで設定
+### 外部SMS送信サービスとの連携設定
+
+SMS認証では、外部APIを呼び出してOTPを送信します。このステップでは、外部サービスとの連携を設定します。
 
 ```bash
+SMS_AUTH_CONFIG_ID=$(uuidgen)
+
 curl -X POST "http://localhost:8080/v1/management/organizations/${ORGANIZATION_ID}/tenants/${TENANT_ID}/authentication-configurations" \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer ${ADMIN_TOKEN}" \
-  -d '{
-    "type": "sms",
-    "enabled": true,
-    "otp_length": 6,
-    "otp_expiry_seconds": 300,
-    "sms_template": "Your verification code is: {otp}. Valid for 5 minutes."
-  }'
+  -d "{
+    \"id\": \"${SMS_AUTH_CONFIG_ID}\",
+    \"type\": \"sms\",
+    \"attributes\": {},
+    \"metadata\": {
+      \"type\": \"external\",
+      \"description\": \"SMS authentication for MFA\",
+      \"transaction_id_param\": \"transaction_id\",
+      \"verification_code_param\": \"verification_code\",
+      \"retry_count_limitation\": 5,
+      \"expire_seconds\": 300
+    },
+    \"interactions\": {
+      \"sms-authentication-challenge\": {
+        \"request\": {
+          \"schema\": {
+            \"type\": \"object\",
+            \"properties\": {
+              \"phone_number\": { \"type\": \"string\" },
+              \"template\": { \"type\": \"string\" }
+            }
+          }
+        },
+        \"pre_hook\": {},
+        \"execution\": {
+          \"function\": \"http_request\",
+          \"http_request\": {
+            \"url\": \"http://host.docker.internal:4000/sms-authentication-challenge\",
+            \"method\": \"POST\",
+            \"oauth_authorization\": {
+              \"type\": \"password\",
+              \"token_endpoint\": \"http://host.docker.internal:4000/token\",
+              \"client_id\": \"your-client-id\",
+              \"username\": \"username\",
+              \"password\": \"password\",
+              \"scope\": \"application\"
+            },
+            \"header_mapping_rules\": [
+              { \"static_value\": \"application/json\", \"to\": \"Content-Type\" }
+            ],
+            \"body_mapping_rules\": [
+              { \"from\": \"$.request_body\", \"to\": \"*\" }
+            ]
+          },
+          \"http_request_store\": {
+            \"key\": \"sms-authentication-challenge\",
+            \"interaction_mapping_rules\": [
+              { \"from\": \"$.response_body.transaction_id\", \"to\": \"transaction_id\" }
+            ]
+          }
+        },
+        \"post_hook\": {},
+        \"response\": {
+          \"body_mapping_rules\": [
+            { \"from\": \"$.execution_http_request.response_body\", \"to\": \"*\" }
+          ]
+        }
+      },
+      \"sms-authentication\": {
+        \"request\": {
+          \"schema\": {
+            \"type\": \"object\",
+            \"properties\": {
+              \"verification_code\": { \"type\": \"string\" }
+            }
+          }
+        },
+        \"pre_hook\": {},
+        \"execution\": {
+          \"function\": \"http_request\",
+          \"previous_interaction\": {
+            \"key\": \"sms-authentication-challenge\"
+          },
+          \"http_request\": {
+            \"url\": \"http://host.docker.internal:4000/sms-authentication\",
+            \"method\": \"POST\",
+            \"oauth_authorization\": {
+              \"type\": \"password\",
+              \"token_endpoint\": \"http://host.docker.internal:4000/token\",
+              \"client_id\": \"your-client-id\",
+              \"username\": \"username\",
+              \"password\": \"password\",
+              \"scope\": \"application\"
+            },
+            \"header_mapping_rules\": [
+              { \"static_value\": \"application/json\", \"to\": \"Content-Type\" }
+            ],
+            \"body_mapping_rules\": [
+              { \"from\": \"$.request_body\", \"to\": \"*\" }
+            ]
+          }
+        },
+        \"post_hook\": {},
+        \"response\": {
+          \"body_mapping_rules\": [
+            { \"from\": \"$.execution_http_request.response_body\", \"to\": \"*\" }
+          ]
+        }
+      }
+    }
+  }"
 ```
 
 ### レスポンス
@@ -69,85 +168,132 @@ curl -X POST "http://localhost:8080/v1/management/organizations/${ORGANIZATION_I
 {
   "dry_run": false,
   "result": {
-    "id": "660e8400-e29b-41d4-a716-446655440001",
+    "id": "sms-auth-config-id",
     "type": "sms",
     "enabled": true,
-    "otp_length": 6,
-    "otp_expiry_seconds": 300,
-    "sms_template": "Your verification code is: {otp}. Valid for 5 minutes."
+    "attributes": {},
+    "metadata": {
+      "type": "external",
+      "description": "SMS authentication for MFA",
+      "expire_seconds": 300,
+      "retry_count_limitation": 5
+    },
+    "interactions": {
+      "sms-authentication-challenge": { ... },
+      "sms-authentication": { ... }
+    }
   }
 }
 ```
 
 **設定内容**:
-- ✅ OTP（ワンタイムパスワード）6桁
-- ✅ 有効期限5分（300秒）
-- ✅ SMSテンプレート定義
+- ✅ 外部SMS送信API（`http://host.docker.internal:4000`）との連携
+- ✅ OTP有効期限5分（300秒）
+- ✅ リトライ回数上限5回
+- ✅ チャレンジ（SMS送信）と認証（OTP検証）の2ステップ
+
+**重要ポイント**:
+- `interactions`: 認証フローの各ステップを定義
+  - `sms-authentication-challenge`: SMS送信（チャレンジ）
+  - `sms-authentication`: OTP検証
+- `http_request`: 外部APIへのHTTPリクエスト設定
+- `http_request_store`: 外部APIレスポンスの保存（transaction_id等）
 
 ---
 
 ## Step 2: 認証ポリシーをMFA対応に更新
 
-パスワード認証**と**SMS OTP認証の**両方**を要求する設定に変更します。
+新規登録とログインの両方で、MFA（SMS OTP）を要求する設定を作成します。
 
 ```bash
-curl -X PUT "http://localhost:8080/v1/management/organizations/${ORGANIZATION_ID}/tenants/${TENANT_ID}/authentication-policies/oauth" \
+AUTH_POLICY_ID=$(uuidgen)
+
+curl -X POST "http://localhost:8080/v1/management/organizations/${ORGANIZATION_ID}/tenants/${TENANT_ID}/authentication-policies" \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer ${ADMIN_TOKEN}" \
-  -d '{
-    "flow": "oauth",
-    "available_methods": ["password", "sms"],
-    "success_conditions": {
-      "any_of": [
-        [
-          {
-            "path": "$.password-authentication.success_count",
-            "type": "integer",
-            "operation": "gte",
-            "value": 1
-          },
-          {
-            "path": "$.sms-authentication.success_count",
-            "type": "integer",
-            "operation": "gte",
-            "value": 1
-          }
-        ]
-      ]
-    }
-  }'
+  -d "{
+    \"id\": \"${AUTH_POLICY_ID}\",
+    \"flow\": \"oauth\",
+    \"enabled\": true,
+    \"policies\": [
+      {
+        \"description\": \"mfa_required_for_registration_and_login\",
+        \"priority\": 10,
+        \"conditions\": {
+          \"scopes\": [\"openid\"]
+        },
+        \"available_methods\": [\"password\", \"initial-registration\", \"sms\"],
+        \"success_conditions\": {
+          \"any_of\": [
+            [
+              {
+                \"path\": \"$.password-authentication.success_count\",
+                \"type\": \"integer\",
+                \"operation\": \"gte\",
+                \"value\": 1
+              },
+              {
+                \"path\": \"$.sms-authentication.success_count\",
+                \"type\": \"integer\",
+                \"operation\": \"gte\",
+                \"value\": 1
+              }
+            ],
+            [
+              {
+                \"path\": \"$.initial-registration.success_count\",
+                \"type\": \"integer\",
+                \"operation\": \"gte\",
+                \"value\": 1
+              },
+              {
+                \"path\": \"$.sms-authentication.success_count\",
+                \"type\": \"integer\",
+                \"operation\": \"gte\",
+                \"value\": 1
+              }
+            ]
+          ]
+        }
+      }
+    ]
+  }"
 ```
 
-**重要な変更点**:
-- `available_methods`: `["password"]` → `["password", "sms"]` - 両方許可
-- `any_of`の内側配列に複数条件 = **AND条件**（両方成功が必要 = MFA）
-- `any_of`の外側配列に複数グループ = **OR条件**（どれか1つでOK）
+**重要な構造**:
+- `policies`: ポリシーの配列（複数のポリシーを優先度順に定義可能）
+- `priority`: ポリシーの優先度（数値が大きいほど優先）
+- `conditions`: ポリシー適用条件（スコープ、クライアントID、ACR値等）
+- `available_methods`: 利用可能な認証方式
+  - `password`: パスワード認証（ログイン時）
+  - `initial-registration`: 新規ユーザー登録
+  - `sms`: SMS OTP認証（2要素目）
+- `success_conditions.any_of`: 認証成功条件
+  - **内側配列の複数条件 = AND条件**（すべて満たす必要）
+  - **外側配列の複数グループ = OR条件**（いずれか1つでOK）
+
+**このポリシーの意味**:
+```
+[(password-authentication AND sms-authentication) >= 1]
+  OR
+[(initial-registration AND sms-authentication) >= 1]
+
+→ ログイン時: パスワード認証 + SMS認証（MFA）
+→ 登録時: ユーザー登録 + SMS認証（MFA）
+```
+
+**重要なポイント**:
+- ✅ ログインでも登録でも、SMS認証（2要素目）が必須
+- ✅ `any_of` の外側配列で2パターンを定義（ログイン OR 登録）
+- ✅ 各パターン内でAND条件（1要素目 AND 2要素目）
 
 ---
 
-## Step 3: ユーザーに電話番号を設定
+## Step 3: 新規ユーザー登録時のMFAフロー
 
-SMS OTPを送信するには、ユーザーに電話番号が必要です。
+新規ユーザー登録時も、MFAポリシーが適用されます。登録フローでは、`initial-registration`（1要素目）の後に、SMS OTP認証（2要素目）が必要です。
 
-```bash
-curl -X PUT "http://localhost:8080/v1/management/organizations/${ORGANIZATION_ID}/tenants/${TENANT_ID}/users/${USER_ID}" \
-  -H "Content-Type: application/json" \
-  -H "Authorization: Bearer ${ADMIN_TOKEN}" \
-  -d '{
-    "phone_number": "+81-90-1234-5678",
-    "phone_number_verified": true
-  }'
-```
-
-**電話番号形式**:
-- ✅ E.164形式推奨: `+81-90-1234-5678`
-- ✅ ハイフンあり・なし両対応: `+819012345678`
-
----
-
-## Step 4: MFA動作確認
-
-### 4.1 Authorization Request（通常通り）
+### 3.1 Authorization Request（認可開始）
 
 ```bash
 curl -v "http://localhost:8080/${TENANT_ID}/v1/authorizations?\
@@ -155,219 +301,419 @@ response_type=code&\
 client_id=${CLIENT_ID}&\
 redirect_uri=${REDIRECT_URI}&\
 scope=openid+profile&\
-state=random-state"
-```
-
-### 4.2 第1要素: パスワード認証
-
-```bash
-curl -X POST "http://localhost:8080/${TENANT_ID}/v1/authentications/${AUTH_TRANSACTION_ID}" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "username": "test-user@example.com",
-    "password": "Test1234"
-  }'
+state=random-state-registration"
 ```
 
 **レスポンス**:
-```json
-{
-  "status": "ADDITIONAL_AUTHENTICATION_REQUIRED",
-  "next_authentication_methods": ["sms"],
-  "message": "Please complete SMS OTP authentication"
-}
+```
+HTTP/1.1 302 Found
+Location: http://localhost:8080/authorize?id=auth-transaction-id-xxxxx
 ```
 
-**重要**: `status: "ADDITIONAL_AUTHENTICATION_REQUIRED"` - まだ認証完了していない！
+`id` パラメータを取得します。
 
-### 4.3 SMS OTP送信リクエスト
+### 3.2 第1要素: Initial Registration（電話番号含む）
 
 ```bash
-curl -X POST "http://localhost:8080/${TENANT_ID}/v1/authentications/${AUTH_TRANSACTION_ID}/sms/send" \
+AUTH_ID="auth-transaction-id-xxxxx"
+
+curl -X POST "http://localhost:8080/${TENANT_ID}/v1/authorizations/${AUTH_ID}/initial-registration" \
   -H "Content-Type: application/json" \
   -d '{
+    "email": "new-user@example.com",
+    "password": "Test1234!",
+    "name": "New Test User",
     "phone_number": "+81-90-1234-5678"
   }'
 ```
 
-**レスポンス**:
+**電話番号形式**:
+- 外部SMS送信サービスの仕様に依存します
+- 一般的にはE.164形式（`+81-90-1234-5678`）が推奨されます
+- 利用するサービスのドキュメントを確認してください
+
+**成功レスポンス**:
 ```json
 {
-  "status": "OTP_SENT",
+  "status": "success"
+}
+```
+
+**重要**: この時点ではまだ登録完了していません。SMS OTP認証が必要です。
+
+### 3.3 第2要素: SMS OTP送信リクエスト（登録用）
+
+```bash
+curl -X POST "http://localhost:8080/${TENANT_ID}/v1/authorizations/${AUTH_ID}/sms-authentication-challenge" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "phone_number": "+81-90-1234-5678",
+    "template": "registration"
+  }'
+```
+
+**`template` パラメータ**:
+- `"registration"`: ユーザー登録時のSMS（新規ユーザー向けメッセージ）
+- `"authentication"`: ログイン時のSMS（既存ユーザー向けメッセージ）
+
+**成功レスポンス**:
+```json
+{
+  "transaction_id": "sms-transaction-xxxxx",
+  "verification_code": "123456",
   "expires_in": 300
 }
 ```
 
-**実際の動作**: ユーザーの電話にSMSが届く
-```
-Your verification code is: 123456. Valid for 5 minutes.
-```
+**実際の動作**:
+- 新規ユーザーの電話にSMSが届く（登録用テンプレート）
+- 開発環境ではレスポンスに `verification_code` が含まれる（テスト用）
 
-### 4.4 第2要素: SMS OTP検証
+### 3.4 第2要素: SMS OTP検証
 
 ```bash
-curl -X POST "http://localhost:8080/${TENANT_ID}/v1/authentications/${AUTH_TRANSACTION_ID}/sms/verify" \
+curl -X POST "http://localhost:8080/${TENANT_ID}/v1/authorizations/${AUTH_ID}/sms-authentication" \
   -H "Content-Type: application/json" \
   -d '{
-    "otp": "123456"
+    "verification_code": "123456"
   }'
 ```
 
 **成功レスポンス**:
 ```json
 {
-  "status": "SUCCESS",
-  "redirect_uri": "https://app.example.com/callback?code=abc123&state=random-state"
+  "status": "success"
 }
 ```
 
-**MFA完了！**
+### 3.5 認可完了（ユーザー登録完了）
+
+```bash
+curl -X POST "http://localhost:8080/${TENANT_ID}/v1/authorizations/${AUTH_ID}/authorize" \
+  -H "Content-Type: application/json" \
+  -d '{}'
+```
+
+**成功レスポンス**:
+```json
+{
+  "redirect_uri": "https://app.example.com/callback?code=abc123&state=random-state-registration"
+}
+```
+
+**ユーザー登録完了！** MFAを完了した状態でauthorization codeが発行されます。
+
+---
+
+## Step 4: 既存ユーザーログイン時のMFAフロー
+
+既存ユーザーがログインする場合、パスワード認証（1要素目）の後に、SMS OTP認証（2要素目）が必要です。
+
+### 4.1 Authorization Request（認可開始）
+
+```bash
+curl -v "http://localhost:8080/${TENANT_ID}/v1/authorizations?\
+response_type=code&\
+client_id=${CLIENT_ID}&\
+redirect_uri=${REDIRECT_URI}&\
+scope=openid+profile&\
+state=random-state-login"
+```
+
+**レスポンス**:
+```
+HTTP/1.1 302 Found
+Location: http://localhost:8080/authorize?id=auth-transaction-id-yyyyy
+```
+
+### 4.2 第1要素: パスワード認証
+
+```bash
+AUTH_ID="auth-transaction-id-yyyyy"
+
+curl -X POST "http://localhost:8080/${TENANT_ID}/v1/authorizations/${AUTH_ID}/password-authentication" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "username": "new-user@example.com",
+    "password": "Test1234!"
+  }'
+```
+
+**成功レスポンス**:
+```json
+{
+  "status": "success"
+}
+```
+
+**重要**: この時点ではまだ認証完了していません。SMS OTP認証が必要です。
+
+### 4.3 第2要素: SMS OTP送信リクエスト（ログイン用）
+
+```bash
+curl -X POST "http://localhost:8080/${TENANT_ID}/v1/authorizations/${AUTH_ID}/sms-authentication-challenge" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "phone_number": "+81-90-1234-5678",
+    "template": "authentication"
+  }'
+```
+
+**成功レスポンス**:
+```json
+{
+  "transaction_id": "sms-transaction-yyyyy",
+  "verification_code": "654321",
+  "expires_in": 300
+}
+```
+
+**実際の動作**:
+- ユーザーの電話にSMSが届く（ログイン用テンプレート）
+- 本番環境では `verification_code` は含まれず、SMSでのみ確認可能
+
+### 4.4 第2要素: SMS OTP検証
+
+```bash
+curl -X POST "http://localhost:8080/${TENANT_ID}/v1/authorizations/${AUTH_ID}/sms-authentication" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "verification_code": "654321"
+  }'
+```
+
+**成功レスポンス**:
+```json
+{
+  "status": "success"
+}
+```
+
+### 4.5 認可完了
+
+```bash
+curl -X POST "http://localhost:8080/${TENANT_ID}/v1/authorizations/${AUTH_ID}/authorize" \
+  -H "Content-Type: application/json" \
+  -d '{}'
+```
+
+**成功レスポンス**:
+```json
+{
+  "redirect_uri": "https://app.example.com/callback?code=def456&state=random-state-login"
+}
+```
+
+**MFA完了！** リダイレクトURIにauthorization codeが含まれています。
 
 ---
 
 ## MFA設定のバリエーション
 
-### パターン1: パスワード + SMS OTP（このガイド）
+### パターン1: 登録＆ログイン両方でMFA（このガイド）
 
 ```json
 {
-  "available_methods": ["password", "sms"],
-  "success_conditions": {
-    "any_of": [
-      [
-        { "path": "$.password-authentication.success_count", "type": "integer", "operation": "gte", "value": 1 },
-        { "path": "$.sms-authentication.success_count", "type": "integer", "operation": "gte", "value": 1 }
-      ]
-    ]
-  }
+  "policies": [
+    {
+      "description": "mfa_required_for_registration_and_login",
+      "priority": 10,
+      "conditions": { "scopes": ["openid"] },
+      "available_methods": ["password", "initial-registration", "sms"],
+      "success_conditions": {
+        "any_of": [
+          [
+            { "path": "$.password-authentication.success_count", "type": "integer", "operation": "gte", "value": 1 },
+            { "path": "$.sms-authentication.success_count", "type": "integer", "operation": "gte", "value": 1 }
+          ],
+          [
+            { "path": "$.initial-registration.success_count", "type": "integer", "operation": "gte", "value": 1 },
+            { "path": "$.sms-authentication.success_count", "type": "integer", "operation": "gte", "value": 1 }
+          ]
+        ]
+      }
+    }
+  ]
 }
 ```
 
-### パターン2: パスワード + TOTP
+**意味**: （パスワード + SMS）**OR**（登録 + SMS）
+
+### パターン2: Email認証でMFA
 
 ```json
 {
-  "available_methods": ["password", "totp"],
-  "success_conditions": {
-    "any_of": [
-      [
-        { "path": "$.password-authentication.success_count", "type": "integer", "operation": "gte", "value": 1 },
-        { "path": "$.totp-authentication.success_count", "type": "integer", "operation": "gte", "value": 1 }
-      ]
-    ]
-  }
+  "policies": [
+    {
+      "description": "mfa_with_email",
+      "priority": 10,
+      "conditions": { "scopes": ["openid"] },
+      "available_methods": ["password", "initial-registration", "email"],
+      "success_conditions": {
+        "any_of": [
+          [
+            { "path": "$.password-authentication.success_count", "type": "integer", "operation": "gte", "value": 1 },
+            { "path": "$.email-authentication.success_count", "type": "integer", "operation": "gte", "value": 1 }
+          ],
+          [
+            { "path": "$.initial-registration.success_count", "type": "integer", "operation": "gte", "value": 1 },
+            { "path": "$.email-authentication.success_count", "type": "integer", "operation": "gte", "value": 1 }
+          ]
+        ]
+      }
+    }
+  ]
 }
 ```
 
-### パターン3: 選択式MFA（パスワード必須 + SMS または TOTP）
+**意味**: （パスワード + Email）**OR**（登録 + Email）
+
+### パターン3: 選択式MFA（SMS または Email）
 
 ```json
 {
-  "available_methods": ["password", "sms", "totp"],
-  "success_conditions": {
-    "any_of": [
-      [
-        { "path": "$.password-authentication.success_count", "type": "integer", "operation": "gte", "value": 1 },
-        { "path": "$.sms-authentication.success_count", "type": "integer", "operation": "gte", "value": 1 }
-      ],
-      [
-        { "path": "$.password-authentication.success_count", "type": "integer", "operation": "gte", "value": 1 },
-        { "path": "$.totp-authentication.success_count", "type": "integer", "operation": "gte", "value": 1 }
-      ]
-    ]
-  }
+  "policies": [
+    {
+      "description": "mfa_with_sms_or_email",
+      "priority": 10,
+      "conditions": { "scopes": ["openid"] },
+      "available_methods": ["password", "initial-registration", "sms", "email"],
+      "success_conditions": {
+        "any_of": [
+          [
+            { "path": "$.password-authentication.success_count", "type": "integer", "operation": "gte", "value": 1 },
+            { "path": "$.sms-authentication.success_count", "type": "integer", "operation": "gte", "value": 1 }
+          ],
+          [
+            { "path": "$.password-authentication.success_count", "type": "integer", "operation": "gte", "value": 1 },
+            { "path": "$.email-authentication.success_count", "type": "integer", "operation": "gte", "value": 1 }
+          ],
+          [
+            { "path": "$.initial-registration.success_count", "type": "integer", "operation": "gte", "value": 1 },
+            { "path": "$.sms-authentication.success_count", "type": "integer", "operation": "gte", "value": 1 }
+          ],
+          [
+            { "path": "$.initial-registration.success_count", "type": "integer", "operation": "gte", "value": 1 },
+            { "path": "$.email-authentication.success_count", "type": "integer", "operation": "gte", "value": 1 }
+          ]
+        ]
+      }
+    }
+  ]
 }
 ```
 
-**意味**: （パスワード + SMS）**OR**（パスワード + TOTP）
+**意味**: （パスワード + SMS）**OR**（パスワード + Email）**OR**（登録 + SMS）**OR**（登録 + Email）
 
 ---
 
 ## よくあるエラー
 
-### エラー1: OTPが期限切れ
+### エラー1: 認証設定が見つからない
 
 **エラー**:
 ```json
 {
-  "error": "otp_expired",
-  "error_description": "OTP has expired"
+  "error": "invalid_request",
+  "error_description": "Authentication configuration not found"
 }
 ```
 
-**原因**: OTPの有効期限（5分）を過ぎた
+**原因**: Step 1のSMS認証設定が作成されていない
 
-**解決策**: `/sms/send`を再実行して新しいOTPを取得
+**解決策**: Step 1を実施してSMS認証設定を作成
 
 ---
 
-### エラー2: OTPが間違っている
+### エラー2: 外部APIへの接続エラー
 
 **エラー**:
 ```json
 {
-  "error": "invalid_otp",
-  "error_description": "Invalid OTP"
+  "error": "server_error",
+  "error_description": "Failed to connect to external authentication service"
 }
 ```
 
-**原因**: OTPの入力ミス
+**原因**: 外部SMS送信サービス（`http://host.docker.internal:4000`）が起動していない
+
+**解決策**:
+- 開発環境: モックサービスを起動
+- 本番環境: 外部サービスのURLと認証情報を確認
+
+---
+
+### エラー3: OTP検証失敗
+
+**エラー**:
+```json
+{
+  "error": "invalid_grant",
+  "error_description": "Verification code is invalid or expired"
+}
+```
+
+**原因**: OTPの入力ミス、または有効期限切れ（5分）
 
 **解決策**:
 - SMSを確認して正しいOTPを入力
-- 3回失敗すると新しいOTP送信が必要
+- 期限切れの場合は `/sms-authentication-challenge` を再実行
 
 ---
 
-### エラー3: 電話番号が登録されていない
+### エラー4: 電話番号が登録されていない
 
 **エラー**:
 ```json
 {
-  "error": "phone_number_not_found",
+  "error": "invalid_request",
   "error_description": "User does not have a phone number"
 }
 ```
 
 **原因**: ユーザーに電話番号が設定されていない
 
-**解決策**: Step 3を実施してユーザーに電話番号を設定
+**解決策**: Step 3を実施してユーザー登録時に電話番号を設定
 
 ---
 
 ## SMS送信サービスの設定
 
-**注意**: SMS送信には外部サービス（Twilio、AWS SNS等）との連携が必要です。
+### 開発環境（モックサービス）
 
-### 開発環境（モック）
-
-開発環境では、実際のSMSを送信せず、ログに出力：
+開発環境では、モックサービスを使用してSMS送信をシミュレートします。
 
 ```bash
-# ログ確認
-tail -f logs/idp-server.log | grep "SMS OTP"
+# モックサービスのレスポンス例
+POST http://host.docker.internal:4000/sms-authentication-challenge
+→ { "transaction_id": "xxx", "verification_code": "123456" }
 
-# 出力例
-SMS OTP sent to +81-90-1234-5678: 123456
+POST http://host.docker.internal:4000/sms-authentication
+→ { "status": "success" }
 ```
 
-### 本番環境（Twilio連携）
+### 本番環境（実際のSMS送信サービス）
 
-```bash
-# Twilio設定を追加
-curl -X POST "http://localhost:8080/v1/management/organizations/${ORGANIZATION_ID}/tenants/${TENANT_ID}/notification-configurations" \
-  -H "Content-Type: application/json" \
-  -H "Authorization: Bearer ${ADMIN_TOKEN}" \
-  -d '{
-    "type": "sms",
-    "provider": "twilio",
-    "account_sid": "your-account-sid",
-    "auth_token": "your-auth-token",
-    "from_number": "+1-555-0100"
-  }'
+本番環境では、Twilio、AWS SNS、または独自のSMS送信サービスと連携します。
+
+**Step 1の `http_request.url` を変更**:
+```json
+{
+  "http_request": {
+    "url": "https://your-sms-service.example.com/send",
+    "method": "POST",
+    "oauth_authorization": {
+      "type": "password",
+      "token_endpoint": "https://your-sms-service.example.com/token",
+      "client_id": "your-production-client-id",
+      "username": "your-username",
+      "password": "your-password",
+      "scope": "sms:send"
+    },
+    ...
+  }
+}
 ```
-
-**詳細**: [外部サービス連携ガイド](../content_06_developer-guide/04-implementation-guides/impl-17-external-integration.md)
 
 ---
 
@@ -377,9 +723,17 @@ curl -X POST "http://localhost:8080/v1/management/organizations/${ORGANIZATION_I
 
 ### さらにセキュリティを強化
 - [How-to: FIDO2設定](../phase-3-advanced/fido-uaf/02-registration.md) - 生体認証
+- [How-to: デバイス登録ポリシー](./02-device-registration-policy.md) - ACRベースのアクセス制御
+
+### セキュリティイベントの確認
+```bash
+# SMS認証の成功/失敗イベントを確認
+curl "http://localhost:8080/v1/management/organizations/${ORGANIZATION_ID}/tenants/${TENANT_ID}/security-events?event_type=sms_verification_success" \
+  -H "Authorization: Bearer ${ADMIN_TOKEN}"
+```
 
 ---
 
-**最終更新**: 2025-10-13
-**難易度**: ⭐⭐☆☆☆（初級〜中級）
+**最終更新**: 2025-01-19
+**難易度**: ⭐⭐⭐☆☆（中級）
 **対象**: MFAを初めて設定する管理者・開発者


### PR DESCRIPTION
## 概要

MFAと認証ポリシーガイドにおいて、ドキュメントと実装の間に重大な乖離がありました。ユーザーがドキュメント通りに実装すると動作しない状態だったため、E2Eテストと実装コードに基づいて全面的に修正しました。

## 変更内容

### `01-mfa-setup.md` の修正

**重大な修正**:
- ✅ 認証ポリシー構造を修正（必須の `policies` 配列を追加）
- ✅ SMS認証設定を修正（`interactions` と `metadata` の外部API連携設定を追加）
- ✅ APIエンドポイントを修正（`/authentications` → `/authorizations`）
- ✅ HTTPメソッドを修正（ポリシー作成時 `PUT` → `POST`）

**構造改善**:
- ✅ 新規ユーザー登録フロー（Step 3）とログインフロー（Step 4）を明確に分離
- ✅ `template` パラメータの説明を追加（`registration` vs `authentication`）
- ✅ 電話番号形式が外部サービスに依存することを明記
- ✅ E2Eテストパターンに合わせて全例を更新

### `03-authentication-policy-advanced.md` の修正

**新規コンテンツ**:
- ✅ Level 4: `step_definitions` セクションを追加（包括的な説明）
  - 1st/2nd factor の概念（`requires_user`, `allow_registration`）
  - `user_identity_source` の説明
  - Keycloak パターンへの参照
  - 実践例（Email→SMS, SSO→Email/SMS）

**重大な修正**:
- ✅ `all_of` への言及を削除（実装に存在せず、`any_of` のみサポート）
- ✅ `all_of` が不要である理由を説明
- ✅ JSONPath命名規則を修正:
  - 基本形式: `$.{method}-authentication.{property}`
  - 例外: `$.external-token.*`, `$.oidc-*.*`
- ✅ すべてのポリシー例に `initial-registration` を追加
- ✅ MDXコンパイルエラーを修正（自己閉じタグ `<br />`）

**構造改善**:
- ✅ 古い「エンタープライズ認証ポリシー」例を削除
- ✅ Levelを再編成（Level 4-6）
- ✅ すべてのコード例をE2Eテストに合わせて更新

## 検証

以下のファイルで検証済み:
- E2Eテスト: `e2e/src/tests/usecase/mfa/mfa-02-security-event-logging.test.js`
- E2Eテスト: `e2e/src/tests/usecase/mfa/mfa-03-fido-uaf-device-registration-acr-policy.test.js`
- E2Eテスト: `e2e/src/tests/usecase/mfa/mfa-04-fido2-device-registration-acr-policy.test.js`
- ソースコード: `libs/idp-server-core/src/main/java/org/idp/server/core/openid/authentication/policy/`
- 設定例: `config/examples/e2e/test-tenant/authentication-policy/oauth.json`

## 影響

従来のドキュメントに従うとエラーが発生していました。このPRにより、ドキュメントが実装と一致し、ユーザーがMFAと認証ポリシーを正しく設定できるようになります。

## 主要な乖離箇所

### 1. 認証ポリシーのデータ構造
**修正前**:
```json
{
  "flow": "oauth",
  "available_methods": ["password", "sms"],
  "success_conditions": { ... }
}
```

**修正後**:
```json
{
  "id": "policy-id",
  "flow": "oauth",
  "enabled": true,
  "policies": [                          // ← 必須配列
    {
      "description": "...",
      "priority": 10,
      "conditions": { "scopes": [...] },
      "available_methods": [...],
      "success_conditions": { ... }
    }
  ]
}
```

### 2. SMS認証設定の構造
**修正前**:
```json
{
  "type": "sms",
  "otp_length": 6,
  "otp_expiry_seconds": 300
}
```

**修正後**:
```json
{
  "id": "sms-config-id",
  "type": "sms",
  "attributes": {},
  "metadata": {
    "type": "external",
    "transaction_id_param": "transaction_id",
    "verification_code_param": "verification_code",
    "retry_count_limitation": 5,
    "expire_seconds": 300
  },
  "interactions": {                      // ← 必須
    "sms-authentication-challenge": { ... },
    "sms-authentication": { ... }
  }
}
```

### 3. APIエンドポイント
**修正前**: `/v1/authentications/{id}`  
**修正後**: `/v1/authorizations/{id}`

### 4. フロー分離
**修正前**: 登録とログインが混在  
**修正後**: Step 3（新規登録）、Step 4（ログイン）を明確に分離

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 (1M context) <noreply@anthropic.com>