### PR TITLE
feat: http_requests複数APIチェーン実験ガイド・モック改善

### DIFF
--- a/.claude/skills/use-case-external-password-auth/skill.md
+++ b/.claude/skills/use-case-external-password-auth/skill.md
@@ -37,25 +37,22 @@ bash config/templates/use-cases/external-password-auth/setup.sh --dry-run
 
 ユーザーが具体的にやりたいことを言った場合は、qa.md を参照して該当するQ&Aの設定キー+値を提示すること。
 
-## 設定変更 x 挙動確認
+## 設定変更 x 挙動確認（ハンズオン）
 
-**検証スクリプト**: `config/templates/use-cases/external-password-auth/verify.sh`
+**「設定を変えて → 挙動が変わることを体験する」実験ガイド**:
 
-setup.sh 実行後に `verify.sh` を使って動作確認できる。モックサーバー（`mock-server.js`）を起動してローカルで検証可能。
+- `config/templates/use-cases/external-password-auth/EXPERIMENTS.md` - `http_request`（単数）の基本実験
+- `config/templates/use-cases/external-password-auth/EXPERIMENTS-http-requests.md` - `http_requests`（複数形）の複数API チェーン実験
 
-```bash
-# モックサーバー起動（別ターミナル）
-node config/templates/use-cases/external-password-auth/mock-server.js
+設定の効果を手元で確認したい場合はこれらのガイドを案内すること。
 
-# 検証実行
-bash config/templates/use-cases/external-password-auth/verify.sh
-```
+**自動検証スクリプト**: `config/templates/use-cases/external-password-auth/verify.sh`
 
 ## ヒアリング項目
 
 | # | 決めること | 選択肢 | 影響する設定 |
 |---|-----------|--------|-------------|
-| 1 | 外部認証サービスURL | 実サービスURL / モック（localhost:4000） | 認証メソッド設定 `http_request.url` |
+| 1 | 外部認証サービスURL | 実サービスURL / モック（localhost:4001） | 認証メソッド設定 `http_request.url` |
 | 2 | 外部プロバイダーID | 任意の識別子（例: `ldap-wrapper`, `legacy-auth`） | 認証メソッド設定 `user_mapping_rules[].static_value` |
 | 3 | アカウントロック条件 | 失敗回数（デフォルト: 5回） | 認証ポリシー `failure_conditions` / `lock_conditions` |
 | 4 | セッション有効期限 | 秒数（デフォルト: 86400 = 24時間） | テナント `session_config.timeout_seconds` |
@@ -69,7 +66,7 @@ bash config/templates/use-cases/external-password-auth/verify.sh
 
 | ヒアリング項目 | 環境変数 | デフォルト値 |
 |--------------|---------|-------------|
-| 外部認証サービスURL | `EXTERNAL_AUTH_URL` | `http://host.docker.internal:4000/auth/password` |
+| 外部認証サービスURL | `EXTERNAL_AUTH_URL` | `http://host.docker.internal:4001/auth/password` |
 | 外部プロバイダー識別子 | `EXTERNAL_PROVIDER_ID` | `external-auth` |
 
 ### セッション設定
@@ -171,6 +168,58 @@ bash config/templates/use-cases/external-password-auth/verify.sh
 | `email` | `email` | メールアドレス |
 | `name` | `name` | 表示名 |
 | (static) | `provider_id` | 外部サービス識別子 |
+
+### 1b. 複数API チェーン設定（http_requests）
+
+複数の外部APIを順番に呼び出し、結果を統合するパターン。例: 認証API → ユーザー詳細API。
+
+| | `http_request`（単数） | `http_requests`（複数形） |
+|---|---|---|
+| リクエスト数 | 1つ | 複数（順番に実行） |
+| 設定キー | `execution.http_request` (object) | `execution.http_requests` (array) |
+| 結果パス | `$.execution_http_request.response_body.*` | `$.execution_http_requests[0].response_body.*` |
+| チェーン | 不可 | 前のレスポンスを次のリクエストで使える |
+| エラー時 | 即座に返却 | 失敗した時点で中断、それまでの結果を保持 |
+
+**複数API呼び出し時のエラーハンドリング**:
+
+成功フィールドとエラーフィールドが共存しないよう、`allOf` + `missing` 複合条件を使う:
+
+```json
+{
+  "from": "$.execution_http_requests[0].response_body.user_id",
+  "to": "user_id",
+  "condition": {
+    "operation": "allOf",
+    "value": [
+      { "operation": "exists", "path": "$.execution_http_requests[0].response_body.user_id" },
+      { "operation": "missing", "path": "$.execution_http_requests[1].response_body.error" }
+    ]
+  }
+}
+```
+
+- `exists` のみだと、API 2 が失敗してもAPI 1 の成功フィールドが返ってしまう
+- `allOf` で「自身が存在 AND 後続APIのエラーが missing」を両方満たす場合のみ出力
+
+**functions（ヘッダー動的生成）**:
+
+```json
+"header_mapping_rules": [
+  {
+    "from": "$.unused",
+    "to": "x-request-id",
+    "functions": [
+      { "name": "random_string", "args": { "length": 8 } },
+      { "name": "format", "args": { "template": "trace-{{value}}" } }
+    ]
+  }
+]
+```
+
+使える functions: `format`（テンプレート変換）、`random_string`（ランダム文字列）、`now`（現在時刻）、`exists`（boolean化）。`from: "$.unused"` は入力不要な functions 用の特殊パス。
+
+詳細と実験手順は `EXPERIMENTS-http-requests.md` を参照。
 
 ### 2. 認証ポリシー（パスワードのみ、failure/lock_conditions あり）
 

