### PR TITLE
fix: CIBAトークン発行時にid_token_claims/userinfo_claimsをマッピング

### DIFF
--- a/e2e/src/tests/spec/ciba_token_request.test.js
+++ b/e2e/src/tests/spec/ciba_token_request.test.js
@@ -2,6 +2,8 @@ import { describe, expect, it } from "@jest/globals";
 
 import {
   getAuthenticationDeviceAuthenticationTransaction,
+  getUserinfo,
+  getJwks,
   postAuthenticationDeviceInteraction,
   requestBackchannelAuthentications,
   requestToken
@@ -11,12 +13,89 @@ import {
   clientSecretPostClient,
   serverConfig,
 } from "../testConfig";
-import { sleep } from "../../lib/util";
+import { createBearerHeader, sleep } from "../../lib/util";
 import { createClientAssertion } from "../../lib/oauth";
+import { verifyAndDecodeJwt } from "../../lib/jose";
 import { get } from "../../lib/http";
 
 describe("OpenID Connect Client-Initiated Backchannel Authentication Flow - Core 1.0", () => {
   const ciba = serverConfig.ciba;
+
+  describe("10. Token Success Response", () => {
+    it("should return userinfo claims (profile, email) when scope includes profile and email", async () => {
+      const backchannelAuthenticationResponse =
+        await requestBackchannelAuthentications({
+          endpoint: serverConfig.backchannelAuthenticationEndpoint,
+          clientId: clientSecretPostClient.clientId,
+          scope: "openid profile email" + (clientSecretPostClient.scope ? " " + clientSecretPostClient.scope : ""),
+          bindingMessage: ciba.bindingMessage,
+          userCode: ciba.userCode,
+          loginHint: ciba.loginHint,
+          clientSecret: clientSecretPostClient.clientSecret,
+        });
+      console.log(backchannelAuthenticationResponse.data);
+      expect(backchannelAuthenticationResponse.status).toBe(200);
+
+      const authenticationTransactionResponse = await getAuthenticationDeviceAuthenticationTransaction({
+        endpoint: serverConfig.authenticationDeviceEndpoint,
+        deviceId: serverConfig.ciba.authenticationDeviceId,
+        params: {
+          "attributes.auth_req_id": backchannelAuthenticationResponse.data.auth_req_id
+        },
+      });
+      console.log(authenticationTransactionResponse.data);
+      expect(authenticationTransactionResponse.status).toBe(200);
+
+      const authenticationTransaction = authenticationTransactionResponse.data.list[0];
+      console.log(authenticationTransaction);
+
+      const completeResponse = await postAuthenticationDeviceInteraction({
+        endpoint: serverConfig.authenticationDeviceInteractionEndpoint,
+        flowType: authenticationTransaction.flow,
+        id: authenticationTransaction.id,
+        interactionType: "password-authentication",
+        body: {
+          username: serverConfig.ciba.username,
+          password: serverConfig.ciba.userCode,
+        }
+      });
+      console.log(completeResponse.data);
+      expect(completeResponse.status).toBe(200);
+
+      const tokenResponse = await requestToken({
+        endpoint: serverConfig.tokenEndpoint,
+        grantType: "urn:openid:params:grant-type:ciba",
+        authReqId: backchannelAuthenticationResponse.data.auth_req_id,
+        clientId: clientSecretPostClient.clientId,
+        clientSecret: clientSecretPostClient.clientSecret,
+      });
+      console.log(tokenResponse.data);
+      expect(tokenResponse.status).toBe(200);
+      expect(tokenResponse.data).toHaveProperty("access_token");
+      expect(tokenResponse.data).toHaveProperty("id_token");
+
+      const jwksResponse = await getJwks({ endpoint: serverConfig.jwksEndpoint });
+      expect(jwksResponse.status).toBe(200);
+
+      const decodedIdToken = verifyAndDecodeJwt({
+        jwt: tokenResponse.data.id_token,
+        jwks: jwksResponse.data,
+      });
+      console.log(decodedIdToken);
+      expect(decodedIdToken.payload).toHaveProperty("sub");
+
+      const headers = createBearerHeader(tokenResponse.data.access_token);
+      const userinfoResponse = await getUserinfo({
+        endpoint: serverConfig.userinfoEndpoint,
+        authorizationHeader: headers,
+      });
+      console.log(userinfoResponse.data);
+      expect(userinfoResponse.status).toBe(200);
+      expect(userinfoResponse.data).toHaveProperty("sub");
+      expect(userinfoResponse.data).toHaveProperty("email");
+      expect(userinfoResponse.data).toHaveProperty("name");
+    });
+  });
 
   describe("11. Token Error Response", () => {
     it("authorization_pending The authorization request is still pending as the end-user hasn't yet been authenticated.", async () => {

--- a/libs/idp-server-core-extension-ciba/src/main/java/org/idp/server/core/extension/ciba/grant/CibaGrantFactory.java
+++ b/libs/idp-server-core-extension-ciba/src/main/java/org/idp/server/core/extension/ciba/grant/CibaGrantFactory.java
@@ -16,6 +16,7 @@
 
 package org.idp.server.core.extension.ciba.grant;
 
+import java.util.List;
 import org.idp.server.core.extension.ciba.CibaRequestContext;
 import org.idp.server.core.extension.ciba.request.BackchannelAuthenticationRequest;
 import org.idp.server.core.extension.ciba.request.BackchannelAuthenticationRequestIdentifier;
@@ -23,7 +24,12 @@ import org.idp.server.core.extension.ciba.response.BackchannelAuthenticationResp
 import org.idp.server.core.openid.authentication.Authentication;
 import org.idp.server.core.openid.grant_management.grant.AuthorizationGrant;
 import org.idp.server.core.openid.grant_management.grant.AuthorizationGrantBuilder;
+import org.idp.server.core.openid.grant_management.grant.GrantIdTokenClaims;
+import org.idp.server.core.openid.grant_management.grant.GrantUserinfoClaims;
 import org.idp.server.core.openid.identity.User;
+import org.idp.server.core.openid.identity.id_token.RequestedIdTokenClaims;
+import org.idp.server.core.openid.identity.id_token.RequestedUserinfoClaims;
+import org.idp.server.core.openid.oauth.configuration.AuthorizationServerConfiguration;
 import org.idp.server.core.openid.oauth.configuration.client.ClientAttributes;
 import org.idp.server.core.openid.oauth.rar.AuthorizationDetails;
 import org.idp.server.core.openid.oauth.type.ciba.AuthReqId;
@@ -31,6 +37,7 @@ import org.idp.server.core.openid.oauth.type.ciba.Interval;
 import org.idp.server.core.openid.oauth.type.extension.ExpiresAt;
 import org.idp.server.core.openid.oauth.type.oauth.GrantType;
 import org.idp.server.core.openid.oauth.type.oauth.RequestedClientId;
+import org.idp.server.core.openid.oauth.type.oauth.ResponseType;
 import org.idp.server.core.openid.oauth.type.oauth.Scopes;
 import org.idp.server.platform.multi_tenancy.tenant.TenantIdentifier;
 
@@ -63,12 +70,28 @@ public class CibaGrantFactory {
     Scopes scopes = context.scopes();
     AuthorizationDetails authorizationDetails = context.authorizationDetails();
 
+    AuthorizationServerConfiguration serverConfig = context.authorizationServerConfiguration();
+    List<String> supportedClaims = serverConfig.claimsSupported();
+    boolean idTokenStrictMode = serverConfig.isIdTokenStrictMode();
+
+    GrantIdTokenClaims grantIdTokenClaims =
+        GrantIdTokenClaims.create(
+            scopes,
+            ResponseType.undefined,
+            supportedClaims,
+            new RequestedIdTokenClaims(),
+            idTokenStrictMode);
+    GrantUserinfoClaims grantUserinfoClaims =
+        GrantUserinfoClaims.create(scopes, supportedClaims, new RequestedUserinfoClaims());
+
     AuthorizationGrantBuilder builder =
         new AuthorizationGrantBuilder(tenantIdentifier, requestedClientId, GrantType.ciba, scopes)
             .add(clientAttributes)
             .add(user)
             .add(authentication)
-            .add(authorizationDetails);
+            .add(authorizationDetails)
+            .add(grantIdTokenClaims)
+            .add(grantUserinfoClaims);
 
     AuthorizationGrant authorizationGrant = builder.build();
     AuthReqId authReqId = response.authReqId();


### PR DESCRIPTION
## Summary

- `CibaGrantFactory.create()`で`AuthorizationGrantBuilder`に`GrantIdTokenClaims`と`GrantUserinfoClaims`を追加
- CIBAフローで`scope=openid profile email`を指定した場合、UserInfo/ID Tokenに`email`, `name`等のクレームが正しく含まれるようになった

## 修正内容

`CibaGrantFactory.java`で、`OAuthAuthorizeContext.authorize()`と同様に`GrantIdTokenClaims.create()`と`GrantUserinfoClaims.create()`を呼び出し、ビルダーに設定。

## Test plan

- [x] 修正前: E2Eテスト失敗（UserInfoが`sub`のみ返却）
- [x] 修正後: E2Eテスト成功（UserInfoに`email`, `name`, `email_verified`等が含まれる）
- [x] `ciba_token_request.test.js`にトークン成功時のUserInfoクレーム検証テストを追加

Closes #1323

🤖 Generated with [Claude Code](https://claude.com/claude-code)