### PR TITLE
refactor: OneTimePassword を platform層に移動

### DIFF
--- a/libs/idp-server-authentication-interactors/src/main/java/org/idp/server/authentication/interactors/email/EmailVerificationChallenge.java
+++ b/libs/idp-server-authentication-interactors/src/main/java/org/idp/server/authentication/interactors/email/EmailVerificationChallenge.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import java.util.Objects;
 import org.idp.server.platform.date.SystemDateTime;
 import org.idp.server.platform.json.JsonReadable;
+import org.idp.server.platform.random.OneTimePassword;
 
 public class EmailVerificationChallenge implements Serializable, JsonReadable {
 

--- a/libs/idp-server-authentication-interactors/src/main/java/org/idp/server/authentication/interactors/email/executor/EmailChallengeAuthenticationExecutor.java
+++ b/libs/idp-server-authentication-interactors/src/main/java/org/idp/server/authentication/interactors/email/executor/EmailChallengeAuthenticationExecutor.java
@@ -17,7 +17,9 @@
 package org.idp.server.authentication.interactors.email.executor;
 
 import java.util.Map;
-import org.idp.server.authentication.interactors.email.*;
+import org.idp.server.authentication.interactors.email.EmailAuthenticationConfiguration;
+import org.idp.server.authentication.interactors.email.EmailVerificationChallenge;
+import org.idp.server.authentication.interactors.email.EmailVerificationTemplate;
 import org.idp.server.core.openid.authentication.AuthenticationTransactionIdentifier;
 import org.idp.server.core.openid.authentication.config.AuthenticationExecutionConfig;
 import org.idp.server.core.openid.authentication.interaction.execution.AuthenticationExecutionRequest;
@@ -31,6 +33,8 @@ import org.idp.server.platform.notification.email.EmailSendResult;
 import org.idp.server.platform.notification.email.EmailSender;
 import org.idp.server.platform.notification.email.EmailSenders;
 import org.idp.server.platform.notification.email.EmailSendingRequest;
+import org.idp.server.platform.random.OneTimePassword;
+import org.idp.server.platform.random.OneTimePasswordGenerator;
 import org.idp.server.platform.type.RequestAttributes;
 
 public class EmailChallengeAuthenticationExecutor implements AuthenticationExecutor {

--- a/libs/idp-server-authentication-interactors/src/main/java/org/idp/server/authentication/interactors/sms/executor/SmsChallengeAuthenticationExecutor.java
+++ b/libs/idp-server-authentication-interactors/src/main/java/org/idp/server/authentication/interactors/sms/executor/SmsChallengeAuthenticationExecutor.java
@@ -18,8 +18,6 @@ package org.idp.server.authentication.interactors.sms.executor;
 
 import java.util.HashMap;
 import java.util.Map;
-import org.idp.server.authentication.interactors.email.OneTimePassword;
-import org.idp.server.authentication.interactors.email.OneTimePasswordGenerator;
 import org.idp.server.authentication.interactors.sms.SmsAuthenticationConfiguration;
 import org.idp.server.core.openid.authentication.AuthenticationTransactionIdentifier;
 import org.idp.server.core.openid.authentication.config.AuthenticationExecutionConfig;
@@ -34,6 +32,8 @@ import org.idp.server.platform.notification.sms.SmsSendResult;
 import org.idp.server.platform.notification.sms.SmsSender;
 import org.idp.server.platform.notification.sms.SmsSenders;
 import org.idp.server.platform.notification.sms.SmsSendingRequest;
+import org.idp.server.platform.random.OneTimePassword;
+import org.idp.server.platform.random.OneTimePasswordGenerator;
 import org.idp.server.platform.type.RequestAttributes;
 
 public class SmsChallengeAuthenticationExecutor implements AuthenticationExecutor {

--- a/libs/idp-server-authentication-interactors/src/main/java/org/idp/server/authentication/interactors/sms/executor/SmsVerificationChallenge.java
+++ b/libs/idp-server-authentication-interactors/src/main/java/org/idp/server/authentication/interactors/sms/executor/SmsVerificationChallenge.java
@@ -21,9 +21,9 @@ import java.time.LocalDateTime;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
-import org.idp.server.authentication.interactors.email.OneTimePassword;
 import org.idp.server.platform.date.SystemDateTime;
 import org.idp.server.platform.json.JsonReadable;
+import org.idp.server.platform.random.OneTimePassword;
 
 public class SmsVerificationChallenge implements Serializable, JsonReadable {
 

--- a/libs/idp-server-platform/src/main/java/org/idp/server/platform/random/OneTimePassword.java
+++ b/libs/idp-server-platform/src/main/java/org/idp/server/platform/random/OneTimePassword.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.idp.server.authentication.interactors.email;
+package org.idp.server.platform.random;
 
 import java.util.Objects;
 

--- a/libs/idp-server-platform/src/main/java/org/idp/server/platform/random/OneTimePasswordGenerator.java
+++ b/libs/idp-server-platform/src/main/java/org/idp/server/platform/random/OneTimePasswordGenerator.java
@@ -14,15 +14,16 @@
  * limitations under the License.
  */
 
-package org.idp.server.authentication.interactors.email;
+package org.idp.server.platform.random;
 
-import java.util.Random;
+import java.security.SecureRandom;
 
 public class OneTimePasswordGenerator {
 
+  private static final SecureRandom SECURE_RANDOM = new SecureRandom();
+
   public static OneTimePassword generate() {
-    Random random = new Random();
-    int randomValue = random.nextInt(999999);
+    int randomValue = SECURE_RANDOM.nextInt(1_000_000);
     String value = String.format("%06d", randomValue);
     return new OneTimePassword(value);
   }


### PR DESCRIPTION
## Summary
- `OneTimePassword` / `OneTimePasswordGenerator` を `email` パッケージから `platform/random` パッケージに移動
- `RandomStringGenerator` と同じ `static final SecureRandom` パターンに統一
- `nextInt(999999)` → `nextInt(1_000_000)` の off-by-one 修正

## Test plan
- [x] `./gradlew spotlessApply` 成功
- [x] `./gradlew build` 成功（全テストパス）

Closes #1262

🤖 Generated with [Claude Code](https://claude.com/claude-code)