--- a/config/templates/use-cases/external-password-auth/EXPERIMENTS-http-requests.md
+++ b/config/templates/use-cases/external-password-auth/EXPERIMENTS-http-requests.md
@@ -1,0 +1,542 @@
+# http_requests（複数API チェーン）実験ガイド
+
+`http_requests`（複数形）executor を使って、**複数の外部 API を順番に呼び出し、結果を統合する**パターンを体験するガイドです。
+
+> **`http_request`（単数）との違い**:
+>
+> | | `http_request` | `http_requests` |
+> |---|---|---|
+> | リクエスト数 | 1つ | 複数（順番に実行） |
+> | 設定キー | `execution.http_request` (object) | `execution.http_requests` (array) |
+> | 結果パス | `$.execution_http_request.response_body.*` | `$.execution_http_requests[0].response_body.*` |
+> | チェーン | 不可 | 前のレスポンスを次のリクエストで使える |
+> | エラー時 | 即座に返却 | 失敗した時点で中断、それまでの結果を返却 |
+
+> **前提**: `setup.sh` が正常に完了し、モックサーバー（`mock-server.js`）が起動していること。
+
+---
+
+## 共通準備
+
+```bash
+cd config/templates/use-cases/external-password-auth
+source helpers.sh
+
+get_admin_token
+```
+
+### モックサーバーの起動
+
+```bash
+# 別ターミナルで起動
+node mock-server.js
+# → Mock auth server running on http://localhost:4001
+```
+
+**エンドポイント**:
+
+| パス | 用途 | レスポンス |
+|------|------|-----------|
+| `POST /auth/password` | パスワード認証 | `{user_id, email, name}` or `{error, error_description}` |
+| `POST /user/details` | ユーザー詳細取得 | `{user_id, birthdate, phone_number, zoneinfo, locale, role}` |
+
+```bash
+# 動作確認
+curl -s -X POST http://localhost:4001/auth/password \
+  -H 'Content-Type: application/json' \
+  -d '{"username":"test@example.com","password":"correct"}' | jq .
+
+curl -s -X POST http://localhost:4001/user/details \
+  -H 'Content-Type: application/json' \
+  -d '{"user_id":"ext-user-test-example-com"}' | jq .
+```
+
+---
+
+## Experiment 1: 認証 → ユーザー詳細を2段階で取得する（基本）
+
+> **やりたいこと**: パスワード認証（API 1）→ ユーザー詳細取得（API 2）を1回の認証フローで実行したい
+>
+> **変わる設定**: `authentication-configurations` の `execution` を `http_request` → `http_requests` に変更
+>
+> **ポイント**: API 1 のレスポンス（`user_id`）を API 2 のリクエストボディで使う **チェーン** パターン。
+
+### 1. ベースライン確認（http_request 単数 = 現在の設定）
+
+```bash
+start_auth_flow
+password_login "chain-$(date +%s)@example.com" "correct-password" > /dev/null
+complete_auth_flow > /dev/null
+
+echo "--- ベースライン: UserInfo（name, email のみ） ---"
+get_userinfo | jq '{name, email, birthdate, phone_number, zoneinfo}'
+```
+
+> `birthdate`, `phone_number`, `zoneinfo` は `null` のはず（単一APIでは取得していない）。
+
+### 2. 設定変更：execution を http_requests に切り替え
+
+```bash
+update_auth_config '
+  .interactions["password-authentication"].execution = {
+    "function": "http_requests",
+    "http_requests": [
+      {
+        "url": "http://host.docker.internal:4001/auth/password",
+        "method": "POST",
+        "header_mapping_rules": [
+          { "static_value": "application/json", "to": "Content-Type" }
+        ],
+        "body_mapping_rules": [
+          { "from": "$.request_body.username", "to": "username" },
+          { "from": "$.request_body.password", "to": "password" }
+        ]
+      },
+      {
+        "url": "http://host.docker.internal:4001/user/details",
+        "method": "POST",
+        "header_mapping_rules": [
+          { "static_value": "application/json", "to": "Content-Type" }
+        ],
+        "body_mapping_rules": [
+          { "from": "$.execution_http_requests[0].response_body.user_id", "to": "user_id" }
+        ]
+      }
+    ]
+  }
+  |
+  .interactions["password-authentication"].user_resolve.user_mapping_rules = [
+    { "from": "$.execution_http_requests[0].response_body.user_id", "to": "external_user_id" },
+    { "from": "$.execution_http_requests[0].response_body.email", "to": "email" },
+    { "from": "$.execution_http_requests[0].response_body.name", "to": "name" },
+    { "from": "$.execution_http_requests[1].response_body.birthdate", "to": "birthdate" },
+    { "from": "$.execution_http_requests[1].response_body.phone_number", "to": "phone_number" },
+    { "from": "$.execution_http_requests[1].response_body.zoneinfo", "to": "zoneinfo" },
+    { "from": "$.execution_http_requests[1].response_body.locale", "to": "locale" },
+    { "static_value": "external-auth", "to": "provider_id" }
+  ]
+  |
+  .interactions["password-authentication"].response.body_mapping_rules = [
+    {
+      "from": "$.execution_http_requests[0].response_body.user_id",
+      "to": "user_id",
+      "condition": { "operation": "exists", "path": "$.execution_http_requests[0].response_body.user_id" }
+    },
+    {
+      "from": "$.execution_http_requests[0].response_body.email",
+      "to": "email",
+      "condition": { "operation": "exists", "path": "$.execution_http_requests[0].response_body.email" }
+    },
+    {
+      "from": "$.execution_http_requests[0].response_body.error",
+      "to": "error",
+      "condition": { "operation": "exists", "path": "$.execution_http_requests[0].response_body.error" }
+    },
+    {
+      "from": "$.execution_http_requests[0].response_body.error_description",
+      "to": "error_description",
+      "condition": { "operation": "exists", "path": "$.execution_http_requests[0].response_body.error_description" }
+    }
+  ]
+' | jq '.interactions["password-authentication"].execution.function // .'
+```
+
+### 3. 挙動確認
+
+```bash
+start_auth_flow
+password_login "chain2-$(date +%s)@example.com" "correct-password" > /dev/null
+complete_auth_flow > /dev/null
+
+echo "--- http_requests 後: UserInfo（詳細情報が追加されているはず） ---"
+get_userinfo | jq '{name, email, birthdate, phone_number, zoneinfo, locale}'
+```
+
+### 4. 期待結果
+
+| タイミング | UserInfo の内容 | 理由 |
+|-----------|----------------|------|
+| 変更前（http_request） | `name`, `email` のみ | `/auth/password` の返却値のみ |
+| 変更後（http_requests） | `name`, `email` + `birthdate`, `phone_number`, `zoneinfo`, `locale` | `/auth/password`(API 1) + `/user/details`(API 2) の統合 |
+
+```
+実行フロー:
+  API 1: POST /auth/password   → { user_id, email, name }
+                                     ↓ user_id をチェーン
+  API 2: POST /user/details    → { birthdate, phone_number, zoneinfo, locale, role }
+                                     ↓
+  user_mapping_rules: [0] から email/name、[1] から birthdate/phone_number/zoneinfo/locale
+```
+
+### 5. 元に戻す
+
+```bash
+restore_auth_config
+```
+
+---
+
+## Experiment 2: functions でヘッダー値を動的生成する
+
+> **やりたいこと**: トレースID、タイムスタンプ、Bearer トークンなどのヘッダーを動的に生成したい
+>
+> **変わる設定**: `header_mapping_rules` の `functions`
+>
+> **使える functions**: `format`（テンプレート変換）、`random_string`（ランダム文字列）、`now`（現在時刻）
+
+### 1. 設定変更：functions 付きヘッダーを追加
+
+```bash
+update_auth_config '
+  .interactions["password-authentication"].execution = {
+    "function": "http_requests",
+    "http_requests": [
+      {
+        "url": "http://host.docker.internal:4001/auth/password",
+        "method": "POST",
+        "header_mapping_rules": [
+          { "static_value": "application/json", "to": "Content-Type" }
+        ],
+        "body_mapping_rules": [
+          { "from": "$.request_body.username", "to": "username" },
+          { "from": "$.request_body.password", "to": "password" }
+        ]
+      },
+      {
+        "url": "http://host.docker.internal:4001/user/details",
+        "method": "POST",
+        "header_mapping_rules": [
+          { "static_value": "application/json", "to": "Content-Type" },
+          {
+            "from": "$.unused",
+            "to": "x-request-id",
+            "functions": [
+              { "name": "random_string", "args": { "length": 8 } },
+              { "name": "format", "args": { "template": "trace-{{value}}" } }
+            ]
+          },
+          {
+            "from": "$.unused",
+            "to": "issued_at",
+            "functions": [
+              { "name": "now", "args": { "zone": "Asia/Tokyo", "pattern": "yyyy-MM-dd HH:mm:ss" } }
+            ]
+          }
+        ],
+        "body_mapping_rules": [
+          { "from": "$.execution_http_requests[0].response_body.user_id", "to": "user_id" }
+        ]
+      }
+    ]
+  }
+  |
+  .interactions["password-authentication"].user_resolve.user_mapping_rules = [
+    { "from": "$.execution_http_requests[0].response_body.user_id", "to": "external_user_id" },
+    { "from": "$.execution_http_requests[0].response_body.email", "to": "email" },
+    { "from": "$.execution_http_requests[0].response_body.name", "to": "name" },
+    { "from": "$.execution_http_requests[1].response_body.birthdate", "to": "birthdate" },
+    { "from": "$.execution_http_requests[1].response_body.zoneinfo", "to": "zoneinfo" },
+    { "static_value": "external-auth", "to": "provider_id" }
+  ]
+  |
+  .interactions["password-authentication"].response.body_mapping_rules = [
+    {
+      "from": "$.execution_http_requests[0].response_body.user_id",
+      "to": "user_id",
+      "condition": { "operation": "exists", "path": "$.execution_http_requests[0].response_body.user_id" }
+    },
+    {
+      "from": "$.execution_http_requests[0].response_body.error",
+      "to": "error",
+      "condition": { "operation": "exists", "path": "$.execution_http_requests[0].response_body.error" }
+    }
+  ]
+' | jq '.interactions["password-authentication"].execution.http_requests[1].header_mapping_rules // .'
+```
+
+### 2. 挙動確認
+
+```bash
+start_auth_flow
+echo "--- functions 付きヘッダーで認証 ---"
+password_login "func-$(date +%s)@example.com" "correct-password" | jq .
+```
+
+> モックサーバーのターミナルで、`x-request-id: trace-xxxxxxxx` と `issued_at: 2026-03-11 ...` のヘッダーが受信されていることを確認。
+>
+> モックサーバーのレスポンスに `requested_at` が含まれている（`issued_at` ヘッダーの値をエコーバック）。
+
+### 3. functions 一覧
+
+| function | 用途 | args | 例 |
+|---|---|---|---|
+| `format` | テンプレート変換 | `{"template": "Bearer {{value}}"}` | 入力 `abc` → `Bearer abc` |
+| `random_string` | ランダム文字列生成 | `{"length": 8}` | `a3kf9xm2` |
+| `now` | 現在時刻生成 | `{"zone": "Asia/Tokyo", "pattern": "yyyy-MM-dd HH:mm:ss"}` | `2026-03-11 15:30:00` |
+| `exists` | 存在チェック（boolean化） | `{}` | 値あり → `true` |
+
+**`from: "$.unused"`**: 入力値なしで functions を実行する特殊パス。`random_string` や `now` のように入力不要な functions で使う。
+
+**functions チェーン**: 配列で複数指定すると左から順に適用される。
+```json
+"functions": [
+  { "name": "random_string", "args": { "length": 6 } },
+  { "name": "format", "args": { "template": "trace-id-{{value}}" } }
+]
+// → "abc123" → "trace-id-abc123"
+```
+
+### 4. 元に戻す
+
+```bash
+restore_auth_config
+```
+
+---
+
+## Experiment 3: 途中のリクエストが失敗した場合の挙動
+
+> **やりたいこと**: 2段階 API のうち1つが失敗した場合にどうなるか確認したい
+>
+> **確認する挙動**: `http_requests` は失敗した時点で中断し、それまでの結果を返却する
+>
+> **ポイント**: `response.body_mapping_rules` の `condition` で **どの API が失敗したか** を判定し、適切なエラーレスポンスを返す。
+
+### 1. 設定：API 2 のエラーも API 1 のエラーも condition で拾う
+
+```bash
+update_auth_config '
+  .interactions["password-authentication"].execution = {
+    "function": "http_requests",
+    "http_requests": [
+      {
+        "url": "http://host.docker.internal:4001/auth/password",
+        "method": "POST",
+        "header_mapping_rules": [
+          { "static_value": "application/json", "to": "Content-Type" }
+        ],
+        "body_mapping_rules": [
+          { "from": "$.request_body.username", "to": "username" },
+          { "from": "$.request_body.password", "to": "password" }
+        ]
+      },
+      {
+        "url": "http://host.docker.internal:9999/not-exist",
+        "method": "POST",
+        "header_mapping_rules": [
+          { "static_value": "application/json", "to": "Content-Type" }
+        ],
+        "body_mapping_rules": [
+          { "from": "$.execution_http_requests[0].response_body.user_id", "to": "user_id" }
+        ]
+      }
+    ]
+  }
+  |
+  .interactions["password-authentication"].user_resolve.user_mapping_rules = [
+    { "from": "$.execution_http_requests[0].response_body.user_id", "to": "external_user_id" },
+    { "from": "$.execution_http_requests[0].response_body.email", "to": "email" },
+    { "from": "$.execution_http_requests[0].response_body.name", "to": "name" },
+    { "static_value": "external-auth", "to": "provider_id" }
+  ]
+  |
+  .interactions["password-authentication"].response.body_mapping_rules = [
+    {
+      "from": "$.execution_http_requests[0].response_body.user_id",
+      "to": "user_id",
+      "condition": {
+        "operation": "allOf",
+        "value": [
+          { "operation": "exists", "path": "$.execution_http_requests[0].response_body.user_id" },
+          { "operation": "missing", "path": "$.execution_http_requests[1].response_body.error" }
+        ]
+      }
+    },
+    {
+      "from": "$.execution_http_requests[0].response_body.email",
+      "to": "email",
+      "condition": {
+        "operation": "allOf",
+        "value": [
+          { "operation": "exists", "path": "$.execution_http_requests[0].response_body.email" },
+          { "operation": "missing", "path": "$.execution_http_requests[1].response_body.error" }
+        ]
+      }
+    },
+    {
+      "from": "$.execution_http_requests[0].response_body.error",
+      "to": "error",
+      "condition": { "operation": "exists", "path": "$.execution_http_requests[0].response_body.error" }
+    },
+    {
+      "from": "$.execution_http_requests[0].response_body.error_description",
+      "to": "error_description",
+      "condition": { "operation": "exists", "path": "$.execution_http_requests[0].response_body.error_description" }
+    },
+    {
+      "from": "$.execution_http_requests[1].response_body.error",
+      "to": "error",
+      "condition": { "operation": "exists", "path": "$.execution_http_requests[1].response_body.error" }
+    },
+    {
+      "from": "$.execution_http_requests[1].response_body.error_description",
+      "to": "error_description",
+      "condition": { "operation": "exists", "path": "$.execution_http_requests[1].response_body.error_description" }
+    }
+  ]
+' | jq '.interactions["password-authentication"].response.body_mapping_rules | length'
+```
+
+> **設定のポイント**:
+> - 成功フィールド（`user_id`, `email`）は `allOf` 複合条件で **自身が存在 AND API 2 のエラーが missing** の両方を満たす場合のみ出力
+> - `[0].response_body.error` → API 1（認証）のエラー（`invalid_credentials` 等）
+> - `[1].response_body.error` → API 2（詳細取得）のエラー（`network_error` 等）
+> - これにより、API 2 が失敗した場合はエラー情報のみ返り、成功フィールドは含まれない
+
+### 2. 挙動確認：API 2 が接続不可
+
+```bash
+start_auth_flow
+echo "--- API 1 は成功するが API 2 が接続不可 ---"
+password_login "error-$(date +%s)@example.com" "correct-password" | jq .
+```
+
+> `ConnectException` → idp-server が API 2 の結果を `{error: "network_error", error_description: "HTTP request failed"}` として保持。
+> `body_mapping_rules` の `[1].response_body.error` condition にマッチし、`error` / `error_description` が返る。
+
+### 3. 挙動確認：API 1 が認証失敗
+
+```bash
+start_auth_flow
+echo "--- API 1 が認証失敗 → API 2 はスキップ ---"
+password_login "error2@example.com" "invalid" | jq .
+```
+
+> API 1 が 401 → `isClientError()` で中断。API 2 は実行されない。
+> `[0].response_body.error` condition にマッチし、`invalid_credentials` が返る。
+
+### 4. 期待結果
+
+| シナリオ | API 1 | API 2 | idp-server レスポンス | body の内容 |
+|---------|-------|-------|---------------------|-------------|
+| API 1 が認証失敗 | 401 | スキップ | 200 | `{error: "invalid_credentials", error_description: "..."}` |
+| API 2 が接続不可 | 200 OK | ConnectException (503) | 500 | `{error: "network_error", error_description: "HTTP request failed"}` |
+| 両方正常 | 200 OK | 200 OK | 200 | `{user_id: "...", email: "..."}` |
+
+> **ポイント**:
+> - `http_requests` は**前から順番に実行**し、**エラーが出た時点で中断**する
+> - API 1 が失敗すれば API 2 は実行されない。API 2 が失敗しても API 1 の結果は保持される
+> - `response.body_mapping_rules` の `condition` で **各 API のエラーを個別に検出**し、適切なエラー情報をレスポンスに含める
+
+### 5. 元に戻す
+
+```bash
+restore_auth_config
+```
+
+---
+
+## Experiment 4: ワイルドカード展開でリクエストボディ全体を転送する
+
+> **やりたいこと**: リクエストボディのフィールドを1つずつ指定するのではなく、全体を一括転送したい
+>
+> **変わる設定**: `body_mapping_rules` で `{ "from": "$.request_body", "to": "*" }` を使う
+>
+> **ポイント**: `"to": "*"` はソースオブジェクトの全キーをそのまま展開する。
+
+### 1. 設定変更：ワイルドカード展開を使用
+
+```bash
+update_auth_config '
+  .interactions["password-authentication"].execution = {
+    "function": "http_requests",
+    "http_requests": [
+      {
+        "url": "http://host.docker.internal:4001/auth/password",
+        "method": "POST",
+        "header_mapping_rules": [
+          { "static_value": "application/json", "to": "Content-Type" }
+        ],
+        "body_mapping_rules": [
+          { "from": "$.request_body", "to": "*" }
+        ]
+      },
+      {
+        "url": "http://host.docker.internal:4001/user/details",
+        "method": "POST",
+        "header_mapping_rules": [
+          { "static_value": "application/json", "to": "Content-Type" }
+        ],
+        "body_mapping_rules": [
+          { "from": "$.execution_http_requests[0].response_body.user_id", "to": "user_id" }
+        ]
+      }
+    ]
+  }
+  |
+  .interactions["password-authentication"].user_resolve.user_mapping_rules = [
+    { "from": "$.execution_http_requests[0].response_body.user_id", "to": "external_user_id" },
+    { "from": "$.execution_http_requests[0].response_body.email", "to": "email" },
+    { "from": "$.execution_http_requests[0].response_body.name", "to": "name" },
+    { "from": "$.execution_http_requests[1].response_body.birthdate", "to": "birthdate" },
+    { "static_value": "external-auth", "to": "provider_id" }
+  ]
+  |
+  .interactions["password-authentication"].response.body_mapping_rules = [
+    {
+      "from": "$.execution_http_requests[0].response_body.user_id",
+      "to": "user_id",
+      "condition": { "operation": "exists", "path": "$.execution_http_requests[0].response_body.user_id" }
+    },
+    {
+      "from": "$.execution_http_requests[0].response_body.error",
+      "to": "error",
+      "condition": { "operation": "exists", "path": "$.execution_http_requests[0].response_body.error" }
+    }
+  ]
+' | jq '.interactions["password-authentication"].execution.http_requests[0].body_mapping_rules // .'
+```
+
+### 2. 挙動確認
+
+```bash
+start_auth_flow
+echo "--- ワイルドカード展開で認証（username/password が全体転送される） ---"
+password_login "wild-$(date +%s)@example.com" "correct-password" | jq .
+```
+
+### 3. 明示指定 vs ワイルドカードの比較
+
+| パターン | body_mapping_rules | 外部サービスに送るJSON |
+|---------|---|---|
+| 明示指定 | `{"from": "$.request_body.username", "to": "username"}, ...` | `{"username": "...", "password": "..."}` |
+| ワイルドカード | `{"from": "$.request_body", "to": "*"}` | `{"username": "...", "password": "..."}` + リクエストの全フィールド |
+
+> **ポイント**: ワイルドカードはリクエストボディの全フィールドを転送するため、
+> 外部サービスが想定外のフィールドを受け取る可能性がある。
+> 明示指定の方がセキュリティ面で安全（必要なフィールドだけ送る）。
+>
+> **使いどころ**: 外部サービスのフィールドが動的に変わる場合や、
+> プロトタイプ段階で素早く連携したい場合に便利。
+
+### 4. 元に戻す
+
+```bash
+restore_auth_config
+```
+
+---
+
+## 実験一覧
+
+| # | やりたいこと | 使う機能 | 確認できること |
+|---|------------|---------|--------------|
+| 1 | 2つの API を順番に呼びたい | `http_requests` + チェーン | API 1 → API 2 の結果を統合して UserInfo に反映 |
+| 2 | ヘッダーを動的生成したい | `functions` (format, random_string, now) | トレースID、タイムスタンプ等の自動生成 |
+| 3 | 途中で失敗した場合を確認 | `http_requests` エラーハンドリング | 失敗時点で中断、それまでの結果は保持 |
+| 4 | ボディ全体を一括転送したい | `"to": "*"` ワイルドカード | 明示指定 vs 全体転送の違い |
+
+## 関連
+
+- `EXPERIMENTS.md` - `http_request`（単数）の基本実験
+- `config/examples/e2e/test-tenant/authentication-config/external-token/mocky.json` - `http_requests` の実例

