### PR TITLE
Fix: HttpResponseResolver throws 500 when external service returns non-JSON response

### DIFF
--- a/docker/mockoon/config.json
+++ b/docker/mockoon/config.json
@@ -1454,6 +1454,70 @@
           "callbacks": []
         },
         {
+          "uuid": "error-401-plain-text",
+          "body": "Authentication required",
+          "latency": 50,
+          "statusCode": 401,
+          "label": "401 Unauthorized (Plain Text)",
+          "headers": [
+            {
+              "key": "Content-Type",
+              "value": "text/plain"
+            }
+          ],
+          "bodyType": "INLINE",
+          "filePath": "",
+          "databucketID": "",
+          "sendFileAsBody": false,
+          "rules": [
+            {
+              "target": "body",
+              "modifier": "status",
+              "value": "401_text",
+              "invert": false,
+              "operator": "equals"
+            }
+          ],
+          "rulesOperator": "OR",
+          "disableTemplating": false,
+          "fallbackTo404": false,
+          "default": false,
+          "crudKey": "id",
+          "callbacks": []
+        },
+        {
+          "uuid": "error-503-html",
+          "body": "<html><body><h1>503 Service Unavailable</h1></body></html>",
+          "latency": 50,
+          "statusCode": 503,
+          "label": "503 Service Unavailable (HTML)",
+          "headers": [
+            {
+              "key": "Content-Type",
+              "value": "text/html"
+            }
+          ],
+          "bodyType": "INLINE",
+          "filePath": "",
+          "databucketID": "",
+          "sendFileAsBody": false,
+          "rules": [
+            {
+              "target": "body",
+              "modifier": "status",
+              "value": "503_html",
+              "invert": false,
+              "operator": "equals"
+            }
+          ],
+          "rulesOperator": "OR",
+          "disableTemplating": false,
+          "fallbackTo404": false,
+          "default": false,
+          "crudKey": "id",
+          "callbacks": []
+        },
+        {
           "uuid": "error-default-200",
           "body": "{\n  \"status\": \"success\",\n  \"application_id\": \"{{ uuid }}\",\n  \"verification_status\": \"pending\"\n}",
           "latency": 50,

--- a/e2e/src/tests/integration/authentication-interactors/integration-01-authentication-interactor-error-propagation.test.js
+++ b/e2e/src/tests/integration/authentication-interactors/integration-01-authentication-interactor-error-propagation.test.js
@@ -366,6 +366,37 @@ describe("Authentication Interactor: External Service Error Code Propagation", (
     }
   );
 
+  it.each([
+    {
+      statusCode: "401_text",
+      expectedStatus: 401,
+      description: "plain text response",
+    },
+    {
+      statusCode: "503_html",
+      expectedStatus: 503,
+      description: "HTML response",
+    },
+  ])(
+    "should propagate $expectedStatus from external service returning $description without 500 error",
+    async ({ statusCode, expectedStatus }) => {
+      const authId = await startAuthorizationAndRegister();
+
+      const response = await sendFidoUafRegistrationWithStatus(
+        authId,
+        statusCode
+      );
+
+      console.log(
+        `Response status: ${response.status} (expected: ${expectedStatus})`
+      );
+      console.log("Response data:", JSON.stringify(response.data, null, 2));
+
+      expect(response.status).toBe(expectedStatus);
+      expect(response.status).not.toBe(500);
+    }
+  );
+
   it("should return 200 when external FIDO-UAF service succeeds", async () => {
     const authId = await startAuthorizationAndRegister();
 


### PR DESCRIPTION
## Summary
- `HttpResponseResolver.resolveResponseBody()` で `JsonRuntimeException` をキャッチし、非JSONボディを `raw_body` キーでラップして返すようにした
- 外部サービスがプレーンテキストやHTMLを返した場合でも、ステータスコード（401, 503等）がそのまま保持される
- mockoonに非JSONレスポンス（プレーンテキスト/HTML）のモックを追加
- E2Eテスト2ケース追加（プレーンテキスト401、HTML 503の伝搬検証）

## Test plan
- [x] `./gradlew build` ビルド成功
- [x] E2Eテスト 9/9 通過（既存6 + 新規2 + 正常系1）

Closes #1254

🤖 Generated with [Claude Code](https://claude.com/claude-code)