### PR TITLE
docs: spec-rbacスキル新設、監査ログとセキュリティイベントの区別を明確化

### DIFF
--- a/.claude/skills/dev-control-plane/skill.md
+++ b/.claude/skills/dev-control-plane/skill.md
@@ -17,7 +17,7 @@ description: 管理API（Control Plane）の開発・修正を行う際に使用
 Control Planeは、idp-serverの管理API層。システム全体の設定管理、組織・テナント管理、リソース構成を行う。
 - **2層構造**: System Level（プラットフォーム全体）、Organization Level（組織別）
 - **Dry-runモード**: 全変更操作でサポート
-- **権限モデル**: 40+のデフォルト管理者権限
+- **権限モデル**: 73のデフォルト管理者権限（詳細は `spec-rbac`）
 
 ## モジュール構成
 
@@ -163,18 +163,11 @@ public class IdpServerStarterContextCreator {
 
 ## 権限モデル
 
-`DefaultAdminPermission` 列挙型（45権限）で管理 API の権限を定義。値は `idp:` プレフィックス付き（例: `idp:client:create`）。
+`DefaultAdminPermission` 列挙型（73権限）で管理APIの権限を定義。`idp:resource:action` 形式。ワイルドカードマッチング（`idp:*`, `idp:user:*`）をサポート。
 
-### 権限カテゴリ
+- **検証**: `ApiPermissionVerifier`（システムレベル）、`OrganizationAccessVerifier`（組織レベル4段階検証）
+- **カスタム権限**: `idp:` 名前空間は予約。カスタムは任意の名前空間を使用可能
 
-ORGANIZATION, TENANT_INVITATION, TENANT, AUTHORIZATION_SERVER, CLIENT, USER, PERMISSION, ROLE, AUTHENTICATION_CONFIG, AUTHENTICATION_POLICY, IDENTITY_VERIFICATION_CONFIG, FEDERATION_CONFIG, SECURITY_EVENT_HOOK_CONFIG, SECURITY_EVENT_HOOK, SECURITY_EVENT, AUDIT_LOG, AUTHENTICATION_TRANSACTION, AUTHENTICATION_INTERACTION, ADMIN_USER, SESSION, GRANT, SYSTEM, CONTROL_PLANE_ALL (ワイルドカード)
+**詳細は `spec-rbac` スキルを参照。**
 
-### 権限判定メソッド
-
-- `isAdminUserPermission()`: admin-user スコープの権限か
-- `isPublicUserPermission()`: user スコープの権限か
-- `isSystemPermission()`: システムレベル権限か
-- `isWildcard()`: ワイルドカード権限か
-- `toTenantPermissions()`: システム権限を除外
-
-**探索起点**: `libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/admin/DefaultAdminPermission.java`
+**探索起点**: `libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/base/definition/DefaultAdminPermission.java`

--- a/.claude/skills/spec-enterprise/skill.md
+++ b/.claude/skills/spec-enterprise/skill.md
@@ -1,0 +1,160 @@
+---
+name: spec-enterprise
+description: idp-serverのエンタープライズ機能の全体像を把握する際に使用。組織ガバナンス、法規制、監査、スケールの4観点で提供・未提供機能を整理し、今後の拡張方針の判断に役立つ。
+---
+
+# エンタープライズ機能
+
+## エンタープライズとは
+
+「技術的に動く」ではなく**「組織・法規制・監査・スケールに耐える」**。
+
+| 観点 | 「技術的に動く」 | 「エンタープライズ」 |
+|------|-----------------|-------------------|
+| **組織** | 1人の管理者が全部見る | 部門別の委任管理、承認フロー、職掌分離 |
+| **法規制** | 機能がある | 証跡が残る、説明できる、監査に耐える |
+| **監査** | ログが出る | いつ誰が何をなぜ変えたか追跡可能 |
+| **スケール** | 動く | 数千テナント、数百万ユーザーで安定運用 |
+
+---
+
+## 1. 組織ガバナンス
+
+idp-serverは Organization → Tenant → User/Role/Permission の階層で、マルチテナント環境の組織管理を提供する。
+
+### 提供している機能
+
+| 機能 | 説明 | 関連スキル |
+|------|------|-----------|
+| マルチテナント分離 | テナント間のデータ・設定の完全分離。PostgreSQL RLSによるDB層強制 | `ops-tenant-config` |
+| 組織階層管理 | Organization → Tenant → User/Role の階層構造 | `dev-control-plane` |
+| RBAC | ロール・パーミッションによるアクセス制御 | `spec-rbac`, `dev-control-plane` |
+| 委任管理 | 組織管理者への管理権限委譲（Organization-level API） | `spec-rbac`, `dev-control-plane` |
+| 委任管理の粒度制御 | Resource×Action単位の細粒度権限（73種類）+ ワイルドカード委譲 | `spec-rbac` |
+
+#### 委任管理の粒度制御 詳細
+
+`idp:resource:action` 形式で73種類の権限を定義（ワイルドカード含む）。AWS IAMスタイルのワイルドカードマッチング（`idp:*`, `idp:user:*`）により段階的な権限委譲が可能。`OrganizationAccessVerifier` による4段階の組織スコープ検証で、マルチテナント環境での安全な委任管理を実現。
+
+**詳細は `spec-rbac` スキルを参照。**
+
+### 未提供の機能
+
+| 機能 | 説明 |
+|------|------|
+| リソースID単位の制限 | 「特定クライアントのみ編集可」等の個別リソースへのアクセス制限 |
+| MemberRoleの活用 | OWNER/EDITOR/VIEWER等の組織内ロールと権限体系の紐付け |
+| 設定変更の承認フロー | 4-eyes principle、maker-checker（変更申請→承認→適用） |
+| 職掌分離の強制 | 設定者と承認者の分離を技術的に強制 |
+| 設定変更のロールバック | 任意の時点への設定巻き戻し |
+| 設定のバージョン管理 | 変更履歴の世代管理 |
+| 環境間プロモーション | dev → staging → prod の設定昇格フロー |
+
+---
+
+## 2. 法規制・コンプライアンス
+
+idp-serverは金融規制（FAPI）と身元確認（OIDC4IDA）に特化した規制対応機能を提供する。
+
+### 提供している機能
+
+| 機能 | 説明 | 関連スキル |
+|------|------|-----------|
+| eKYC/身元確認 | OIDC4IDA準拠の外部eKYCサービス連携 | `spec-identity-verification`, `use-case-ekyc` |
+| verified_claims | 身元確認済み属性の発行・管理 | `spec-identity-verification` |
+| FAPI準拠 | FAPI 1.0 Baseline/Advanced、mTLS、PAR、JARM | `spec-fapi`, `use-case-financial-grade` |
+| FAPI CIBA | 金融グレードのデバイス分離認証 | `spec-ciba`, `use-case-ciba` |
+| 同意管理 | OAuth同意の取得・記録 | `spec-grant` |
+| Verifiable Credentials | OID4VCI準拠のCredential発行 | `spec-verifiable-credentials` |
+| PII制御 | セキュリティイベントログのPII出力制御（include_user_pii等） | `spec-security-event` |
+
+### 未提供の機能
+
+| 機能 | 説明 |
+|------|------|
+| GDPR削除要求 | Right to be forgotten対応（ユーザーデータの完全削除） |
+| データ保持ポリシー | 期間指定の自動削除・アーカイブ |
+| データ所在地制御 | リージョン制約（データレジデンシー） |
+| 規制準拠レポート | 定期レポート自動生成 |
+| 同意の取消・履歴 | 同意変更の追跡可能性 |
+
+---
+
+## 3. 監査・説明責任
+
+idp-serverは2つの独立した記録体系を持つ。**監査ログ**（管理操作の追跡）と**セキュリティイベント**（認証・認可フローの記録）は別のテーブル・別の仕組みで動作する。
+
+### 監査ログ（Audit Log） — Control Plane
+
+管理API操作の「誰が何をいつどう変えたか」を記録する。`audit_log` テーブルに保存。
+
+| 機能 | 説明 | 関連スキル |
+|------|------|-----------|
+| 設定変更の差分記録 | 変更前/変更後の両方を保存するdiff記録（`before`/`after` ペイロード） | `dev-control-plane` |
+| 監査ログ取得API | Management APIからの監査ログ取得・検索 | `dev-control-plane` |
+| テナント統計 | テナント単位のメトリクス収集 | `ops-deployment` |
+
+### セキュリティイベント（Security Event） — Application Plane
+
+OAuth/OIDCフローの「認証・認可で何が起きたか」を記録する。`security_event` テーブルに保存。
+
+| 機能 | 説明 | 関連スキル |
+|------|------|-----------|
+| セキュリティイベント記録 | 認可フロー、トークン発行、ログアウト、CIBA等のイベント記録 | `spec-security-event` |
+| セキュリティイベントフック | イベント駆動のフック連携（Slack/Email/Webhook/Datadog/SSF） | `spec-security-event` |
+| Shared Signals Framework | リアルタイムセキュリティイベントストリーミング | `spec-security-event` |
+| パーティショニング | 日単位RANGE、90日保持。pg_partman / MySQL Event Schedulerで自動管理 | `spec-security-event` |
+| アーカイブ | 90日超過データをarchiveスキーマにDETACH → 外部エクスポート（stub実装） | `spec-security-event` |
+
+### データ保持の違い
+
+| | security_event | audit_log |
+|---|:---:|:---:|
+| パーティショニング | 日単位（90日保持） | なし |
+| アーカイブ | 自動（pg_partman / Event Scheduler） | なし |
+| 保持方針 | 90日後に削除 | 永続保存（コンプライアンス要件） |
+
+### 未提供の機能
+
+| 機能 | 対象 | 説明 |
+|------|------|------|
+| 変更理由の記録 | 監査ログ | なぜ変更したか（チケット番号・変更理由の記録） |
+| 改ざん不能ログ | 両方 | append-only、署名付きログ |
+| 監査ログの長期保存戦略 | 監査ログ | 永続保存テーブルの肥大化対策（外部アーカイブ等） |
+| 定期監査レポート | 両方 | 監査人向けレポート自動生成 |
+
+---
+
+## 4. スケール・運用耐性
+
+idp-serverはPostgreSQL RLSによるDB層のテナント分離と、両DB対応による柔軟なデプロイを提供する。
+
+### 提供している機能
+
+| 機能 | 説明 | 関連スキル |
+|------|------|-----------|
+| PostgreSQL RLS | DB層でのテナント分離強制（FORCE ROW LEVEL SECURITY） | `dev-database` |
+| 両DB対応 | PostgreSQL / MySQL | `dev-database` |
+| ヘルスチェック | サービス死活監視エンドポイント | `ops-deployment` |
+| テナント統計 | メトリクス収集 | `ops-deployment` |
+| 期限切れデータ削除 | 不要データの自動クリーンアップ | `ops-deployment` |
+
+### 未提供の機能
+
+| 機能 | 説明 |
+|------|------|
+| 障害の影響局所化 | blast radius制御（障害時の影響範囲の限定） |
+| バックアップ/リストア | 設定・データの世代管理 |
+| キャパシティプランニング | 使用量予測・アラート |
+
+---
+
+## 今後の拡張方針
+
+| 優先度 | 機能 | 理由 |
+|:------:|------|------|
+| 1 | 変更理由の記録 | 監査ログに reason フィールド追加。低コスト高効果 |
+| 2 | 委任管理の粒度制御 | MemberRoleと権限体系の紐付け等 |
+| 3 | GDPR削除要求 | eKYC/verified_claimsとセットで規制対応の訴求力大 |
+
+$ARGUMENTS

--- a/.claude/skills/spec-rbac/skill.md
+++ b/.claude/skills/spec-rbac/skill.md
@@ -1,0 +1,337 @@
+---
+name: spec-rbac
+description: idp-serverのRBAC（ロール・パーミッション）仕様を把握する際に使用。権限体系、ロール設計、ワイルドカードマッチング、アクセス検証フロー、カスタム権限の実装指針に役立つ。
+---
+
+# RBAC（ロールベースアクセス制御）仕様
+
+## 概要
+
+idp-serverは `idp:resource:action` 形式の細粒度権限とワイルドカード委譲を組み合わせたRBACシステムを提供する。AWS IAMスタイルのパーミッションマッチングにより、段階的な権限委譲が可能。
+
+---
+
+## 権限体系
+
+### DefaultAdminPermission（73権限）
+
+`libs/idp-server-control-plane/.../base/definition/DefaultAdminPermission.java`
+
+#### ワイルドカード（1）
+
+| 権限 | 説明 |
+|------|------|
+| `idp:*` | 全Control Plane権限 |
+
+#### リソース管理（CRUD: 各4権限 x 14リソース = 56）
+
+| リソース | 権限 |
+|----------|------|
+| `idp:organization:` | create, read, update, delete |
+| `idp:tenant-invitation:` | create, read, update, delete |
+| `idp:tenant:` | create, read, update, delete |
+| `idp:authorization-server:` | create, read, update, delete |
+| `idp:client:` | create, read, update, delete |
+| `idp:permission:` | create, read, update, delete |
+| `idp:role:` | create, read, update, delete |
+| `idp:authentication-config:` | create, read, update, delete |
+| `idp:authentication-policy-config:` | create, read, update, delete |
+| `idp:identity-verification-config:` | create, read, update, delete |
+| `idp:federation-config:` | create, read, update, delete |
+| `idp:security-event-hook-config:` | create, read, update, delete |
+| `idp:admin-user:` | create, read, update, delete |
+| `idp:user:` | create, read, update, delete |
+
+#### ユーザー追加操作（4）
+
+| 権限 | 説明 |
+|------|------|
+| `idp:user:invite` | ユーザー招待 |
+| `idp:user:suspend` | ユーザー停止 |
+| `idp:admin-user:invite` | 管理者招待 |
+| `idp:admin-user:suspend` | 管理者停止 |
+
+#### 参照・特殊操作（12）
+
+| 権限 | 説明 |
+|------|------|
+| `idp:security-event-hook:read` | セキュリティイベントフック参照 |
+| `idp:security-event-hook:retry` | 失敗フックの再実行 |
+| `idp:security-event:read` | セキュリティイベント参照 |
+| `idp:audit-log:read` | 監査ログ参照 |
+| `idp:authentication-transaction:read` | 認証トランザクション参照 |
+| `idp:authentication-interaction:read` | 認証インタラクション参照 |
+| `idp:session:read` | セッション参照 |
+| `idp:session:delete` | セッション削除 |
+| `idp:grant:read` | 認可グラント参照 |
+| `idp:grant:delete` | 認可グラント削除/失効 |
+| `idp:system:read` | システム設定参照 |
+| `idp:system:write` | システム設定書き込み |
+
+### 権限分類メソッド
+
+| メソッド | 用途 |
+|----------|------|
+| `isSystemPermission()` | `idp:system:*` — 管理テナントのみ付与 |
+| `isAdminUserPermission()` | `idp:admin-user:*` — 管理者ユーザー操作 |
+| `isPublicUserPermission()` | `idp:user:*` — 一般ユーザー操作 |
+| `isWildcard()` | ワイルドカード権限か |
+| `toTenantPermissions()` | システム権限を除外した権限セット（テナントオンボーディング用） |
+
+---
+
+## ロール体系
+
+### DefaultAdminRole
+
+`libs/idp-server-control-plane/.../base/definition/DefaultAdminRole.java`
+
+| ロール | 権限 | 説明 |
+|--------|------|------|
+| `ADMINISTRATOR` | `idp:*`（ワイルドカード） | 全Control Plane権限を持つデフォルトロール |
+
+- テナントオンボーディング時に自動作成される
+- カスタムロールを作成することで、より細粒度の権限委譲が可能
+
+### MemberRole（定義済み・未活用）
+
+`libs/idp-server-platform/.../organization/MemberRole.java`
+
+| ロール | 説明 |
+|--------|------|
+| `OWNER` | 組織オーナー |
+| `ADMINISTRATOR` | 管理者 |
+| `EDITOR` | 編集者 |
+| `VIEWER` | 閲覧者 |
+
+組織階層上のロールとして定義されているが、権限体系（DefaultAdminPermission）との紐付けは未実装。
+
+---
+
+## ワイルドカードマッチング
+
+### PermissionMatcher
+
+`libs/idp-server-core/.../identity/permission/PermissionMatcher.java`
+
+#### マッチングルール
+
+| パターン | マッチ対象 | 例 |
+|----------|-----------|-----|
+| `*` | 全権限 | 全てにマッチ |
+| `idp:*` | 全Control Plane権限 | `idp:user:create`, `idp:client:delete` 等 |
+| `idp:user:*` | ユーザー管理全般 | `idp:user:create`, `idp:user:suspend` 等 |
+| `idp:user:create` | 完全一致のみ | `idp:user:create` のみ |
+
+#### 主要メソッド
+
+| メソッド | 用途 |
+|----------|------|
+| `matches(userPerm, requiredPerm)` | 完全一致 or ワイルドカードマッチ |
+| `matchesAny(userPerms, requiredPerm)` | ユーザーの権限セットのいずれかがマッチするか |
+| `matchesAll(userPerms, requiredPerms)` | ユーザーが必要な全権限を持つか |
+| `normalize(permission)` | レガシー形式を正規化（後方互換） |
+
+#### 後方互換性
+
+`normalize()` がレガシー形式を自動変換:
+- `organization:create` → `idp:organization:create`（名前空間なし → `idp:` 付加）
+- `admin_user:create` → `idp:admin-user:create`（アンダースコア → ハイフン）
+
+---
+
+## アクセス検証フロー
+
+### ApiPermissionVerifier（システムレベル）
+
+`libs/idp-server-control-plane/.../base/ApiPermissionVerifier.java`
+
+```
+verify(User operator, AdminPermissions required)
+  └→ 権限不足 → PermissionDeniedException
+```
+
+シンプルな権限チェックのみ。組織・テナントのスコープ制限なし。
+
+### OrganizationAccessVerifier（組織レベル）
+
+`libs/idp-server-control-plane/.../base/OrganizationAccessVerifier.java`
+
+4段階の検証を順次実行:
+
+```
+verify(Organization, TenantIdentifier, User, AdminPermissions)
+  ├→ 1. 組織メンバーシップ確認（assignedOrganizations）
+  ├→ 2. テナントアクセス確認（assignedTenants）
+  ├→ 3. 組織-テナント関係確認
+  └→ 4. 必要権限の確認（PermissionMatcher使用）
+```
+
+- ステップ1-3失敗 → `OrganizationAccessDeniedException`
+- ステップ4失敗 → `PermissionDeniedException`
+
+### AdminPermissions ラッパー
+
+`libs/idp-server-control-plane/.../base/definition/AdminPermissions.java`
+
+API操作に必要な権限セットを表現するラッパークラス。
+
+```java
+AdminPermissions required = new AdminPermissions(
+    Set.of(DefaultAdminPermission.CLIENT_READ)
+);
+required.includesAll(user.permissionsAsSet()); // 権限判定
+```
+
+---
+
+## データモデル
+
+### DBテーブル
+
+| テーブル | テナントスコープ | 用途 |
+|----------|:-----------:|------|
+| `permission` | Yes (RLS) | 権限定義（tenant_id, name, description） |
+| `role` | Yes (RLS) | ロール定義（tenant_id, name, description） |
+| `role_permission` | Yes (RLS) | ロール-権限マッピング |
+| `idp_user_roles` | Yes (RLS) | ユーザー-ロールマッピング |
+
+### ビュー
+
+| ビュー | 用途 |
+|--------|------|
+| `role_permission_view` | ロール → 権限の読みやすい結合ビュー |
+| `user_effective_permissions_view` | ユーザー → ロール → 権限の実効権限ビュー |
+
+### ユニーク制約
+
+- `uk_tenant_permission`: (tenant_id, name) — テナント内で権限名は一意
+- `uk_tenant_role`: (tenant_id, name) — テナント内でロール名は一意
+
+### PostgreSQL RLS
+
+全RBACテーブルで `USING (tenant_id = current_setting('app.tenant_id')::uuid)` によるテナント分離を強制。
+
+---
+
+## Management API
+
+### ロール管理
+
+#### システムレベル（RoleManagementHandler）
+
+`libs/idp-server-control-plane/.../management/role/handler/RoleManagementHandler.java`
+
+テナント内のロールCRUD。`ApiPermissionVerifier` で権限チェック。
+
+#### 組織レベル（OrgRoleManagementHandler）
+
+`libs/idp-server-control-plane/.../management/role/handler/OrgRoleManagementHandler.java`
+
+組織スコープのロールCRUD。`OrganizationAccessVerifier` で4段階検証。
+
+### 操作一覧
+
+| 操作 | 必要権限 |
+|------|---------|
+| ロール作成 | `idp:role:create` |
+| ロール一覧 | `idp:role:read` |
+| ロール取得 | `idp:role:read` |
+| ロール更新 | `idp:role:update` |
+| ロール削除 | `idp:role:delete` |
+| 権限作成 | `idp:permission:create` |
+| 権限一覧 | `idp:permission:read` |
+| 権限更新 | `idp:permission:update` |
+| 権限削除 | `idp:permission:delete` |
+
+---
+
+## カスタム権限
+
+### PermissionNamespaceValidator
+
+`libs/idp-server-core/.../identity/permission/PermissionNamespaceValidator.java`
+
+#### 名前空間ルール
+
+- **予約**: `idp:` — システム権限専用、カスタム権限には使用不可
+- **カスタム**: `myapp:`, `custom:` 等、任意の名前空間を使用可能
+
+```
+idp:user:create          → NG（予約名前空間）
+myapp:report:generate    → OK（カスタム名前空間）
+billing:invoice:create   → OK（カスタム名前空間）
+```
+
+#### メソッド
+
+| メソッド | 用途 |
+|----------|------|
+| `validate(name)` | 予約名前空間の場合に例外スロー |
+| `usesReservedNamespace(name)` | 予約名前空間か判定 |
+| `extractNamespace(name)` | 最初の `:` 前の名前空間を抽出 |
+
+---
+
+## ユースケース例
+
+### クライアント設定のみ変更可能な管理者
+
+```
+ロール: client-manager
+権限:
+  - idp:client:create
+  - idp:client:read
+  - idp:client:update
+  - idp:client:delete
+```
+
+### 読み取り専用の監査担当者
+
+```
+ロール: auditor
+権限:
+  - idp:audit-log:read
+  - idp:security-event:read
+  - idp:security-event-hook:read
+  - idp:session:read
+  - idp:grant:read
+```
+
+### ユーザー管理全般の委譲
+
+```
+ロール: user-admin
+権限:
+  - idp:user:*（ワイルドカードで user の全操作）
+  - idp:admin-user:*（ワイルドカードで admin-user の全操作）
+```
+
+### 認証設定の管理者
+
+```
+ロール: auth-config-manager
+権限:
+  - idp:authentication-config:*
+  - idp:authentication-policy-config:*
+  - idp:federation-config:*
+```
+
+---
+
+## 主要参照ファイル
+
+| ファイル | 役割 |
+|----------|------|
+| `libs/idp-server-control-plane/.../base/definition/DefaultAdminPermission.java` | 全権限定義（73 enum値） |
+| `libs/idp-server-control-plane/.../base/definition/DefaultAdminRole.java` | デフォルトロール定義 |
+| `libs/idp-server-control-plane/.../base/definition/AdminPermissions.java` | 権限セットラッパー |
+| `libs/idp-server-core/.../identity/permission/PermissionMatcher.java` | ワイルドカードマッチング |
+| `libs/idp-server-core/.../identity/permission/PermissionNamespaceValidator.java` | カスタム権限の名前空間検証 |
+| `libs/idp-server-control-plane/.../base/OrganizationAccessVerifier.java` | 組織レベル4段階検証 |
+| `libs/idp-server-control-plane/.../base/ApiPermissionVerifier.java` | システムレベル権限検証 |
+| `libs/idp-server-control-plane/.../management/role/handler/RoleManagementHandler.java` | システムレベルロール管理 |
+| `libs/idp-server-control-plane/.../management/role/handler/OrgRoleManagementHandler.java` | 組織レベルロール管理 |
+| `libs/idp-server-platform/.../organization/MemberRole.java` | 組織メンバーロール（未活用） |
+
+$ARGUMENTS

--- a/.claude/skills/spec-security-event/skill.md
+++ b/.claude/skills/spec-security-event/skill.md
@@ -64,13 +64,34 @@ libs/
 
 **注意**: 統一されたEventHookExecutorインターフェースではなく、各フックタイプごとに個別のExecutorクラスが存在します。
 
-## 処理フロー
+## データライフサイクル
 
 ```
-[認証/認可イベント発生]
+[1. 発生] 認証/認可イベント発生（Application Plane）
     ↓
-[SecurityEvent発行] (@Async)
+[2. 発行] SecurityEvent発行（@Async、非同期）
     ↓
+[3. 処理] SecurityEventHandler.handle()
+    ├── DB保存（security_event テーブル）
+    ├── 統計データ更新（statistics_events）
+    ├── アクティブユーザー更新（DAU/MAU/YAU）
+    ├── ログ出力
+    └── フック実行（Slack/Datadog/Webhook/SSF）
+    ↓  ※保存失敗時: SecurityEventRetryScheduler（60秒間隔、最大3回）
+[4. 保持] アクティブパーティションに保存（日単位RANGE、90日間）
+    ↓  ※PostgreSQL: pg_partman 毎日 02:00 UTC / MySQL: Event Scheduler 毎日 02:30 AM
+[5. アーカイブ] 90日超過パーティションをDETACH → archiveスキーマに移動
+    ↓  ※PostgreSQL: 毎日 03:00 UTC
+[6. エクスポート] 外部ストレージへエクスポート（stub実装、S3/GCS対応可）
+    ↓  ※エクスポート成功時のみ次のステップへ
+[7. 削除] パーティションDROP
+```
+
+## 処理フロー（詳細）
+
+ステップ3の `SecurityEventHandler.handle()` の詳細:
+
+```
 [SecurityEventHandler.handle()]
     ├── [1] イベントをDBに保存
     ├── [2] 統計データ更新（statistics_events）
@@ -165,6 +186,47 @@ public interface SecurityEventHook {
   }
 }
 ```
+
+## パーティショニング・アーカイブ（ライフサイクル ステップ4-7）
+
+### パーティショニング（ステップ4: 保持）
+
+`security_event` と `security_event_hook_results` は日単位の RANGE パーティショニングで管理。保持期間は90日。
+
+| テーブル | パーティション | 保持期間 | 主キー |
+|----------|:----------:|:-------:|--------|
+| `security_event` | 日単位 | 90日 | `(id, created_at)` |
+| `security_event_hook_results` | 日単位 | 90日 | `(id, created_at)` |
+
+- **PostgreSQL**: pg_partman で自動管理（premake = 90日分先行作成）
+- **MySQL**: Event Scheduler + ストアドプロシージャで自動管理
+
+### アーカイブ・エクスポート・削除（ステップ5-7）
+
+90日超過データは自動アーカイブ後に削除される。
+
+**PostgreSQL:**
+```
+pg_partman retention (毎日 02:00 UTC)
+  → [5] 90日超過パーティションを archive スキーマに DETACH
+archive.process_archived_partitions() (毎日 03:00 UTC)
+  → [6] 外部ストレージにエクスポート → [7] 成功時 DROP
+```
+
+**MySQL:**
+```
+Event Scheduler (毎日 02:30 AM)
+  → [5] maintain_security_event_partitions()
+  → [6] EXCHANGE PARTITION → archive テーブル → [7] DROP
+```
+
+外部ストレージへのエクスポートはスタブ実装（S3/GCS等に対応可能）。
+
+**探索起点:**
+- `libs/idp-server-database/postgresql/V0_9_21_1__add_event_partitioning.sql`
+- `libs/idp-server-database/postgresql/V0_9_21_3__archive_support.sql`
+- `libs/idp-server-database/postgresql/operation/setup-pg-cron-jobs.sql`
+- `libs/idp-server-springboot-adapter/.../event/SecurityEventRetryScheduler.java`
 
 ## 通知アダプター
 


### PR DESCRIPTION
## Summary

- `spec-rbac` スキルを新規作成（RBAC仕様の独立ドキュメント化）
- `spec-enterprise` の監査セクションで監査ログとセキュリティイベントを明確に分離
- `spec-security-event` にデータライフサイクル（パーティショニング・アーカイブ）を追記
- `dev-control-plane` の権限モデルセクションを簡潔化し `spec-rbac` へ誘導
- Keycloak比較セクションを削除、インフラ層の責務（レート制限等）を整理

## 変更ファイル

| ファイル | 変更内容 |
|----------|----------|
| `.claude/skills/spec-rbac/skill.md` | 新規作成: 権限体系（73権限）、ロール、ワイルドカード、検証フロー、DB、カスタム権限 |
| `.claude/skills/spec-enterprise/skill.md` | 監査ログ/セキュリティイベント分離、Keycloak比較削除、データ保持の違いテーブル追加 |
| `.claude/skills/spec-security-event/skill.md` | データライフサイクル7ステップ、パーティショニング・アーカイブ詳細を追記 |
| `.claude/skills/dev-control-plane/skill.md` | 権限モデルを簡潔化（45→73修正）、`spec-rbac` 参照追加 |

## Test plan

- [ ] 各スキルファイルが正しいMarkdown構文であること
- [ ] 相互参照が循環せず適切に連携していること
- [ ] 権限数（73）がソースコード `DefaultAdminPermission.java` と一致すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)