--- a/config/templates/use-cases/external-password-auth/EXPERIMENTS.md
+++ b/config/templates/use-cases/external-password-auth/EXPERIMENTS.md
@@ -1,0 +1,844 @@
+# 設定変更 × 挙動確認 実験ガイド
+
+設定を1つ変えて → 挙動がどう変わるかを手元で確認するためのガイドです。
+「この設定って何に効くの？」を体感で理解できます。
+
+> **前提**: `setup.sh` が正常に完了し、モックサーバー（`mock-server.js`）が起動していること。
+
+---
+
+## 共通準備
+
+`helpers.sh` を source すると、変数・関数がすべて使えるようになります。
+
+```bash
+cd config/templates/use-cases/external-password-auth
+source helpers.sh                  # デフォルト組織名
+# source helpers.sh --org my-org   # 組織名を指定する場合
+
+get_admin_token   # 設定変更に必要な管理トークンを取得
+```
+
+> **重要**: テナント更新 API（PUT）は**フル置換**です。
+> 送らなかったフィールドは空のデフォルトにリセットされます。
+> `helpers.sh` の `update_tenant` / `update_auth_server` / `update_auth_config` を使えば、ベースのJSON から変えたいフィールドだけ上書きして送れます。
+
+> **トラブルシューティング**: 設定変更が効かない場合、まずAPIレスポンスを確認してください。
+> `update_tenant` / `update_auth_server` のレスポンスにエラーが含まれている場合、
+> 管理トークンの期限切れ（`get_admin_token` を再実行）や、リクエストの不備が原因です。
+> レスポンス全体を見るには `| jq .` を付けてください。
+
+### モックサーバーの起動
+
+```bash
+# 別ターミナルで起動（依存パッケージ不要）
+node mock-server.js
+# → Mock auth server running on http://localhost:4001
+```
+
+**モックサーバーの認証ルール**:
+- `password` が `"invalid"` → 401（認証失敗）
+- `username` / `password` が空 → 401（認証失敗）
+- それ以外 → 200（認証成功）
+
+### helpers.sh で使える関数
+
+| 関数 | 用途 | 使用例 |
+|------|------|--------|
+| `get_admin_token` | 管理トークン取得 | `get_admin_token` |
+| `update_tenant` | テナント設定を部分変更 | `update_tenant '.session_config.timeout_seconds = 15'` |
+| `restore_tenant` | テナント設定を元に戻す | `restore_tenant` |
+| `update_auth_server` | 認可サーバー設定を部分変更 | `update_auth_server '.extension.access_token_duration = 10'` |
+| `restore_auth_server` | 認可サーバー設定を元に戻す | `restore_auth_server` |
+| `update_auth_policy` | 認証ポリシーを更新 | `update_auth_policy '{"flow":"oauth",...}'` |
+| `restore_auth_policy` | 認証ポリシーを元に戻す | `restore_auth_policy` |
+| `update_auth_config` | 認証メソッド設定を部分変更 | `update_auth_config '.interactions[...].execution.http_request.url = "..."'` |
+| `restore_auth_config` | 認証メソッド設定を元に戻す | `restore_auth_config` |
+| `update_client` | クライアント設定を部分変更 | `update_client '.scope = "openid profile"'` |
+| `restore_client` | クライアント設定を元に戻す | `restore_client` |
+| `start_auth_flow` | 認可リクエスト開始 | `start_auth_flow` / `start_auth_flow openid` |
+| `password_login` | パスワード認証（外部サービス経由） | `password_login "a@b.com" "Pass123"` |
+| `complete_auth_flow` | 認可→トークン取得 | `complete_auth_flow` |
+| `get_userinfo` | UserInfo 取得 | `get_userinfo` / `get_userinfo "${OTHER_TOKEN}"` |
+
+---
+
+## Experiment 1: 外部認証サービスでログインする（基本動作確認）
+
+> **やりたいこと**: 外部パスワード認証委譲が正しく動作するか確認したい
+>
+> **確認する設定**: `authentication-configurations`（http_request executor）
+
+### 1. 認証成功を確認
+
+```bash
+start_auth_flow
+
+echo "--- 正しいパスワードでログイン（モックサーバーは invalid 以外を受け入れる） ---"
+password_login "user1@example.com" "correct-password" | jq .
+```
+
+### 2. 認可→トークン取得→UserInfo
+
+```bash
+complete_auth_flow
+
+echo "--- UserInfo ---"
+get_userinfo | jq .
+```
+
+### 3. 認証失敗を確認
+
+```bash
+start_auth_flow
+
+echo "--- 間違ったパスワード（invalid）でログイン → 拒否されるはず ---"
+password_login "user1@example.com" "invalid" | jq .
+```
+
+### 4. 期待結果
+
+| パスワード | 結果 | 理由 |
+|-----------|------|------|
+| `correct-password` | 成功 | モックサーバーが 200 を返す |
+| `invalid` | 拒否 | モックサーバーが 401 を返す |
+
+> UserInfo には `sub`, `email`, `name` 等が含まれるはずです。
+> `email` は外部サービスから返された値がマッピングされます。
+
+---
+
+## Experiment 2: アカウントロックを体験する
+
+> **やりたいこと**: N回パスワードを間違えたらロックされることを確認したい
+>
+> **変わる設定**: 認証ポリシー `failure_conditions` / `lock_conditions`
+>
+> **login-password-only との違い**: このテンプレートはデフォルトで failure/lock_conditions が有効（5回）。この実験では閾値を3回に変更してロックを素早く体験する。
+
+### 1. 設定変更：ロック閾値を 3回に
+
+```bash
+update_auth_policy '{
+  "flow": "oauth",
+  "enabled": true,
+  "policies": [
+    {
+      "description": "external_password_lock_3",
+      "priority": 1,
+      "conditions": {},
+      "available_methods": ["password"],
+      "success_conditions": {
+        "any_of": [
+          [{"path": "$.password-authentication.success_count", "type": "integer", "operation": "gte", "value": 1}]
+        ]
+      },
+      "failure_conditions": {
+        "any_of": [
+          [{"path": "$.password-authentication.failure_count", "type": "integer", "operation": "gte", "value": 3}]
+        ]
+      },
+      "lock_conditions": {
+        "any_of": [
+          [{"path": "$.password-authentication.failure_count", "type": "integer", "operation": "gte", "value": 3}]
+        ]
+      }
+    }
+  ]
+}' | jq '{id, flow, enabled} // .'
+```
+
+### 2. 挙動確認：わざと3回間違える
+
+```bash
+LOCK_EMAIL="locktest-$(date +%s)@example.com"
+start_auth_flow
+
+echo "--- 1回目: 間違ったパスワード ---"
+password_login "${LOCK_EMAIL}" "invalid" | jq .
+
+echo "--- 2回目: 間違ったパスワード ---"
+password_login "${LOCK_EMAIL}" "invalid" | jq .
+
+echo "--- 3回目: 間違ったパスワード → ここでロック ---"
+password_login "${LOCK_EMAIL}" "invalid" | jq .
+
+echo "--- 4回目: 正しいパスワード → ロック中なので拒否されるはず ---"
+password_login "${LOCK_EMAIL}" "correct-password" | jq .
+```
+
+### 3. 期待結果
+
+| 回数 | パスワード | 結果 | 理由 |
+|------|-----------|------|------|
+| 1回目 | `invalid` | 認証失敗 | モックサーバーが 401 |
+| 2回目 | `invalid` | 認証失敗 | モックサーバーが 401 |
+| 3回目 | `invalid` | ロック発動 | `failure_count >= 3` で `lock_conditions` に該当 |
+| 4回目 | `correct-password` | 拒否 | 正しいパスワードでもロック中 |
+
+### 4. 元に戻す
+
+```bash
+restore_auth_policy
+```
+
+---
+
+## Experiment 3: 外部認証サービスの URL を変更する
+
+> **やりたいこと**: 外部認証サービスの接続先を切り替えたい
+>
+> **変わる設定**: `authentication-configurations` の `execution.http_request.url`
+>
+> **外部パスワード認証固有**: login-password-only には存在しない、このテンプレート特有の実験。
+
+### 1. 設定変更：存在しないURLに変更
+
+```bash
+update_auth_config '
+  .interactions["password-authentication"].execution.http_request.url = "http://host.docker.internal:9999/auth/not-exist"
+' | jq '.interactions["password-authentication"].execution.http_request.url // .'
+```
+
+### 2. 挙動確認：認証を試みる → 外部サービスに接続できず失敗
+
+```bash
+start_auth_flow
+
+echo "--- 存在しないURLに認証リクエスト → エラーになるはず ---"
+password_login "test@example.com" "correct-password" | jq .
+```
+
+### 3. 設定変更：正しいURLに戻す
+
+```bash
+restore_auth_config
+
+echo "--- 元のURLに戻して認証 → 成功するはず ---"
+start_auth_flow
+password_login "test@example.com" "correct-password" | jq .
+```
+
+### 4. 期待結果
+
+| URL | 結果 | 理由 |
+|-----|------|------|
+| `http://host.docker.internal:9999/auth/not-exist` | エラー | 外部サービスに接続不可 |
+| `http://host.docker.internal:4001/auth/password`（元の設定） | 成功 | モックサーバーが応答 |
+
+---
+
+## Experiment 4: マッピングルールを変更して UserInfo の内容を変える
+
+> **やりたいこと**: 外部サービスのレスポンスから別のフィールドをマッピングしたい
+>
+> **変わる設定**: `authentication-configurations` の `user_mapping_rules`
+>
+> **外部パスワード認証固有**: 外部レスポンスと idp-server ユーザー属性の対応を自由に変更できる。
+
+### 1. ベースラインを確認
+
+```bash
+start_auth_flow
+password_login "mapping-$(date +%s)@example.com" "correct-password" > /dev/null
+complete_auth_flow > /dev/null
+
+echo "--- ベースライン: UserInfo ---"
+get_userinfo | jq .
+```
+
+> `name` が `"External User"`（モックサーバーのデフォルト）のはずです。
+
+### 2. 設定変更：name マッピングを email に上書き
+
+```bash
+update_auth_config '
+  .interactions["password-authentication"].user_resolve.user_mapping_rules = [
+    { "from": "$.execution_http_request.response_body.user_id", "to": "external_user_id" },
+    { "from": "$.execution_http_request.response_body.email", "to": "email" },
+    { "from": "$.execution_http_request.response_body.email", "to": "name" },
+    { "static_value": "external-auth", "to": "provider_id" }
+  ]
+' | jq '.interactions["password-authentication"].user_resolve.user_mapping_rules // .'
+```
+
+### 3. 挙動確認：新しいユーザーでログイン
+
+```bash
+MAPPING_EMAIL="mapped-$(date +%s)@example.com"
+start_auth_flow
+password_login "${MAPPING_EMAIL}" "correct-password" > /dev/null
+complete_auth_flow > /dev/null
+
+echo "--- マッピング変更後: UserInfo ---"
+get_userinfo | jq '{name, email}'
+```
+
+### 4. 期待結果
+
+| タイミング | `name` の値 | 理由 |
+|-----------|------------|------|
+| 変更前 | `External User` | `response_body.name` からマッピング |
+| 変更後 | `mapped-xxxx@example.com` | `response_body.email` を `name` にマッピング |
+
+### 5. 元に戻す
+
+```bash
+restore_auth_config
+```
+
+---
+
+## Experiment 5: claims_supported を変えて UserInfo の返却値を確認する
+
+> **やりたいこと**: UserInfo で返るクレームを制御したい
+>
+> **変わる設定**: `authorization_server.claims_supported`
+
+### 1. まずベースラインを確認
+
+```bash
+start_auth_flow
+password_login "claims-$(date +%s)@example.com" "correct-password" > /dev/null
+complete_auth_flow
+
+echo "--- ベースライン: UserInfo ---"
+get_userinfo | jq .
+```
+
+> `sub`, `email`, `name` 等が返ってくるはずです。
+
+### 2. 設定変更：claims_supported を sub のみに
+
+```bash
+update_auth_server '.claims_supported = ["sub", "iss", "auth_time", "acr"]' \
+  | jq '.result.claims_supported // .'
+```
+
+### 3. 挙動確認：新しいトークンで UserInfo を取得
+
+```bash
+start_auth_flow
+password_login "claims2-$(date +%s)@example.com" "correct-password" > /dev/null
+complete_auth_flow
+
+echo "--- claims_supported 制限後: UserInfo ---"
+get_userinfo | jq .
+```
+
+### 4. 期待結果
+
+| タイミング | claims_supported | UserInfo の内容 |
+|-----------|------------------|----------------|
+| 変更前 | 全クレーム | `sub`, `email`, `name` 等 |
+| 変更後 | `["sub", "iss", "auth_time", "acr"]` | `sub` のみ（email, name は消える） |
+
+### 5. 元に戻す
+
+```bash
+restore_auth_server
+```
+
+---
+
+## Experiment 6: トークン有効期限を短くして期限切れを体験する
+
+> **やりたいこと**: アクセストークンの有効期限を短くしたい → 期限切れ後にどうなるか見たい
+>
+> **変わる設定**: `authorization_server.extension.access_token_duration`
+
+### 1. 設定変更：AT を 10秒に
+
+```bash
+update_auth_server '.extension.access_token_duration = 10' \
+  | jq '.result.extension.access_token_duration // .'
+```
+
+### 2. 挙動確認
+
+```bash
+start_auth_flow
+password_login "token-$(date +%s)@example.com" "correct-password" > /dev/null
+complete_auth_flow
+
+echo "--- 即座に UserInfo（成功するはず） ---"
+get_userinfo | jq .
+
+echo ""
+echo "--- 15秒待機... ---"
+sleep 15
+
+echo "--- 期限切れ後に UserInfo（401 になるはず） ---"
+curl -s -w "\nHTTP %{http_code}" -H "Authorization: Bearer ${ACCESS_TOKEN}" \
+  "${TENANT_BASE}/v1/userinfo"
+
+echo ""
+echo "--- リフレッシュトークンで再取得 ---"
+REFRESH_RESPONSE=$(curl -s -X POST "${TENANT_BASE}/v1/tokens" \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  --data-urlencode "grant_type=refresh_token" \
+  --data-urlencode "refresh_token=${REFRESH_TOKEN}" \
+  --data-urlencode "client_id=${CLIENT_ID}" \
+  --data-urlencode "client_secret=${CLIENT_SECRET}")
+
+NEW_ACCESS_TOKEN=$(echo "${REFRESH_RESPONSE}" | jq -r '.access_token')
+NEW_EXPIRES_IN=$(echo "${REFRESH_RESPONSE}" | jq -r '.expires_in')
+echo "New AT expires_in: ${NEW_EXPIRES_IN}s"
+
+echo "--- 新しい AT で UserInfo（成功するはず） ---"
+get_userinfo "${NEW_ACCESS_TOKEN}" | jq .
+```
+
+### 3. 期待結果
+
+| タイミング | 結果 | 理由 |
+|-----------|------|------|
+| 即座に UserInfo | 200 OK | AT 有効期間内 |
+| 15秒後に UserInfo | 401 Unauthorized | AT 期限切れ（10秒） |
+| RT で再取得 → UserInfo | 200 OK | 新しい AT が有効 |
+| 新 AT の `expires_in` | `10` | 設定した有効期限が反映されている |
+
+### 4. 元に戻す
+
+```bash
+restore_auth_server
+```
+
+---
+
+## Experiment 7: セッション有効期限を変えて再認証を体験する
+
+> **やりたいこと**: セッション有効期限を短くしたい → 期限切れ後にどうなるか見たい
+>
+> **変わる設定**: `session_config.timeout_seconds`
+>
+> **重要**: セッションの `expiresAt` はセッション作成時に確定します。
+> そのため、**設定変更前に作られたセッションは影響を受けません**。
+> この実験では **設定変更後に新しいセッションを作って** 挙動を確認します。
+
+### 1. 設定変更：セッションを 15秒に
+
+```bash
+update_tenant '.session_config.timeout_seconds = 15' \
+  | jq '.result.session_config // .'
+```
+
+### 2. 挙動確認：設定変更後に新しいセッションを作成
+
+```bash
+# 設定変更後に新しいユーザー＋新しいセッションを作成
+start_auth_flow
+password_login "session-$(date +%s)@example.com" "correct-password" > /dev/null
+complete_auth_flow > /dev/null
+
+# この時点のセッションは timeout=15秒 で作成されている
+try_prompt_none "即座（セッション有効）"
+
+echo ""; echo "20秒待機..."; sleep 20
+try_prompt_none "20秒後（セッション切れ）"
+```
+
+### 3. 期待結果
+
+```
+--- 即座（セッション有効） ---
+  Result: session valid (code issued)
+
+--- 20秒後（セッション切れ） ---
+  Result: login_required
+  # または
+  Result: redirect to login (session expired)
+```
+
+### 4. 元に戻す
+
+```bash
+restore_tenant
+```
+
+---
+
+## Experiment 8: プロバイダーIDを変更して複数外部サービスの識別を確認する
+
+> **やりたいこと**: 外部サービスの provider_id を変えると、ユーザーがどう識別されるか確認したい
+>
+> **変わる設定**: `authentication-configurations` の `user_mapping_rules` (static_value: provider_id)
+>
+> **外部パスワード認証固有**: provider_id によって外部サービスの区別ができる。
+
+### 1. provider_id = "external-auth" でログイン（デフォルト）
+
+```bash
+PROVIDER_EMAIL="provider-$(date +%s)@example.com"
+start_auth_flow
+password_login "${PROVIDER_EMAIL}" "correct-password" > /dev/null
+complete_auth_flow > /dev/null
+
+echo "--- provider_id=external-auth（デフォルト）---"
+get_userinfo | jq .
+```
+
+### 2. 設定変更：provider_id を変更
+
+```bash
+update_auth_config '
+  .interactions["password-authentication"].user_resolve.user_mapping_rules[-1].static_value = "ldap-wrapper"
+' | jq '.interactions["password-authentication"].user_resolve.user_mapping_rules // .'
+```
+
+### 3. 挙動確認：同じメールアドレスでログイン → 別ユーザーとして扱われる
+
+```bash
+start_auth_flow
+password_login "${PROVIDER_EMAIL}" "correct-password" > /dev/null
+complete_auth_flow > /dev/null
+
+echo "--- provider_id=ldap-wrapper ---"
+get_userinfo | jq .
+```
+
+### 4. 期待結果
+
+| provider_id | 結果 | 理由 |
+|-------------|------|------|
+| `external-auth` | ユーザーA として認証 | `sub` は最初のログインで作成されたユーザー |
+| `ldap-wrapper` | 別のユーザーとして新規作成 | `provider_id` が異なるため同一ユーザーと見なされない |
+
+> `identity_unique_key_type = "EMAIL_OR_EXTERNAL_USER_ID"` のため、
+> `external_user_id` + `provider_id` の組み合わせでユーザーが識別されます。
+
+### 5. 元に戻す
+
+```bash
+restore_auth_config
+```
+
+---
+
+## Experiment 9: リクエストのボディフィールド名を変更する
+
+> **やりたいこと**: 外部サービスが期待するフィールド名が `username` / `password` でない場合に対応したい
+>
+> **変わる設定**: `authentication-configurations` の `execution.http_request.body_mapping_rules`
+>
+> **外部パスワード認証固有**: 外部サービスの API 契約に合わせてリクエストボディのフィールド名を自由に変更できる。
+
+### 1. ベースラインを確認（デフォルト: `username` / `password`）
+
+```bash
+echo "--- 現在の body_mapping_rules ---"
+cat "${CONFIG_DIR}/authentication-config-password.json" | \
+  jq '.interactions["password-authentication"].execution.http_request.body_mapping_rules'
+
+start_auth_flow
+echo "--- デフォルトのフィールド名で認証（成功するはず） ---"
+password_login "body-test@example.com" "correct-password" | jq .
+```
+
+### 2. 設定変更：`username` → `user` に変更
+
+```bash
+update_auth_config '
+  .interactions["password-authentication"].execution.http_request.body_mapping_rules = [
+    { "from": "$.request_body.username", "to": "user" },
+    { "from": "$.request_body.password", "to": "password" }
+  ]
+' | jq '.interactions["password-authentication"].execution.http_request.body_mapping_rules // .'
+```
+
+> idp-server は外部サービスに `{"user": "...", "password": "..."}` を送るようになります。
+> モックサーバーは `{"username": "...", "password": "..."}` を期待しているため、
+> `username` が `undefined` → 認証失敗になります。
+
+### 3. 挙動確認：認証を試みる → フィールド名不一致で失敗
+
+```bash
+start_auth_flow
+echo "--- フィールド名変更後に認証 → 失敗するはず ---"
+password_login "body-test@example.com" "correct-password" | jq .
+```
+
+### 4. 期待結果
+
+| `body_mapping_rules` の `to` | 外部サービスに送るJSON | 結果 | 理由 |
+|------|------|------|------|
+| `"username"` (デフォルト) | `{"username": "...", "password": "..."}` | 成功 | モックが期待するフィールド名と一致 |
+| `"user"` (変更後) | `{"user": "...", "password": "..."}` | 失敗 | モックは `username` を期待しているが `user` が来た |
+
+> **ポイント**: 外部サービスの API 仕様に合わせて `body_mapping_rules` の `to` を正確に設定する必要がある。
+> フィールド名の不一致は認証失敗の原因になるため、外部サービスの API ドキュメントを必ず確認すること。
+
+### 5. 元に戻す
+
+```bash
+restore_auth_config
+```
+
+---
+
+## Experiment 10: カスタムヘッダーを外部サービスに送信する
+
+> **やりたいこと**: 外部サービスが API キーや認証トークンをヘッダーで要求する場合に対応したい
+>
+> **変わる設定**: `authentication-configurations` の `execution.http_request.header_mapping_rules`
+>
+> **外部パスワード認証固有**: 外部サービスへのリクエストにカスタムヘッダーを追加できる。API キー認証やトレーサビリティ用のヘッダーを設定する場面で使う。
+
+### 1. ベースラインを確認
+
+```bash
+echo "--- 現在の header_mapping_rules ---"
+cat "${CONFIG_DIR}/authentication-config-password.json" | \
+  jq '.interactions["password-authentication"].execution.http_request.header_mapping_rules'
+```
+
+> デフォルトは `Content-Type: application/json` のみ。
+
+### 2. 設定変更：API キーヘッダーを追加
+
+```bash
+update_auth_config '
+  .interactions["password-authentication"].execution.http_request.header_mapping_rules = [
+    { "static_value": "application/json", "to": "Content-Type" },
+    { "static_value": "my-secret-api-key-123", "to": "X-Api-Key" },
+    { "static_value": "idp-server", "to": "X-Request-Source" }
+  ]
+' | jq '.interactions["password-authentication"].execution.http_request.header_mapping_rules // .'
+```
+
+### 3. 挙動確認：認証を試みる
+
+```bash
+start_auth_flow
+echo "--- カスタムヘッダー追加後に認証（モックはヘッダーを検証しないので成功するはず） ---"
+password_login "header-test@example.com" "correct-password" | jq .
+```
+
+### 4. 設定変更：Content-Type を削除してみる
+
+```bash
+update_auth_config '
+  .interactions["password-authentication"].execution.http_request.header_mapping_rules = [
+    { "static_value": "my-secret-api-key-123", "to": "X-Api-Key" }
+  ]
+' | jq '.interactions["password-authentication"].execution.http_request.header_mapping_rules // .'
+
+start_auth_flow
+echo "--- Content-Type なしで認証 → モックはJSONパース可能なので成功する場合もある ---"
+password_login "header-test2@example.com" "correct-password" | jq .
+```
+
+### 5. 期待結果
+
+| header_mapping_rules | 結果 | 理由 |
+|-----|------|------|
+| `Content-Type` + `X-Api-Key` + `X-Request-Source` | 成功 | モックはヘッダーを検証しない |
+| `X-Api-Key` のみ（`Content-Type` なし） | 成功 / 失敗 | 外部サービスの実装による |
+
+> **ポイント**: 実際の外部サービスでは `Content-Type` が必須の場合が多い。
+> また `Authorization: Bearer <token>` や `X-Api-Key` でリクエストを認証するケースでは、
+> `static_value` に秘密鍵やトークンを直接設定する。
+>
+> **`from` でリクエストヘッダーを転送**: `{ "from": "$.request_headers.X-Forwarded-For", "to": "X-Forwarded-For" }` のように、
+> 元のリクエストのヘッダーを外部サービスに転送することも可能。
+
+### 6. 元に戻す
+
+```bash
+restore_auth_config
+```
+
+---
+
+## Experiment 11: レスポンスの条件付きマッピングを確認する
+
+> **やりたいこと**: 外部サービスのレスポンスから、条件に応じてフィールドを返却したい / 条件の効果を確認したい
+>
+> **変わる設定**: `authentication-configurations` の `response.body_mapping_rules` の `condition`
+>
+> **外部パスワード認証固有**: `condition` を使うと、外部サービスのレスポンスに特定のフィールドが存在する場合のみマッピングできる。成功時は `user_id` / `email`、失敗時は `error` / `error_description` を返すパターン。
+
+### 1. ベースラインを確認（条件付きマッピング有効）
+
+```bash
+echo "--- 現在の response.body_mapping_rules ---"
+cat "${CONFIG_DIR}/authentication-config-password.json" | \
+  jq '.interactions["password-authentication"].response.body_mapping_rules'
+
+echo ""
+echo "--- 認証成功時のレスポンス（user_id, email あり / error なし） ---"
+start_auth_flow
+password_login "condition-$(date +%s)@example.com" "correct-password" | jq .
+
+echo ""
+echo "--- 認証失敗時のレスポンス（error, error_description あり / user_id なし） ---"
+start_auth_flow
+password_login "condition-fail@example.com" "invalid" | jq .
+```
+
+### 2. 設定変更：condition を全て削除
+
+```bash
+update_auth_config '
+  .interactions["password-authentication"].response.body_mapping_rules = [
+    { "from": "$.execution_http_request.response_body.user_id", "to": "user_id" },
+    { "from": "$.execution_http_request.response_body.email", "to": "email" },
+    { "from": "$.execution_http_request.response_body.error", "to": "error" },
+    { "from": "$.execution_http_request.response_body.error_description", "to": "error_description" }
+  ]
+' | jq '.interactions["password-authentication"].response.body_mapping_rules // .'
+```
+
+### 3. 挙動確認：成功/失敗時のレスポンスを比較
+
+```bash
+echo "--- condition 削除後: 認証成功時のレスポンス ---"
+start_auth_flow
+password_login "nocond-$(date +%s)@example.com" "correct-password" | jq .
+
+echo ""
+echo "--- condition 削除後: 認証失敗時のレスポンス ---"
+start_auth_flow
+password_login "nocond-fail@example.com" "invalid" | jq .
+```
+
+### 4. 期待結果
+
+| condition | 認証成功時のレスポンス | 認証失敗時のレスポンス |
+|-----------|---------------------|---------------------|
+| あり（デフォルト） | `user_id`, `email` のみ（error は condition 不成立で省略） | `error`, `error_description` のみ（user_id は condition 不成立で省略） |
+| なし（削除後） | `user_id`, `email`, `error`(null), `error_description`(null) 全て含まれる | `error`, `error_description`, `user_id`(null), `email`(null) 全て含まれる |
+
+> **ポイント**: `condition` を使うことで、成功/失敗のレスポンスを綺麗に分離できる。
+> `condition` なしだと、存在しないフィールドも null として含まれるため、
+> クライアント側で null チェックが必要になる。
+
+### 5. 元に戻す
+
+```bash
+restore_auth_config
+```
+
+---
+
+## Experiment 12: ユーザー識別方式を変更する（identity_unique_key_type）
+
+> **やりたいこと**: ユーザーの一意識別キーを `EMAIL_OR_EXTERNAL_USER_ID` から `EMAIL` に変えたらどうなるか確認したい
+>
+> **変わる設定**: テナント `identity_policy_config.identity_unique_key_type`
+>
+> **外部パスワード認証固有**: `EMAIL_OR_EXTERNAL_USER_ID` は `external_user_id` + `provider_id` でユーザーを識別する（外部サービス前提の設定）。`EMAIL` に変えるとメールアドレスのみで識別する。
+
+### 1. ベースラインを確認（EMAIL_OR_EXTERNAL_USER_ID）
+
+```bash
+echo "--- 現在の identity_unique_key_type ---"
+echo "${TENANT_JSON}" | jq '.identity_policy_config.identity_unique_key_type'
+```
+
+### 2. provider_id が異なると別ユーザーになることを確認
+
+```bash
+ID_EMAIL="idtype-$(date +%s)@example.com"
+
+echo "--- provider_id=external-auth でログイン ---"
+start_auth_flow
+password_login "${ID_EMAIL}" "correct-password" > /dev/null
+complete_auth_flow > /dev/null
+FIRST_SUB=$(get_userinfo | jq -r '.sub')
+echo "sub: ${FIRST_SUB}"
+
+echo ""
+echo "--- provider_id を ldap-wrapper に変更 ---"
+update_auth_config '
+  .interactions["password-authentication"].user_resolve.user_mapping_rules[-1].static_value = "ldap-wrapper"
+' > /dev/null
+
+echo "--- 同じメールで再ログイン ---"
+start_auth_flow
+password_login "${ID_EMAIL}" "correct-password" > /dev/null
+complete_auth_flow > /dev/null
+SECOND_SUB=$(get_userinfo | jq -r '.sub')
+echo "sub: ${SECOND_SUB}"
+
+echo ""
+echo "--- 比較: EMAIL_OR_EXTERNAL_USER_ID モード ---"
+echo "同じメール / 異なる provider_id → sub が異なる: ${FIRST_SUB} vs ${SECOND_SUB}"
+
+restore_auth_config > /dev/null
+```
+
+### 3. 設定変更：identity_unique_key_type を EMAIL に変更
+
+```bash
+update_tenant '.identity_policy_config.identity_unique_key_type = "EMAIL"' \
+  | jq '.result.identity_policy_config.identity_unique_key_type // .'
+```
+
+### 4. 挙動確認：provider_id が異なっても同一ユーザーになる
+
+```bash
+ID_EMAIL2="idtype2-$(date +%s)@example.com"
+
+echo "--- provider_id=external-auth でログイン ---"
+start_auth_flow
+password_login "${ID_EMAIL2}" "correct-password" > /dev/null
+complete_auth_flow > /dev/null
+THIRD_SUB=$(get_userinfo | jq -r '.sub')
+echo "sub: ${THIRD_SUB}"
+
+echo ""
+echo "--- provider_id を ldap-wrapper に変更 ---"
+update_auth_config '
+  .interactions["password-authentication"].user_resolve.user_mapping_rules[-1].static_value = "ldap-wrapper"
+' > /dev/null
+
+echo "--- 同じメールで再ログイン ---"
+start_auth_flow
+password_login "${ID_EMAIL2}" "correct-password" > /dev/null
+complete_auth_flow > /dev/null
+FOURTH_SUB=$(get_userinfo | jq -r '.sub')
+echo "sub: ${FOURTH_SUB}"
+
+echo ""
+echo "--- 比較: EMAIL モード ---"
+echo "同じメール / 異なる provider_id → sub が同じ: ${THIRD_SUB} vs ${FOURTH_SUB}"
+```
+
+### 5. 期待結果
+
+| identity_unique_key_type | 同一メール + 異なる provider_id | 理由 |
+|--------------------------|-------------------------------|------|
+| `EMAIL_OR_EXTERNAL_USER_ID` (デフォルト) | **別ユーザー** (`sub` が異なる) | `external_user_id` + `provider_id` で識別するため |
+| `EMAIL` | **同一ユーザー** (`sub` が同じ) | メールアドレスのみで識別するため |
+
+> **ポイント**: 外部認証委譲では通常 `EMAIL_OR_EXTERNAL_USER_ID` を使う。
+> - **複数の外部サービスを併用する場合**: `EMAIL_OR_EXTERNAL_USER_ID` が必須（provider_id で区別）
+> - **外部サービスが1つだけの場合**: `EMAIL` でも運用可能（シンプル）
+> - **移行時の注意**: 途中で変更すると既存ユーザーの識別に影響が出る可能性がある
+
+### 6. 元に戻す
+
+```bash
+restore_auth_config > /dev/null
+restore_tenant
+```
+
+---
+
+## 実験一覧
+
+| # | やりたいこと | 変わる設定 | 確認できること |
+|---|------------|-----------|--------------|
+| 1 | 外部認証の基本動作 | （設定変更なし） | 認証成功/失敗の基本フロー |
+| 2 | アカウントロックしたい | `failure_conditions` / `lock_conditions` | N回失敗でロックされる |
+| 3 | 外部サービスURLを変えたい | `http_request.url` | 接続先切り替え、接続エラー |
+| 4 | マッピングを変えたい | `user_mapping_rules` | UserInfo に異なる値が入る |
+| 5 | UserInfo の返却値を制御したい | `claims_supported` | クレームが消える/増える |
+| 6 | AT 有効期限を短くしたい | `access_token_duration` | 期限切れで 401 → RT で復活 |
+| 7 | セッションを短くしたい | `session_config.timeout_seconds` | 期限切れで再認証を要求 |
+| 8 | プロバイダーIDを変えたい | `user_mapping_rules` (provider_id) | 同一メールでも別ユーザーになる |
+| 9 | リクエストのフィールド名を変えたい | `body_mapping_rules` | 外部APIの契約に合わせた送信 |
+| 10 | カスタムヘッダーを送りたい | `header_mapping_rules` | API キー、トレーサビリティヘッダー |
+| 11 | レスポンスの条件マッピングを確認 | `response.body_mapping_rules.condition` | 成功/失敗の返却値を分離 |
+| 12 | ユーザー識別方式を変えたい | `identity_unique_key_type` | EMAIL vs EXTERNAL_USER_ID の違い |

