### PR TITLE
perf: セキュリティイベントCOUNTクエリにLIMIT上限を追加

### DIFF
--- a/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/security/event/query/MysqlExecutor.java
+++ b/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/security/event/query/MysqlExecutor.java
@@ -31,7 +31,7 @@ public class MysqlExecutor implements SecurityEventSqlExecutor {
   public Map<String, String> selectCount(Tenant tenant, SecurityEventQueries queries) {
     SqlExecutor sqlExecutor = new SqlExecutor();
     String selectSql = """
-            SELECT COUNT(*) as count FROM security_event
+            SELECT 1 FROM security_event
             """;
     StringBuilder sql = new StringBuilder(selectSql).append(" WHERE tenant_id = ?");
     List<Object> params = new ArrayList<>();
@@ -109,7 +109,8 @@ public class MysqlExecutor implements SecurityEventSqlExecutor {
       }
     }
 
-    return sqlExecutor.selectOne(sql.toString(), params);
+    String countSql = "SELECT COUNT(*) as count FROM (" + sql.toString() + " LIMIT 1000001) t";
+    return sqlExecutor.selectOne(countSql, params);
   }
 
   @Override

--- a/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/security/event/query/PostgresqlExecutor.java
+++ b/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/security/event/query/PostgresqlExecutor.java
@@ -31,7 +31,7 @@ public class PostgresqlExecutor implements SecurityEventSqlExecutor {
   public Map<String, String> selectCount(Tenant tenant, SecurityEventQueries queries) {
     SqlExecutor sqlExecutor = new SqlExecutor();
     String selectSql = """
-            SELECT COUNT(*) FROM security_event
+            SELECT 1 FROM security_event
             """;
     StringBuilder sql = new StringBuilder(selectSql).append(" WHERE tenant_id = ?::uuid");
     List<Object> params = new ArrayList<>();
@@ -109,7 +109,8 @@ public class PostgresqlExecutor implements SecurityEventSqlExecutor {
       }
     }
 
-    return sqlExecutor.selectOne(sql.toString(), params);
+    String countSql = "SELECT COUNT(*) FROM (" + sql.toString() + " LIMIT 1000001) t";
+    return sqlExecutor.selectOne(countSql, params);
   }
 
   @Override


### PR DESCRIPTION
## Summary

- セキュリティイベント一覧APIの`COUNT(*)`クエリにサブクエリ`LIMIT 1,000,001`を追加し、大量データ時のフルテーブルスキャンを防止
- 1,000,001件が返った場合、フロントエンドで「1,000,000+」と表示可能
- API互換性は維持（`total_count`フィールドはそのまま）

## Test plan

- [x] `./gradlew spotlessApply && ./gradlew build` でビルド確認
- [ ] `cd e2e && npm test -- --testPathPattern="organization_security_event_management"` で互換性確認
- [ ] `cd e2e && npm test -- --testPathPattern="scenario-07-user-deletion"` で互換性確認

closes #1258

🤖 Generated with [Claude Code](https://claude.com/claude-code)