### PR TITLE
feat: support cookie_path configuration for API Gateway deployments

### DIFF
--- a/.claude/skills/tenant-configuration/skill.md
+++ b/.claude/skills/tenant-configuration/skill.md
@@ -1,0 +1,225 @@
+---
+name: tenant-configuration
+description: テナント設定（Tenant Configuration）の開発・修正を行う際に使用。session_config、cors_config、ui_config、identity_policy、マルチテナント設計実装時に役立つ。
+---
+
+# テナント設定（Tenant Configuration）開発ガイド
+
+## ドキュメント
+
+- `documentation/docs/content_06_developer-guide/05-configuration/tenant.md` - テナント設定ガイド（詳細）
+- `documentation/openapi/swagger-control-plane-ja.yaml` - OpenAPI仕様（SessionConfiguration等のスキーマ）
+- `documentation/docs/content_11_learning/07-multi-tenancy/tenant-isolation.md` - テナント分離の概念
+- `documentation/docs/content_06_developer-guide/04-implementation-guides/oauth-oidc/session-management.md` - セッション管理実装ガイド
+- `documentation/docs/content_03_concepts/03-authentication-authorization/concept-03-session-management.md` - セッション管理概念
+- `documentation/docs/content_03_concepts/03-authentication-authorization/concept-03-session-management-security.md` - セッションセキュリティ
+- `documentation/docs/content_11_learning/19-session-management/01-web-session-basics.md` - Webセッションの基礎
+
+## 機能概要
+
+Tenantはマルチテナント環境における完全に独立した認証・認可ドメイン。
+
+- **テナント種別**: ADMIN（システム管理）、ORGANIZER（組織管理）、PUBLIC（アプリケーション用）
+- **設定カテゴリ**: session_config、cors_config、ui_config、security_event_log_config、identity_policy_config
+- **データ分離**: ユーザー、クライアント、認証ポリシー、トークン設定、監査ログ
+
+## モジュール構成
+
+```
+libs/
+├── idp-server-platform/                      # テナント基盤
+│   └── .../multi_tenancy/tenant/
+│       ├── Tenant.java                       # テナントエンティティ
+│       ├── TenantIdentifier.java             # テナント識別子
+│       ├── config/
+│       │   ├── SessionConfiguration.java     # セッション設定
+│       │   ├── CorsConfiguration.java        # CORS設定
+│       │   ├── UIConfiguration.java          # UI設定
+│       │   └── ...
+│       └── policy/
+│           ├── TenantIdentityPolicy.java     # ID Policy
+│           └── PasswordPolicyConfig.java     # パスワードポリシー
+│
+└── idp-server-control-plane/                 # 管理API
+    └── .../management/tenant/
+        ├── TenantManagementApi.java          # テナント管理API
+        └── TenantManagementRegistrationContextCreator.java
+```
+
+## 主要設定カテゴリ
+
+### Session Configuration
+
+セッション管理とCookie設定。
+
+```java
+public class SessionConfiguration {
+    String cookieName;           // Cookie名（null時は自動生成）
+    String cookieDomain;         // Cookie Domain属性
+    String cookieSameSite;       // SameSite属性（None/Lax/Strict）
+    boolean useSecureCookie;     // Secure属性
+    boolean useHttpOnlyCookie;   // HttpOnly属性
+    String cookiePath;           // Cookieパス（API Gateway対応）
+    int timeoutSeconds;          // セッションタイムアウト
+    String switchPolicy;         // セッション切替ポリシー
+}
+```
+
+**重要: cookie_path（API Gateway対応）**
+
+API Gateway経由でコンテキストパス付きでデプロイする場合に設定。
+
+```json
+{
+  "session_config": {
+    "cookie_path": "/idp-admin",
+    "cookie_same_site": "None",
+    "use_secure_cookie": true
+  }
+}
+```
+
+設定すると、Cookieパスが `/idp-admin/{tenant_id}/` となり、API Gateway経由のリクエストでもCookieが正しく送信される。
+
+**設定例**: `config/examples/oidcc-cross-site-context-path/`
+
+### CORS Configuration
+
+クロスオリジンリソース共有。
+
+```java
+public class CorsConfiguration {
+    List<String> allowOrigins;   // 許可オリジン
+    String allowHeaders;         // 許可ヘッダー
+    String allowMethods;         // 許可メソッド
+    boolean allowCredentials;    // クレデンシャル許可
+}
+```
+
+### Identity Policy Configuration
+
+ユーザー識別キーとパスワードポリシー。
+
+```java
+public class TenantIdentityPolicy {
+    IdentityUniqueKeyType identityUniqueKeyType;  // EMAIL_OR_EXTERNAL_USER_ID等
+    PasswordPolicyConfig passwordPolicy;
+}
+```
+
+## 構成パターン
+
+### 同一オリジン構成
+```json
+{
+  "session_config": {
+    "cookie_same_site": "Lax"
+  }
+}
+```
+
+### サブドメイン構成
+```json
+{
+  "session_config": {
+    "cookie_domain": "example.com",
+    "cookie_same_site": "Lax"
+  }
+}
+```
+
+### クロスサイト構成
+```json
+{
+  "session_config": {
+    "cookie_same_site": "None",
+    "use_secure_cookie": true
+  },
+  "cors_config": {
+    "allow_origins": ["https://app.another.com"]
+  }
+}
+```
+
+### API Gateway + コンテキストパス構成
+```json
+{
+  "session_config": {
+    "cookie_path": "/idp-admin",
+    "cookie_same_site": "None",
+    "use_secure_cookie": true
+  }
+}
+```
+
+## API
+
+### テナント作成（組織レベル）
+```
+POST /v1/management/organizations/{org-id}/tenants
+```
+
+### テナント更新
+```
+PUT /v1/management/tenants/{tenant-id}
+```
+
+### テナント取得
+```
+GET /v1/management/tenants/{tenant-id}
+```
+
+## E2Eテスト
+
+```
+e2e/src/tests/
+├── spec/
+│   └── management/tenant/ - テナント管理APIテスト
+└── scenario/
+    └── scenario-xx-multi-tenant.test.js - マルチテナントシナリオ
+```
+
+## コマンド
+
+```bash
+# ビルド
+./gradlew :libs:idp-server-platform:compileJava
+
+# テナント設定更新（ローカル）
+bash config/examples/oidcc-cross-site-context-path/update.sh
+
+# API Gateway対応app-view起動
+docker compose up -d --build app-view-context-path nginx
+```
+
+## トラブルシューティング
+
+### auth_session_mismatch エラー
+
+**症状**: `Missing AUTH_SESSION cookie` エラー
+
+**原因**: API Gateway経由でコンテキストパスが追加されているが、Cookieパスが一致しない
+
+**解決策**: `session_config.cookie_path` にコンテキストパスを設定
+
+### CORS エラー
+
+**症状**: `has been blocked by CORS policy`
+
+**原因**: `cors_config.allow_origins` にオリジンが含まれていない
+
+**解決策**: 許可するオリジンを追加
+
+### セッション切替エラー
+
+**症状**: 別ユーザーでログインできない
+
+**原因**: `switch_policy: "STRICT"` 設定
+
+**解決策**: ログアウトしてから再認証、または `SWITCH_ALLOWED` に変更
+
+## 関連スキル
+
+- `session-management` - セッション管理の詳細
+- `control-plane` - 管理API全般
+- `local-environment` - ローカル開発環境