--- a/config/templates/use-cases/external-password-auth/README.md
+++ b/config/templates/use-cases/external-password-auth/README.md
@@ -91,7 +91,7 @@ Content-Type: application/json
 
 ```bash
 node mock-server.js
-# → Mock auth server running on http://localhost:4000
+# → Mock auth server running on http://localhost:4001
 ```
 
 `mock-server.js` は Node.js 標準ライブラリのみで動作し、依存パッケージのインストールは不要です。
@@ -138,7 +138,7 @@ REFRESH_TOKEN_DURATION=604800 \
 
 | 環境変数 | デフォルト | 説明 |
 |---------|-----------|------|
-| `EXTERNAL_AUTH_URL` | `http://host.docker.internal:4000/auth/password` | 外部認証サービスのURL |
+| `EXTERNAL_AUTH_URL` | `http://host.docker.internal:4001/auth/password` | 外部認証サービスのURL |
 | `EXTERNAL_PROVIDER_ID` | `external-auth` | 外部プロバイダー識別子 |
 
 #### セッション設定

--- a/config/templates/use-cases/external-password-auth/VERIFY.md
+++ b/config/templates/use-cases/external-password-auth/VERIFY.md
@@ -77,7 +77,7 @@ curl -s -X POST "${EXTERNAL_AUTH_URL_LOCAL}" \
 
 ```bash
 node mock-server.js
-# → Mock auth server running on http://localhost:4000
+# → Mock auth server running on http://localhost:4001
 ```
 
 ---

