### PR TITLE
fix: 身元確認キャンセル時にcancelledイベントを発行 (#1270)

### DIFF
--- a/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/application/enduser/IdentityVerificationApplicationEntryService.java
+++ b/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/application/enduser/IdentityVerificationApplicationEntryService.java
@@ -319,6 +319,17 @@ public class IdentityVerificationApplicationEntryService
       eventPublisher.publish(tenant, oAuthToken, typeSpecificRejectedEvent, requestAttributes);
     }
 
+    if (updated.isCancelled()) {
+      eventPublisher.publishSync(
+          tenant,
+          oAuthToken,
+          DefaultSecurityEventType.identity_verification_application_cancelled,
+          requestAttributes);
+      SecurityEventType typeSpecificCancelledEvent =
+          new SecurityEventType(type.name() + "_cancelled");
+      eventPublisher.publish(tenant, oAuthToken, typeSpecificCancelledEvent, requestAttributes);
+    }
+
     IdentityVerificationContext updatedContext =
         new IdentityVerificationContextBuilder()
             .previousContext(applyingResult.applicationContext())

--- a/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/application/identity_verification_service/IdentityVerificationCallbackEntryService.java
+++ b/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/application/identity_verification_service/IdentityVerificationCallbackEntryService.java
@@ -240,6 +240,23 @@ public class IdentityVerificationCallbackEntryService implements IdentityVerific
           requestAttributes);
     }
 
+    if (updatedApplication.isCancelled()) {
+      eventPublisher.publishSync(
+          tenant,
+          application.requestedClientId(),
+          user,
+          DefaultSecurityEventType.identity_verification_application_cancelled.toEventType(),
+          requestAttributes);
+      SecurityEventType typeSpecificCancelledEvent =
+          new SecurityEventType(type.name() + "_cancelled");
+      eventPublisher.publish(
+          tenant,
+          application.requestedClientId(),
+          user,
+          typeSpecificCancelledEvent,
+          requestAttributes);
+    }
+
     return IdentityVerificationDynamicResponseMapper.buildDynamicResponse(
         context, processConfiguration.response());
   }


### PR DESCRIPTION
## Summary

- 身元確認アプリケーションがCANCELLED状態に遷移した際、`identity_verification_application_cancelled`イベントおよびタイプ別cancelledイベントが発行されるように修正
- `IdentityVerificationApplicationEntryService.process()` と `IdentityVerificationCallbackEntryService.updateApplicationAndCreateResponse()` の2箇所に `isCancelled()` ハンドリングを追加

## Background

承認（`isApproved`）・却下（`isRejected`）時にはセキュリティイベントが発行されるが、キャンセル（`isCancelled`）時のハンドリングが漏れていた。このため統計データの `monthly_summary` に `identity_verification_application_cancelled` が計上されず、idp-adminダッシュボードのキャンセル件数が常に0件と表示されていた。

## Changes

### `IdentityVerificationApplicationEntryService.java`
- `process()` メソッドに `updated.isCancelled()` ブロックを追加
- 汎用イベント `identity_verification_application_cancelled` を `publishSync` で発行
- タイプ別イベント `{type}_cancelled` を `publish` で発行

### `IdentityVerificationCallbackEntryService.java`
- `updateApplicationAndCreateResponse()` メソッドに `updatedApplication.isCancelled()` ブロックを追加
- 承認・却下と同一パターンでイベントを発行

## Test plan

- [ ] 身元確認申請のキャンセルフロー（process API経由）でイベントが発行されることを確認
- [ ] コールバック経由のキャンセルでイベントが発行されることを確認
- [ ] 統計データの `monthly_summary` に `identity_verification_application_cancelled` が計上されることを確認
- [ ] ダッシュボードでキャンセル件数が正しく表示されることを確認

Closes #1270

🤖 Generated with [Claude Code](https://claude.com/claude-code)