### PR TITLE
perf: セキュリティイベントフックコンフィグ取得のキャッシュ化

### DIFF
--- a/.claude/skills/security-event/SKILL.md
+++ b/.claude/skills/security-event/SKILL.md
@@ -76,6 +76,12 @@ libs/
 - `statistics_events`テーブルで直接upsert
 - 10ms → 0.53ms（約19倍高速化）
 
+### パフォーマンス改善（#1231）
+- フックコンフィグ取得をAdapter層でキャッシュ（TTL 5分）
+- 設定の登録/更新/削除時にキャッシュ自動無効化
+- `TenantQueryDataSource`と同じパターンで実装
+- 実装: `SecurityEventHookConfigurationQueryDataSource`, `SecurityEventHookConfigurationCommandDataSource`
+
 ## フック種別
 
 | フック | 用途 |

--- a/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/security/hook/configuration/command/SecurityEventHookConfigurationCommandDataSource.java
+++ b/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/security/hook/configuration/command/SecurityEventHookConfigurationCommandDataSource.java
@@ -16,6 +16,8 @@
 
 package org.idp.server.core.adapters.datasource.security.hook.configuration.command;
 
+import org.idp.server.core.adapters.datasource.security.hook.configuration.query.SecurityEventHookConfigurationQueryDataSource;
+import org.idp.server.platform.datasource.cache.CacheStore;
 import org.idp.server.platform.json.JsonConverter;
 import org.idp.server.platform.multi_tenancy.tenant.Tenant;
 import org.idp.server.platform.security.hook.configuration.SecurityEventHookConfiguration;
@@ -26,25 +28,35 @@ public class SecurityEventHookConfigurationCommandDataSource
 
   SecurityEventHookConfigSqlExecutor executor;
   JsonConverter converter;
+  CacheStore cacheStore;
 
   public SecurityEventHookConfigurationCommandDataSource(
-      SecurityEventHookConfigSqlExecutor executor) {
+      SecurityEventHookConfigSqlExecutor executor, CacheStore cacheStore) {
     this.executor = executor;
     this.converter = JsonConverter.snakeCaseInstance();
+    this.cacheStore = cacheStore;
   }
 
   @Override
   public void register(Tenant tenant, SecurityEventHookConfiguration configuration) {
+    invalidateCache(tenant);
     executor.insert(tenant, configuration);
   }
 
   @Override
   public void update(Tenant tenant, SecurityEventHookConfiguration configuration) {
+    invalidateCache(tenant);
     executor.update(tenant, configuration);
   }
 
   @Override
   public void delete(Tenant tenant, SecurityEventHookConfiguration configuration) {
+    invalidateCache(tenant);
     executor.delete(tenant, configuration);
+  }
+
+  private void invalidateCache(Tenant tenant) {
+    String cacheKey = SecurityEventHookConfigurationQueryDataSource.cacheKey(tenant);
+    cacheStore.delete(cacheKey);
   }
 }

--- a/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/security/hook/configuration/command/SecurityEventHookConfigurationDataSourceProvider.java
+++ b/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/security/hook/configuration/command/SecurityEventHookConfigurationDataSourceProvider.java
@@ -17,6 +17,7 @@
 package org.idp.server.core.adapters.datasource.security.hook.configuration.command;
 
 import org.idp.server.platform.datasource.ApplicationDatabaseTypeProvider;
+import org.idp.server.platform.datasource.cache.CacheStore;
 import org.idp.server.platform.dependency.ApplicationComponentDependencyContainer;
 import org.idp.server.platform.dependency.ApplicationComponentProvider;
 import org.idp.server.platform.security.repository.SecurityEventHookConfigurationCommandRepository;
@@ -34,8 +35,9 @@ public class SecurityEventHookConfigurationDataSourceProvider
       ApplicationComponentDependencyContainer container) {
     ApplicationDatabaseTypeProvider databaseTypeProvider =
         container.resolve(ApplicationDatabaseTypeProvider.class);
+    CacheStore cacheStore = container.resolve(CacheStore.class);
     SecurityEventHookConfigSqlExecutors executors = new SecurityEventHookConfigSqlExecutors();
     SecurityEventHookConfigSqlExecutor executor = executors.get(databaseTypeProvider.provide());
-    return new SecurityEventHookConfigurationCommandDataSource(executor);
+    return new SecurityEventHookConfigurationCommandDataSource(executor, cacheStore);
   }
 }