--- a/config/templates/use-cases/external-password-auth/helpers.sh
+++ b/config/templates/use-cases/external-password-auth/helpers.sh
@@ -373,10 +373,17 @@ password_login() {
   local username="$1"
   local password="$2"
 
-  curl -s -b "${COOKIE_JAR}" -c "${COOKIE_JAR}" \
+  local response http_code body
+  response=$(curl -s -w "\n%{http_code}" -b "${COOKIE_JAR}" -c "${COOKIE_JAR}" \
     -X POST "${TENANT_BASE}/v1/authorizations/${AUTHORIZATION_ID}/password-authentication" \
     -H "Content-Type: application/json" \
-    -d "{\"username\": \"${username}\", \"password\": \"${password}\"}"
+    -d "{\"username\": \"${username}\", \"password\": \"${password}\"}")
+
+  http_code=$(echo "${response}" | tail -1)
+  body=$(echo "${response}" | sed '$d')
+
+  echo "← ${http_code} POST /password-authentication" >&2
+  echo "${body}"
 }
 
 # 認可 → コード取得 → トークン交換

--- a/config/templates/use-cases/external-password-auth/mock-server.js
+++ b/config/templates/use-cases/external-password-auth/mock-server.js
@@ -1,64 +1,158 @@
 // External Auth Mock Server
 //
 // idp-server の外部パスワード認証をローカルで検証するためのモックサーバー。
