### PR TITLE
fix: user_signupイベントの発行タイミングをDB永続化成功時に修正

### DIFF
--- a/libs/idp-server-authentication-interactors/src/main/java/org/idp/server/authentication/interactors/initial_registration/InitialRegistrationInteractor.java
+++ b/libs/idp-server-authentication-interactors/src/main/java/org/idp/server/authentication/interactors/initial_registration/InitialRegistrationInteractor.java
@@ -93,7 +93,11 @@ public class InitialRegistrationInteractor implements AuthenticationInteractor {
       response.put("error_messages", validationResult.errors());
 
       return AuthenticationInteractionRequestResult.clientError(
-          response, type, operationType(), method(), DefaultSecurityEventType.user_signup_failure);
+          response,
+          type,
+          operationType(),
+          method(),
+          DefaultSecurityEventType.user_initial_registration_failure);
     }
 
     String email = request.optValueAsString("email", "");
@@ -107,7 +111,11 @@ public class InitialRegistrationInteractor implements AuthenticationInteractor {
       response.put("error_description", "user is conflict with username and password");
 
       return AuthenticationInteractionRequestResult.clientError(
-          response, type, operationType(), method(), DefaultSecurityEventType.user_signup_conflict);
+          response,
+          type,
+          operationType(),
+          method(),
+          DefaultSecurityEventType.user_initial_registration_conflict);
     }
 
     // Validate password against tenant password policy
@@ -133,7 +141,7 @@ public class InitialRegistrationInteractor implements AuthenticationInteractor {
               type,
               operationType(),
               method(),
-              DefaultSecurityEventType.user_signup_failure);
+              DefaultSecurityEventType.user_initial_registration_failure);
         }
         log.debug("Password policy validation succeeded for initial registration");
       } catch (IllegalArgumentException validationException) {
@@ -149,7 +157,7 @@ public class InitialRegistrationInteractor implements AuthenticationInteractor {
             type,
             operationType(),
             method(),
-            DefaultSecurityEventType.user_signup_failure);
+            DefaultSecurityEventType.user_initial_registration_failure);
       }
     }
 
@@ -168,7 +176,7 @@ public class InitialRegistrationInteractor implements AuthenticationInteractor {
         method(),
         user,
         response,
-        DefaultSecurityEventType.user_signup);
+        DefaultSecurityEventType.user_initial_registration_success);
   }
 
   /**

--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/identity/UserRegistrationResult.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/identity/UserRegistrationResult.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2025 Hirokazu Kobayashi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.idp.server.core.openid.identity;
+
+public class UserRegistrationResult {
+
+  User user;
+  boolean newRegistration;
+
+  public UserRegistrationResult(User user, boolean newRegistration) {
+    this.user = user;
+    this.newRegistration = newRegistration;
+  }
+
+  public User user() {
+    return user;
+  }
+
+  public boolean isNewRegistration() {
+    return newRegistration;
+  }
+}

--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/identity/UserRegistrator.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/identity/UserRegistrator.java
@@ -33,7 +33,7 @@ public class UserRegistrator {
     this.userVerifier = new UserVerifier(userQueryRepository);
   }
 
-  public User registerOrUpdate(Tenant tenant, User user) {
+  public UserRegistrationResult registerOrUpdate(Tenant tenant, User user) {
 
     User existingUser = userQueryRepository.findById(tenant, user.userIdentifier());
 
@@ -41,7 +41,7 @@ public class UserRegistrator {
       User updatedUser = existingUser.updateWith(user);
       applyIdentityPolicyIfNeeded(tenant, updatedUser);
       userCommandRepository.update(tenant, updatedUser);
-      return updatedUser;
+      return new UserRegistrationResult(updatedUser, false);
     }
 
     // Apply identity policy to set preferred_username if not set
@@ -56,7 +56,7 @@ public class UserRegistrator {
 
     userCommandRepository.register(tenant, user);
 
-    return user;
+    return new UserRegistrationResult(user, true);
   }
 
   /**

--- a/libs/idp-server-platform/src/main/java/org/idp/server/platform/security/event/DefaultSecurityEventType.java
+++ b/libs/idp-server-platform/src/main/java/org/idp/server/platform/security/event/DefaultSecurityEventType.java
@@ -53,9 +53,10 @@ package org.idp.server.platform.security.event;
 public enum DefaultSecurityEventType {
 
   // User lifecycle
+  user_initial_registration_success("Initial registration form was completed successfully"),
   user_signup("User account was created via self-registration"),
-  user_signup_failure("Self-registration failed"),
-  user_signup_conflict("Self-registration rejected due to duplicate account"),
+  user_initial_registration_failure("Initial registration form validation failed"),
+  user_initial_registration_conflict("Initial registration rejected due to duplicate account"),
   user_self_delete("User deleted their own account (irreversible)", true),
 
   // Password authentication


### PR DESCRIPTION
## Summary

- `user_signup`イベントをDB永続化成功時（`OAuthFlowEntryService.authorize()`）に発行するよう修正
- 初期登録フォーム完了時は`user_initial_registration_success`を発行するよう変更
- 初期登録関連イベントを`user_initial_registration_*`にリネーム（failure, conflict含む）
- `UserRegistrationResult`クラスを追加し、新規登録/更新を判別

Closes #1289

## Test plan

- [x] `./gradlew build` がパスすることを確認
- [x] E2Eテスト成功
- [x] 動作確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)