### PR TITLE
feat: 身元確認コールバック受信ログを追加

### DIFF
--- a/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/application/identity_verification_service/IdentityVerificationCallbackEntryService.java
+++ b/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/application/identity_verification_service/IdentityVerificationCallbackEntryService.java
@@ -39,6 +39,7 @@ import org.idp.server.core.openid.identity.repository.UserQueryRepository;
 import org.idp.server.core.openid.token.UserEventPublisher;
 import org.idp.server.platform.datasource.Transaction;
 import org.idp.server.platform.http.HttpRequestExecutor;
+import org.idp.server.platform.log.LoggerWrapper;
 import org.idp.server.platform.multi_tenancy.tenant.Tenant;
 import org.idp.server.platform.multi_tenancy.tenant.TenantIdentifier;
 import org.idp.server.platform.multi_tenancy.tenant.TenantQueryRepository;
@@ -58,6 +59,7 @@ public class IdentityVerificationCallbackEntryService implements IdentityVerific
   UserQueryRepository userQueryRepository;
   UserCommandRepository userCommandRepository;
   UserEventPublisher eventPublisher;
+  LoggerWrapper log = LoggerWrapper.getLogger(IdentityVerificationCallbackEntryService.class);
 
   public IdentityVerificationCallbackEntryService(
       IdentityVerificationConfigurationQueryRepository configurationQueryRepository,
@@ -111,6 +113,7 @@ public class IdentityVerificationCallbackEntryService implements IdentityVerific
 
     String applicationIdParams = verificationConfiguration.getCallbackApplicationId(process);
     String applicationId = request.getValueAsString(applicationIdParams);
+    log.info("IdentityVerification callback received {}: {}", applicationIdParams, applicationId);
     IdentityVerificationApplication application =
         applicationQueryRepository.get(tenant, applicationIdParams, applicationId);
 


### PR DESCRIPTION
## Summary
- IdentityVerificationCallbackEntryServiceにINFOレベルのログを追加
- コールバック受信時にapplicationIdParamsとapplicationIdを出力し、運用時のトラブルシューティングを容易にする

## Test plan
- [x] ビルドが通ることを確認
- [x] 身元確認コールバック受信時にログが出力されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)