--- a/config/examples/oidcc-cross-site-context-path/README.md
+++ b/config/examples/oidcc-cross-site-context-path/README.md
@@ -1,0 +1,170 @@
+# OIDCC Certification Test Configuration (Cross-Site)
+
+OpenID Connect Core 認定テスト用の設定ファイルです。
+
+## ファイル構成
+
+```
+oidcc-cross-site/
+├── README.md                 # このファイル
+├── onboarding-request.json   # Onboarding API 用設定（組織・テナント・ユーザー・クライアント1）
+├── client-post.json          # 2つ目のクライアント（client_secret_post）
+├── client-second.json        # 3つ目のクライアント（second client）
+├── setup.sh                  # セットアップスクリプト
+├── update.sh                 # 更新スクリプト
+└── delete.sh                 # 削除スクリプト
+```
+
+## テストプラン
+
+| 項目 | 値                                           |
+|------|---------------------------------------------|
+| テストプラン名 | `oidcc-xxx`                                 |
+| 認定プロファイル | Form Post OP                                |
+| Response Type | `code`                                      |
+| Response Mode | `form_post`                                 |
+| Client Auth | `client_secret_basic`, `client_secret_post` |
+
+## セットアップ
+
+### 1. 前提条件
+
+- idp-server が起動していること
+- `.env` ファイルに管理者認証情報が設定されていること
+
+### 2. セットアップ実行
+
+```bash
+cd config/examples/oidcc-cross-site
+chmod +x setup.sh
+./setup.sh
+```
+
+### 3. セットアップ結果
+
+| リソース | 値 |
+|---------|-----|
+| Tenant ID | `e8c169c2-019f-46c9-af39-7be12ec51e4d` |
+| Issuer | `https://api.local.dev/e8c169c2-019f-46c9-af39-7be12ec51e4d` |
+
+### 4. 設定更新
+
+設定ファイルを編集後、以下のスクリプトで反映できます：
+
+```bash
+# テナント・認可サーバー・クライアントを更新
+./update.sh
+```
+
+更新対象:
+- テナント設定
+- 認可サーバー設定（JWKS含む）
+- クライアント設定（3つ全て）
+
+**鍵ローテーション（OIDCC テスト用）:**
+`onboarding-request.json` の `jwks` を編集し、新しい鍵を追加後 `./update.sh` を実行
+
+## クライアント設定
+
+### Client 1: client_secret_basic
+
+| 項目 | 値 |
+|------|-----|
+| Client ID | `35f40824-807c-4f36-bf91-a8da0692b032` |
+| Client ID Alias | `oidcc-basic-client` |
+| Client Secret | `oidcc-basic-secret-32characters!` |
+| Auth Method | `client_secret_basic` |
+| Redirect URI | `https://localhost.emobix.co.uk:8443/test/a/oidc-core-basic/callback` |
+
+### Client 2: client_secret_post
+
+| 項目 | 値 |
+|------|-----|
+| Client ID | `f8702ea8-33b1-4433-9b5d-f1034f0bd5b5` |
+| Client ID Alias | `oidcc-post-client` |
+| Client Secret | `oidcc-post-secret-32characters!!` |
+| Auth Method | `client_secret_post` |
+| Redirect URI | `https://localhost.emobix.co.uk:8443/test/a/oidc-core-basic/callback` |
+
+### Client 3: Second Client
+
+| 項目 | 値 |
+|------|-----|
+| Client ID | `94db3cf2-7306-48a0-ab19-201742754236` |
+| Client ID Alias | `oidcc-second-client` |
+| Client Secret | `oidcc-second-secret-32characters!` |
+| Auth Method | `client_secret_basic` |
+| Redirect URI | `https://localhost.emobix.co.uk:8443/test/a/oidc-core-basic/callback` |
+
+## テストユーザー
+
+| 項目 | 値 |
+|------|-----|
+| Email | `oidcc-test@example.com` |
+| Password | `OidccTestPassword123!` |
+| Name | `OIDCC Test User` |
+| Phone | `+81-90-1234-5678` |
+| Address | `123 Test Street, Tokyo, Japan 100-0001` |
+
+## Conformance Suite 設定
+
+OpenID Conformance Suite で以下の設定を使用:
+
+```
+Server:
+  Issuer: https://api.local.dev/e8c169c2-019f-46c9-af39-7be12ec51e4d
+
+Client (client_secret_basic):
+  Client ID: 35f40824-807c-4f36-bf91-a8da0692b032
+  Client Secret: oidcc-basic-secret-32characters1
+
+Client (client_secret_post):
+  Client ID: f8702ea8-33b1-4433-9b5d-f1034f0bd5b5
+  Client Secret: oidcc-post-secret-32characters12
+
+Second Client:
+  Client ID: 94db3cf2-7306-48a0-ab19-201742754236
+  Client Secret: oidcc-second-secret-32characters
+
+User:
+  Username: oidcc-test@example.com
+  Password: OidccTestPassword123!
+```
+
+## サポートされる機能
+
+| 機能 | サポート |
+|------|---------|
+| response_mode=form_post | Yes |
+| response_type=code | Yes |
+| prompt=none | Yes |
+| prompt=login | Yes |
+| max_age | Yes |
+| acr_values | Yes |
+| login_hint | Yes |
+| id_token_hint | Yes |
+| claims parameter | Yes |
+| request parameter | Yes |
+| request_uri parameter | Yes |
+| PKCE | Yes |
+| Refresh Token | Yes |
+
+## テストモジュール (38個)
+
+1. oidcc-server - 基本フロー
+2. oidcc-response-type-missing - response_type省略エラー
+3. oidcc-idtoken-signature - ID Token署名検証
+4. oidcc-userinfo-get - UserInfo GET
+5. oidcc-userinfo-post-header - UserInfo POST (header)
+6. oidcc-userinfo-post-body - UserInfo POST (body)
+7. oidcc-scope-profile/email/address/phone/all - スコープテスト
+8. oidcc-prompt-login/none - prompt パラメータ
+9. oidcc-max-age-1/10000 - max_age パラメータ
+10. oidcc-id-token-hint - id_token_hint
+11. oidcc-login-hint - login_hint
+12. oidcc-codereuse - 認可コード再利用防止
+13. oidcc-refresh-token - リフレッシュトークン
+14. oidcc-ensure-request-with-valid-pkce-succeeds - PKCE
+... など
+
+詳細は OpenID Conformance Suite のドキュメントを参照。

--- a/config/examples/oidcc-cross-site-context-path/client-post.json
+++ b/config/examples/oidcc-cross-site-context-path/client-post.json
@@ -1,0 +1,31 @@
+{
+  "client_id": "a58c5ffd-1cfb-4b4e-ba40-5ae29779acca",
+  "client_id_alias": "oidcc-post-client-context-path",
+  "client_secret": "oidcc-post-secret-32characters12",
+  "redirect_uris": [
+    "https://localhost.emobix.co.uk:8443/test/a/oidc-core-basic-context-path/callback",
+    "https://localhost.emobix.co.uk:8443/test/a/oidc-core-comprehensive-test-context-path/callback",
+    "https://localhost.emobix.co.uk:8443/test/a/oidcc-rp-initiated-logout-context-path/callback"
+  ],
+  "response_types": [
+    "code",
+    "token",
+    "id_token",
+    "code token",
+    "code id_token",
+    "token id_token",
+    "code token id_token",
+    "none"
+  ],
+  "grant_types": [
+    "authorization_code",
+    "refresh_token"
+  ],
+  "scope": "openid profile email address phone offline_access",
+  "client_name": "OIDCC Post Client Context Path (client_secret_post)",
+  "token_endpoint_auth_method": "client_secret_post",
+  "application_type": "web",
+  "post_logout_redirect_uris": [
+    "https://localhost.emobix.co.uk:8443/test/a/oidcc-rp-initiated-logout-context-path/post_logout_redirect"
+  ]
+}

--- a/config/examples/oidcc-cross-site-context-path/client-second.json
+++ b/config/examples/oidcc-cross-site-context-path/client-second.json
@@ -1,0 +1,31 @@
+{
+  "client_id": "7b7ccd40-a6db-4f32-bd7d-6cb3ad43a26c",
+  "client_id_alias": "oidcc-second-client-context-path",
+  "client_secret": "oidcc-second-secret-32characters",
+  "redirect_uris": [
+    "https://localhost.emobix.co.uk:8443/test/a/oidc-core-basic-context-path/callback",
+    "https://localhost.emobix.co.uk:8443/test/a/oidc-core-comprehensive-test-context-path/callback",
+    "https://localhost.emobix.co.uk:8443/test/a/oidcc-rp-initiated-logout-context-path/callback"
+  ],
+  "response_types": [
+    "code",
+    "token",
+    "id_token",
+    "code token",
+    "code id_token",
+    "token id_token",
+    "code token id_token",
+    "none"
+  ],
+  "grant_types": [
+    "authorization_code",
+    "refresh_token"
+  ],
+  "scope": "openid profile email address phone offline_access",
+  "client_name": "OIDCC Second Client Context Path",
+  "token_endpoint_auth_method": "client_secret_basic",
+  "application_type": "web",
+  "post_logout_redirect_uris": [
+    "https://localhost.emobix.co.uk:8443/test/a/oidcc-rp-initiated-logout-context-path/post_logout_redirect"
+  ]
+}

