### PR TITLE
fix: HttpRequestExecutorのデフォルトログレベルをinfoに変更

### DIFF
--- a/app/src/main/resources/application.yaml
+++ b/app/src/main/resources/application.yaml
@@ -131,7 +131,7 @@ logging:
           adapters.springboot: "${LOGGING_LEVEL_IDP_SERVER_ADAPTERS_SPRING_BOOT:info}"
           usecases: "${LOGGING_LEVEL_IDP_SERVER_USECASES:info}"
           authenticators.webauthn4j: "${LOGGING_LEVEL_IDP_SERVER_AUTHENTICATORS_WEBAUTHN4J:info}"
-    org.idp.server.platform.http.HttpRequestExecutor: "${LOGGING_LEVEL_IDP_SERVER_HTTP_REQUEST_EXECUTOR:debug}"
+    org.idp.server.platform.http.HttpRequestExecutor: "${LOGGING_LEVEL_IDP_SERVER_HTTP_REQUEST_EXECUTOR:info}"
     org.idp.server.adapters.springboot.logging.RequestResponseLoggingFilter: "${LOGGING_LEVEL_REQUEST_RESPONSE_LOGGING_FILTER:info}"
 
 spring:


### PR DESCRIPTION
## Summary

- `LOGGING_LEVEL_IDP_SERVER_HTTP_REQUEST_EXECUTOR` のデフォルト値を `debug` から `info` に変更

## Why

- 本番環境でデフォルトのログレベルが `debug` だと不要なログが出力される
- 必要な場合は環境変数で `debug` に変更可能

Closes #1236

🤖 Generated with [Claude Code](https://claude.com/claude-code)