### PR TITLE
perf: セキュリティイベント処理のパフォーマンス改善

### DIFF
--- a/libs/idp-server-platform/src/main/java/org/idp/server/platform/security/handler/SecurityEventHandler.java
+++ b/libs/idp-server-platform/src/main/java/org/idp/server/platform/security/handler/SecurityEventHandler.java
@@ -138,7 +138,12 @@ public class SecurityEventHandler {
    * @param securityEvent the security event
    */
   private void updateStatistics(Tenant tenant, SecurityEvent securityEvent) {
-    if (securityEvent == null) {
+
+    // to reduce statistics event
+    if (securityEvent == null
+        || DefaultSecurityEventType.inspect_token_success
+            .toEventType()
+            .equals(securityEvent.type())) {
       return;
     }
 
@@ -191,7 +196,7 @@ public class SecurityEventHandler {
             tenant.identifier(), eventDate, userId, userName);
 
     if (isNewDailyUser) {
-      log.debug(
+      log.trace(
           "New daily active user: tenant={}, date={}, user={}",
           tenant.identifierValue(),
           eventDate,
@@ -205,7 +210,7 @@ public class SecurityEventHandler {
             tenant.identifier(), monthStart, userId, userName);
 
     if (isNewMonthlyUser) {
-      log.debug(
+      log.trace(
           "New monthly active user: tenant={}, month={}, user={}",
           tenant.identifierValue(),
           monthStart,
@@ -222,7 +227,7 @@ public class SecurityEventHandler {
             tenant.identifier(), yearStart, userId, userName);
 
     if (isNewYearlyUser) {
-      log.debug(
+      log.trace(
           "New yearly active user: tenant={}, year={}, user={}",
           tenant.identifierValue(),
           yearStart,
@@ -245,7 +250,7 @@ public class SecurityEventHandler {
    * @param eventType event type to increment
    */
   private void incrementMetric(Tenant tenant, LocalDate date, String eventType) {
-    log.debug(
+    log.trace(
         "Incrementing metric: tenant={}, date={}, eventType={}",
         tenant.identifierValue(),
         date,

--- a/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/application/enduser/CibaFlowEntryService.java
+++ b/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/application/enduser/CibaFlowEntryService.java
@@ -133,13 +133,17 @@ public class CibaFlowEntryService implements CibaFlowApi {
         authenticationTransaction.updateWith(interactionRequestResult);
     authenticationTransactionCommandRepository.register(tenant, updatedTransaction);
 
-    eventPublisher.publish(
-        tenant,
-        issueResponse.request(),
-        issueResponse.user(),
-        interactionRequestResult.eventType(),
-        requestAttributes,
-        issueResponse.clientAttributes());
+    // to reduce unnecessary security event
+    if (!OperationType.NO_ACTION.equals(authenticationInteractor.operationType())) {
+      eventPublisher.publish(
+          tenant,
+          issueResponse.request(),
+          issueResponse.user(),
+          interactionRequestResult.eventType(),
+          requestAttributes,
+          issueResponse.clientAttributes());
+    }
+
     return issueResponse.toResponse();
   }
 


### PR DESCRIPTION
## Summary

- `inspect_token_success` イベントの統計更新をスキップ（高頻度で呼ばれるため）
- DAU/MAU/YAU追跡ログを `debug` → `trace` に変更
- `NO_ACTION` の Interactor はセキュリティイベント発行をスキップ

## Test plan

- [x] ビルドが通ること
- [x] Token Introspection実行時に `statistics_events` テーブルが更新されないこと
- [x] CIBA NO_ACTION Interactor実行時にセキュリティイベントが発行されないこと

Closes #1228

🤖 Generated with [Claude Code](https://claude.com/claude-code)