--- a/config/examples/oidcc-cross-site-context-path/delete.sh
+++ b/config/examples/oidcc-cross-site-context-path/delete.sh
@@ -1,0 +1,253 @@
+#!/bin/bash
+set -e
+
+# OIDCC Form Post Basic Certification Test Delete Script
+# This script deletes organization and all related resources
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+ENV_FILE="${PROJECT_ROOT}/.env"
+
+echo "=========================================="
+echo "OIDCC Form Post Basic Delete"
+echo "=========================================="
+
+# Load .env file
+if [ ! -f "${ENV_FILE}" ]; then
+  echo "Error: .env file not found at ${ENV_FILE}"
+  exit 1
+fi
+
+echo "Loading environment variables from .env..."
+set -a
+source "${ENV_FILE}"
+set +a
+
+echo "Environment variables loaded"
+echo "   Server: ${AUTHORIZATION_SERVER_URL}"
+echo ""
+
+# Step 1: Get access token
+echo "Step 1: Getting system administrator access token..."
+TOKEN_RESPONSE=$(curl -s -X POST \
+  "${AUTHORIZATION_SERVER_URL}/${ADMIN_TENANT_ID}/v1/tokens" \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  --data-urlencode "grant_type=password" \
+  --data-urlencode "username=${ADMIN_USER_EMAIL}" \
+  --data-urlencode "password=${ADMIN_USER_PASSWORD}" \
+  --data-urlencode "client_id=${ADMIN_CLIENT_ID}" \
+  --data-urlencode "client_secret=${ADMIN_CLIENT_SECRET}" \
+  --data-urlencode "scope=account management")
+
+SYSTEM_ACCESS_TOKEN=$(echo "${TOKEN_RESPONSE}" | jq -r '.access_token')
+
+if [ -z "${SYSTEM_ACCESS_TOKEN}" ] || [ "${SYSTEM_ACCESS_TOKEN}" = "null" ]; then
+  echo "Error: Failed to get access token"
+  echo "Response: ${TOKEN_RESPONSE}"
+  exit 1
+fi
+
+echo "Access token obtained: ${SYSTEM_ACCESS_TOKEN:0:20}..."
+echo ""
+
+# Read IDs from configuration files
+ONBOARDING_REQUEST="${SCRIPT_DIR}/onboarding-request.json"
+
+if [ ! -f "${ONBOARDING_REQUEST}" ]; then
+  echo "Error: onboarding-request.json not found at ${ONBOARDING_REQUEST}"
+  exit 1
+fi
+
+echo "Reading resource IDs from configuration files..."
+ORG_ID=$(jq -r '.organization.id' "${ONBOARDING_REQUEST}")
+TENANT_ID=$(jq -r '.tenant.id' "${ONBOARDING_REQUEST}")
+USER_ID=$(jq -r '.user.sub' "${ONBOARDING_REQUEST}")
+CLIENT_BASIC_ID=$(jq -r '.client.client_id' "${ONBOARDING_REQUEST}")
+
+CLIENT_POST_FILE="${SCRIPT_DIR}/client-post.json"
+if [ -f "${CLIENT_POST_FILE}" ]; then
+  CLIENT_POST_ID=$(jq -r '.client_id' "${CLIENT_POST_FILE}")
+else
+  CLIENT_POST_ID=""
+fi
+
+CLIENT_SECOND_FILE="${SCRIPT_DIR}/client-second.json"
+if [ -f "${CLIENT_SECOND_FILE}" ]; then
+  CLIENT_SECOND_ID=$(jq -r '.client_id' "${CLIENT_SECOND_FILE}")
+else
+  CLIENT_SECOND_ID=""
+fi
+
+echo "Resource IDs loaded"
+echo "   Organization ID:  ${ORG_ID}"
+echo "   Tenant ID:        ${TENANT_ID}"
+echo "   User ID:          ${USER_ID}"
+echo "   Client Basic ID:  ${CLIENT_BASIC_ID}"
+if [ -n "${CLIENT_POST_ID}" ]; then
+  echo "   Client Post ID:   ${CLIENT_POST_ID}"
+fi
+if [ -n "${CLIENT_SECOND_ID}" ]; then
+  echo "   Client Second ID: ${CLIENT_SECOND_ID}"
+fi
+echo ""
+
+# Step 2: Delete client (client_secret_basic)
+echo "Step 2: Deleting client (client_secret_basic)..."
+CLIENT_BASIC_DELETE_RESPONSE=$(curl -s -w "\n%{http_code}" -X DELETE \
+  "${AUTHORIZATION_SERVER_URL}/v1/management/tenants/${TENANT_ID}/clients/${CLIENT_BASIC_ID}" \
+  -H "Authorization: Bearer ${SYSTEM_ACCESS_TOKEN}")
+
+CLIENT_BASIC_DELETE_HTTP_CODE=$(echo "${CLIENT_BASIC_DELETE_RESPONSE}" | tail -n1)
+CLIENT_BASIC_DELETE_BODY=$(echo "${CLIENT_BASIC_DELETE_RESPONSE}" | sed '$d')
+
+if [ "${CLIENT_BASIC_DELETE_HTTP_CODE}" = "204" ]; then
+  echo "Client (basic) deleted successfully"
+elif [ "${CLIENT_BASIC_DELETE_HTTP_CODE}" = "404" ]; then
+  echo "Warning: Client (basic) not found (may already be deleted)"
+else
+  echo "Warning: Client (basic) deletion failed (HTTP ${CLIENT_BASIC_DELETE_HTTP_CODE})"
+  if [ -n "${CLIENT_BASIC_DELETE_BODY}" ]; then
+    echo "Response: ${CLIENT_BASIC_DELETE_BODY}" | jq '.' || echo "${CLIENT_BASIC_DELETE_BODY}"
+  fi
+fi
+
+echo ""
+
+# Step 3: Delete client (client_secret_post)
+if [ -n "${CLIENT_POST_ID}" ]; then
+  echo "Step 3: Deleting client (client_secret_post)..."
+  CLIENT_POST_DELETE_RESPONSE=$(curl -s -w "\n%{http_code}" -X DELETE \
+    "${AUTHORIZATION_SERVER_URL}/v1/management/tenants/${TENANT_ID}/clients/${CLIENT_POST_ID}" \
+    -H "Authorization: Bearer ${SYSTEM_ACCESS_TOKEN}")
+
+  CLIENT_POST_DELETE_HTTP_CODE=$(echo "${CLIENT_POST_DELETE_RESPONSE}" | tail -n1)
+  CLIENT_POST_DELETE_BODY=$(echo "${CLIENT_POST_DELETE_RESPONSE}" | sed '$d')
+
+  if [ "${CLIENT_POST_DELETE_HTTP_CODE}" = "204" ]; then
+    echo "Client (post) deleted successfully"
+  elif [ "${CLIENT_POST_DELETE_HTTP_CODE}" = "404" ]; then
+    echo "Warning: Client (post) not found (may already be deleted)"
+  else
+    echo "Warning: Client (post) deletion failed (HTTP ${CLIENT_POST_DELETE_HTTP_CODE})"
+    if [ -n "${CLIENT_POST_DELETE_BODY}" ]; then
+      echo "Response: ${CLIENT_POST_DELETE_BODY}" | jq '.' || echo "${CLIENT_POST_DELETE_BODY}"
+    fi
+  fi
+
+  echo ""
+else
+  echo "Step 3: Skipping client (post) deletion (not configured)"
+  echo ""
+fi
+
+# Step 4: Delete client (second client)
+if [ -n "${CLIENT_SECOND_ID}" ]; then
+  echo "Step 4: Deleting client (second client)..."
+  CLIENT_SECOND_DELETE_RESPONSE=$(curl -s -w "\n%{http_code}" -X DELETE \
+    "${AUTHORIZATION_SERVER_URL}/v1/management/tenants/${TENANT_ID}/clients/${CLIENT_SECOND_ID}" \
+    -H "Authorization: Bearer ${SYSTEM_ACCESS_TOKEN}")
+
+  CLIENT_SECOND_DELETE_HTTP_CODE=$(echo "${CLIENT_SECOND_DELETE_RESPONSE}" | tail -n1)
+  CLIENT_SECOND_DELETE_BODY=$(echo "${CLIENT_SECOND_DELETE_RESPONSE}" | sed '$d')
+
+  if [ "${CLIENT_SECOND_DELETE_HTTP_CODE}" = "204" ]; then
+    echo "Client (second) deleted successfully"
+  elif [ "${CLIENT_SECOND_DELETE_HTTP_CODE}" = "404" ]; then
+    echo "Warning: Client (second) not found (may already be deleted)"
+  else
+    echo "Warning: Client (second) deletion failed (HTTP ${CLIENT_SECOND_DELETE_HTTP_CODE})"
+    if [ -n "${CLIENT_SECOND_DELETE_BODY}" ]; then
+      echo "Response: ${CLIENT_SECOND_DELETE_BODY}" | jq '.' || echo "${CLIENT_SECOND_DELETE_BODY}"
+    fi
+  fi
+
+  echo ""
+else
+  echo "Step 4: Skipping client (second) deletion (not configured)"
+  echo ""
+fi
+
+# Step 5: Delete user
+echo "Step 5: Deleting user..."
+USER_DELETE_RESPONSE=$(curl -s -w "\n%{http_code}" -X DELETE \
+  "${AUTHORIZATION_SERVER_URL}/v1/management/tenants/${TENANT_ID}/users/${USER_ID}" \
+  -H "Authorization: Bearer ${SYSTEM_ACCESS_TOKEN}")
+
+USER_DELETE_HTTP_CODE=$(echo "${USER_DELETE_RESPONSE}" | tail -n1)
+USER_DELETE_BODY=$(echo "${USER_DELETE_RESPONSE}" | sed '$d')
+
+if [ "${USER_DELETE_HTTP_CODE}" = "204" ]; then
+  echo "User deleted successfully"
+elif [ "${USER_DELETE_HTTP_CODE}" = "404" ]; then
+  echo "Warning: User not found (may already be deleted)"
+else
+  echo "Warning: User deletion failed (HTTP ${USER_DELETE_HTTP_CODE})"
+  if [ -n "${USER_DELETE_BODY}" ]; then
+    echo "Response: ${USER_DELETE_BODY}" | jq '.' || echo "${USER_DELETE_BODY}"
+  fi
+fi
+
+echo ""
+
+# Step 6: Delete tenant
+echo "Step 6: Deleting tenant..."
+TENANT_DELETE_RESPONSE=$(curl -s -w "\n%{http_code}" -X DELETE \
+  "${AUTHORIZATION_SERVER_URL}/v1/management/tenants/${TENANT_ID}" \
+  -H "Authorization: Bearer ${SYSTEM_ACCESS_TOKEN}")
+
+TENANT_DELETE_HTTP_CODE=$(echo "${TENANT_DELETE_RESPONSE}" | tail -n1)
+TENANT_DELETE_BODY=$(echo "${TENANT_DELETE_RESPONSE}" | sed '$d')
+
+if [ "${TENANT_DELETE_HTTP_CODE}" = "204" ]; then
+  echo "Tenant deleted successfully"
+elif [ "${TENANT_DELETE_HTTP_CODE}" = "404" ]; then
+  echo "Warning: Tenant not found (may already be deleted)"
+else
+  echo "Error: Tenant deletion failed (HTTP ${TENANT_DELETE_HTTP_CODE})"
+  if [ -n "${TENANT_DELETE_BODY}" ]; then
+    echo "Response: ${TENANT_DELETE_BODY}" | jq '.' || echo "${TENANT_DELETE_BODY}"
+  fi
+  echo "Warning: Cannot proceed to organization deletion"
+  exit 1
+fi
+
+echo ""
+
+# Step 7: Delete organization
+echo "Step 7: Deleting organization..."
+ORG_DELETE_RESPONSE=$(curl -s -w "\n%{http_code}" -X DELETE \
+  "${AUTHORIZATION_SERVER_URL}/v1/management/orgs/${ORG_ID}" \
+  -H "Authorization: Bearer ${SYSTEM_ACCESS_TOKEN}")
+
+ORG_DELETE_HTTP_CODE=$(echo "${ORG_DELETE_RESPONSE}" | tail -n1)
+ORG_DELETE_BODY=$(echo "${ORG_DELETE_RESPONSE}" | sed '$d')
+
+if [ "${ORG_DELETE_HTTP_CODE}" = "204" ]; then
+  echo "Organization deleted successfully"
+elif [ "${ORG_DELETE_HTTP_CODE}" = "404" ]; then
+  echo "Warning: Organization not found (may already be deleted)"
+else
+  echo "Error: Organization deletion failed (HTTP ${ORG_DELETE_HTTP_CODE})"
+  if [ -n "${ORG_DELETE_BODY}" ]; then
+    echo "Response: ${ORG_DELETE_BODY}" | jq '.' || echo "${ORG_DELETE_BODY}"
+  fi
+  exit 1
+fi
+
+echo ""
+echo "=========================================="
+echo "Delete Complete!"
+echo "=========================================="
+echo ""
+echo "Deleted Resources:"
+echo "   Organization ID:  ${ORG_ID}"
+echo "   Tenant ID:        ${TENANT_ID}"
+echo "   User ID:          ${USER_ID}"
+echo "   Client Basic ID:  ${CLIENT_BASIC_ID}"
+if [ -n "${CLIENT_POST_ID}" ]; then
+  echo "   Client Post ID:   ${CLIENT_POST_ID}"
+fi
+if [ -n "${CLIENT_SECOND_ID}" ]; then
+  echo "   Client Second ID: ${CLIENT_SECOND_ID}"
+fi
+echo ""

