### PR TITLE
fix: SecurityEventTypeにequals/hashCodeを追加

### DIFF
--- a/libs/idp-server-platform/src/main/java/org/idp/server/platform/security/event/SecurityEventType.java
+++ b/libs/idp-server-platform/src/main/java/org/idp/server/platform/security/event/SecurityEventType.java
@@ -16,6 +16,8 @@
 
 package org.idp.server.platform.security.event;
 
+import java.util.Objects;
+
 public class SecurityEventType {
 
   String value;
@@ -32,5 +34,18 @@ public class SecurityEventType {
 
   public boolean isFailure() {
     return value != null && value.contains("failure");
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    SecurityEventType that = (SecurityEventType) o;
+    return Objects.equals(value, that.value);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(value);
   }
 }


### PR DESCRIPTION
## Summary

`SecurityEventType`クラスに`equals()`と`hashCode()`を追加し、`inspect_token_success`イベントの統計スキップが正しく機能するように修正。

## Problem

`SecurityEventHandler.updateStatistics()`で`inspect_token_success`をスキップする条件判定が常に`false`になっていた。

```java
DefaultSecurityEventType.inspect_token_success
    .toEventType()              // 新しいインスタンス作成
    .equals(securityEvent.type())  // 別のインスタンスと比較 → 常にfalse
```

`equals()`が未実装のため、Javaのデフォルト参照比較が使われていた。

## Solution

```java
@Override
public boolean equals(Object o) {
  if (this == o) return true;
  if (o == null || getClass() != o.getClass()) return false;
  SecurityEventType that = (SecurityEventType) o;
  return Objects.equals(value, that.value);
}

@Override
public int hashCode() {
  return Objects.hash(value);
}
```

## Test plan

- [ ] ビルド成功を確認
- [ ] Token Introspection実行後、`statistics_events`に`inspect_token_success`が記録されないことを確認

closes #1233

🤖 Generated with [Claude Code](https://claude.com/claude-code)