--- a/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/security/hook/configuration/query/SecurityEventHookConfigurationDataSourceProvider.java
+++ b/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/security/hook/configuration/query/SecurityEventHookConfigurationDataSourceProvider.java
@@ -17,6 +17,7 @@
 package org.idp.server.core.adapters.datasource.security.hook.configuration.query;
 
 import org.idp.server.platform.datasource.ApplicationDatabaseTypeProvider;
+import org.idp.server.platform.datasource.cache.CacheStore;
 import org.idp.server.platform.dependency.ApplicationComponentDependencyContainer;
 import org.idp.server.platform.dependency.ApplicationComponentProvider;
 import org.idp.server.platform.security.repository.SecurityEventHookConfigurationQueryRepository;
@@ -34,8 +35,9 @@ public class SecurityEventHookConfigurationDataSourceProvider
       ApplicationComponentDependencyContainer container) {
     ApplicationDatabaseTypeProvider databaseTypeProvider =
         container.resolve(ApplicationDatabaseTypeProvider.class);
+    CacheStore cacheStore = container.resolve(CacheStore.class);
     SecurityEventHookConfigSqlExecutors executors = new SecurityEventHookConfigSqlExecutors();
     SecurityEventHookConfigSqlExecutor executor = executors.get(databaseTypeProvider.provide());
-    return new SecurityEventHookConfigurationQueryDataSource(executor);
+    return new SecurityEventHookConfigurationQueryDataSource(executor, cacheStore);
   }
 }

--- a/libs/idp-server-platform/src/main/java/org/idp/server/platform/security/handler/SecurityEventHandler.java
+++ b/libs/idp-server-platform/src/main/java/org/idp/server/platform/security/handler/SecurityEventHandler.java
@@ -34,7 +34,6 @@ import org.idp.server.platform.security.hook.configuration.SecurityEventHookConf
 import org.idp.server.platform.security.hook.configuration.SecurityEventHookConfigurations;
 import org.idp.server.platform.security.log.SecurityEventLogConfiguration;
 import org.idp.server.platform.security.log.SecurityEventLogService;
-import org.idp.server.platform.security.repository.SecurityEventCommandRepository;
 import org.idp.server.platform.security.repository.SecurityEventHookConfigurationQueryRepository;
 import org.idp.server.platform.security.repository.SecurityEventHookResultCommandRepository;
 import org.idp.server.platform.statistics.FiscalYearCalculator;
@@ -46,7 +45,6 @@ import org.idp.server.platform.statistics.repository.YearlyActiveUserCommandRepo
 
 public class SecurityEventHandler {
 
-  SecurityEventCommandRepository securityEventCommandRepository;
   SecurityEventHookResultCommandRepository resultsCommandRepository;
   SecurityEventHooks securityEventHooks;
   SecurityEventHookConfigurationQueryRepository securityEventHookConfigurationQueryRepository;


### PR DESCRIPTION
## Summary

- セキュリティイベント処理時のフックコンフィグ取得をAdapter層でキャッシュ化
- 設定の登録/更新/削除時にキャッシュを自動無効化
- `TenantQueryDataSource`と同じパターンで実装

## Changes

### コード変更
| ファイル | 変更内容 |
|---------|---------|
| `SecurityEventHookConfigurationQueryDataSource` | キャッシュ読み取り（TTL 5分） |
| `SecurityEventHookConfigurationCommandDataSource` | register/update/delete時のキャッシュ無効化 |
| `*DataSourceProvider` | CacheStore注入 |
| `SecurityEventHandler` | 未使用フィールド削除 |

### ドキュメント更新
- `skill.md`: パフォーマンス改善（#1231）の記録を追加
- `09-security-event.md`: FAQ Q4「Hook設定を変更したのに反映されない？」を追加

## Test plan

- [ ] ビルド成功を確認
- [ ] フックコンフィグ取得時にキャッシュが使用されることを確認
- [ ] 設定更新時にキャッシュが無効化されることを確認

closes #1231

🤖 Generated with [Claude Code](https://claude.com/claude-code)