--- a/config/examples/oidcc-cross-site-context-path/oidc-test/oidc-comprehensive-test.json
+++ b/config/examples/oidcc-cross-site-context-path/oidc-test/oidc-comprehensive-test.json
@@ -1,0 +1,11 @@
+{
+  "alias": "oidc-core-comprehensive-test-context-path",
+  "description": "Context Path Test - comprehensive",
+  "server": {
+    "discoveryUrl": "https://api.local.dev/76ec54ab-8923-468d-b04b-0d8d0a5eaade/.well-known/openid-configuration"
+  },
+  "client": {
+    "client_id": "context-path-client",
+    "client_secret": "context-path-secret-32characters1"
+  }
+}

--- a/config/examples/oidcc-cross-site-context-path/oidc-test/oidc-core-basic.json
+++ b/config/examples/oidcc-cross-site-context-path/oidc-test/oidc-core-basic.json
@@ -1,0 +1,17 @@
+{
+  "alias": "oidc-core-basic-context-path",
+  "description": "Context Path Test - cookie_path verification",
+  "server": {
+    "issuer": "https://api.local.dev/76ec54ab-8923-468d-b04b-0d8d0a5eaade",
+    "jwks_uri": "https://api.local.dev/76ec54ab-8923-468d-b04b-0d8d0a5eaade/v1/jwks",
+    "authorization_endpoint": "https://api.local.dev/idp-admin/76ec54ab-8923-468d-b04b-0d8d0a5eaade/v1/authorizations",
+    "token_endpoint": "https://api.local.dev/idp-admin/76ec54ab-8923-468d-b04b-0d8d0a5eaade/v1/tokens",
+    "userinfo_endpoint": "https://api.local.dev/idp-admin/76ec54ab-8923-468d-b04b-0d8d0a5eaade/v1/userinfo",
+    "acr_values": "urn:mace:incommon:iap:bronze",
+    "login_hint": "context-path-test"
+  },
+  "client": {
+    "client_id": "context-path-client",
+    "client_secret": "context-path-secret-32characters1"
+  }
+}

--- a/config/examples/oidcc-cross-site-context-path/oidc-test/oidcc-discovery-endpoint-verification.json
+++ b/config/examples/oidcc-cross-site-context-path/oidc-test/oidcc-discovery-endpoint-verification.json
@@ -1,0 +1,11 @@
+{
+  "alias": "oidcc-discovery-endpoint-verification-context-path",
+  "description": "Context Path Test - discovery endpoint verification",
+  "server": {
+    "discoveryUrl": "https://api.local.dev/76ec54ab-8923-468d-b04b-0d8d0a5eaade/.well-known/openid-configuration"
+  },
+  "client": {
+    "client_id": "context-path-client",
+    "client_secret": "context-path-secret-32characters1"
+  }
+}

--- a/config/examples/oidcc-cross-site-context-path/onboarding-request.json
+++ b/config/examples/oidcc-cross-site-context-path/onboarding-request.json
@@ -1,0 +1,187 @@
+{
+  "organization": {
+    "id": "eccdc55b-0e24-4e3c-8cf2-a1bcda7906fe",
+    "name": "Context Path Test Organization",
+    "description": "Organization for testing cookie path with API Gateway context path"
+  },
+  "tenant": {
+    "id": "76ec54ab-8923-468d-b04b-0d8d0a5eaade",
+    "name": "Context Path Test Tenant",
+    "type": "ORGANIZER",
+    "domain": "https://api.local.dev",
+    "authorization_provider": "idp-server",
+    "ui_config": {
+      "base_url": "https://auth-cp.idp.local",
+      "signin_page": "/signin/",
+      "signup_page": "/signup/"
+    },
+    "session_config": {
+      "cookie_name": "CONTEXT_PATH_SESSION",
+      "cookie_path": "/idp-admin",
+      "cookie_same_site": "None",
+      "use_secure_cookie": true,
+      "timeout_seconds": 3600
+    },
+    "cors_config": {
+      "allow_origins": [
+        "https://auth-cp.idp.local",
+        "https://api.local.dev"
+      ]
+    }
+  },
+  "authorization_server": {
+    "issuer": "https://api.local.dev/76ec54ab-8923-468d-b04b-0d8d0a5eaade",
+    "authorization_endpoint": "https://api.local.dev/76ec54ab-8923-468d-b04b-0d8d0a5eaade/v1/authorizations",
+    "token_endpoint": "https://api.local.dev/76ec54ab-8923-468d-b04b-0d8d0a5eaade/v1/tokens",
+    "token_endpoint_auth_methods_supported": [
+      "client_secret_basic",
+      "client_secret_post"
+    ],
+    "token_endpoint_auth_signing_alg_values_supported": [
+      "RS256",
+      "ES256"
+    ],
+    "userinfo_endpoint": "https://api.local.dev/76ec54ab-8923-468d-b04b-0d8d0a5eaade/v1/userinfo",
+    "end_session_endpoint": "https://api.local.dev/76ec54ab-8923-468d-b04b-0d8d0a5eaade/v1/logout",
+    "jwks_uri": "https://api.local.dev/76ec54ab-8923-468d-b04b-0d8d0a5eaade/v1/jwks",
+    "jwks": "{\"keys\":[{\"kty\":\"EC\",\"x\":\"_g1pn_N84_T82eU-YVN4pcgQt3tfvZWJMPabMFNgbVg\",\"y\":\"B3vLi4eGNz9rzoj493h7zHBpM5G3lSM7Af57fru2-FE\",\"crv\":\"P-256\",\"d\":\"xHfNjJqElnZajzexFG49MQqO01TrveM4mL4tlz8T9jw\",\"use\":\"sig\",\"kid\":\"signing_key_1\",\"alg\":\"ES256\"}]}",
+    "grant_types_supported": [
+      "authorization_code",
+      "refresh_token"
+    ],
+    "token_signed_key_id": "signing_key_1",
+    "id_token_signed_key_id": "signing_key_1",
+    "scopes_supported": [
+      "openid",
+      "profile",
+      "email",
+      "address",
+      "phone",
+      "offline_access"
+    ],
+    "response_types_supported": [
+      "code",
+      "token",
+      "id_token",
+      "code token",
+      "code id_token",
+      "token id_token",
+      "code token id_token",
+      "none"
+    ],
+    "response_modes_supported": [
+      "query",
+      "form_post"
+    ],
+    "acr_values_supported": [
+      "urn:mace:incommon:iap:silver",
+      "urn:mace:incommon:iap:bronze"
+    ],
+    "subject_types_supported": [
+      "public"
+    ],
+    "id_token_signing_alg_values_supported": [
+      "RS256",
+      "ES256"
+    ],
+    "claims_supported": [
+      "sub",
+      "iss",
+      "auth_time",
+      "acr",
+      "name",
+      "given_name",
+      "family_name",
+      "nickname",
+      "profile",
+      "picture",
+      "website",
+      "email",
+      "email_verified",
+      "locale",
+      "zoneinfo",
+      "birthdate",
+      "gender",
+      "preferred_username",
+      "middle_name",
+      "updated_at",
+      "address",
+      "phone_number",
+      "phone_number_verified"
+    ],
+    "claims_parameter_supported": true,
+    "request_parameter_supported": true,
+    "request_uri_parameter_supported": true,
+    "token_introspection_endpoint": "https://api.local.dev/76ec54ab-8923-468d-b04b-0d8d0a5eaade/v1/tokens/introspection",
+    "token_revocation_endpoint": "https://api.local.dev/76ec54ab-8923-468d-b04b-0d8d0a5eaade/v1/tokens/revocation",
+    "extension": {
+      "access_token_type": "JWT",
+      "token_signed_key_id": "signing_key_1",
+      "id_token_signed_key_id": "signing_key_1",
+      "access_token_duration": 3600,
+      "id_token_duration": 3600,
+      "refresh_token_duration": 86400,
+      "id_token_strict_mode": true
+    }
+  },
+  "user": {
+    "sub": "b37692d3-321c-425b-a259-c52f8ee4a035",
+    "provider_id": "idp-server",
+    "name": "Context Path Test User",
+    "given_name": "Test",
+    "family_name": "User",
+    "middle_name": "OIDCC",
+    "nickname": "testuser",
+    "preferred_username": "oidcc-test",
+    "profile": "https://example.com/profile/oidcc-test",
+    "picture": "https://example.com/picture/oidcc-test.jpg",
+    "website": "https://example.com",
+    "email": "context-path-test@example.com",
+    "email_verified": true,
+    "gender": "male",
+    "birthdate": "1990-01-15",
+    "zoneinfo": "Asia/Tokyo",
+    "locale": "ja-JP",
+    "phone_number": "+81-90-1234-5678",
+    "phone_number_verified": true,
+    "address": {
+      "formatted": "123 Test Street, Tokyo, Japan 100-0001",
+      "street_address": "123 Test Street",
+      "locality": "Chiyoda-ku",
+      "region": "Tokyo",
+      "postal_code": "100-0001",
+      "country": "Japan"
+    },
+    "raw_password": "TestPassword123!"
+  },
+  "client": {
+    "client_id": "3905126c-b203-448d-b6fe-0159ce48532f",
+    "client_id_alias": "context-path-client",
+    "client_secret": "context-path-secret-32characters1",
+    "redirect_uris": [
+      "https://sample.local.dev/api/auth/callback/idp-server",
+      "https://localhost.emobix.co.uk:8443/test/a/oidc-core-basic-context-path/callback"
+    ],
+    "response_types": [
+      "code",
+      "token",
+      "id_token",
+      "code token",
+      "code id_token",
+      "token id_token",
+      "code token id_token",
+      "none"
+    ],
+    "grant_types": [
+      "authorization_code",
+      "refresh_token"
+    ],
+    "scope": "openid profile email address phone offline_access",
+    "client_name": "Context Path Test Client",
+    "token_endpoint_auth_method": "client_secret_basic",
+    "application_type": "web",
+    "post_logout_redirect_uris": [
+      "https://localhost.emobix.co.uk:8443/test/a/oidcc-rp-initiated-logout/post_logout_redirect"
+    ]
+  }
+}

