### PR TITLE
fix: 外部サービスHTTPレスポンスのエラーログレベルをwarnに昇格

### DIFF
--- a/libs/idp-server-platform/src/main/java/org/idp/server/platform/http/HttpRequestExecutor.java
+++ b/libs/idp-server-platform/src/main/java/org/idp/server/platform/http/HttpRequestExecutor.java
@@ -191,8 +191,7 @@ public class HttpRequestExecutor {
 
       HttpResponse<String> httpResponse = ssrfProtectedHttpClient.send(httpRequest);
 
-      log.debug("Http Response status: {}", httpResponse.statusCode());
-      log.debug("Http Response body: {}", httpResponse.body());
+      logResponse(httpResponse);
 
       JsonNodeWrapper jsonResponse = HttpResponseResolver.resolveResponseBody(httpResponse);
 
@@ -201,6 +200,16 @@ public class HttpRequestExecutor {
     } catch (HttpNetworkErrorException e) {
       log.warn("Http request was error: {}", e.getMessage(), e);
       return HttpResponseResolver.resolveException(e);
+    }
+  }
+
+  private void logResponse(HttpResponse<String> httpResponse) {
+    if (httpResponse.statusCode() >= 400) {
+      log.warn(
+          "Http Response status: {}, body: {}", httpResponse.statusCode(), httpResponse.body());
+    } else {
+      log.debug(
+          "Http Response status: {}, body: {}", httpResponse.statusCode(), httpResponse.body());
     }
   }
 
@@ -222,8 +231,7 @@ public class HttpRequestExecutor {
 
       HttpResponse<String> httpResponse = ssrfProtectedHttpClient.send(httpRequest);
 
-      log.debug("Http Response status: {}", httpResponse.statusCode());
-      log.debug("Http Response body: {}", httpResponse.body());
+      logResponse(httpResponse);
 
       return HttpResponseResolver.resolve(httpResponse, resolveConfigs);
     } catch (HttpNetworkErrorException e) {

--- a/libs/idp-server-platform/src/main/java/org/idp/server/platform/http/HttpResponseResolver.java
+++ b/libs/idp-server-platform/src/main/java/org/idp/server/platform/http/HttpResponseResolver.java
@@ -59,6 +59,14 @@ public class HttpResponseResolver {
       return new HttpRequestResult(httpResponse.statusCode(), httpResponse.headers().map(), body);
     }
 
+    if (matchedConfig.mappedStatusCode() >= 400
+        && matchedConfig.mappedStatusCode() != httpResponse.statusCode()) {
+      log.warn(
+          "Http Response mapped status: {}, body: {}",
+          matchedConfig.mappedStatusCode(),
+          httpResponse.body());
+    }
+
     return new HttpRequestResult(
         matchedConfig.mappedStatusCode(), httpResponse.headers().map(), body);
   }


### PR DESCRIPTION
## Summary
- 外部サービスへのHTTPリクエストでエラーレスポンス（400+）のログレベルを`debug`→`warn`に昇格し、運用時の問題検知を改善
- ステータスコードとボディを1行に統合し、高負荷時のログ混在を防止
- レスポンス条件マッチングでステータスがマッピングされた場合、実ステータスと異なる場合のみ`mapped status`として追加ログを出力し、二重ログを防止

## Test plan
- [x] E2Eテストでログ出力を確認済み
  - 200 → mapped 400: `HttpRequestExecutor`がDEBUG、`HttpResponseResolver`がWARNで`mapped status`出力
  - 504: `HttpRequestExecutor`がWARNで出力、重複なし

Closes #1286

🤖 Generated with [Claude Code](https://claude.com/claude-code)