-// POST /auth/password に対して、外部認証サービスと同じ API 契約で応答する。
 //
 // 起動:
 //   node mock-server.js
 //
-// 認証ルール:
-//   - password が "invalid"     → 401 (認証失敗)
-//   - username/password が空    → 401 (認証失敗)
-//   - それ以外                  → 200 (認証成功、user_id/email/name を返す)
+// エンドポイント:
+//
+//   POST /auth/password  - パスワード認証（基本）
+//     認証ルール:
+//       - password が "invalid"     → 401 (認証失敗)
+//       - username/password が空    → 401 (認証失敗)
+//       - それ以外                  → 200 (認証成功、user_id/email/name を返す)
+//
+//   POST /user/details   - ユーザー詳細取得（http_requests チェーン用）
+//     - user_id を受け取り、詳細情報（birthdate, phone_number, zoneinfo, locale, role）を返す
+//     - user_id が空 → 400
 //
 // テスト例:
-//   curl -s -X POST http://localhost:4000/auth/password \
+//   curl -s -X POST http://localhost:4001/auth/password \
 //     -H 'Content-Type: application/json' \
 //     -d '{"username":"test@example.com","password":"correct"}'    → 200
 //
-//   curl -s -X POST http://localhost:4000/auth/password \
+//   curl -s -X POST http://localhost:4001/auth/password \
 //     -H 'Content-Type: application/json' \
 //     -d '{"username":"test@example.com","password":"invalid"}'    → 401