--- a/config/examples/oidcc-cross-site-context-path/rotation-privateKey.json
+++ b/config/examples/oidcc-cross-site-context-path/rotation-privateKey.json
@@ -1,0 +1,28 @@
+{
+  "keys": [
+    {
+      "kty": "EC",
+      "x": "_g1pn_N84_T82eU-YVN4pcgQt3tfvZWJMPabMFNgbVg",
+      "y": "B3vLi4eGNz9rzoj493h7zHBpM5G3lSM7Af57fru2-FE",
+      "crv": "P-256",
+      "d": "xHfNjJqElnZajzexFG49MQqO01TrveM4mL4tlz8T9jw",
+      "use": "sig",
+      "kid": "signing_key_1",
+      "alg": "ES256"
+    },
+    {
+      "p": "9YxjK848R_KUjcm8w18v3FVIFR2VflXldcyINBbKHYgYYTdXrFcHxoahFi_jTZiQ7HPXIpwyBWgV5iN6J1TrjePnDMv3zUCkJDRekVHDm9dhD0bFosvIIDpnTejXeAWQdCGq3Ej9eRdJLwljZQ92PMAMjh8_BaGou7VoaHdukg8",
+      "kty": "RSA",
+      "q": "1INIe86zLIm1J85pon06yh8lTidy0je8GVDGHzNkbua0emhYNuPuX5Sszwpsok_Wr3Z8AuWAPp699IykB61p8AYwsP-mbjMrEcmmQ_oy4vtUbyZN6ZPx5Q7WXKJh55wbOylvTjWlhN-y_c1hEKMDTI2vZj7owqokuOkl4rEvJCE",
+      "d": "SvEJEJaimgVtGqEzNk7LK7LO9u7dr78eynIo5GsLhIvud2MMg6nFmx_soAsGo0EgMB4JeFTjhY8rQ05w7jtgX3UEnOL-V4_JG-pZSpnz7DVZi-P7wZVyp6YBrsXoTc2f8bfvmD6DkP9kU9do6T_iIvrehkMbaHEzy1PqdxfoR9f3R0EsURz3ce8AkfBU6rc2hFvkq_2-mEM3803Dz0LoqD7air03hrlECt5Da_fzXSVmPsR6-PIS21ixA9UtcmKUqmyE-SMYoI8mN_aZy6t-efsIPlhSfG9K1HbhkqxiK0RGrMDp-si03ff9E5NuYy5b2B5dBob3Sbiuefr7H8x-QQ",
+      "e": "AQAB",
+      "use": "sig",
+      "kid": "signing_key_2",
+      "qi": "uEQIldK2hPfRxZRH4-yFV9rbzoVaKTUK8uxgMNm2WLqEr7Ww3AdYp_sx6ODz4Fduj46DeIEwN_ab72Fcj274_0hXUIduLrOaycGzQbnVMKGDeAikxKAk90vGumaLzXu8OPHFtU74d7NJnVwLKwgWKW33M7-1lI4iN8QlYHf-YpI",
+      "dp": "cJijkR7M_aD7BdmQOXaYl8xzdVtPhdMVmWLkwh4BKHGT3GBoT5rI8fwiOe5TqO1g50xnRnOhbGFCSXnTNd329eWfuXp-cxxFKGTrSG_Z5shotXyafAA-EKk3Xb57r4m9p8MYelLuCGzpHiyL63efnFPkbfdeCtMKcKjK67x4c3k",
+      "alg": "RS256",
+      "dq": "b6nb-FIQC6MAMT5geyTaM0JSU9Kenp7yk0rCD7rtVuiahIc3cwApTMfOVavgkRjqcaAMYWk-DalTnqAXwID6XUijZR2v0c_JHbubRbS98E6new_heI5oWDeHo30ffJemJ1wKREokAsGYR4wXKKq_HQaF12_O1hqY2SCI66i2YIE",
+      "n": "y9YufULPQCmN3vtgacHne87xTay7GxypCG93ZReue9A4pKeyo58-mV80WNxMRDUd_DhTyiMUtk3t_FeMn7ZgvD2J2nLNJVjMCCdorFK6keOxhL_gcLf6ccENfayWRXv0ZBUiu9giayYVAeC1OGocshREONZ3Axkmpbg3yjjgpOdQZrDd6x_5EadJIIbFr1O--4NROlPJmXm9gc_PBjaUdL6r-ovR4-wow6TUPdKEY0ac-AyC5seGAo05xe6pp6yoHYy4-pGpK0iQFxSWQM9jRJQMygw3Lud5vWhFcikCjmRGrwsmjLtyOfjBJ2Rx24lC0zagus1KZto9MqLKIYvv7w"
+    }
+  ]
+}

