### PR TITLE
fix: AuthenticationDeviceLogのログ出力をEntryService側に移動しユーザーコンテキストを設定

### DIFF
--- a/libs/idp-server-springboot-adapter/src/main/java/org/idp/server/adapters/springboot/application/restapi/authentication/device/AuthenticationDeviceV1Api.java
+++ b/libs/idp-server-springboot-adapter/src/main/java/org/idp/server/adapters/springboot/application/restapi/authentication/device/AuthenticationDeviceV1Api.java
@@ -26,8 +26,6 @@ import org.idp.server.core.openid.identity.device.AuthenticationDeviceIdentifier
 import org.idp.server.core.openid.identity.device.AuthenticationDeviceLogApi;
 import org.idp.server.core.openid.identity.device.AuthenticationDeviceLogRequest;
 import org.idp.server.core.openid.identity.device.AuthenticationDeviceLogResponse;
-import org.idp.server.platform.json.JsonNodeWrapper;
-import org.idp.server.platform.log.LoggerWrapper;
 import org.idp.server.platform.multi_tenancy.tenant.TenantIdentifier;
 import org.idp.server.platform.type.RequestAttributes;
 import org.idp.server.usecases.IdpServerApplication;
@@ -42,7 +40,6 @@ public class AuthenticationDeviceV1Api implements ParameterTransformable {
 
   AuthenticationTransactionApi authenticationTransactionApi;
   AuthenticationDeviceLogApi authenticationDeviceLogApi;
-  LoggerWrapper log = LoggerWrapper.getLogger(AuthenticationDeviceV1Api.class);
 
   public AuthenticationDeviceV1Api(IdpServerApplication idpServerApplication) {
     this.authenticationTransactionApi = idpServerApplication.authenticationApi();
@@ -78,9 +75,6 @@ public class AuthenticationDeviceV1Api implements ParameterTransformable {
       @PathVariable("tenant-id") TenantIdentifier tenantIdentifier,
       @RequestBody Map<String, Object> requestBody,
       HttpServletRequest httpServletRequest) {
-
-    JsonNodeWrapper jsonNodeWrapper = JsonNodeWrapper.fromMap(requestBody);
-    log.info(jsonNodeWrapper.toJson());
 
     RequestAttributes requestAttributes = transform(httpServletRequest);
     AuthenticationDeviceLogRequest request = new AuthenticationDeviceLogRequest(requestBody);


### PR DESCRIPTION
## Summary
- コントローラー層でのログ出力ではMDCにユーザー情報が設定されないため、EntryService側に移動
- `findUser()` 後に `setUserContext()` で MDC に `user_id` / `user_ex_sub` / `user_name` を設定
- ユーザー未発見時もリクエスト内容をログ出力（デバッグ用）

## Test plan
- [x] CIBAデバイスログAPIでログに `tenant_id`, `user_id`, `user_name` が正しく出力されることを確認済み

Closes #1276

🤖 Generated with [Claude Code](https://claude.com/claude-code)