### PR TITLE
refactor: WebHookSecurityEventExecutorをSSFと同じ設定パターンに統一

### DIFF
--- a/documentation/docs/content_10_ai_developer/ai-50-notification-security-event.md
+++ b/documentation/docs/content_10_ai_developer/ai-50-notification-security-event.md
@@ -492,18 +492,18 @@ public interface SecurityEventHook {
 
 #### WebHookSecurityEventExecutor - Webhook実装
 
-**情報源**: [WebHookSecurityEventExecutor.java:35](../../../libs/idp-server-security-event-hooks/src/main/java/org/idp/server/security/event/hooks/webhook/WebHookSecurityEventExecutor.java#L35)
+**情報源**: [WebHookSecurityEventExecutor.java:36](../../../libs/idp-server-security-event-hooks/src/main/java/org/idp/server/security/event/hooks/webhook/WebHookSecurityEventExecutor.java#L36)
 
 ```java
 /**
  * Webhook実装（RFC 8935準拠）
- * 確認方法: 実ファイルの35-80行目
+ * SSFと同じ設定パターン: hookConfiguration.getEvent()でイベント設定を取得
+ * HttpRequestExecutor.execute(config, params)経由でリトライ・認証・タイムアウトを自動処理
  * @see <a href="https://datatracker.ietf.org/doc/html/rfc8935">RFC 8935 - Push-Based SET Delivery</a>
  */
 public class WebHookSecurityEventExecutor implements SecurityEventHook {
 
   HttpRequestExecutor httpRequestExecutor;
-  JsonConverter jsonConverter;
 
   @Override
   public SecurityEventHookType type() {
@@ -519,57 +519,42 @@ public class WebHookSecurityEventExecutor implements SecurityEventHook {
     long startTime = System.currentTimeMillis();
 
     try {
-      // 1. 設定取得
-      WebHookConfiguration configuration =
-          jsonConverter.read(hookConfiguration, WebHookConfiguration.class);
+      // 1. イベントタイプ別の設定取得（SSFと同じパターン）
+      SecurityEventConfig securityEventConfig = hookConfiguration.getEvent(securityEvent.type());
+      SecurityEventExecutionConfig executionConfig = securityEventConfig.execution();
+      HttpRequestExecutionConfig httpRequestConfig = executionConfig.httpRequest();
 
-      // 2. イベントタイプ別の設定取得
-      HttpRequestUrl httpRequestUrl = configuration.httpRequestUrl(securityEvent.type());
-      HttpMethod httpMethod = configuration.httpMethod(securityEvent.type());
-      HttpRequestStaticHeaders httpRequestStaticHeaders =
-          configuration.httpRequestHeaders(securityEvent.type());
-      HttpRequestDynamicBodyKeys httpRequestDynamicBodyKeys =
-          configuration.httpRequestDynamicBodyKeys(securityEvent.type());
-      HttpRequestStaticBody httpRequestStaticBody =
-          configuration.httpRequestStaticBody(securityEvent.type());
-
-      // 3. リクエストボディ生成（動的マッピング）
-      HttpRequestBodyCreator requestBodyCreator =
-          new HttpRequestBodyCreator(
-              new HttpRequestBaseParams(securityEvent.toMap()),
-              httpRequestDynamicBodyKeys,
-              httpRequestStaticBody);
-      Map<String, Object> requestBody = requestBodyCreator.create();
-
-      // 4. HTTPリクエスト実行
-      HttpRequest httpRequest = HttpRequest.newBuilder()
-          .uri(new URI(httpRequestUrl.value()))
-          .method(httpMethod.value(), /* body */)
-          .headers(httpRequestStaticHeaders.toArray())
-          .build();
-
-      HttpRequestResult result = httpRequestExecutor.execute(httpRequest);
-
+      // 2. HTTPリクエスト実行（リトライ・認証・タイムアウト自動処理）
+      HttpRequestBaseParams params = new HttpRequestBaseParams(securityEvent.toMap());
+      HttpRequestResult httpResult = httpRequestExecutor.execute(httpRequestConfig, params);
       long executionDurationMs = System.currentTimeMillis() - startTime;
 
-      if (result.isSuccess()) {
-        return SecurityEventHookResult.success(securityEvent, result, executionDurationMs);
+      Map<String, Object> responseBody = httpResult.toMap();
+
+      if (httpResult.isSuccess()) {
+        return SecurityEventHookResult.successWithContext(
+            hookConfiguration, securityEvent, responseBody, executionDurationMs);
       } else {
-        return SecurityEventHookResult.failure(securityEvent, result, executionDurationMs);
+        return SecurityEventHookResult.failureWithContext(
+            hookConfiguration, securityEvent, responseBody, executionDurationMs,
+            "HTTP_ERROR", "HTTP request failed with status: " + httpResult.statusCode());
       }
 
     } catch (Exception e) {
       long executionDurationMs = System.currentTimeMillis() - startTime;
-      return SecurityEventHookResult.error(securityEvent, e, executionDurationMs);
+      return SecurityEventHookResult.failureWithContext(
+          hookConfiguration, securityEvent, null, executionDurationMs,
+          e.getClass().getSimpleName(), "Webhook request failed: " + e.getMessage());
     }
   }
 }
 ```
 
 **重要ポイント**:
+- ✅ **SSFと同じ設定パターン**: `hookConfiguration.getEvent(eventType)` → `SecurityEventConfig` → `HttpRequestExecutionConfig`
+- ✅ **HttpRequestExecutor.execute(config, params)経由**: リトライ（指数バックオフ）・OAuth2/HMAC認証・タイムアウト・SSRF保護を自動処理
 - ✅ **Tenant第一引数**: マルチテナント分離
 - ✅ **実行時間計測**: `executionDurationMs`でパフォーマンス監視
-- ✅ **動的設定**: イベントタイプ別にURL/メソッド/ヘッダー/ボディを設定可能
 - ✅ **例外ハンドリング**: 成功/失敗/エラーを明確に区別
 
 #### SlackSecurityEventHookExecutor - Slack実装

--- a/e2e/src/tests/usecase/advance/advance-02-multiple-webhook-hooks-per-event.test.js
+++ b/e2e/src/tests/usecase/advance/advance-02-multiple-webhook-hooks-per-event.test.js
@@ -1,0 +1,191 @@
+import { describe, expect, it, beforeAll, afterAll } from "@jest/globals";
+import { get, postWithJson, deletion } from "../../../lib/http";
+import { requestToken } from "../../../api/oauthClient";
+import { requestAuthorizations } from "../../../oauth/request";
+import {
+  adminServerConfig,
+  backendUrl,
+  mockApiBaseUrl,
+  serverConfig,
+  clientSecretPostClient,
+} from "../../testConfig";
+import { v4 as uuidv4 } from "uuid";
+import { sleep } from "../../../lib/util";
+
+/**
+ * Advance Use Case: Multiple Webhook Hooks Per Event
+ *
+ * Verifies that a single security event can trigger multiple webhook
+ * hook configurations simultaneously.
+ *
+ * SecurityEventHandler iterates over ALL SecurityEventHookConfigurations
+ * for the tenant and executes each one whose triggers list contains the
+ * event type. This test registers two WEBHOOK-type hook configurations
+ * with the same trigger, fires the event via the authorization code flow
+ * (which triggers password_success through interactive authentication),
+ * and asserts that both hooks produced execution results.
+ *
+ * Flow:
+ * 1. Register webhook hook config A (triggers: ["password_success"])
+ * 2. Register webhook hook config B (triggers: ["password_success"])
+ * 3. Perform authorization code flow with password authentication
+ *    -> fires password_success event
+ * 4. Verify security-event-hooks results contain entries for BOTH configs
+ * 5. Cleanup
+ */
+describe("Advance Use Case: Multiple Webhook Hooks Per Event", () => {
+  let adminAccessToken;
+  const hookConfigIdA = uuidv4();
+  const hookConfigIdB = uuidv4();
+
+  beforeAll(async () => {
+    // Get system admin token for management API
+    const tokenResponse = await requestToken({
+      endpoint: adminServerConfig.tokenEndpoint,
+      grantType: "password",
+      username: adminServerConfig.oauth.username,
+      password: adminServerConfig.oauth.password,
+      scope: adminServerConfig.adminClient.scope,
+      clientId: adminServerConfig.adminClient.clientId,
+      clientSecret: adminServerConfig.adminClient.clientSecret,
+    });
+    expect(tokenResponse.status).toBe(200);
+    adminAccessToken = tokenResponse.data.access_token;
+
+    // Register webhook hook config A
+    const createA = await postWithJson({
+      url: `${backendUrl}/v1/management/tenants/${serverConfig.tenantId}/security-event-hook-configurations`,
+      headers: { Authorization: `Bearer ${adminAccessToken}` },
+      body: {
+        id: hookConfigIdA,
+        type: "WEBHOOK",
+        triggers: ["password_success"],
+        events: {
+          default: {
+            execution: {
+              function: "http_request",
+              http_request: {
+                url: `${mockApiBaseUrl}/webhook-hook-a`,
+                method: "POST",
+                auth_type: "none",
+                body_mapping_rules: [
+                  { from: "event_type", to: "event_type" },
+                  { static_value: "hook-a", to: "hook_id" },
+                ],
+              },
+            },
+          },
+        },
+        enabled: true,
+      },
+    });
+    console.log("Hook config A create status:", createA.status);
+    expect(createA.status).toBe(201);
+
+    // Register webhook hook config B
+    const createB = await postWithJson({
+      url: `${backendUrl}/v1/management/tenants/${serverConfig.tenantId}/security-event-hook-configurations`,
+      headers: { Authorization: `Bearer ${adminAccessToken}` },
+      body: {
+        id: hookConfigIdB,
+        type: "WEBHOOK",
+        triggers: ["password_success"],
+        events: {
+          default: {
+            execution: {
+              function: "http_request",
+              http_request: {
+                url: `${mockApiBaseUrl}/webhook-hook-b`,
+                method: "POST",
+                auth_type: "none",
+                body_mapping_rules: [
+                  { from: "event_type", to: "event_type" },
+                  { static_value: "hook-b", to: "hook_id" },
+                ],
+              },
+            },
+          },
+        },
+        enabled: true,
+      },
+    });
+    console.log("Hook config B create status:", createB.status);
+    expect(createB.status).toBe(201);
+  });
+
+  afterAll(async () => {
+    // Cleanup both hook configurations
+    try {
+      await deletion({
+        url: `${backendUrl}/v1/management/tenants/${serverConfig.tenantId}/security-event-hook-configurations/${hookConfigIdA}`,
+        headers: { Authorization: `Bearer ${adminAccessToken}` },
+      });
+      console.log("Hook config A deleted");
+    } catch (e) {
+      console.log("Hook config A cleanup skipped:", e.message);
+    }
+
+    try {
+      await deletion({
+        url: `${backendUrl}/v1/management/tenants/${serverConfig.tenantId}/security-event-hook-configurations/${hookConfigIdB}`,
+        headers: { Authorization: `Bearer ${adminAccessToken}` },
+      });
+      console.log("Hook config B deleted");
+    } catch (e) {
+      console.log("Hook config B cleanup skipped:", e.message);
+    }
+  });
+
+  it("should execute both webhook hooks when a single event fires", async () => {
+    // Fire a password_success event via authorization code flow
+    // requestAuthorizations performs: authorization request -> password authentication -> authorize
+    // The password authentication step fires the password_success security event
+    const { authorizationResponse } = await requestAuthorizations({
+      endpoint: serverConfig.authorizationEndpoint,
+      authorizeEndpoint: serverConfig.authorizeEndpoint,
+      clientId: clientSecretPostClient.clientId,
+      responseType: "code",
+      state: "test-state",
+      scope: "openid",
+      redirectUri: clientSecretPostClient.redirectUri,
+    });
+    expect(authorizationResponse.code).toBeDefined();
+    console.log(
+      "Authorization code flow completed - password_success event fired"
+    );
+
+    // Wait for async hook execution
+    await sleep(3000);
+
+    // Get security event hook results
+    const hooksResponse = await get({
+      url: `${backendUrl}/v1/management/tenants/${serverConfig.tenantId}/security-event-hooks?event_type=password_success&limit=50&offset=0`,
+      headers: { Authorization: `Bearer ${adminAccessToken}` },
+    });
+    expect(hooksResponse.status).toBe(200);
+    console.log(
+      "Hook results:",
+      JSON.stringify(hooksResponse.data, null, 2)
+    );
+
+    const hookResults = hooksResponse.data.list || [];
+    expect(hookResults.length).toBeGreaterThan(0);
+
+    // Find hook results for our specific hook configs by matching hook type WEBHOOK
+    // Both configs are type WEBHOOK and triggered by password_success
+    const webhookResults = hookResults.filter(
+      (r) => r.type === "WEBHOOK"
+    );
+    console.log(
+      `Found ${webhookResults.length} WEBHOOK hook results for password_success`
+    );
+
+    // We should have at least 2 WEBHOOK results (one from each config)
+    // Note: there may be pre-existing WEBHOOK configs, so we check >= 2
+    expect(webhookResults.length).toBeGreaterThanOrEqual(2);
+
+    console.log(
+      "Verified: a single event triggered multiple webhook hook executions"
+    );
+  });
+});

--- a/libs/idp-server-security-event-hooks/build.gradle
+++ b/libs/idp-server-security-event-hooks/build.gradle
@@ -16,6 +16,8 @@ dependencies {
 
 	testImplementation platform('org.junit:junit-bom:5.10.0')
 	testImplementation 'org.junit.jupiter:junit-jupiter'
+	testImplementation 'org.mockito:mockito-core:5.8.0'
+	testImplementation 'org.mockito:mockito-junit-jupiter:5.8.0'
 }
 
 test {

--- a/libs/idp-server-security-event-hooks/src/main/java/org/idp/server/security/event/hooks/webhook/WebHookSecurityEventExecutor.java
+++ b/libs/idp-server-security-event-hooks/src/main/java/org/idp/server/security/event/hooks/webhook/WebHookSecurityEventExecutor.java
@@ -16,16 +16,17 @@
 
 package org.idp.server.security.event.hooks.webhook;
 
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.net.http.HttpRequest;
 import java.util.Map;
-import org.idp.server.platform.http.*;
-import org.idp.server.platform.json.JsonConverter;
+import org.idp.server.platform.http.HttpRequestBaseParams;
+import org.idp.server.platform.http.HttpRequestExecutionConfig;
+import org.idp.server.platform.http.HttpRequestExecutor;
+import org.idp.server.platform.http.HttpRequestResult;
 import org.idp.server.platform.multi_tenancy.tenant.Tenant;
 import org.idp.server.platform.security.SecurityEvent;
 import org.idp.server.platform.security.hook.*;
 import org.idp.server.platform.security.hook.SecurityEventHook;
+import org.idp.server.platform.security.hook.configuration.SecurityEventConfig;
+import org.idp.server.platform.security.hook.configuration.SecurityEventExecutionConfig;
 import org.idp.server.platform.security.hook.configuration.SecurityEventHookConfiguration;
 
 /**
@@ -35,11 +36,9 @@ import org.idp.server.platform.security.hook.configuration.SecurityEventHookConf
 public class WebHookSecurityEventExecutor implements SecurityEventHook {
 
   HttpRequestExecutor httpRequestExecutor;
-  JsonConverter jsonConverter;
 
   public WebHookSecurityEventExecutor(HttpRequestExecutor httpRequestExecutor) {
     this.httpRequestExecutor = httpRequestExecutor;
-    this.jsonConverter = JsonConverter.snakeCaseInstance();
   }
 
   @Override
@@ -56,39 +55,14 @@ public class WebHookSecurityEventExecutor implements SecurityEventHook {
     long startTime = System.currentTimeMillis();
 
     try {
+      SecurityEventConfig securityEventConfig = hookConfiguration.getEvent(securityEvent.type());
+      SecurityEventExecutionConfig executionConfig = securityEventConfig.execution();
+      HttpRequestExecutionConfig httpRequestConfig = executionConfig.httpRequest();
 
-      WebHookConfiguration configuration =
-          jsonConverter.read(hookConfiguration, WebHookConfiguration.class);
-      HttpRequestUrl httpRequestUrl = configuration.httpRequestUrl(securityEvent.type());
-      HttpMethod httpMethod = configuration.httpMethod(securityEvent.type());
-      HttpRequestStaticHeaders httpRequestStaticHeaders =
-          configuration.httpRequestHeaders(securityEvent.type());
-      HttpRequestDynamicBodyKeys httpRequestDynamicBodyKeys =
-          configuration.httpRequestDynamicBodyKeys(securityEvent.type());
-      HttpRequestStaticBody httpRequestStaticBody =
-          configuration.httpRequestStaticBody(securityEvent.type());
-
-      HttpRequestBodyCreator requestBodyCreator =
-          new HttpRequestBodyCreator(
-              new HttpRequestBaseParams(securityEvent.toMap()),
-              httpRequestDynamicBodyKeys,
-              httpRequestStaticBody);
-      Map<String, Object> requestBody = requestBodyCreator.create();
-
-      HttpRequest.Builder httpRequestBuilder =
-          HttpRequest.newBuilder()
-              .uri(new URI(httpRequestUrl.value()))
-              .header("Content-Type", "application/json");
-
-      setHeaders(httpRequestBuilder, httpRequestStaticHeaders);
-      setParams(httpRequestBuilder, httpMethod, requestBody);
-
-      HttpRequest httpRequest = httpRequestBuilder.build();
-
-      HttpRequestResult httpResult = httpRequestExecutor.execute(httpRequest);
+      HttpRequestBaseParams params = new HttpRequestBaseParams(securityEvent.toMap());
+      HttpRequestResult httpResult = httpRequestExecutor.execute(httpRequestConfig, params);
       long executionDurationMs = System.currentTimeMillis() - startTime;
 
-      // Parse response body if it's JSON
       Map<String, Object> responseBody = httpResult.toMap();
 
       if (httpResult.isSuccess()) {
@@ -104,15 +78,6 @@ public class WebHookSecurityEventExecutor implements SecurityEventHook {
             "HTTP request failed with status: " + httpResult.statusCode());
       }
 
-    } catch (URISyntaxException e) {
-      long executionDurationMs = System.currentTimeMillis() - startTime;
-      return SecurityEventHookResult.failureWithContext(
-          hookConfiguration,
-          securityEvent,
-          null,
-          executionDurationMs,
-          "URISyntaxException",
-          "WebhookUrl is invalid: " + e.getMessage());
     } catch (Exception e) {
       long executionDurationMs = System.currentTimeMillis() - startTime;
       return SecurityEventHookResult.failureWithContext(
@@ -122,36 +87,6 @@ public class WebHookSecurityEventExecutor implements SecurityEventHook {
           executionDurationMs,
           e.getClass().getSimpleName(),
           "Webhook request failed: " + e.getMessage());
-    }
-  }
-
-  private void setHeaders(
-      HttpRequest.Builder httpRequestBuilder, HttpRequestStaticHeaders httpRequestStaticHeaders) {
-    httpRequestStaticHeaders.forEach(httpRequestBuilder::header);
-  }
-
-  private void setParams(
-      HttpRequest.Builder builder, HttpMethod httpMethod, Map<String, Object> requestBody) {
-
-    switch (httpMethod) {
-      case GET:
-        builder.GET();
-        break;
-      case POST:
-        {
-          builder.POST(HttpRequest.BodyPublishers.ofString(jsonConverter.write(requestBody)));
-          break;
-        }
-      case PUT:
-        {
-          builder.PUT(HttpRequest.BodyPublishers.ofString(jsonConverter.write(requestBody)));
-          break;
-        }
-      case DELETE:
-        {
-          builder.DELETE();
-          break;
-        }
     }
   }
 }

--- a/libs/idp-server-security-event-hooks/src/test/java/org/idp/server/security/event/hooks/webhook/WebHookSecurityEventExecutorTest.java
+++ b/libs/idp-server-security-event-hooks/src/test/java/org/idp/server/security/event/hooks/webhook/WebHookSecurityEventExecutorTest.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright 2025 Hirokazu Kobayashi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.idp.server.security.event.hooks.webhook;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+import java.util.*;
+import org.idp.server.platform.http.HttpRequestBaseParams;
+import org.idp.server.platform.http.HttpRequestExecutionConfig;
+import org.idp.server.platform.http.HttpRequestExecutor;
+import org.idp.server.platform.http.HttpRequestResult;
+import org.idp.server.platform.json.JsonNodeWrapper;
+import org.idp.server.platform.multi_tenancy.tenant.Tenant;
+import org.idp.server.platform.security.SecurityEvent;
+import org.idp.server.platform.security.event.*;
+import org.idp.server.platform.security.hook.SecurityEventHookResult;
+import org.idp.server.platform.security.hook.SecurityEventHookType;
+import org.idp.server.platform.security.hook.StandardSecurityEventHookType;
+import org.idp.server.platform.security.hook.configuration.SecurityEventConfig;
+import org.idp.server.platform.security.hook.configuration.SecurityEventHookConfiguration;
+import org.idp.server.platform.security.type.IpAddress;
+import org.idp.server.platform.security.type.UserAgent;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class WebHookSecurityEventExecutorTest {
+
+  @Mock HttpRequestExecutor httpRequestExecutor;
+  @Mock Tenant tenant;
+
+  WebHookSecurityEventExecutor executor;
+  SecurityEvent securityEvent;
+
+  @BeforeEach
+  void setUp() {
+    executor = new WebHookSecurityEventExecutor(httpRequestExecutor);
+
+    SecurityEventTenant eventTenant =
+        new SecurityEventTenant("tenant-id", "https://tenant.example.com", "Test Tenant");
+    SecurityEventClient eventClient = new SecurityEventClient("client-id", "client-123");
+    SecurityEventUser eventUser =
+        new SecurityEventUser("user-123", "Test User", "user-ex-123", "test@example.com", null);
+    SecurityEventDetail detail = new SecurityEventDetail(Map.of("key", "value"));
+
+    securityEvent =
+        new SecurityEventBuilder()
+            .add(new SecurityEventType("authentication_success"))
+            .add(new SecurityEventDescription("User authenticated"))
+            .add(eventTenant)
+            .add(eventClient)
+            .add(eventUser)
+            .add(new IpAddress("192.168.1.1"))
+            .add(new UserAgent("Mozilla/5.0"))
+            .add(detail)
+            .build();
+  }
+
+  @Test
+  void type_shouldReturnWebhookType() {
+    SecurityEventHookType hookType = executor.type();
+    assertEquals(StandardSecurityEventHookType.WEBHOOK.toHookType(), hookType);
+  }
+
+  @Test
+  void execute_shouldReturnSuccessWhenHttpRequestSucceeds() {
+    HttpRequestResult httpResult =
+        new HttpRequestResult(200, Map.of(), JsonNodeWrapper.fromMap(Map.of("ok", true)));
+    when(httpRequestExecutor.execute(
+            any(HttpRequestExecutionConfig.class), any(HttpRequestBaseParams.class)))
+        .thenReturn(httpResult);
+
+    SecurityEventHookConfiguration hookConfiguration =
+        createHookConfiguration("authentication_success");
+
+    SecurityEventHookResult result = executor.execute(tenant, securityEvent, hookConfiguration);
+
+    assertTrue(result.isSuccess());
+    verify(httpRequestExecutor)
+        .execute(any(HttpRequestExecutionConfig.class), any(HttpRequestBaseParams.class));
+  }
+
+  @Test
+  void execute_shouldReturnFailureWhenHttpRequestFails() {
+    HttpRequestResult httpResult =
+        new HttpRequestResult(500, Map.of(), JsonNodeWrapper.fromMap(Map.of("error", "internal")));
+    when(httpRequestExecutor.execute(
+            any(HttpRequestExecutionConfig.class), any(HttpRequestBaseParams.class)))
+        .thenReturn(httpResult);
+
+    SecurityEventHookConfiguration hookConfiguration =
+        createHookConfiguration("authentication_success");
+
+    SecurityEventHookResult result = executor.execute(tenant, securityEvent, hookConfiguration);
+
+    assertTrue(result.isFailure());
+  }
+
+  @Test
+  void execute_shouldReturnFailureWhenExceptionThrown() {
+    when(httpRequestExecutor.execute(
+            any(HttpRequestExecutionConfig.class), any(HttpRequestBaseParams.class)))
+        .thenThrow(new RuntimeException("Connection refused"));
+
+    SecurityEventHookConfiguration hookConfiguration =
+        createHookConfiguration("authentication_success");
+
+    SecurityEventHookResult result = executor.execute(tenant, securityEvent, hookConfiguration);
+
+    assertTrue(result.isFailure());
+  }
+
+  @Test
+  void execute_shouldUseDefaultEventConfigWhenSpecificEventNotConfigured() {
+    HttpRequestResult httpResult =
+        new HttpRequestResult(200, Map.of(), JsonNodeWrapper.fromMap(Map.of("ok", true)));
+    when(httpRequestExecutor.execute(
+            any(HttpRequestExecutionConfig.class), any(HttpRequestBaseParams.class)))
+        .thenReturn(httpResult);
+
+    SecurityEventHookConfiguration hookConfiguration = createHookConfigurationWithDefaultOnly();
+
+    SecurityEventHookResult result = executor.execute(tenant, securityEvent, hookConfiguration);
+
+    assertTrue(result.isSuccess());
+    verify(httpRequestExecutor)
+        .execute(any(HttpRequestExecutionConfig.class), any(HttpRequestBaseParams.class));
+  }
+
+  private SecurityEventHookConfiguration createHookConfiguration(String eventType) {
+    SecurityEventConfig securityEventConfig = new SecurityEventConfig();
+
+    Map<String, SecurityEventConfig> events = new HashMap<>();
+    events.put(eventType, securityEventConfig);
+
+    return new SecurityEventHookConfiguration(
+        "hook-1",
+        "WEBHOOK",
+        new HashMap<>(),
+        new HashMap<>(),
+        List.of(eventType),
+        100,
+        events,
+        true,
+        true);
+  }
+
+  private SecurityEventHookConfiguration createHookConfigurationWithDefaultOnly() {
+    SecurityEventConfig securityEventConfig = new SecurityEventConfig();
+
+    Map<String, SecurityEventConfig> events = new HashMap<>();
+    events.put("default", securityEventConfig);
+
+    return new SecurityEventHookConfiguration(
+        "hook-1",
+        "WEBHOOK",
+        new HashMap<>(),
+        new HashMap<>(),
+        List.of("authentication_success"),
+        100,
+        events,
+        true,
+        true);
+  }
+}


### PR DESCRIPTION
## Summary

- `WebHookSecurityEventExecutor`の独自パターン（`WebHookConfiguration`/base/overlays + 手動`HttpRequest`構築）を廃止し、SSFと同じ設定パターン（`hookConfiguration.getEvent()` → `SecurityEventConfig` → `HttpRequestExecutionConfig` → `httpRequestExecutor.execute(config, params)`）に統一
- これにより、リトライ（指数バックオフ）・OAuth2/HMAC認証・タイムアウト・SSRF保護が`HttpRequestExecutor`経由で自動適用される
- JUnitテスト（Mockito、5ケース）・E2Eテスト（複数Webhook同時実行）・ドキュメント更新を含む

## Test plan

- [x] `./gradlew :libs:idp-server-security-event-hooks:test` - JUnitテスト5件パス
- [x] `npm test -- --testPathPattern="advance-02"` - E2Eテスト（複数Webhookフック同時実行）パス
- [x] `./gradlew build && ./gradlew test` - フルビルド・テスト

🤖 Generated with [Claude Code](https://claude.com/claude-code)