--- a/config/examples/oidcc-cross-site-context-path/setup.sh
+++ b/config/examples/oidcc-cross-site-context-path/setup.sh
@@ -1,0 +1,198 @@
+#!/bin/bash
+set -e
+
+# OIDCC Form Post Basic Certification Test Setup Script
+# This script sets up the environment for OIDCC certification tests
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+ENV_FILE="${PROJECT_ROOT}/.env"
+ONBOARDING_REQUEST="${SCRIPT_DIR}/onboarding-request.json"
+
+echo "=========================================="
+echo "OIDCC Form Post Basic Certification Setup"
+echo "=========================================="
+
+# Load .env file
+if [ ! -f "${ENV_FILE}" ]; then
+  echo "Error: .env file not found at ${ENV_FILE}"
+  exit 1
+fi
+
+echo "Loading environment variables from .env..."
+set -a
+source "${ENV_FILE}"
+set +a
+
+# Validate required variables
+if [ -z "${AUTHORIZATION_SERVER_URL}" ]; then
+  echo "Error: AUTHORIZATION_SERVER_URL not set in .env"
+  exit 1
+fi
+
+if [ -z "${ADMIN_TENANT_ID}" ]; then
+  echo "Error: ADMIN_TENANT_ID not set in .env"
+  exit 1
+fi
+
+if [ -z "${ADMIN_USER_EMAIL}" ]; then
+  echo "Error: ADMIN_USER_EMAIL not set in .env"
+  exit 1
+fi
+
+echo "Environment variables loaded"
+echo "   Server: ${AUTHORIZATION_SERVER_URL}"
+echo "   Tenant: ${ADMIN_TENANT_ID}"
+echo "   Admin:  ${ADMIN_USER_EMAIL}"
+echo ""
+
+# Step 1: Get access token
+echo "Step 1: Getting system administrator access token..."
+TOKEN_RESPONSE=$(curl -s -X POST \
+  "${AUTHORIZATION_SERVER_URL}/${ADMIN_TENANT_ID}/v1/tokens" \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  --data-urlencode "grant_type=password" \
+  --data-urlencode "username=${ADMIN_USER_EMAIL}" \
+  --data-urlencode "password=${ADMIN_USER_PASSWORD}" \
+  --data-urlencode "client_id=${ADMIN_CLIENT_ID}" \
+  --data-urlencode "client_secret=${ADMIN_CLIENT_SECRET}" \
+  --data-urlencode "scope=account management")
+
+SYSTEM_ACCESS_TOKEN=$(echo "${TOKEN_RESPONSE}" | jq -r '.access_token')
+
+if [ -z "${SYSTEM_ACCESS_TOKEN}" ] || [ "${SYSTEM_ACCESS_TOKEN}" = "null" ]; then
+  echo "Error: Failed to get access token"
+  echo "Response: ${TOKEN_RESPONSE}"
+  exit 1
+fi
+
+echo "Access token obtained: ${SYSTEM_ACCESS_TOKEN:0:20}..."
+echo ""
+
+# Step 2: Execute onboarding API
+echo "Step 2: Executing onboarding API..."
+ONBOARDING_RESPONSE=$(curl -s -w "\n%{http_code}" -X POST \
+  "${AUTHORIZATION_SERVER_URL}/v1/management/onboarding" \
+  -H "Authorization: Bearer ${SYSTEM_ACCESS_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d @"${ONBOARDING_REQUEST}")
+
+HTTP_CODE=$(echo "${ONBOARDING_RESPONSE}" | tail -n1)
+RESPONSE_BODY=$(echo "${ONBOARDING_RESPONSE}" | sed '$d')
+
+if [ "${HTTP_CODE}" = "201" ]; then
+  echo "Onboarding successful!"
+  echo ""
+  echo "Response:"
+  echo "${RESPONSE_BODY}" | jq '.'
+  echo ""
+
+  # Extract IDs from response
+  ORG_ID=$(echo "${RESPONSE_BODY}" | jq -r '.organization.id')
+  TENANT_ID=$(echo "${RESPONSE_BODY}" | jq -r '.tenant.id')
+
+  # Step 3: Create second client (client_secret_post)
+  echo "Step 3: Creating second client (client_secret_post)..."
+
+  CLIENT_POST_FILE="${SCRIPT_DIR}/client-post.json"
+  if [ -f "${CLIENT_POST_FILE}" ]; then
+    CLIENT_POST_JSON=$(cat "${CLIENT_POST_FILE}")
+
+    CLIENT_POST_RESPONSE=$(curl -s -w "\n%{http_code}" -X POST \
+      "${AUTHORIZATION_SERVER_URL}/v1/management/tenants/${TENANT_ID}/clients" \
+      -H "Authorization: Bearer ${SYSTEM_ACCESS_TOKEN}" \
+      -H "Content-Type: application/json" \
+      -d "${CLIENT_POST_JSON}")
+
+    CLIENT_POST_HTTP_CODE=$(echo "${CLIENT_POST_RESPONSE}" | tail -n1)
+    CLIENT_POST_RESPONSE_BODY=$(echo "${CLIENT_POST_RESPONSE}" | sed '$d')
+
+    if [ "${CLIENT_POST_HTTP_CODE}" = "200" ] || [ "${CLIENT_POST_HTTP_CODE}" = "201" ]; then
+      echo "Second client created successfully"
+    else
+      echo "Warning: Second client creation failed (HTTP ${CLIENT_POST_HTTP_CODE})"
+      echo "Response: ${CLIENT_POST_RESPONSE_BODY}" | jq '.' || echo "${CLIENT_POST_RESPONSE_BODY}"
+    fi
+  else
+    echo "Warning: client-post.json not found, skipping second client creation"
+  fi
+  echo ""
+
+  # Step 4: Create third client (second client for conformance suite)
+  echo "Step 4: Creating third client (second client)..."
+
+  CLIENT_SECOND_FILE="${SCRIPT_DIR}/client-second.json"
+  if [ -f "${CLIENT_SECOND_FILE}" ]; then
+    CLIENT_SECOND_JSON=$(cat "${CLIENT_SECOND_FILE}")
+
+    CLIENT_SECOND_RESPONSE=$(curl -s -w "\n%{http_code}" -X POST \
+      "${AUTHORIZATION_SERVER_URL}/v1/management/tenants/${TENANT_ID}/clients" \
+      -H "Authorization: Bearer ${SYSTEM_ACCESS_TOKEN}" \
+      -H "Content-Type: application/json" \
+      -d "${CLIENT_SECOND_JSON}")
+
+    CLIENT_SECOND_HTTP_CODE=$(echo "${CLIENT_SECOND_RESPONSE}" | tail -n1)
+    CLIENT_SECOND_RESPONSE_BODY=$(echo "${CLIENT_SECOND_RESPONSE}" | sed '$d')
+
+    if [ "${CLIENT_SECOND_HTTP_CODE}" = "200" ] || [ "${CLIENT_SECOND_HTTP_CODE}" = "201" ]; then
+      echo "Third client created successfully"
+    else
+      echo "Warning: Third client creation failed (HTTP ${CLIENT_SECOND_HTTP_CODE})"
+      echo "Response: ${CLIENT_SECOND_RESPONSE_BODY}" | jq '.' || echo "${CLIENT_SECOND_RESPONSE_BODY}"
+    fi
+  else
+    echo "Warning: client-second.json not found, skipping third client creation"
+  fi
+  echo ""
+
+  echo "=========================================="
+  echo "Setup Complete!"
+  echo "=========================================="
+  echo ""
+  echo "Created Resources:"
+  echo "   Organization ID: ${ORG_ID}"
+  echo "   Tenant ID:       ${TENANT_ID}"
+  echo ""
+  echo "Test User:"
+  echo "   Email:    oidcc-test@example.com"
+  echo "   Password: OidccTestPassword123!"
+  echo ""
+  echo "Client 1 (client_secret_basic):"
+  echo "   Client ID:     35f40824-807c-4f36-bf91-a8da0692b032"
+  echo "   Client Alias:  oidcc-basic-client"
+  echo "   Client Secret: oidcc-basic-secret-32characters!"
+  echo "   Auth Method:   client_secret_basic"
+  echo ""
+  echo "Client 2 (client_secret_post):"
+  echo "   Client ID:     f8702ea8-33b1-4433-9b5d-f1034f0bd5b5"
+  echo "   Client Alias:  oidcc-post-client"
+  echo "   Client Secret: oidcc-post-secret-32characters!!"
+  echo "   Auth Method:   client_secret_post"
+  echo ""
+  echo "Client 3 (second client):"
+  echo "   Client ID:     94db3cf2-7306-48a0-ab19-201742754236"
+  echo "   Client Alias:  oidcc-second-client"
+  echo "   Client Secret: oidcc-second-secret-32characters!"
+  echo "   Auth Method:   client_secret_basic"
+  echo ""
+  echo "OIDC Discovery:"
+  echo "   ${AUTHORIZATION_SERVER_URL}/${TENANT_ID}/.well-known/openid-configuration"
+  echo ""
+  echo "Conformance Suite Configuration:"
+  echo "   Issuer:                  ${AUTHORIZATION_SERVER_URL}/${TENANT_ID}"
+  echo "   Client ID (basic):       35f40824-807c-4f36-bf91-a8da0692b032"
+  echo "   Client Secret (basic):   oidcc-basic-secret-32characters!"
+  echo "   Client ID (post):        f8702ea8-33b1-4433-9b5d-f1034f0bd5b5"
+  echo "   Client Secret (post):    oidcc-post-secret-32characters!!"
+  echo "   Second Client ID:        94db3cf2-7306-48a0-ab19-201742754236"
+  echo "   Second Client Secret:    oidcc-second-secret-32characters!"
+  echo "   Redirect URI:            https://localhost.emobix.co.uk:8443/test/a/oidc-core-basic/callback"
+  echo ""
+else
+  echo "Onboarding failed (HTTP ${HTTP_CODE})"
+  echo ""
+  echo "Error Response:"
+  echo "${RESPONSE_BODY}" | jq '.' || echo "${RESPONSE_BODY}"
+  echo ""
+  exit 1
+fi

--- a/config/examples/oidcc-cross-site-context-path/update.sh
+++ b/config/examples/oidcc-cross-site-context-path/update.sh
@@ -1,0 +1,215 @@
+#!/bin/bash
+set -e
+
+# OIDCC Form Post Basic - Update Script
+# This script updates tenant, authorization server, and clients
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+ENV_FILE="${PROJECT_ROOT}/.env"
+ONBOARDING_REQUEST="${SCRIPT_DIR}/onboarding-request.json"
+
+echo "=========================================="
+echo "OIDCC Form Post Basic Update"
+echo "=========================================="
+
+# Load .env file
+if [ ! -f "${ENV_FILE}" ]; then
+  echo "Error: .env file not found at ${ENV_FILE}"
+  exit 1
+fi
+
+echo "Loading environment variables from .env..."
+set -a
+source "${ENV_FILE}"
+set +a
+
+echo "Environment variables loaded"
+echo "   Server: ${AUTHORIZATION_SERVER_URL}"
+echo ""
+
+# Read IDs from configuration files
+TENANT_ID=$(jq -r '.tenant.id' "${ONBOARDING_REQUEST}")
+CLIENT_BASIC_ID=$(jq -r '.client.client_id' "${ONBOARDING_REQUEST}")
+
+CLIENT_POST_FILE="${SCRIPT_DIR}/client-post.json"
+if [ -f "${CLIENT_POST_FILE}" ]; then
+  CLIENT_POST_ID=$(jq -r '.client_id' "${CLIENT_POST_FILE}")
+else
+  CLIENT_POST_ID=""
+fi
+
+CLIENT_SECOND_FILE="${SCRIPT_DIR}/client-second.json"
+if [ -f "${CLIENT_SECOND_FILE}" ]; then
+  CLIENT_SECOND_ID=$(jq -r '.client_id' "${CLIENT_SECOND_FILE}")
+else
+  CLIENT_SECOND_ID=""
+fi
+
+echo "Resource IDs:"
+echo "   Tenant ID:        ${TENANT_ID}"
+echo "   Client Basic ID:  ${CLIENT_BASIC_ID}"
+if [ -n "${CLIENT_POST_ID}" ]; then
+  echo "   Client Post ID:   ${CLIENT_POST_ID}"
+fi
+if [ -n "${CLIENT_SECOND_ID}" ]; then
+  echo "   Client Second ID: ${CLIENT_SECOND_ID}"
+fi
+echo ""
+
+# Step 1: Get access token
+echo "Step 1: Getting system administrator access token..."
+TOKEN_RESPONSE=$(curl -s -X POST \
+  "${AUTHORIZATION_SERVER_URL}/${ADMIN_TENANT_ID}/v1/tokens" \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  --data-urlencode "grant_type=password" \
+  --data-urlencode "username=${ADMIN_USER_EMAIL}" \
+  --data-urlencode "password=${ADMIN_USER_PASSWORD}" \
+  --data-urlencode "client_id=${ADMIN_CLIENT_ID}" \
+  --data-urlencode "client_secret=${ADMIN_CLIENT_SECRET}" \
+  --data-urlencode "scope=account management")
+
+SYSTEM_ACCESS_TOKEN=$(echo "${TOKEN_RESPONSE}" | jq -r '.access_token')
+
+if [ -z "${SYSTEM_ACCESS_TOKEN}" ] || [ "${SYSTEM_ACCESS_TOKEN}" = "null" ]; then
+  echo "Error: Failed to get access token"
+  echo "Response: ${TOKEN_RESPONSE}"
+  exit 1
+fi
+
+echo "Access token obtained: ${SYSTEM_ACCESS_TOKEN:0:20}..."
+echo ""
+
+# Step 2: Update tenant
+echo "Step 2: Updating tenant..."
+TENANT_JSON=$(jq '.tenant' "${ONBOARDING_REQUEST}")
+
+TENANT_RESPONSE=$(curl -s -w "\n%{http_code}" -X PUT \
+  "${AUTHORIZATION_SERVER_URL}/v1/management/tenants/${TENANT_ID}" \
+  -H "Authorization: Bearer ${SYSTEM_ACCESS_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d "${TENANT_JSON}")
+
+TENANT_HTTP_CODE=$(echo "${TENANT_RESPONSE}" | tail -n1)
+TENANT_RESPONSE_BODY=$(echo "${TENANT_RESPONSE}" | sed '$d')
+
+if [ "${TENANT_HTTP_CODE}" = "200" ] || [ "${TENANT_HTTP_CODE}" = "204" ]; then
+  echo "Tenant updated successfully"
+else
+  echo "Warning: Tenant update failed (HTTP ${TENANT_HTTP_CODE})"
+  echo "Response: ${TENANT_RESPONSE_BODY}" | jq '.' 2>/dev/null || echo "${TENANT_RESPONSE_BODY}"
+fi
+echo ""
+
+# Step 3: Update authorization server
+echo "Step 3: Updating authorization server..."
+AUTH_SERVER_JSON=$(jq '.authorization_server' "${ONBOARDING_REQUEST}")
+
+AUTH_SERVER_RESPONSE=$(curl -s -w "\n%{http_code}" -X PUT \
+  "${AUTHORIZATION_SERVER_URL}/v1/management/tenants/${TENANT_ID}/authorization-server" \
+  -H "Authorization: Bearer ${SYSTEM_ACCESS_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d "${AUTH_SERVER_JSON}")
+
+AUTH_SERVER_HTTP_CODE=$(echo "${AUTH_SERVER_RESPONSE}" | tail -n1)
+AUTH_SERVER_RESPONSE_BODY=$(echo "${AUTH_SERVER_RESPONSE}" | sed '$d')
+
+if [ "${AUTH_SERVER_HTTP_CODE}" = "200" ] || [ "${AUTH_SERVER_HTTP_CODE}" = "204" ]; then
+  echo "Authorization server updated successfully"
+else
+  echo "Warning: Authorization server update failed (HTTP ${AUTH_SERVER_HTTP_CODE})"
+  echo "Response: ${AUTH_SERVER_RESPONSE_BODY}" | jq '.' 2>/dev/null || echo "${AUTH_SERVER_RESPONSE_BODY}"
+fi
+echo ""
+
+# Step 4: Update client (client_secret_basic)
+echo "Step 4: Updating client (client_secret_basic)..."
+CLIENT_BASIC_JSON=$(jq '.client' "${ONBOARDING_REQUEST}")
+
+CLIENT_BASIC_RESPONSE=$(curl -s -w "\n%{http_code}" -X PUT \
+  "${AUTHORIZATION_SERVER_URL}/v1/management/tenants/${TENANT_ID}/clients/${CLIENT_BASIC_ID}" \
+  -H "Authorization: Bearer ${SYSTEM_ACCESS_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d "${CLIENT_BASIC_JSON}")
+
+CLIENT_BASIC_HTTP_CODE=$(echo "${CLIENT_BASIC_RESPONSE}" | tail -n1)
+CLIENT_BASIC_RESPONSE_BODY=$(echo "${CLIENT_BASIC_RESPONSE}" | sed '$d')
+
+if [ "${CLIENT_BASIC_HTTP_CODE}" = "200" ] || [ "${CLIENT_BASIC_HTTP_CODE}" = "204" ]; then
+  echo "Client (basic) updated successfully"
+else
+  echo "Warning: Client (basic) update failed (HTTP ${CLIENT_BASIC_HTTP_CODE})"
+  echo "Response: ${CLIENT_BASIC_RESPONSE_BODY}" | jq '.' 2>/dev/null || echo "${CLIENT_BASIC_RESPONSE_BODY}"
+fi
+echo ""
+
+# Step 5: Update client (client_secret_post)
+if [ -n "${CLIENT_POST_ID}" ] && [ -f "${CLIENT_POST_FILE}" ]; then
+  echo "Step 5: Updating client (client_secret_post)..."
+  CLIENT_POST_JSON=$(cat "${CLIENT_POST_FILE}")
+
+  CLIENT_POST_RESPONSE=$(curl -s -w "\n%{http_code}" -X PUT \
+    "${AUTHORIZATION_SERVER_URL}/v1/management/tenants/${TENANT_ID}/clients/${CLIENT_POST_ID}" \
+    -H "Authorization: Bearer ${SYSTEM_ACCESS_TOKEN}" \
+    -H "Content-Type: application/json" \
+    -d "${CLIENT_POST_JSON}")
+
+  CLIENT_POST_HTTP_CODE=$(echo "${CLIENT_POST_RESPONSE}" | tail -n1)
+  CLIENT_POST_RESPONSE_BODY=$(echo "${CLIENT_POST_RESPONSE}" | sed '$d')
+
+  if [ "${CLIENT_POST_HTTP_CODE}" = "200" ] || [ "${CLIENT_POST_HTTP_CODE}" = "204" ]; then
+    echo "Client (post) updated successfully"
+  else
+    echo "Warning: Client (post) update failed (HTTP ${CLIENT_POST_HTTP_CODE})"
+    echo "Response: ${CLIENT_POST_RESPONSE_BODY}" | jq '.' 2>/dev/null || echo "${CLIENT_POST_RESPONSE_BODY}"
+  fi
+  echo ""
+else
+  echo "Step 5: Skipping client (post) update (not configured)"
+  echo ""
+fi
+
+# Step 6: Update client (second client)
+if [ -n "${CLIENT_SECOND_ID}" ] && [ -f "${CLIENT_SECOND_FILE}" ]; then
+  echo "Step 6: Updating client (second client)..."
+  CLIENT_SECOND_JSON=$(cat "${CLIENT_SECOND_FILE}")
+
+  CLIENT_SECOND_RESPONSE=$(curl -s -w "\n%{http_code}" -X PUT \
+    "${AUTHORIZATION_SERVER_URL}/v1/management/tenants/${TENANT_ID}/clients/${CLIENT_SECOND_ID}" \
+    -H "Authorization: Bearer ${SYSTEM_ACCESS_TOKEN}" \
+    -H "Content-Type: application/json" \
+    -d "${CLIENT_SECOND_JSON}")
+
+  CLIENT_SECOND_HTTP_CODE=$(echo "${CLIENT_SECOND_RESPONSE}" | tail -n1)
+  CLIENT_SECOND_RESPONSE_BODY=$(echo "${CLIENT_SECOND_RESPONSE}" | sed '$d')
+
+  if [ "${CLIENT_SECOND_HTTP_CODE}" = "200" ] || [ "${CLIENT_SECOND_HTTP_CODE}" = "204" ]; then
+    echo "Client (second) updated successfully"
+  else
+    echo "Warning: Client (second) update failed (HTTP ${CLIENT_SECOND_HTTP_CODE})"
+    echo "Response: ${CLIENT_SECOND_RESPONSE_BODY}" | jq '.' 2>/dev/null || echo "${CLIENT_SECOND_RESPONSE_BODY}"
+  fi
+  echo ""
+else
+  echo "Step 6: Skipping client (second) update (not configured)"
+  echo ""
+fi
+
+echo "=========================================="
+echo "Update Complete!"
+echo "=========================================="
+echo ""
+echo "Updated Resources:"
+echo "   Tenant ID:        ${TENANT_ID}"
+echo "   Client Basic ID:  ${CLIENT_BASIC_ID}"
+if [ -n "${CLIENT_POST_ID}" ]; then
+  echo "   Client Post ID:   ${CLIENT_POST_ID}"
+fi
+if [ -n "${CLIENT_SECOND_ID}" ]; then
+  echo "   Client Second ID: ${CLIENT_SECOND_ID}"
+fi
+echo ""
+echo "Verify at:"
+echo "   Discovery: ${AUTHORIZATION_SERVER_URL}/${TENANT_ID}/.well-known/openid-configuration"
+echo "   JWKS:      ${AUTHORIZATION_SERVER_URL}/${TENANT_ID}/v1/jwks"
+echo ""

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -411,6 +411,22 @@ services:
     depends_on:
       - idp-server-1
 
+  # Cross-site Auth UI with API Gateway context path
+  # Access via https://auth.idp.local (port 3001 internally)
+  # Tests cookie_path configuration when IDP is behind API Gateway with /idp-admin context path
+  app-view-context-path:
+    build:
+      context: .
+      dockerfile: docker/app-view/Dockerfile
+      args:
+        BASE_PATH: ""
+        NEXT_PUBLIC_BACKEND_URL: "https://api.local.dev/idp-admin"
+    container_name: app-view-context-path
+    environment:
+      NODE_ENV: production
+    depends_on:
+      - idp-server-1
+
   sample-web:
     build:
       context: .

--- a/docker/nginx/nginx.conf
+++ b/docker/nginx/nginx.conf
@@ -32,6 +32,10 @@ http {
     server app-view-crosssite:3000;
   }
 
+  upstream app_view_context_path {
+    server app-view-context-path:3000;
+  }
+
   # HTTP → HTTPS redirect
   server {
     listen 80;
@@ -47,6 +51,19 @@ http {
     ssl_certificate /etc/nginx/certs/_wildcard.local.dev+1.pem;
     ssl_certificate_key /etc/nginx/certs/_wildcard.local.dev+1-key.pem;
     ssl_protocols TLSv1.2 TLSv1.3;
+
+    # API Gateway simulation: /idp-admin/* -> /*
+    # Tests cookie path behavior when deployed behind API Gateway with context path
+    location /idp-admin/ {
+      proxy_pass http://idp_backend/;
+      proxy_http_version 1.1;
+      proxy_set_header Connection "";
+      proxy_set_header Host $host;
+      proxy_set_header X-Real-IP $remote_addr;
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header X-Forwarded-Proto $scheme;
+      proxy_set_header X-Forwarded-Host $host;
+    }
 
     location / {
       proxy_pass http://idp_backend/;
@@ -113,6 +130,36 @@ http {
     # Next.js WebSocket for hot reload (development)
     location /_next/webpack-hmr {
       proxy_pass http://app_view_crosssite/_next/webpack-hmr;
+      proxy_http_version 1.1;
+      proxy_set_header Upgrade $http_upgrade;
+      proxy_set_header Connection "upgrade";
+    }
+  }
+
+  # Cross-site Auth UI with context path for testing (auth-cp.idp.local)
+  # Tests cookie_path configuration when IDP is behind API Gateway with /idp-admin context path
+  server {
+    listen 443 ssl;
+    server_name auth-cp.idp.local;
+
+    ssl_certificate /etc/nginx/certs/_wildcard.idp.local+1.pem;
+    ssl_certificate_key /etc/nginx/certs/_wildcard.idp.local+1-key.pem;
+    ssl_protocols TLSv1.2 TLSv1.3;
+
+    location / {
+      proxy_pass http://app_view_context_path/;
+      proxy_http_version 1.1;
+      proxy_set_header Connection "";
+      proxy_set_header Host $host;
+      proxy_set_header X-Real-IP $remote_addr;
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header X-Forwarded-Proto $scheme;
+      proxy_set_header X-Forwarded-Host $host;
+    }
+
+    # Next.js WebSocket for hot reload (development)
+    location /_next/webpack-hmr {
+      proxy_pass http://app_view_context_path/_next/webpack-hmr;
       proxy_http_version 1.1;
       proxy_set_header Upgrade $http_upgrade;
       proxy_set_header Connection "upgrade";

--- a/documentation/docs/content_06_developer-guide/05-configuration/tenant.md
+++ b/documentation/docs/content_06_developer-guide/05-configuration/tenant.md
@@ -744,7 +744,7 @@ idp-serverでは、Tenant設定を型安全な6つのConfigurationクラスに�
 | `cookie_same_site` | string | `None` | SameSite属性 (`None`, `Lax`, `Strict`) |
 | `use_secure_cookie` | boolean | `true` | Secure属性を使用 |
 | `use_http_only_cookie` | boolean | `true` | HttpOnly属性を使用 |
-| `cookie_path` | string | `/` | Cookieのパス |
+| `cookie_path` | string | `/` | Cookieのパス（API Gateway対応、詳細は下記参照） |
 | `timeout_seconds` | number | `3600` | セッションタイムアウト（秒） |
 | `switch_policy` | string | `SWITCH_ALLOWED` | セッション切替ポリシー |
 
@@ -853,6 +853,46 @@ Cookieは設定元のホストにのみ送信される:
 }
 ```
 → Cross-Siteからの全リクエストでCookie送信を拒否
+
+#### cookie_path - API Gateway対応
+
+**背景**: idp-serverをAPI Gateway経由でデプロイする場合、コンテキストパス（例: `/idp-admin`）が追加されることがあります。この場合、Cookieのパスを適切に設定しないと、ブラウザがCookieを送信せず認証エラーが発生します。
+
+**問題の例**:
+```
+# API Gateway構成
+https://api.example.com/idp-admin/* → idp-server (/)
+
+# デフォルトのCookieパス（cookie_path未設定）
+Set-Cookie: IDP_AUTH_SESSION=xxx; Path=/{tenant_id}/
+
+# ブラウザがアクセスするパス
+/idp-admin/{tenant_id}/v1/authorizations
+
+# → パスが一致しないためCookieが送信されない → auth_session_mismatch エラー
+```
+
+**解決策**: `cookie_path`にAPI Gatewayのコンテキストパスを設定
+
+```json
+{
+  "session_config": {
+    "cookie_path": "/idp-admin",
+    "cookie_same_site": "None",
+    "use_secure_cookie": true
+  }
+}
+```
+
+**設定後のCookieパス**:
+```
+Set-Cookie: IDP_AUTH_SESSION=xxx; Path=/idp-admin/{tenant_id}/
+```
+→ API Gateway経由のリクエストでもCookieが正しく送信される
+
+**設定例**: `config/examples/oidcc-cross-site-context-path/` にAPI Gateway + コンテキストパスの完全な設定例があります。
+
+**ローカルテスト**: docker-compose.yamlの`app-view-context-path`サービスとnginx.confの`/idp-admin/`ルーティングを使用してAPI Gateway動作をシミュレートできます。
 
 **実装**: [SessionConfiguration.java](../../../libs/idp-server-platform/src/main/java/org/idp/server/platform/multi_tenancy/tenant/config/SessionConfiguration.java)
 

--- a/documentation/openapi/swagger-control-plane-ja.yaml
+++ b/documentation/openapi/swagger-control-plane-ja.yaml
@@ -7205,7 +7205,15 @@ components:
         cookie_path:
           type: string
           default: /
-          description: Cookieのパス
+          description: |
+            Cookieのパス。API Gateway経由でコンテキストパス付きでデプロイする場合に設定します。
+
+            **API Gateway対応例:**
+            API Gatewayで `/idp-admin/*` → idp-server にルーティングする場合、
+            `cookie_path: "/idp-admin"` を設定すると、Cookieパスが `/idp-admin/{tenant_id}/` となり、
+            ブラウザがCookieを正しく送信します。
+
+            未設定または `/` の場合は、Cookieパスは `/{tenant_id}/` となります。
         timeout_seconds:
           type: integer
           default: 3600


### PR DESCRIPTION
## Summary

- API Gateway経由でコンテキストパス（例: `/idp-admin`）付きでデプロイされた場合のCookieパス問題を修正
- `session_config.cookie_path`を設定することで、正しいCookieパスを指定可能に
- ローカルテスト環境（Nginx + app-view-context-path）を追加

Fixes #1242

## Changes

- `AuthSessionCookieService`と`SessionCookieService`にcookie_path解決ロジックを追加
- `app-view-context-path`サービスをdocker-compose.yamlに追加
- Nginxに`auth-cp.idp.local`サブドメインとAPI Gatewayシミュレーション設定を追加
- `config/examples/oidcc-cross-site-context-path/`にテスト設定を追加
- ドキュメントとOpenAPI仕様を更新

## Test plan

- [x] ローカル環境でAPI Gateway経由の認証フローを確認
- [x] Cookieパスが`/idp-admin/{tenant_id}/`で設定されることを確認
- [x] 通常ルート（コンテキストパスなし）が影響を受けないことを確認

🤖 Generated with [Claude Code](https://claude.ai/claude-code)