### PR TITLE
fix: HashAlgorithm の MessageDigest インスタンス共有によるスレッド安全性の問題を修正

### DIFF
--- a/libs/idp-server-platform/src/main/java/org/idp/server/platform/hash/HashAlgorithm.java
+++ b/libs/idp-server-platform/src/main/java/org/idp/server/platform/hash/HashAlgorithm.java
@@ -28,15 +28,9 @@ enum HashAlgorithm {
   SHA_512("SHA-512");
 
   String value;
-  MessageDigest messageDigest;
 
   HashAlgorithm(String value) {
     this.value = value;
-    try {
-      this.messageDigest = MessageDigest.getInstance(value);
-    } catch (NoSuchAlgorithmException exception) {
-      throw new RuntimeException(exception);
-    }
   }
 
   public String value() {
@@ -44,6 +38,10 @@ enum HashAlgorithm {
   }
 
   public MessageDigest messageDigest() {
-    return messageDigest;
+    try {
+      return MessageDigest.getInstance(value);
+    } catch (NoSuchAlgorithmException exception) {
+      throw new RuntimeException(exception);
+    }
   }
 }

--- a/libs/idp-server-platform/src/test/java/org/idp/server/platform/hash/MessageDigestableThreadSafetyTest.java
+++ b/libs/idp-server-platform/src/test/java/org/idp/server/platform/hash/MessageDigestableThreadSafetyTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2025 Hirokazu Kobayashi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.idp.server.platform.hash;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+
+class MessageDigestableThreadSafetyTest implements MessageDigestable {
+
+  @Test
+  void digestWithSha256_shouldBeThreadSafe() throws Exception {
+    int threadCount = 10;
+    int iterationsPerThread = 1000;
+    ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+    CountDownLatch startLatch = new CountDownLatch(1);
+    AtomicInteger errorCount = new AtomicInteger(0);
+
+    List<Future<?>> futures = new ArrayList<>();
+    for (int i = 0; i < threadCount; i++) {
+      futures.add(
+          executor.submit(
+              () -> {
+                try {
+                  startLatch.await();
+                } catch (InterruptedException e) {
+                  Thread.currentThread().interrupt();
+                  return;
+                }
+                for (int j = 0; j < iterationsPerThread; j++) {
+                  try {
+                    digestWithSha256("test-input-" + j);
+                  } catch (Exception e) {
+                    errorCount.incrementAndGet();
+                  }
+                }
+              }));
+    }
+
+    startLatch.countDown();
+
+    for (Future<?> future : futures) {
+      future.get(30, TimeUnit.SECONDS);
+    }
+
+    executor.shutdown();
+
+    assertEquals(0, errorCount.get(), "concurrent digest calls should not cause errors");
+  }
+}


### PR DESCRIPTION
## Summary
- `HashAlgorithm` enum が `MessageDigest` インスタンスをフィールドにキャッシュしており、アプリ全体で共有されていた
- `MessageDigest` はスレッドセーフでないため、並行リクエスト時に内部バッファが破壊され `ArrayIndexOutOfBoundsException` が発生
- `messageDigest()` で毎回 `MessageDigest.getInstance()` を呼んで新しいインスタンスを返すように修正
- マルチスレッド再現テストを追加（10スレッド × 1,000回の並行呼び出し）

## 再現テスト結果（修正前）

| Run | エラー数 | 総操作数 | エラー率 |
|-----|---------|---------|---------|
| 1 | 314 | 10,000 | 3.14% |
| 2 | 45 | 10,000 | 0.45% |
| 3 | 38 | 10,000 | 0.38% |
| 4 | 48 | 10,000 | 0.48% |
| 5 | 26 | 10,000 | 0.26% |

修正後は同テストで **0エラー**。

## Test plan
- [x] マルチスレッドユニットテスト (`MessageDigestableThreadSafetyTest`) がグリーン
- [x] 既存テストが全てパス (`./gradlew test`)

Closes #1341

🤖 Generated with [Claude Code](https://claude.com/claude-code)