### PR TITLE
fix: AuthenticationExecutors.get() で存在しないexecutor functionが指定された場合 404 error

### DIFF
--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/authentication/interaction/execution/AuthenticationExecutors.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/authentication/interaction/execution/AuthenticationExecutors.java
@@ -18,7 +18,7 @@ package org.idp.server.core.openid.authentication.interaction.execution;
 
 import java.util.HashMap;
 import java.util.Map;
-import org.idp.server.platform.exception.UnSupportedException;
+import org.idp.server.platform.exception.NotFoundException;
 
 public class AuthenticationExecutors {
 
@@ -36,7 +36,7 @@ public class AuthenticationExecutors {
     AuthenticationExecutor executor = executors.get(type);
 
     if (executor == null) {
-      throw new UnSupportedException("No authentication executor found for type: " + type);
+      throw new NotFoundException("No authentication executor found for type: " + type);
     }
 
     return executor;


### PR DESCRIPTION
## Summary

- `AuthenticationExecutors.get()` で存在しないexecutor functionが指定された場合、500エラー（UnSupportedException）ではなく404エラー（NotFoundException）を返すように修正
- E2Eテストを追加して動作を検証

Fixes #1241

## Changes

- `AuthenticationExecutors.java`: `UnSupportedException` → `NotFoundException` に変更
- `mfa-01-password-reset-email-auth.test.js`: Issue #1241のテストケースを追加

## Test plan

- [x] E2Eテストで404エラーが返されることを確認
- [x] エラーメッセージに「No authentication executor found for type: {type}」が含まれることを確認

🤖 Generated with [Claude Code](https://claude.ai/claude-code)