### PR TITLE
fix: resolve multiple bugs in platform HTTP layer

### DIFF
--- a/libs/idp-server-platform/src/main/java/org/idp/server/platform/http/BasicAuthConvertable.java
+++ b/libs/idp-server-platform/src/main/java/org/idp/server/platform/http/BasicAuthConvertable.java
@@ -18,8 +18,27 @@ package org.idp.server.platform.http;
 
 import java.util.Base64;
 
+/**
+ * Converts an HTTP Basic Authentication header into a {@link BasicAuth} credential pair.
+ *
+ * <p>Implements parsing according to RFC 7617. Uses standard Base64 decoding (not URL-safe) and
+ * splits at the first colon, as user-id MUST NOT contain a colon character per the specification.
+ *
+ * @see <a href="https://datatracker.ietf.org/doc/html/rfc7617">RFC 7617 - The 'Basic' HTTP
+ *     Authentication Scheme</a>
+ */
 public interface BasicAuthConvertable {
 
+  /**
+   * Parses an Authorization header with the Basic scheme.
+   *
+   * <p>The credential string is decoded using standard Base64 (RFC 4648 Section 4) and split into
+   * user-id and password at the first colon. Passwords may contain colons; user-ids must not.
+   *
+   * @param authorizationHeader the Authorization header value (e.g. "Basic dXNlcjpwYXNz")
+   * @return parsed {@link BasicAuth}, or an empty instance if the header is null, empty, not Basic
+   *     scheme, or missing a colon separator
+   */
   default BasicAuth convertBasicAuth(String authorizationHeader) {
     if (authorizationHeader == null || authorizationHeader.isEmpty()) {
       return new BasicAuth();
@@ -30,12 +49,12 @@ public interface BasicAuthConvertable {
     }
 
     String value = authorizationHeader.substring("Basic ".length());
-    byte[] decode = Base64.getUrlDecoder().decode(value);
+    byte[] decode = Base64.getDecoder().decode(value);
     String decodedValue = new String(decode);
     if (!decodedValue.contains(":")) {
       return new BasicAuth();
     }
-    String[] splitValues = decodedValue.split(":");
+    String[] splitValues = decodedValue.split(":", 2);
     return new BasicAuth(splitValues[0], splitValues[1]);
   }
 }

--- a/libs/idp-server-platform/src/main/java/org/idp/server/platform/http/HttpClientErrorException.java
+++ b/libs/idp-server-platform/src/main/java/org/idp/server/platform/http/HttpClientErrorException.java
@@ -22,6 +22,7 @@ public class HttpClientErrorException extends RuntimeException {
 
   public HttpClientErrorException(String message, int statusCode) {
     super(message);
+    this.statusCode = statusCode;
   }
 
   public int statusCode() {

--- a/libs/idp-server-platform/src/main/java/org/idp/server/platform/http/HttpHmacAuthorizationHeaderCreator.java
+++ b/libs/idp-server-platform/src/main/java/org/idp/server/platform/http/HttpHmacAuthorizationHeaderCreator.java
@@ -66,7 +66,6 @@ public class HttpHmacAuthorizationHeaderCreator {
             .collect(Collectors.joining("\n"));
 
     String signature = hmacHasher.hash(payload);
-    log.debug("HMAC Signature: {}", signature);
 
     return signatureFormat.replace("{signature}", signature);
   }

--- a/libs/idp-server-platform/src/main/java/org/idp/server/platform/http/HttpMethod.java
+++ b/libs/idp-server-platform/src/main/java/org/idp/server/platform/http/HttpMethod.java
@@ -16,6 +16,8 @@
 
 package org.idp.server.platform.http;
 
+import org.idp.server.platform.exception.InvalidConfigurationException;
+
 public enum HttpMethod {
   GET,
   POST,
@@ -31,7 +33,7 @@ public enum HttpMethod {
       }
     }
 
-    return POST;
+    throw new InvalidConfigurationException("Unsupported HTTP method: " + method);
   }
 
   public boolean isGet() {

--- a/libs/idp-server-platform/src/main/java/org/idp/server/platform/http/HttpRequestBuilder.java
+++ b/libs/idp-server-platform/src/main/java/org/idp/server/platform/http/HttpRequestBuilder.java
@@ -109,7 +109,7 @@ public class HttpRequestBuilder {
             .uri(URI.create(urlWithQueryParams))
             .timeout(Duration.ofSeconds(configuration.requestTimeoutSeconds()));
 
-    setHeaders(httpRequestBuilder, headers);
+    setHeaders(httpRequestBuilder, headers, HttpMethod.GET);
     setParams(httpRequestBuilder, HttpMethod.GET, headers, Map.of());
 
     return httpRequestBuilder.build();
@@ -164,19 +164,19 @@ public class HttpRequestBuilder {
             .uri(URI.create(interpolatedUrl.value()))
             .timeout(Duration.ofSeconds(configuration.requestTimeoutSeconds()));
 
-    setHeaders(httpRequestBuilder, headers);
+    setHeaders(httpRequestBuilder, headers, configuration.httpMethod());
     setParams(httpRequestBuilder, configuration.httpMethod(), headers, requestBody);
 
     return httpRequestBuilder.build();
   }
 
   private void setHeaders(
-      HttpRequest.Builder httpRequestBuilder, Map<String, String> httpRequestStaticHeaders) {
-
-    log.debug("Http Request headers: {}", jsonConverter.write(httpRequestStaticHeaders));
+      HttpRequest.Builder httpRequestBuilder,
+      Map<String, String> httpRequestStaticHeaders,
+      HttpMethod httpMethod) {
 
     httpRequestStaticHeaders.forEach(httpRequestBuilder::header);
-    if (!httpRequestStaticHeaders.containsKey("Content-Type")) {
+    if (!httpMethod.isGet() && !httpRequestStaticHeaders.containsKey("Content-Type")) {
       httpRequestBuilder.setHeader("Content-Type", "application/json");
     }
   }

--- a/libs/idp-server-platform/src/main/java/org/idp/server/platform/http/HttpServerErrorException.java
+++ b/libs/idp-server-platform/src/main/java/org/idp/server/platform/http/HttpServerErrorException.java
@@ -21,6 +21,7 @@ public class HttpServerErrorException extends RuntimeException {
 
   public HttpServerErrorException(String message, int statusCode) {
     super(message);
+    this.statusCode = statusCode;
   }
 
   public int statusCode() {

--- a/libs/idp-server-platform/src/main/java/org/idp/server/platform/http/SsrfProtectedHttpClient.java
+++ b/libs/idp-server-platform/src/main/java/org/idp/server/platform/http/SsrfProtectedHttpClient.java
@@ -90,7 +90,13 @@ public class SsrfProtectedHttpClient {
     try {
       log.debug("Sending request to: {}", request.uri());
       return httpClient.send(request, HttpResponse.BodyHandlers.ofString());
-    } catch (IOException | InterruptedException e) {
+    } catch (InterruptedException e) {
+      // Restore the interrupt flag cleared by InterruptedException,
+      // so that callers (e.g. ExecutorService shutdown) can detect the interruption.
+      Thread.currentThread().interrupt();
+      log.error("HTTP request interrupted: {}", e.getMessage(), e);
+      throw new HttpNetworkErrorException("HTTP request interrupted", e);
+    } catch (IOException e) {
       log.error("HTTP request failed: {}", e.getMessage(), e);
       throw new HttpNetworkErrorException("HTTP request failed", e);
     }

--- a/libs/idp-server-platform/src/test/java/org/idp/server/platform/http/BasicAuthConvertableTest.java
+++ b/libs/idp-server-platform/src/test/java/org/idp/server/platform/http/BasicAuthConvertableTest.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright 2025 Hirokazu Kobayashi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.idp.server.platform.http;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.Base64;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class BasicAuthConvertableTest {
+
+  private BasicAuthConvertable converter;
+
+  @BeforeEach
+  void setUp() {
+    converter = new BasicAuthConvertable() {};
+  }
+
+  private String encode(String value) {
+    return Base64.getEncoder().encodeToString(value.getBytes());
+  }
+
+  @Nested
+  @DisplayName("valid Authorization header")
+  class ValidHeader {
+
+    @Test
+    @DisplayName("should parse username and password")
+    void shouldParseUsernameAndPassword() {
+      String header = "Basic " + encode("user:password");
+
+      BasicAuth result = converter.convertBasicAuth(header);
+
+      assertTrue(result.exists());
+      assertEquals("user", result.username());
+      assertEquals("password", result.password());
+    }
+
+    @Test
+    @DisplayName("should handle password containing colons")
+    void shouldHandlePasswordContainingColons() {
+      String header = "Basic " + encode("user:pass:word:123");
+
+      BasicAuth result = converter.convertBasicAuth(header);
+
+      assertTrue(result.exists());
+      assertEquals("user", result.username());
+      assertEquals("pass:word:123", result.password());
+    }
+
+    @Test
+    @DisplayName("should handle special characters in credentials")
+    void shouldHandleSpecialCharacters() {
+      String header = "Basic " + encode("user@example.com:p@$$w0rd!#%");
+
+      BasicAuth result = converter.convertBasicAuth(header);
+
+      assertTrue(result.exists());
+      assertEquals("user@example.com", result.username());
+      assertEquals("p@$$w0rd!#%", result.password());
+    }
+
+    @Test
+    @DisplayName("should use standard Base64 decoder per RFC 7617")
+    void shouldUseStandardBase64Decoder() {
+      // '+' and '/' are standard Base64 characters that differ from URL-safe Base64
+      String credentials = "user+name/test:pass+word/test";
+      String header = "Basic " + encode(credentials);
+
+      BasicAuth result = converter.convertBasicAuth(header);
+
+      assertTrue(result.exists());
+      assertEquals("user+name/test", result.username());
+      assertEquals("pass+word/test", result.password());
+    }
+  }
+
+  @Nested
+  @DisplayName("invalid Authorization header")
+  class InvalidHeader {
+
+    @Test
+    @DisplayName("should return empty BasicAuth when header is null")
+    void shouldReturnEmptyWhenNull() {
+      BasicAuth result = converter.convertBasicAuth(null);
+
+      assertFalse(result.exists());
+    }
+
+    @Test
+    @DisplayName("should return empty BasicAuth when header is empty")
+    void shouldReturnEmptyWhenEmpty() {
+      BasicAuth result = converter.convertBasicAuth("");
+
+      assertFalse(result.exists());
+    }
+
+    @Test
+    @DisplayName("should return empty BasicAuth when header is not Basic scheme")
+    void shouldReturnEmptyWhenNotBasicScheme() {
+      BasicAuth result = converter.convertBasicAuth("Bearer some-token");
+
+      assertFalse(result.exists());
+    }
+
+    @Test
+    @DisplayName("should return empty BasicAuth when decoded value has no colon")
+    void shouldReturnEmptyWhenNoColon() {
+      String header = "Basic " + encode("usernameonly");
+
+      BasicAuth result = converter.convertBasicAuth(header);
+
+      assertFalse(result.exists());
+    }
+  }
+
+  @Nested
+  @DisplayName("edge cases")
+  class EdgeCases {
+
+    @Test
+    @DisplayName("should handle empty username with password")
+    void shouldHandleEmptyUsername() {
+      String header = "Basic " + encode(":password");
+
+      BasicAuth result = converter.convertBasicAuth(header);
+
+      assertEquals("", result.username());
+      assertEquals("password", result.password());
+    }
+
+    @Test
+    @DisplayName("should handle username with empty password")
+    void shouldHandleEmptyPassword() {
+      String header = "Basic " + encode("user:");
+
+      BasicAuth result = converter.convertBasicAuth(header);
+
+      assertEquals("user", result.username());
+      assertEquals("", result.password());
+    }
+
+    @Test
+    @DisplayName("should split at first colon per RFC 7617 (user-id MUST NOT contain colon)")
+    void shouldSplitAtFirstColon() {
+      String header = "Basic " + encode("us:er:pass");
+
+      BasicAuth result = converter.convertBasicAuth(header);
+
+      assertEquals("us", result.username());
+      assertEquals("er:pass", result.password());
+    }
+  }
+}

--- a/libs/idp-server-springboot-adapter/src/main/java/org/idp/server/adapters/springboot/ApiExceptionHandler.java
+++ b/libs/idp-server-springboot-adapter/src/main/java/org/idp/server/adapters/springboot/ApiExceptionHandler.java
@@ -179,6 +179,18 @@ public class ApiExceptionHandler {
         HttpStatus.BAD_REQUEST);
   }
 
+  @ExceptionHandler(InvalidConfigurationException.class)
+  public ResponseEntity<?> handleException(InvalidConfigurationException exception) {
+    log.error("Invalid configuration detected: description={}", exception.getMessage(), exception);
+    Map<String, String> response =
+        Map.of(
+            "error",
+            "server_error",
+            "error_description",
+            "The server has a configuration error. Please contact the administrator.");
+    return new ResponseEntity<>(response, HttpStatus.INTERNAL_SERVER_ERROR);
+  }
+
   @ExceptionHandler
   public ResponseEntity<?> handleException(Exception exception) {
     log.error(exception.getMessage(), exception);


### PR DESCRIPTION
## Summary
- Fix `statusCode` field not assigned in `HttpClientErrorException` / `HttpServerErrorException` constructors
- Fix `BasicAuthConvertable` to use standard Base64 decoder (RFC 7617) and `split(":", 2)` for passwords containing colons
- Remove debug logging of HMAC signatures and Authorization headers to prevent credential leakage
- Throw `InvalidConfigurationException` for unsupported HTTP methods instead of silently defaulting to POST
- Skip `Content-Type` header for GET requests in `HttpRequestBuilder`
- Properly handle `InterruptedException` with interrupt flag restoration in `SsrfProtectedHttpClient`
- Add `InvalidConfigurationException` handler to `ApiExceptionHandler`
- Add Javadoc to `BasicAuthConvertable` documenting RFC 7617 compliance
- Add JUnit tests for `BasicAuthConvertable`

Closes #1245

## Test plan
- [x] `./gradlew :libs:idp-server-platform:test` passed
- [x] `./gradlew :libs:idp-server-springboot-adapter:compileJava` passed
- [ ] CI passes on all modules
- [ ] E2E tests pass with no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)