+//
+//   curl -s -X POST http://localhost:4001/user/details \
+//     -H 'Content-Type: application/json' \
+//     -d '{"user_id":"ext-user-test-example-com"}'                → 200
 
 const http = require("http");
 
+// --- POST /auth/password ---
+function handleAuthPassword(body, res) {
+  try {
+    const { username, password } = JSON.parse(body);
+
+    if (!username || !password) {
+      res.writeHead(401, { "Content-Type": "application/json" });
+      res.end(
+        JSON.stringify({
+          error: "invalid_credentials",
+          error_description: "Username and password are required",
+        })
+      );
+    } else if (password === "invalid") {
+      res.writeHead(401, { "Content-Type": "application/json" });
+      res.end(
+        JSON.stringify({
+          error: "invalid_credentials",
+          error_description: "Invalid username or password",
+        })
+      );
+    } else {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(
+        JSON.stringify({
+          user_id: `ext-user-${username.replace(/[^a-zA-Z0-9]/g, "-")}`,
+          email: username,
+          name: "External User",
+        })
+      );
+    }
+  } catch (e) {
+    res.writeHead(400, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ error: "invalid_request" }));
+  }
+}
+
+// --- POST /user/details ---
+function handleUserDetails(body, req, res) {
+  try {
+    const { user_id } = JSON.parse(body);
+
+    if (!user_id) {
+      res.writeHead(400, { "Content-Type": "application/json" });
+      res.end(
+        JSON.stringify({
+          error: "invalid_request",
+          error_description: "user_id is required",
+        })
+      );
+      return;
+    }
+
+    const requestId = req.headers["x-request-id"] || "none";
+    const issuedAt = req.headers["issued_at"] || "none";
+
+    res.writeHead(200, {
+      "Content-Type": "application/json",
+      "x-trace-id": requestId,
+    });
+    res.end(
+      JSON.stringify({
+        user_id: user_id,
+        birthdate: "1990-01-15",
+        phone_number: "+81-90-1234-5678",
+        zoneinfo: "Asia/Tokyo",
+        locale: "ja",
+        role: "member",
+        requested_at: issuedAt,
+      })
+    );
+  } catch (e) {
+    res.writeHead(400, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ error: "invalid_request" }));
+  }
+}
+
+// --- request/response logging ---
+function logRequest(req, body) {
+  const timestamp = new Date().toISOString();
+  console.log(`\n[${timestamp}] ${req.method} ${req.url}`);
+
+  const skip = new Set(["host", "connection", "content-length", "content-type"]);
+  for (const [key, value] of Object.entries(req.headers)) {
+    if (!skip.has(key)) {
+      console.log(`  ${key}: ${value}`);
+    }
+  }
+
+  if (body) {
+    try {
+      console.log(`  body: ${JSON.stringify(JSON.parse(body))}`);
+    } catch {
+      console.log(`  body: ${body}`);
+    }
+  }
+}
+
+function withLogging(req, res) {
+  const originalWriteHead = res.writeHead.bind(res);
+  res.writeHead = (statusCode, ...args) => {
+    console.log(`  → ${statusCode}`);
+    return originalWriteHead(statusCode, ...args);
+  };
+  return res;
+}
+
 const server = http.createServer((req, res) => {
-  if (req.method === "POST" && req.url === "/auth/password") {
+  if (req.method === "POST") {
     let body = "";
     req.on("data", (chunk) => (body += chunk));
     req.on("end", () => {
-      try {
-        const { username, password } = JSON.parse(body);
-
-        if (!username || !password) {
-          res.writeHead(401, { "Content-Type": "application/json" });
-          res.end(
-            JSON.stringify({
-              error: "invalid_credentials",
-              error_description: "Username and password are required",
-            })
-          );
-        } else if (password === "invalid") {
-          res.writeHead(401, { "Content-Type": "application/json" });
-          res.end(
-            JSON.stringify({
-              error: "invalid_credentials",
-              error_description: "Invalid username or password",
-            })
-          );
-        } else {
-          res.writeHead(200, { "Content-Type": "application/json" });
-          res.end(
-            JSON.stringify({
-              user_id: `ext-user-${username.replace(/[^a-zA-Z0-9]/g, "-")}`,
-              email: username,
-              name: "External User",
-            })
-          );
-        }
-      } catch (e) {
-        res.writeHead(400, { "Content-Type": "application/json" });
-        res.end(JSON.stringify({ error: "invalid_request" }));
+      logRequest(req, body);
+      const logged = withLogging(req, res);
+      if (req.url === "/auth/password") {
+        handleAuthPassword(body, logged);
+      } else if (req.url === "/user/details") {
+        handleUserDetails(body, req, logged);
+      } else {
+        logged.writeHead(404);
+        logged.end();
       }
     });
   } else {
@@ -67,6 +161,7 @@ const server = http.createServer((req, res) => {
   }
 });
 
-server.listen(4000, () =>
-  console.log("Mock auth server running on http://localhost:4000")
+const PORT = process.env.MOCK_PORT || 4001;
+server.listen(PORT, () =>
+  console.log(`Mock auth server running on http://localhost:${PORT}`)
 );

--- a/config/templates/use-cases/external-password-auth/setup.sh
+++ b/config/templates/use-cases/external-password-auth/setup.sh
@@ -116,7 +116,7 @@ TOKEN_SIGNING_KEY_ID="${TOKEN_SIGNING_KEY_ID:-signing_key_1}"
 ID_TOKEN_SIGNING_KEY_ID="${ID_TOKEN_SIGNING_KEY_ID:-signing_key_1}"
 
 # External authentication service settings
-EXTERNAL_AUTH_URL="${EXTERNAL_AUTH_URL:-http://host.docker.internal:4000/auth/password}"
+EXTERNAL_AUTH_URL="${EXTERNAL_AUTH_URL:-http://host.docker.internal:4001/auth/password}"
 EXTERNAL_PROVIDER_ID="${EXTERNAL_PROVIDER_ID:-external-auth}"
 
 # Customizable policy values (non-string, applied via jq overlay)

--- a/documentation/docs/content_02_quickstart/quickstart-10-external-password-auth.md
+++ b/documentation/docs/content_02_quickstart/quickstart-10-external-password-auth.md
@@ -72,6 +72,7 @@
 - **HTTP API 委譲**: 外部サービスの認証APIにユーザー名/パスワードを転送
 - **レスポンスマッピング**: 外部サービスのレスポンスから idp-server のユーザー属性に自動変換
 - **プロバイダー識別**: 外部サービスごとにプロバイダーIDを付与して識別
+- **複数API チェーン**: 認証API → ユーザー詳細APIなど、複数の外部APIを順番に呼び出し、結果を統合
 
 ### OIDCレイヤーの提供
 
@@ -115,6 +116,7 @@
 **idp-serverでの設定**:
 - 認証メソッド設定（`authentication-configurations`）で `execution.function = "http_request"` を使用
 - `body_mapping_rules` でリクエスト、`user_mapping_rules` でレスポンスをマッピング
+- 複数APIを呼ぶ場合は `execution.function = "http_requests"`（複数形）を使用し、前のレスポンスを次のリクエストで参照可能
 
 **外部APIの契約例**:
 
@@ -180,7 +182,8 @@
 
 ### idp-serverが提供すること
 - OAuth 2.0/OpenID Connect標準準拠のログイン機能
-- 外部認証サービスへのHTTP委譲（`http_request` executor）
+- 外部認証サービスへのHTTP委譲（`http_request`/`http_requests` executor）
+- 複数APIチェーン（認証 → 詳細取得など、前のレスポンスを次に引き渡し）
 - レスポンスマッピングによるユーザー情報の自動変換
 - アカウントロック機能（failure_conditions / lock_conditions）
 - セッション管理（SSO、有効期限、セッション切り替え）


### PR DESCRIPTION
## Summary
- `EXPERIMENTS-http-requests.md`: `http_requests`（複数形）の4実験ガイドを追加（基本チェーン、functions動的ヘッダー、エラーハンドリング、ワイルドカード展開）
- `mock-server.js`: リクエスト/レスポンスログ追加、ポート4001に変更（mockoon競合回避）
- `helpers.sh`: `password_login`にHTTPステータスコード表示を追加
- `skill.md`: `http_requests`パターン、`allOf`+`missing`エラーハンドリング、`functions`を追加
- ユースケースドキュメント: 複数APIチェーン機能の記載を追加
- 全ファイル: ポート番号を4000→4001に統一

## Test plan
- [x] `node mock-server.js` でポート4001で起動することを確認
- [x] EXPERIMENTS-http-requests.md の4実験が正常に動作することを確認
- [x] `password_login` でHTTPステータスコードがstderrに表示されることを確認
- [x] mockoon（ポート4000）と同時起動できることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)