### PR TITLE
feat: OPSessionにIPアドレス・User Agent情報を追加

### DIFF
--- a/.claude/skills/session-management/skill.md
+++ b/.claude/skills/session-management/skill.md
@@ -61,6 +61,8 @@ public class OPSession {
     private Instant expiresAt;
     private Instant lastAccessedAt;
     private SessionStatus status;
+    private String ipAddress;    // 認証時のIPアドレス
+    private String userAgent;    // 認証時のUser-Agent
 
     // セッション再利用可否判定（概念的）
     public boolean canReuseFor(Acr requiredAcr) {
@@ -105,10 +107,11 @@ public class OIDCSessionHandler {
         User user,
         Authentication authentication,
         Map<String, Map<String, Object>> interactionResults,
-        OPSession existingSession
+        OPSession existingSession,
+        RequestAttributes requestAttributes
     ) {
         // セッション再利用または新規作成ロジック
-        // ...
+        // RequestAttributesからIPアドレス・User-Agentを抽出してOPSessionに保存
     }
 }
 ```

--- a/documentation/openapi/swagger-control-plane-ja.yaml
+++ b/documentation/openapi/swagger-control-plane-ja.yaml
@@ -7297,6 +7297,16 @@ components:
           enum: [USER_LOGOUT, ADMIN_REVOCATION, TIMEOUT, SESSION_LIMIT_EXCEEDED]
           description: セッション終了理由（終了している場合のみ）
           example: null
+        ip_address:
+          type: string
+          nullable: true
+          description: 認証時のIPアドレス
+          example: "192.168.1.100"
+        user_agent:
+          type: string
+          nullable: true
+          description: 認証時のUser-Agent
+          example: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36"
 
     UserSessionListResponse:
       type: object

--- a/e2e/src/tests/scenario/application/scenario-13-sso-session-management.test.js
+++ b/e2e/src/tests/scenario/application/scenario-13-sso-session-management.test.js
@@ -1265,6 +1265,14 @@ describe("SSO Session Management", () => {
       expect(session).toHaveProperty("sub");
       expect(session.sub).toBe(userSub);
 
+      // Verify ip_address and user_agent are included in response
+      expect(session).toHaveProperty("ip_address");
+      expect(session).toHaveProperty("user_agent");
+      console.log("- IP Address:", session.ip_address);
+      console.log("- User Agent:", session.user_agent);
+      expect(session.ip_address).toBeDefined();
+      expect(session.user_agent).toBeDefined();
+
       console.log("\n=== SUCCESS: Session listing via Management API works! ===");
     });
 

--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/session/OIDCSessionService.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/session/OIDCSessionService.java
@@ -45,7 +45,9 @@ public class OIDCSessionService {
       String acr,
       List<String> amr,
       Map<String, Map<String, Object>> interactionResults,
-      long sessionTimeoutSeconds) {
+      long sessionTimeoutSeconds,
+      String ipAddress,
+      String userAgent) {
     OPSession session =
         OPSession.create(
             tenant.identifier(),
@@ -54,7 +56,9 @@ public class OIDCSessionService {
             acr,
             amr,
             interactionResults,
-            sessionTimeoutSeconds);
+            sessionTimeoutSeconds,
+            ipAddress,
+            userAgent);
     opSessionRepository.register(tenant, session);
     return session;
   }

--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/session/OPSession.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/session/OPSession.java
@@ -45,6 +45,8 @@ public class OPSession implements Serializable {
   private SessionStatus status;
   private Instant terminatedAt;
   private TerminationReason terminationReason;
+  private String ipAddress;
+  private String userAgent;
 
   /** Default constructor for JSON deserialization. */
   public OPSession() {
@@ -62,7 +64,9 @@ public class OPSession implements Serializable {
       BrowserState browserState,
       Instant createdAt,
       Instant expiresAt,
-      Instant lastAccessedAt) {
+      Instant lastAccessedAt,
+      String ipAddress,
+      String userAgent) {
     this.id = id;
     this.tenantId = tenantId;
     this.user = user;
@@ -75,6 +79,8 @@ public class OPSession implements Serializable {
     this.expiresAt = expiresAt;
     this.lastAccessedAt = lastAccessedAt;
     this.status = SessionStatus.ACTIVE;
+    this.ipAddress = ipAddress;
+    this.userAgent = userAgent;
   }
 
   public static OPSession create(
@@ -84,7 +90,9 @@ public class OPSession implements Serializable {
       String acr,
       List<String> amr,
       Map<String, Map<String, Object>> interactionResults,
-      long sessionTimeoutSeconds) {
+      long sessionTimeoutSeconds,
+      String ipAddress,
+      String userAgent) {
     Instant now = Instant.now();
     return new OPSession(
         OPSessionIdentifier.generate(),
@@ -97,7 +105,9 @@ public class OPSession implements Serializable {
         BrowserState.generate(),
         now,
         now.plusSeconds(sessionTimeoutSeconds),
-        now);
+        now,
+        ipAddress,
+        userAgent);
   }
 
   public OPSessionIdentifier id() {
@@ -182,6 +192,14 @@ public class OPSession implements Serializable {
     return terminationReason;
   }
 
+  public String ipAddress() {
+    return ipAddress;
+  }
+
+  public String userAgent() {
+    return userAgent;
+  }
+
   public boolean exists() {
     return id != null && id.exists();
   }
@@ -231,6 +249,8 @@ public class OPSession implements Serializable {
     map.put("status", status != null ? status.name() : null);
     map.put("terminated_at", terminatedAt != null ? terminatedAt.toString() : null);
     map.put("termination_reason", terminationReason != null ? terminationReason.name() : null);
+    map.put("ip_address", ipAddress);
+    map.put("user_agent", userAgent);
     return map;
   }
 

--- a/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/application/enduser/OAuthFlowEntryService.java
+++ b/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/application/enduser/OAuthFlowEntryService.java
@@ -279,7 +279,8 @@ public class OAuthFlowEntryService implements OAuthFlowApi, OAuthUserDelegate {
               updatedTransaction.user(),
               authentication,
               updatedTransaction.interactionResults().toStorageMap(),
-              existingSession);
+              existingSession,
+              requestAttributes);
       oidcSessionHandler.registerSessionCookies(tenant, opSession, sessionCookieDelegate);
     }
 
@@ -381,7 +382,8 @@ public class OAuthFlowEntryService implements OAuthFlowApi, OAuthUserDelegate {
               updatedTransaction.user(),
               authentication,
               updatedTransaction.interactionResults().toStorageMap(),
-              existingSession);
+              existingSession,
+              requestAttributes);
       oidcSessionHandler.registerSessionCookies(tenant, opSession, sessionCookieDelegate);
     }
 


### PR DESCRIPTION
## Summary
- OPSessionに`ipAddress`/`userAgent`フィールドを追加し、認証時のRequestAttributesからIP/UA情報を保存
- セッション一覧APIレスポンスに`ip_address`/`user_agent`を自動的に含むように
- Swagger定義、開発者ガイド、スキルドキュメント、E2Eテストも更新

## Test plan
- [x] `./gradlew spotlessApply && ./gradlew build` ビルド成功
- [x] `./gradlew test` テスト成功
- [x] E2Eテスト `scenario-13-sso-session-management` の "should list user sessions" で `ip_address`/`user_agent` がレスポンスに含まれることを確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)