### PR TITLE
refactor: ログレベルを改善

### DIFF
--- a/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/config/HikariConnectionProvider.java
+++ b/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/config/HikariConnectionProvider.java
@@ -50,7 +50,7 @@ public class HikariConnectionProvider implements DbConnectionProvider {
               : adminDatabaseConfig.writerConfigs().get(databaseType);
       try {
 
-        log.debug(
+        log.trace(
             "DB connection for "
                 + databaseType
                 + " url: "

--- a/libs/idp-server-platform/src/main/java/org/idp/server/platform/audit/AuditLogWriters.java
+++ b/libs/idp-server-platform/src/main/java/org/idp/server/platform/audit/AuditLogWriters.java
@@ -32,7 +32,7 @@ public class AuditLogWriters {
   public void write(Tenant tenant, AuditLog auditLog) {
     for (AuditLogWriter writer : writers) {
       if (writer.shouldExecute(tenant, auditLog)) {
-        log.info(
+        log.trace(
             "TenantId {} AuditLogWriter execute: {}",
             tenant.identifierValue(),
             writer.getClass().getSimpleName());

--- a/libs/idp-server-springboot-adapter/src/main/java/org/idp/server/adapters/springboot/OrgManagementFilter.java
+++ b/libs/idp-server-springboot-adapter/src/main/java/org/idp/server/adapters/springboot/OrgManagementFilter.java
@@ -120,7 +120,7 @@ public class OrgManagementFilter extends OncePerRequestFilter {
           new OrganizationOperatorPrincipal(authenticationContext, authorities);
       SecurityContextHolder.getContext().setAuthentication(principal);
 
-      logger.info(
+      logger.debug(
           "Organization management authentication successful - org: {}, user: {}, tenant: {}",
           organizationId.value(),
           user.userIdentifier().value(),


### PR DESCRIPTION
## Summary

本番環境でのログノイズを削減するため、ルーチン処理のログレベルを調整しました。

- **OrgManagementFilter.java**: 認証成功ログを `INFO` → `DEBUG` に変更
- **HikariConnectionProvider.java**: DB接続情報ログを `debug` → `trace` に変更
- **AuditLogWriters.java**: AuditLogWriter実行ログを `info` → `trace` に変更

## 背景

#1205 の調査で、組織管理API認証成功ログが INFO レベルで大量出力されていることが判明。
これらはルーチン処理であり、本番ログを圧迫していました。

## 影響

- 本番環境（ログレベル=INFO）でのログ出力量が削減される
- DEBUG/TRACE が必要な環境では引き続き出力される
- 認証失敗ログは WARN レベルのまま（影響なし）

## Test plan

- [x] ビルド成功を確認
- [x] 既存E2Eテストがパスすることを確認

Closes #1208

🤖 Generated with [Claude Code](https://claude.com/claude-code)