### PR TITLE
fix: CIBAリクエストのユーザーコンテキストログでuser_idが正しく設定されないバグを修正

### DIFF
--- a/libs/idp-server-core-extension-ciba/src/main/java/org/idp/server/core/extension/ciba/DefaultCibaProtocol.java
+++ b/libs/idp-server-core-extension-ciba/src/main/java/org/idp/server/core/extension/ciba/DefaultCibaProtocol.java
@@ -159,7 +159,11 @@ public class DefaultCibaProtocol implements CibaProtocol {
       TenantLoggingContext.setUserId(user.sub());
 
       if (user.hasExternalUserId()) {
-        TenantLoggingContext.setUserId(user.externalUserId());
+        TenantLoggingContext.setUserExSub(user.externalUserId());
+      }
+
+      if (user.hasPreferredUsername()) {
+        TenantLoggingContext.setUserName(user.preferredUsername());
       }
     }
   }


### PR DESCRIPTION
## Summary
- `setUserContext` で `externalUserId` を `setUserId` に渡していたため、`user_id` が `ex_sub` で上書きされていたバグを修正
- `externalUserId` は `setUserExSub` で正しいフィールドに設定するよう変更
- `preferredUsername` も `setUserName` で追加設定

## Test plan
- [x] CIBAリクエスト実行時のログで `user_id` に正しいsub値が出力されることを確認
- [x] `external_user_id` が設定されている場合、ログの `ex_sub` フィールドに出力されることを確認

Closes #1272

🤖 Generated with [Claude Code](https://claude.com/claude-code)