### PR TITLE
feat: ユーザー削除イベントの主体を区別

### DIFF
--- a/config/examples/e2e/test-tenant/security-event-hook/ssf.json
+++ b/config/examples/e2e/test-tenant/security-event-hook/ssf.json
@@ -4,7 +4,7 @@
   "execution_order": 2,
   "triggers": [
     "fido_uaf_registration_success",
-    "user_delete"
+    "user_self_delete"
   ],
   "attributes": {
     "label": "Security Event Framework",
@@ -56,7 +56,7 @@
         }
       }
     },
-    "user_delete": {
+    "user_self_delete": {
       "execution": {
         "function": "ssf",
         "details": {
@@ -68,7 +68,7 @@
           },
           "security_event_token_additional_payload_mapping_rules": [
             { "from": "$.user.name", "to": "username" },
-            { "static_value": "user_delete", "to": "description" }
+            { "static_value": "user_self_delete", "to": "description" }
           ]
         }
       }

--- a/documentation/docs/content_06_developer-guide/04-implementation-guides/integration/security-event-hooks.md
+++ b/documentation/docs/content_06_developer-guide/04-implementation-guides/integration/security-event-hooks.md
@@ -298,8 +298,9 @@ CREATE TABLE security_event_hook_results
 - `user_create` - ユーザー作成
 - `user_get` - ユーザー情報取得
 - `user_edit` - ユーザー編集
-- `user_delete` - ユーザー削除
-- `user_deletion` - ユーザー削除
+- `user_delete` - ユーザー削除（Admin操作）
+- `user_self_delete` - ユーザー自身による削除
+- `user_deletion` - ユーザー削除（内部イベント）
 - `user_lock` - ユーザーロック
 - `user_disabled` - ユーザー無効化
 - `user_enabled` - ユーザー有効化

--- a/documentation/docs/content_06_developer-guide/05-configuration/security-event-hook.md
+++ b/documentation/docs/content_06_developer-guide/05-configuration/security-event-hook.md
@@ -229,7 +229,8 @@ SSFでもOAuth 2.0認証のキャッシュを利用できます：
 - `oauth_authorize` - Authorization Code発行
 - `token_request_success` - トークン発行
 - `user_locked` - アカウントロック
-- `user_delete` - ユーザー削除
+- `user_delete` - ユーザー削除（Admin操作）
+- `user_self_delete` - ユーザー自身による削除
 
 **完全なリスト**: [DefaultSecurityEventType.java](../../../../libs/idp-server-platform/src/main/java/org/idp/server/platform/security/event/DefaultSecurityEventType.java)
 

--- a/e2e/src/tests/scenario/application/scenario-07-user-deletion.test.js
+++ b/e2e/src/tests/scenario/application/scenario-07-user-deletion.test.js
@@ -77,7 +77,7 @@ describe("User lifecycle", () => {
 
       // Get security event list for user deletion
       const securityEventListResponse = await get({
-        url: `${backendUrl}/v1/management/organizations/${serverConfig.organizationId}/tenants/${serverConfig.tenantId}/security-events?external_user_id=${user.ex_sub}&event_type=user_delete&limit=1`,
+        url: `${backendUrl}/v1/management/organizations/${serverConfig.organizationId}/tenants/${serverConfig.tenantId}/security-events?external_user_id=${user.ex_sub}&event_type=user_self_delete&limit=1`,
         headers: {
           Authorization: `Bearer ${adminAccessToken}`
         }
@@ -85,13 +85,13 @@ describe("User lifecycle", () => {
       console.log("Security Event List:", JSON.stringify(securityEventListResponse.data, null, 2));
       expect(securityEventListResponse.status).toBe(200);
       expect(securityEventListResponse.data.total_count).toBe(1);
-      expect(securityEventListResponse.data.list[0].type).toEqual("user_delete");
+      expect(securityEventListResponse.data.list[0].type).toEqual("user_self_delete");
 
       const securityEventId = securityEventListResponse.data.list[0].id;
 
       // Get security event hook execution result
       const securityEventHookListResponse = await get({
-        url: `${backendUrl}/v1/management/organizations/${serverConfig.organizationId}/tenants/${serverConfig.tenantId}/security-event-hooks?security_event_id=${securityEventId}&event_type=user_delete&limit=1`,
+        url: `${backendUrl}/v1/management/organizations/${serverConfig.organizationId}/tenants/${serverConfig.tenantId}/security-event-hooks?security_event_id=${securityEventId}&event_type=user_self_delete&limit=1`,
         headers: {
           Authorization: `Bearer ${adminAccessToken}`
         }

--- a/libs/idp-server-platform/src/main/java/org/idp/server/platform/security/event/DefaultSecurityEventType.java
+++ b/libs/idp-server-platform/src/main/java/org/idp/server/platform/security/event/DefaultSecurityEventType.java
@@ -23,6 +23,7 @@ public enum DefaultSecurityEventType {
   user_disabled("User disabled"),
   user_enabled("User enabled"),
   user_deletion("User deleted"),
+  user_self_delete("User deleted their own account"),
   password_success("User successfully authenticated with a password"),
   password_failure("User failed authentication with a password"),
   fido_uaf_registration_challenge_success("User challenge registration fido-uaf"),

--- a/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/application/enduser/UserOperationEntryService.java
+++ b/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/application/enduser/UserOperationEntryService.java
@@ -265,7 +265,7 @@ public class UserOperationEntryService implements UserOperationApi {
         new UserLifecycleEvent(tenant, user, UserLifecycleType.DELETE);
     userLifecycleEventPublisher.publish(userLifecycleEvent);
     eventPublisher.publish(
-        tenant, oAuthToken, DefaultSecurityEventType.user_delete, requestAttributes);
+        tenant, oAuthToken, DefaultSecurityEventType.user_self_delete, requestAttributes);
 
     return new UserOperationResponse(UserOperationStatus.NO_CONTENT, null);
   }


### PR DESCRIPTION
## Summary

ユーザー削除時のイベント名で削除の主体（Admin / ユーザー自身）を区別できるようにしました。

| 操作 | イベント名 |
|------|-----------|
| Adminダッシュボードからの削除 | `user_delete` |
| ユーザー自身による削除 | `user_self_delete` |

## 変更内容

### 実装
- `DefaultSecurityEventType` に `user_self_delete` を追加
- `UserOperationEntryService` でユーザー自身の削除時に `user_self_delete` を発行

### テスト・設定
- E2Eテスト (`scenario-07-user-deletion.test.js`) を `user_self_delete` に更新
- セキュリティイベントフック設定 (`ssf.json`) を更新

### ドキュメント
- `security-event-hook.md` にイベント説明を追加
- `security-event-hooks.md` のイベント一覧を更新

## Test plan

- [x] E2Eテストが正常に動作することを確認

Closes #1213

🤖 Generated with [Claude Code](https://claude.com/claude-code)