### PR TITLE
feat: ログトレーシング用request_idの導入

### DIFF
--- a/libs/idp-server-platform/src/main/java/org/idp/server/platform/log/TenantLoggingContext.java
+++ b/libs/idp-server-platform/src/main/java/org/idp/server/platform/log/TenantLoggingContext.java
@@ -17,17 +17,31 @@
 package org.idp.server.platform.log;
 
 import java.util.Objects;
+import java.util.UUID;
 import org.idp.server.platform.multi_tenancy.tenant.TenantIdentifier;
 import org.slf4j.MDC;
 
 public class TenantLoggingContext {
 
+  private static final String REQUEST_ID_KEY = "request_id";
   private static final String TENANT_ID_KEY = "tenant_id";
   private static final String CLIENT_ID_KEY = "client_id";
   private static final String USER_ID_KEY = "user_id";
   private static final String USER_EX_SUB_KEY = "user_ex_sub";
   private static final String USER_NAME_KEY = "user_name";
   private static final String LOG_TYPE_KEY = "log_type";
+
+  public static void setRequestId() {
+    MDC.put(REQUEST_ID_KEY, UUID.randomUUID().toString());
+  }
+
+  public static String getCurrentRequestId() {
+    return MDC.get(REQUEST_ID_KEY);
+  }
+
+  public static void clearRequestId() {
+    MDC.remove(REQUEST_ID_KEY);
+  }
 
   public static void setTenant(TenantIdentifier tenantIdentifier) {
     if (Objects.nonNull(tenantIdentifier) && tenantIdentifier.exists()) {

--- a/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/ManagementTypeEntryServiceProxy.java
+++ b/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/ManagementTypeEntryServiceProxy.java
@@ -22,6 +22,7 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
 import org.idp.server.platform.datasource.*;
 import org.idp.server.platform.log.LoggerWrapper;
+import org.idp.server.platform.log.TenantLoggingContext;
 
 /**
  * Management-type entry service proxy for Organization-level Control Plane APIs.
@@ -116,6 +117,7 @@ public class ManagementTypeEntryServiceProxy implements InvocationHandler {
     if (isTransactional && operationType == OperationType.READ) {
       try {
         OperationContext.set(operationType);
+        TenantLoggingContext.setRequestId();
         log.trace("READ start: class={}, method={}", target.getClass().getName(), method.getName());
 
         DatabaseType databaseType = applicationDatabaseTypeProvider.provide();
@@ -141,11 +143,13 @@ public class ManagementTypeEntryServiceProxy implements InvocationHandler {
             e);
         throw e;
       } finally {
+        TenantLoggingContext.clearAll();
         TransactionManager.closeConnection();
       }
     } else if (isTransactional && operationType == OperationType.WRITE) {
       try {
         OperationContext.set(operationType);
+        TenantLoggingContext.setRequestId();
         log.trace(
             "WRITE start: class={}, method={}", target.getClass().getName(), method.getName());
 
@@ -186,6 +190,7 @@ public class ManagementTypeEntryServiceProxy implements InvocationHandler {
             e);
         throw e;
       } finally {
+        TenantLoggingContext.clearAll();
         TransactionManager.closeConnection();
       }
     } else {

--- a/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/TenantAwareEntryServiceProxy.java
+++ b/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/TenantAwareEntryServiceProxy.java
@@ -105,6 +105,7 @@ public class TenantAwareEntryServiceProxy implements InvocationHandler {
       long startTime = System.currentTimeMillis();
       try {
         OperationContext.set(operationType);
+        TenantLoggingContext.setRequestId();
         TenantIdentifier tenantIdentifier = resolveTenantIdentifier(args);
         TenantLoggingContext.setTenant(tenantIdentifier);
 
@@ -162,6 +163,7 @@ public class TenantAwareEntryServiceProxy implements InvocationHandler {
       long startTime = System.currentTimeMillis();
       try {
         OperationContext.set(operationType);
+        TenantLoggingContext.setRequestId();
         TenantIdentifier tenantIdentifier = resolveTenantIdentifier(args);
         TenantLoggingContext.setTenant(tenantIdentifier);
 


### PR DESCRIPTION
## Summary
- `TenantLoggingContext`に`request_id`（UUID）を追加し、Proxy層のinvoke開始時にMDCへ自動付与
- `TenantAwareEntryServiceProxy`（Application Plane / System-level Control Plane）と`ManagementTypeEntryServiceProxy`（Organization-level Control Plane）の両方に対応
- 既存のLogstashEncoder（`includeMdc=true`）により、追加設定なしでJSONログに`request_id`が出力される
- Datadog APMの`dd.trace_id`等とはキーが異なりバッティングなし

closes #1301

## Test plan
- [x] ローカル環境でリクエスト実行し、JSONログに`request_id`が含まれることを確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)