### PR TITLE
feat: CIBA + 外部パスワード認証ユースケーステンプレート追加

### DIFF
--- a/config/templates/use-cases/ciba_external-password-auth/VERIFY.md
+++ b/config/templates/use-cases/ciba_external-password-auth/VERIFY.md
@@ -1,0 +1,395 @@
+# 動作確認ガイド - CIBA + 外部パスワード認証
+
+setup.sh で構築した環境が正しく動作するかを、1ステップずつ手動で確認するためのガイドです。
+
+> **自動テスト**: `source helpers.sh && get_admin_token && source verify.sh` を実行すると、Phase 1（外部パスワード認証 + デバイスマッピング）と Phase 2（CIBA フロー + binding_message 検証）の全手順を自動で検証できます。
+
+## 前提条件
+
+- `setup.sh` が正常に完了していること
+- モックサーバーが起動していること（`node mock-server.js`）
+- `curl`, `jq`, `python3` がインストール済みであること
+- `config/generated/{organization-name}/` に生成された設定ファイルが存在すること
+
+## 変数設定
+
+```bash
+cd config/templates/use-cases/ciba_external-password-auth
+source helpers.sh
+get_admin_token
+
+echo "Server:       ${AUTHORIZATION_SERVER_URL}"
+echo "Tenant ID:    ${PUBLIC_TENANT_ID}"
+echo "Client ID:    ${CLIENT_ID}"
+echo "Mock Server:  ${MOCK_LOCAL_URL}"
+```
+
+---
+
+## Phase 1: 外部パスワード認証 + デバイスマッピング
+
+### Step 1: Mock Server 接続確認
+
+モックサーバーが稼働しているか確認します。
+
+#### リクエスト
+
+```bash
+curl -s -X POST "${MOCK_LOCAL_URL}/auth/password" \
+  -H "Content-Type: application/json" \
+  -d '{"username":"test@example.com","password":"test"}' | jq .
+```
+
+#### 確認ポイント
+
+- HTTP 200 が返ること
+- `device.id` が UUID 形式であること
+- `device.notification_channel`, `device.notification_token` が含まれていること
+
+---
+
+### Step 2: Discovery Endpoint
+
+OpenID Connect の Discovery エンドポイントが正しく応答するか確認します。
+
+#### リクエスト
+
+```bash
+curl -s "${TENANT_BASE}/.well-known/openid-configuration" | jq .
+```
+
+#### 確認ポイント
+
+- HTTP 200 が返ること
+- `issuer` が `${TENANT_BASE}` と一致すること
+- `backchannel_authentication_endpoint` が含まれていること
+- `grant_types_supported` に `urn:openid:params:grant-type:ciba` が含まれていること
+- `backchannel_token_delivery_modes_supported` に `poll` が含まれていること
+
+---
+
+### Step 3: 外部パスワード認証（ユーザー作成 + デバイスマッピング）
+
+外部パスワード認証を実行し、ユーザー作成とデバイスマッピングを同時に行います。
+
+#### リクエスト
+
+```bash
+TEST_EMAIL="test-ciba-ext-$(date +%s)@example.com"
+TEST_PASSWORD="CorrectPassword123"
+
+start_auth_flow
+password_login "${TEST_EMAIL}" "${TEST_PASSWORD}"
+complete_auth_flow
+```
+
+#### 確認ポイント
+
+- Authorization ID が取得できること
+- パスワード認証が HTTP 200 を返すこと
+- 認可コードが取得できること
+- アクセストークンが取得できること
+
+---
+
+### Step 4: UserInfo で authentication_devices を確認
+
+外部パスワード認証で作成されたユーザーに `authentication_devices` がマッピングされているか確認します。
+
+#### リクエスト
+
+```bash
+USERINFO=$(get_userinfo)
+echo "${USERINFO}"
+
+USER_SUB=$(echo "${USERINFO}" | jq -r '.sub')
+DEVICE_ID=$(echo "${USERINFO}" | jq -r '.authentication_devices[0].id')
+DEVICE_COUNT=$(echo "${USERINFO}" | jq '.authentication_devices | length')
+```
+
+#### 確認ポイント
+
+- HTTP 200 が返ること
+- `authentication_devices` 配列が含まれ、1件以上のデバイスが登録されていること
+- デバイスに `id`, `app_name`, `platform`, `notification_channel`, `notification_token` が含まれていること
+- `id` が UUID 形式であること（ObjectCompositor 配列マッピングの検証）
+
+---
+
+### Step 5: 2回目のログイン（既存ユーザー解決）
+
+同一メールアドレスで再度ログインし、既存ユーザーが正しく解決されることを確認します。
+
+#### リクエスト
+
+```bash
+start_auth_flow
+password_login "${TEST_EMAIL}" "${TEST_PASSWORD}"
+complete_auth_flow
+
+USERINFO2=$(get_userinfo)
+USER_SUB2=$(echo "${USERINFO2}" | jq -r '.sub')
+echo "1st sub: ${USER_SUB}, 2nd sub: ${USER_SUB2}"
+```
+
+#### 確認ポイント
+
+- 2回目のログインでも同一の `sub` が返ること
+
+---
+
+## Phase 2: CIBA フロー（binding_message 検証）
+
+### Step 6: Backchannel Authentication Request
+
+CIBA バックチャンネル認証リクエストを送信します。`login_hint` に外部認証プロバイダー付きメールアドレスを指定し、`binding_message` を含めます。
+
+#### リクエスト
+
+```bash
+EXTERNAL_PROVIDER_ID="${EXTERNAL_PROVIDER_ID:-external-auth}"
+BINDING_MESSAGE="1234"
+
+ciba_request "email:${TEST_EMAIL},idp:${EXTERNAL_PROVIDER_ID}" "${BINDING_MESSAGE}"
+echo "Auth Request ID: ${AUTH_REQ_ID}"
+```
+
+#### 確認ポイント
+
+- HTTP 200 が返ること
+- `auth_req_id` が含まれていること
+- `expires_in` が設定値（120秒）と一致すること
+- `interval` が設定値（5秒）と一致すること
+
+---
+
+### Step 7: CIBA Token Polling（認証前）
+
+認証が完了する前にトークンエンドポイントをポーリングし、`authorization_pending` エラーが返ることを確認します。
+
+#### リクエスト
+
+```bash
+ciba_poll
+```
+
+#### 確認ポイント
+
+- `error` が `authorization_pending` であること
+- デバイス認証が完了するまでこのエラーが返り続けること
+
+---
+
+### Step 8: 認証トランザクション取得（デバイス側）
+
+デバイス側から認証トランザクション情報を取得します。`authentication_type: none` のため、デバイスシークレット JWT なしでアクセスできます。
+
+#### リクエスト
+
+```bash
+TX_RESPONSE=$(curl -s \
+  "${TENANT_BASE}/v1/authentication-devices/${DEVICE_ID}/authentications?attributes.auth_req_id=${AUTH_REQ_ID}")
+
+echo "${TX_RESPONSE}" | jq .
+
+TRANSACTION_ID=$(echo "${TX_RESPONSE}" | jq -r '.list[0].id')
+echo "Transaction ID: ${TRANSACTION_ID}"
+```
+
+#### 確認ポイント
+
+- HTTP 200 が返ること
+- 認証トランザクションが取得できること
+- `flow` が `ciba` であること
+
+> **注意**: `authentication_type: none` の場合、`context`（binding_message, scopes 等）はレスポンスに含まれません。セキュリティ上、認証されたデバイスにのみ詳細情報が返却されます。
+
+---
+
+### Step 9: Binding Message 検証（デバイス側）
+
+認証デバイスから、CIBAリクエスト時に指定した `binding_message` を検証します。消費デバイスに表示されたコードとデバイスで入力されたコードの一致確認を行います。
+
+#### リクエスト
+
+```bash
+curl -s -X POST \
+  "${TENANT_BASE}/v1/authentications/${TRANSACTION_ID}/authentication-device-binding-message" \
+  -H "Content-Type: application/json" \
+  -d "{\"binding_message\": \"${BINDING_MESSAGE}\"}" | jq .
+```
+
+#### 確認ポイント
+
+- HTTP 200 が返ること（検証成功）
+- 不一致のメッセージを送信した場合は HTTP 400 `"Binding Message is unmatched"` が返ること
+
+---
+
+### Step 10: CIBA Token（binding_message 検証後）
+
+binding_message 検証が成功した後、トークンエンドポイントでトークンを取得します。
+
+#### リクエスト
+
+```bash
+ciba_poll
+```
+
+#### 確認ポイント
+
+- HTTP 200 で `access_token` が取得できること
+- `id_token` が含まれていること
+
+---
+
+### Step 11: UserInfo Verification（CIBA トークン）
+
+CIBA トークンで UserInfo エンドポイントを呼び出し、Phase 1 で作成したユーザーと同一であることを確認します。
+
+#### リクエスト
+
+```bash
+CIBA_USERINFO=$(get_userinfo "${CIBA_ACCESS_TOKEN}")
+echo "${CIBA_USERINFO}"
+```
+
+#### 確認ポイント
+
+- HTTP 200 が返ること
+- `sub` が Phase 1 の `sub` と一致すること
+- `email` が登録時のメールアドレスと一致すること
+
+---
+
+## Phase 3: CIBA フロー（device: login_hint）
+
+Phase 2 では `email:` プレフィックスでユーザーを特定しましたが、Phase 3 では外部パスワード認証でマッピングされた `device_id` を使って CIBA フローを実行します。
+
+### Step 12: Backchannel Authentication Request（device: login_hint）
+
+`login_hint` に `device:{device_id},idp:{provider_id}` 形式を指定して CIBA リクエストを送信します。
+
+#### リクエスト
+
+```bash
+BINDING_MESSAGE_D="5678"
+
+ciba_request "device:${DEVICE_ID},idp:${EXTERNAL_PROVIDER_ID}" "${BINDING_MESSAGE_D}"
+echo "Auth Request ID: ${AUTH_REQ_ID}"
+```
+
+#### 確認ポイント
+
+- HTTP 200 が返ること
+- `auth_req_id` が含まれていること
+- 外部パスワード認証でマッピングされた `device_id` でユーザーが正しく特定されること
+
+---
+
+### Step 13: CIBA Token Polling（認証前）
+
+#### リクエスト
+
+```bash
+ciba_poll
+```
+
+#### 確認ポイント
+
+- `error` が `authorization_pending` であること
+
+---
+
+### Step 14: 認証トランザクション取得 + Binding Message 検証
+
+#### リクエスト
+
+```bash
+# 認証トランザクション取得
+TX_RESPONSE=$(curl -s \
+  "${TENANT_BASE}/v1/authentication-devices/${DEVICE_ID}/authentications?attributes.auth_req_id=${AUTH_REQ_ID}")
+
+TRANSACTION_ID=$(echo "${TX_RESPONSE}" | jq -r '.list[0].id')
+echo "Transaction ID: ${TRANSACTION_ID}"
+
+# Binding message 検証
+curl -s -X POST \
+  "${TENANT_BASE}/v1/authentications/${TRANSACTION_ID}/authentication-device-binding-message" \
+  -H "Content-Type: application/json" \
+  -d "{\"binding_message\": \"${BINDING_MESSAGE_D}\"}" | jq .
+```
+
+#### 確認ポイント
+
+- 認証トランザクションが取得できること
+- Binding message 検証が HTTP 200 を返すこと
+
+---
+
+### Step 15: CIBA Token + UserInfo（device hint 経由）
+
+#### リクエスト
+
+```bash
+ciba_poll
+
+CIBA_USERINFO=$(get_userinfo "${CIBA_ACCESS_TOKEN}")
+echo "${CIBA_USERINFO}"
+```
+
+#### 確認ポイント
+
+- HTTP 200 で `access_token` が取得できること
+- `sub` が Phase 1 で作成したユーザーの `sub` と一致すること
+- `email:` login_hint と `device:` login_hint で同一ユーザーが解決されること
+
+---
+
+## チェックリスト
+
+### 設定前提（setup.sh 実行前に確認）
+
+| # | 確認項目 | 結果 |
+|---|---------|------|
+| 1 | `custom_claims_scope_mapping: true` が `authorization_server.extension` に設定済み | |
+| 2 | `claims_supported` に `authentication_devices` が含まれている | |
+| 3 | `scopes_supported` に `claims:authentication_devices` が含まれている | |
+| 4 | `authentication_device_rule.authentication_type` が `none` に設定済み | |
+| 5 | `authentication_device_rule.issue_device_secret` が `false` に設定済み | |
+
+> `custom_claims_scope_mapping` が未設定だと `claims:*` スコープが機能せず、UserInfo/ID Token にカスタムクレーム（`authentication_devices` 等）が含まれません。
+
+### Phase 1: 外部パスワード認証 + デバイスマッピング
+
+| Step | 確認項目 | 結果 |
+|------|---------|------|
+| 1 | Mock server が稼働しデバイス情報を返す | |
+| 2 | Discovery endpoint が HTTP 200 を返す | |
+| 2 | backchannel_authentication_endpoint が含まれている | |
+| 2 | grant_types_supported に ciba が含まれている | |
+| 3 | 外部パスワード認証でトークンが取得できる | |
+| 4 | UserInfo に authentication_devices が含まれる | |
+| 4 | デバイス ID が UUID 形式で正しくマッピングされている | |
+| 4 | notification_token が含まれている | |
+| 5 | 2回目のログインで同一ユーザーが解決される（sub 一致） | |
+
+### Phase 2: CIBA フロー（email: login_hint + binding_message 検証）
+
+| Step | 確認項目 | 結果 |
+|------|---------|------|
+| 6 | CIBA リクエスト（email: login_hint）で auth_req_id が取得できる | |
+| 7 | 認証前ポーリングで authorization_pending が返る | |
+| 8 | 認証トランザクションが取得できる | |
+| 9 | Binding message 検証が成功する（HTTP 200） | |
+| 10 | CIBA token（検証後）で access_token が取得できる | |
+| 11 | UserInfo で sub が Phase 1 と一致する | |
+
+### Phase 3: CIBA フロー（device: login_hint + binding_message 検証）
+
+| Step | 確認項目 | 結果 |
+|------|---------|------|
+| 12 | CIBA リクエスト（device: login_hint）で auth_req_id が取得できる | |
+| 13 | 認証前ポーリングで authorization_pending が返る | |
+| 14 | 認証トランザクション取得 + Binding message 検証が成功する | |
+| 15 | CIBA token で access_token が取得でき、sub が Phase 1 と一致する | |

--- a/config/templates/use-cases/ciba_external-password-auth/authentication-config-password-template.json
+++ b/config/templates/use-cases/ciba_external-password-auth/authentication-config-password-template.json
@@ -1,0 +1,63 @@
+{
+  "type": "password",
+  "attributes": {},
+  "metadata": {
+    "description": "External password authentication with device mapping for CIBA"
+  },
+  "interactions": {
+    "password-authentication": {
+      "execution": {
+        "function": "http_request",
+        "http_request": {
+          "url": "${EXTERNAL_AUTH_URL}",
+          "method": "POST",
+          "header_mapping_rules": [
+            { "static_value": "application/json", "to": "Content-Type" }
+          ],
+          "body_mapping_rules": [
+            { "from": "$.request_body.username", "to": "username" },
+            { "from": "$.request_body.password", "to": "password" }
+          ]
+        }
+      },
+      "user_resolve": {
+        "user_mapping_rules": [
+          { "from": "$.execution_http_request.response_body.user_id", "to": "external_user_id" },
+          { "from": "$.execution_http_request.response_body.email", "to": "email" },
+          { "from": "$.execution_http_request.response_body.name", "to": "name" },
+          { "static_value": "${EXTERNAL_PROVIDER_ID}", "to": "provider_id" },
+          { "from": "$.execution_http_request.response_body.device.id", "to": "authentication_devices.0.id" },
+          { "from": "$.execution_http_request.response_body.device.app_name", "to": "authentication_devices.0.app_name" },
+          { "from": "$.execution_http_request.response_body.device.platform", "to": "authentication_devices.0.platform" },
+          { "from": "$.execution_http_request.response_body.device.notification_channel", "to": "authentication_devices.0.notification_channel" },
+          { "from": "$.execution_http_request.response_body.device.notification_token", "to": "authentication_devices.0.notification_token" },
+          { "from": "$.execution_http_request.response_body.device.priority", "to": "authentication_devices.0.priority" }
+        ]
+      },
+      "response": {
+        "body_mapping_rules": [
+          {
+            "from": "$.execution_http_request.response_body.user_id",
+            "to": "user_id",
+            "condition": { "operation": "exists", "path": "$.execution_http_request.response_body.user_id" }
+          },
+          {
+            "from": "$.execution_http_request.response_body.email",
+            "to": "email",
+            "condition": { "operation": "exists", "path": "$.execution_http_request.response_body.email" }
+          },
+          {
+            "from": "$.execution_http_request.response_body.error",
+            "to": "error",
+            "condition": { "operation": "exists", "path": "$.execution_http_request.response_body.error" }
+          },
+          {
+            "from": "$.execution_http_request.response_body.error_description",
+            "to": "error_description",
+            "condition": { "operation": "exists", "path": "$.execution_http_request.response_body.error_description" }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/config/templates/use-cases/ciba_external-password-auth/authentication-policy-ciba.json
+++ b/config/templates/use-cases/ciba_external-password-auth/authentication-policy-ciba.json
@@ -1,0 +1,24 @@
+{
+  "flow": "ciba",
+  "enabled": true,
+  "policies": [
+    {
+      "description": "ciba_binding_message_verification",
+      "priority": 1,
+      "conditions": {},
+      "available_methods": [],
+      "success_conditions": {
+        "any_of": [
+          [
+            {
+              "path": "$.authentication-device-binding-message.success_count",
+              "type": "integer",
+              "operation": "gte",
+              "value": 1
+            }
+          ]
+        ]
+      }
+    }
+  ]
+}

--- a/config/templates/use-cases/ciba_external-password-auth/authentication-policy-oauth.json
+++ b/config/templates/use-cases/ciba_external-password-auth/authentication-policy-oauth.json
@@ -1,0 +1,48 @@
+{
+  "flow": "oauth",
+  "enabled": true,
+  "policies": [
+    {
+      "description": "external_password_only",
+      "priority": 1,
+      "conditions": {},
+      "available_methods": ["password"],
+      "success_conditions": {
+        "any_of": [
+          [
+            {
+              "path": "$.password-authentication.success_count",
+              "type": "integer",
+              "operation": "gte",
+              "value": 1
+            }
+          ]
+        ]
+      },
+      "failure_conditions": {
+        "any_of": [
+          [
+            {
+              "path": "$.password-authentication.failure_count",
+              "type": "integer",
+              "operation": "gte",
+              "value": 5
+            }
+          ]
+        ]
+      },
+      "lock_conditions": {
+        "any_of": [
+          [
+            {
+              "path": "$.password-authentication.failure_count",
+              "type": "integer",
+              "operation": "gte",
+              "value": 5
+            }
+          ]
+        ]
+      }
+    }
+  ]
+}

--- a/config/templates/use-cases/ciba_external-password-auth/delete.sh
+++ b/config/templates/use-cases/ciba_external-password-auth/delete.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+set -e
+
+# CIBA + External Password Auth - Cleanup Script
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
+ENV_FILE="${PROJECT_ROOT}/.env"
+
+echo "=========================================="
+echo "CIBA + External Password Auth Cleanup"
+echo "=========================================="
+echo ""
+
+# --- Load .env ---
+if [ ! -f "${ENV_FILE}" ]; then
+  echo "Error: .env file not found at ${ENV_FILE}"
+  exit 1
+fi
+
+set -a
+source "${ENV_FILE}"
+set +a
+
+ORGANIZATION_NAME="${ORGANIZATION_NAME:-ciba-ext-pw}"
+CONFIG_DIR="${PROJECT_ROOT}/config/generated/${ORGANIZATION_NAME}"
+
+if [ ! -d "${CONFIG_DIR}" ]; then
+  echo "Config directory not found: ${CONFIG_DIR}"
+  echo "Nothing to clean up."
+  exit 0
+fi
+
+# Read IDs from generated config
+ORGANIZATION_ID=$(jq -r '.organization.id' "${CONFIG_DIR}/onboarding.json" 2>/dev/null)
+
+echo "Organization: ${ORGANIZATION_ID}"
+echo ""
+
+# --- Get system admin token ---
+echo "Getting system administrator access token..."
+
+TOKEN_RESPONSE=$(curl -s -X POST \
+  "${AUTHORIZATION_SERVER_URL}/${ADMIN_TENANT_ID}/v1/tokens" \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  --data-urlencode "grant_type=password" \
+  --data-urlencode "username=${ADMIN_USER_EMAIL}" \
+  --data-urlencode "password=${ADMIN_USER_PASSWORD}" \
+  --data-urlencode "client_id=${ADMIN_CLIENT_ID}" \
+  --data-urlencode "client_secret=${ADMIN_CLIENT_SECRET}" \
+  --data-urlencode "scope=account management")
+
+ACCESS_TOKEN=$(echo "${TOKEN_RESPONSE}" | jq -r '.access_token')
+
+if [ -z "${ACCESS_TOKEN}" ] || [ "${ACCESS_TOKEN}" = "null" ]; then
+  echo "Failed to get access token. Cleaning up local files only."
+  rm -rf "${CONFIG_DIR}"
+  echo "Removed: ${CONFIG_DIR}"
+  exit 0
+fi
+
+# --- Delete organization ---
+echo "Deleting organization ${ORGANIZATION_ID}..."
+
+DELETE_RESPONSE=$(curl -s -w "\n%{http_code}" -X DELETE \
+  "${AUTHORIZATION_SERVER_URL}/v1/management/organizations/${ORGANIZATION_ID}" \
+  -H "Authorization: Bearer ${ACCESS_TOKEN}")
+
+HTTP_CODE=$(echo "${DELETE_RESPONSE}" | tail -n1)
+
+if [ "${HTTP_CODE}" = "204" ] || [ "${HTTP_CODE}" = "200" ]; then
+  echo "  Organization deleted"
+else
+  echo "  Delete returned HTTP ${HTTP_CODE} (may already be deleted)"
+fi
+
+# --- Clean up local files ---
+echo ""
+echo "Cleaning up generated files..."
+rm -rf "${CONFIG_DIR}"
+echo "  Removed: ${CONFIG_DIR}"
+
+echo ""
+echo "Cleanup complete."

--- a/config/templates/use-cases/ciba_external-password-auth/helpers.sh
+++ b/config/templates/use-cases/ciba_external-password-auth/helpers.sh
@@ -1,0 +1,221 @@
+#!/bin/bash
+# CIBA + External Password Auth - Helper Functions
+#
+# Usage:
+#   cd config/templates/use-cases/ciba_external-password-auth
+#   source helpers.sh
+#   get_admin_token
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
+
+# Load .env
+if [ -f "${PROJECT_ROOT}/.env" ]; then
+  set -a
+  source "${PROJECT_ROOT}/.env"
+  set +a
+fi
+
+ORGANIZATION_NAME="${ORGANIZATION_NAME:-ciba-ext-pw}"
+
+# Load generated config
+CONFIG_DIR="${PROJECT_ROOT}/config/generated/${ORGANIZATION_NAME}"
+if [ -d "${CONFIG_DIR}" ]; then
+  ORGANIZATION_ID=$(jq -r '.organization.id' "${CONFIG_DIR}/onboarding.json" 2>/dev/null)
+  ORGANIZER_TENANT_ID=$(jq -r '.tenant.id' "${CONFIG_DIR}/onboarding.json" 2>/dev/null)
+  PUBLIC_TENANT_ID=$(jq -r '.tenant.id' "${CONFIG_DIR}/public-tenant.json" 2>/dev/null)
+  NEW_ADMIN_EMAIL=$(jq -r '.user.email' "${CONFIG_DIR}/onboarding.json" 2>/dev/null)
+  NEW_ADMIN_PASSWORD=$(jq -r '.user.raw_password' "${CONFIG_DIR}/onboarding.json" 2>/dev/null)
+  NEW_ADMIN_CLIENT_ID=$(jq -r '.client.client_id' "${CONFIG_DIR}/onboarding.json" 2>/dev/null)
+  NEW_ADMIN_CLIENT_SECRET=$(jq -r '.client.client_secret' "${CONFIG_DIR}/onboarding.json" 2>/dev/null)
+  CLIENT_ID=$(jq -r '.client_id' "${CONFIG_DIR}/public-client.json" 2>/dev/null)
+  CLIENT_SECRET=$(jq -r '.client_secret' "${CONFIG_DIR}/public-client.json" 2>/dev/null)
+  REDIRECT_URI=$(jq -r '.redirect_uris[0]' "${CONFIG_DIR}/public-client.json" 2>/dev/null)
+
+  ORG_BASE_URL="${AUTHORIZATION_SERVER_URL}/v1/management/organizations/${ORGANIZATION_ID}/tenants"
+  TENANT_BASE="${AUTHORIZATION_SERVER_URL}/${PUBLIC_TENANT_ID}"
+
+  echo "Loaded config for: ${ORGANIZATION_NAME}"
+  echo "  Public Tenant: ${PUBLIC_TENANT_ID}"
+  echo "  Client ID: ${CLIENT_ID}"
+else
+  echo "Warning: Config directory not found: ${CONFIG_DIR}"
+  echo "Run setup.sh first."
+fi
+
+MOCK_LOCAL_URL="${MOCK_LOCAL_URL:-http://localhost:4002}"
+
+# --- Admin token ---
+get_admin_token() {
+  ORG_ACCESS_TOKEN=$(curl -s -X POST \
+    "${AUTHORIZATION_SERVER_URL}/${ORGANIZER_TENANT_ID}/v1/tokens" \
+    -H "Content-Type: application/x-www-form-urlencoded" \
+    --data-urlencode "grant_type=password" \
+    --data-urlencode "username=${NEW_ADMIN_EMAIL}" \
+    --data-urlencode "password=${NEW_ADMIN_PASSWORD}" \
+    --data-urlencode "client_id=${NEW_ADMIN_CLIENT_ID}" \
+    --data-urlencode "client_secret=${NEW_ADMIN_CLIENT_SECRET}" \
+    --data-urlencode "scope=openid profile email management" | jq -r '.access_token')
+
+  if [ -z "${ORG_ACCESS_TOKEN}" ] || [ "${ORG_ACCESS_TOKEN}" = "null" ]; then
+    echo "Failed to get admin token"
+    return 1
+  fi
+  echo "Admin token obtained: ${ORG_ACCESS_TOKEN:0:20}..."
+}
+
+# --- OAuth flow helpers ---
+
+# 認可リクエスト開始（cookie jar で毎回クリーン）
+start_auth_flow() {
+  local scope="${1:-openid+profile+email+claims:authentication_devices}"
+  [ -n "${COOKIE_JAR:-}" ] && [ -f "${COOKIE_JAR}" ] && rm -f "${COOKIE_JAR}"
+  COOKIE_JAR=$(mktemp)
+  STATE="ciba-ext-state-$(date +%s)"
+
+  AUTH_REDIRECT=$(curl -s -c "${COOKIE_JAR}" -o /dev/null \
+    -w "%{redirect_url}" \
+    "${TENANT_BASE}/v1/authorizations?response_type=code&client_id=${CLIENT_ID}&redirect_uri=$(python3 -c "import urllib.parse; print(urllib.parse.quote('${REDIRECT_URI}', safe=''))")&scope=${scope}&state=${STATE}")
+
+  AUTHORIZATION_ID=$(echo "${AUTH_REDIRECT}" | sed -n 's/.*[?&]id=\([^&#]*\).*/\1/p')
+  echo "Authorization ID: ${AUTHORIZATION_ID}"
+}
+
+# パスワード認証（外部サービス経由）
+password_login() {
+  local username="$1"
+  local password="$2"
+
+  local response http_code body
+  response=$(curl -s -w "\n%{http_code}" -b "${COOKIE_JAR}" -c "${COOKIE_JAR}" \
+    -X POST "${TENANT_BASE}/v1/authorizations/${AUTHORIZATION_ID}/password-authentication" \
+    -H "Content-Type: application/json" \
+    -d "{\"username\": \"${username}\", \"password\": \"${password}\"}")
+
+  http_code=$(echo "${response}" | tail -1)
+  body=$(echo "${response}" | sed '$d')
+
+  echo "  Password auth: HTTP ${http_code}"
+  if [ "${http_code}" != "200" ] && [ "${http_code}" != "302" ]; then
+    echo "  ${body}" | jq '.' 2>/dev/null || echo "  ${body}"
+  fi
+}
+
+# 認可 → コード取得 → トークン交換
+complete_auth_flow() {
+  AUTHORIZE_RESPONSE=$(curl -s \
+    -b "${COOKIE_JAR}" -c "${COOKIE_JAR}" \
+    -X POST "${TENANT_BASE}/v1/authorizations/${AUTHORIZATION_ID}/authorize" \
+    -H "Content-Type: application/json" \
+    -d '{}')
+
+  AUTHZ_REDIRECT_URI=$(echo "${AUTHORIZE_RESPONSE}" | jq -r '.redirect_uri')
+  AUTH_CODE=$(echo "${AUTHZ_REDIRECT_URI}" | sed -n 's/.*[?&]code=\([^&#]*\).*/\1/p')
+
+  if [ -n "${AUTH_CODE}" ] && [ "${AUTH_CODE}" != "null" ] && [ "${AUTH_CODE}" != "" ]; then
+    echo "  Authorization code: ${AUTH_CODE:0:20}..."
+
+    TOKEN_RESPONSE=$(curl -s \
+      -X POST "${TENANT_BASE}/v1/tokens" \
+      -H "Content-Type: application/x-www-form-urlencoded" \
+      --data-urlencode "grant_type=authorization_code" \
+      --data-urlencode "code=${AUTH_CODE}" \
+      --data-urlencode "redirect_uri=${REDIRECT_URI}" \
+      --data-urlencode "client_id=${CLIENT_ID}" \
+      --data-urlencode "client_secret=${CLIENT_SECRET}")
+
+    USER_ACCESS_TOKEN=$(echo "${TOKEN_RESPONSE}" | jq -r '.access_token')
+    USER_ID_TOKEN=$(echo "${TOKEN_RESPONSE}" | jq -r '.id_token')
+
+    if [ -n "${USER_ACCESS_TOKEN}" ] && [ "${USER_ACCESS_TOKEN}" != "null" ]; then
+      echo "  Token obtained: ${USER_ACCESS_TOKEN:0:20}..."
+    else
+      echo "  Token exchange failed"
+      echo "  ${TOKEN_RESPONSE}" | jq '.' 2>/dev/null
+    fi
+  else
+    echo "  No authorization code returned"
+    echo "  ${AUTHORIZE_RESPONSE}" | jq '.' 2>/dev/null || echo "  ${AUTHORIZE_RESPONSE}"
+  fi
+}
+
+# --- CIBA helpers ---
+ciba_request() {
+  local LOGIN_HINT="$1"
+  local BINDING_MSG="${2:-}"
+
+  local CURL_ARGS=()
+  CURL_ARGS+=(-s -w "\n%{http_code}" -X POST)
+  CURL_ARGS+=("${TENANT_BASE}/v1/backchannel/authentications")
+  CURL_ARGS+=(-H "Content-Type: application/x-www-form-urlencoded")
+  CURL_ARGS+=(--data-urlencode "scope=openid profile email")
+  CURL_ARGS+=(--data-urlencode "login_hint=${LOGIN_HINT}")
+  if [ -n "${BINDING_MSG}" ]; then
+    CURL_ARGS+=(--data-urlencode "binding_message=${BINDING_MSG}")
+  fi
+  CURL_ARGS+=(--data-urlencode "client_id=${CLIENT_ID}")
+  CURL_ARGS+=(--data-urlencode "client_secret=${CLIENT_SECRET}")
+
+  local RESPONSE
+  RESPONSE=$(curl "${CURL_ARGS[@]}")
+
+  local HTTP_CODE
+  HTTP_CODE=$(echo "${RESPONSE}" | tail -n1)
+  local BODY
+  BODY=$(echo "${RESPONSE}" | sed '$d')
+
+  AUTH_REQ_ID=$(echo "${BODY}" | jq -r '.auth_req_id // empty')
+  CIBA_EXPIRES_IN=$(echo "${BODY}" | jq -r '.expires_in // empty')
+  CIBA_INTERVAL=$(echo "${BODY}" | jq -r '.interval // empty')
+
+  echo "  CIBA request: HTTP ${HTTP_CODE}"
+  if [ -n "${AUTH_REQ_ID}" ] && [ "${AUTH_REQ_ID}" != "null" ]; then
+    echo "  auth_req_id: ${AUTH_REQ_ID}"
+    echo "  expires_in: ${CIBA_EXPIRES_IN}, interval: ${CIBA_INTERVAL}"
+  else
+    echo "  ${BODY}" | jq '.' 2>/dev/null || echo "  ${BODY}"
+  fi
+}
+
+ciba_poll() {
+  local RESPONSE
+  RESPONSE=$(curl -s -w "\n%{http_code}" -X POST \
+    "${TENANT_BASE}/v1/tokens" \
+    -H "Content-Type: application/x-www-form-urlencoded" \
+    --data-urlencode "grant_type=urn:openid:params:grant-type:ciba" \
+    --data-urlencode "auth_req_id=${AUTH_REQ_ID}" \
+    --data-urlencode "client_id=${CLIENT_ID}" \
+    --data-urlencode "client_secret=${CLIENT_SECRET}")
+
+  local HTTP_CODE
+  HTTP_CODE=$(echo "${RESPONSE}" | tail -n1)
+  local BODY
+  BODY=$(echo "${RESPONSE}" | sed '$d')
+
+  CIBA_ACCESS_TOKEN=$(echo "${BODY}" | jq -r '.access_token // empty')
+  CIBA_ERROR=$(echo "${BODY}" | jq -r '.error // empty')
+
+  echo "  CIBA poll: HTTP ${HTTP_CODE}"
+  if [ -n "${CIBA_ACCESS_TOKEN}" ] && [ "${CIBA_ACCESS_TOKEN}" != "null" ] && [ "${CIBA_ACCESS_TOKEN}" != "" ]; then
+    echo "  Access token: ${CIBA_ACCESS_TOKEN:0:20}..."
+  elif [ -n "${CIBA_ERROR}" ]; then
+    echo "  Status: ${CIBA_ERROR}"
+  fi
+}
+
+# --- UserInfo ---
+get_userinfo() {
+  local TOKEN="${1:-${USER_ACCESS_TOKEN}}"
+  curl -s "${TENANT_BASE}/v1/userinfo" \
+    -H "Authorization: Bearer ${TOKEN}" | jq '.'
+}
+
+# --- JWT decode ---
+decode_jwt_payload() {
+  local token="$1"
+  local payload
+  payload=$(echo "${token}" | cut -d. -f2 | tr '_-' '/+')
+  local mod=$((${#payload} % 4))
+  if [ $mod -eq 2 ]; then payload="${payload}=="; elif [ $mod -eq 3 ]; then payload="${payload}="; fi
+  echo "${payload}" | base64 -d 2>/dev/null
+}

--- a/config/templates/use-cases/ciba_external-password-auth/jwks.json
+++ b/config/templates/use-cases/ciba_external-password-auth/jwks.json
@@ -1,0 +1,14 @@
+{
+  "keys": [
+    {
+      "kty": "EC",
+      "x": "_g1pn_N84_T82eU-YVN4pcgQt3tfvZWJMPabMFNgbVg",
+      "y": "B3vLi4eGNz9rzoj493h7zHBpM5G3lSM7Af57fru2-FE",
+      "crv": "P-256",
+      "d": "xHfNjJqElnZajzexFG49MQqO01TrveM4mL4tlz8T9jw",
+      "use": "sig",
+      "kid": "signing_key_1",
+      "alg": "ES256"
+    }
+  ]
+}

--- a/config/templates/use-cases/ciba_external-password-auth/mock-server.js
+++ b/config/templates/use-cases/ciba_external-password-auth/mock-server.js
@@ -1,0 +1,214 @@
+// CIBA + External Password Auth Mock Server
+//
+// 外部パスワード認証 + CIBA デバイス通知をローカルで検証するためのモックサーバー。
+//
+// 起動:
+//   node mock-server.js
+//
+// エンドポイント:
+//
+//   POST /auth/password  - パスワード認証（デバイス情報付き）
+//     認証ルール:
+//       - password が "invalid"     → 401 (認証失敗)
+//       - username/password が空    → 401 (認証失敗)
+//       - それ以外                  → 200 (認証成功、user + device 情報を返す)
+//
+//   POST /ciba/notification - CIBA デバイス通知受信（no-action モード）
+//     - 通知内容をログ出力し、即座に 200 を返す
+//
+//   GET  /ciba/notifications - 受信した CIBA 通知一覧を返す
+//   DELETE /ciba/notifications - 受信した CIBA 通知をクリア
+//
+// テスト例:
+//   curl -s -X POST http://localhost:4002/auth/password \
+//     -H 'Content-Type: application/json' \
+//     -d '{"username":"test@example.com","password":"correct"}'    → 200
+
+const http = require("http");
+const crypto = require("crypto");
+
+// --- State ---
+const cibaNotifications = [];
+
+// Per-user stable device ID (deterministic UUID from username)
+function userDeviceId(username) {
+  const hash = crypto.createHash("md5").update(`device-${username}`).digest("hex");
+  return [
+    hash.slice(0, 8),
+    hash.slice(8, 12),
+    hash.slice(12, 16),
+    hash.slice(16, 20),
+    hash.slice(20, 32),
+  ].join("-");
+}
+
+// --- POST /auth/password ---
+function handleAuthPassword(body, res) {
+  try {
+    const { username, password } = JSON.parse(body);
+
+    if (!username || !password) {
+      res.writeHead(401, { "Content-Type": "application/json" });
+      res.end(
+        JSON.stringify({
+          error: "invalid_credentials",
+          error_description: "Username and password are required",
+        })
+      );
+    } else if (password === "invalid") {
+      res.writeHead(401, { "Content-Type": "application/json" });
+      res.end(
+        JSON.stringify({
+          error: "invalid_credentials",
+          error_description: "Invalid username or password",
+        })
+      );
+    } else {
+      const userId = `ext-user-${username.replace(/[^a-zA-Z0-9]/g, "-")}`;
+      const deviceId = userDeviceId(username);
+
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(
+        JSON.stringify({
+          user_id: userId,
+          email: username,
+          name: "External User",
+          device: {
+            id: deviceId,
+            app_name: "CIBA Mock App",
+            platform: "mock",
+            notification_channel: "mock",
+            notification_token: `mock-token-${deviceId}`,
+            priority: 1,
+          },
+        })
+      );
+    }
+  } catch (e) {
+    res.writeHead(400, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ error: "invalid_request" }));
+  }
+}
+
+// --- POST /ciba/notification ---
+function handleCibaNotification(body, req, res) {
+  try {
+    const notification = JSON.parse(body);
+    const entry = {
+      received_at: new Date().toISOString(),
+      headers: {
+        "content-type": req.headers["content-type"],
+        authorization: req.headers["authorization"] || "none",
+      },
+      body: notification,
+    };
+    cibaNotifications.push(entry);
+    console.log(`  CIBA notification received: ${JSON.stringify(entry, null, 2)}`);
+
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ status: "ok" }));
+  } catch (e) {
+    res.writeHead(400, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ error: "invalid_request" }));
+  }
+}
+
+// --- GET /ciba/notifications ---
+function handleGetCibaNotifications(res) {
+  res.writeHead(200, { "Content-Type": "application/json" });
+  res.end(
+    JSON.stringify({
+      events: cibaNotifications,
+      total: cibaNotifications.length,
+    })
+  );
+}
+
+// --- DELETE /ciba/notifications ---
+function handleDeleteCibaNotifications(res) {
+  cibaNotifications.length = 0;
+  res.writeHead(204);
+  res.end();
+}
+
+// --- request/response logging ---
+function logRequest(req, body) {
+  const timestamp = new Date().toISOString();
+  console.log(`\n[${timestamp}] ${req.method} ${req.url}`);
+
+  const skip = new Set([
+    "host",
+    "connection",
+    "content-length",
+    "content-type",
+  ]);
+  for (const [key, value] of Object.entries(req.headers)) {
+    if (!skip.has(key)) {
+      console.log(`  ${key}: ${value}`);
+    }
+  }
+
+  if (body) {
+    try {
+      console.log(`  body: ${JSON.stringify(JSON.parse(body))}`);
+    } catch {
+      console.log(`  body: ${body}`);
+    }
+  }
+}
+
+function withLogging(req, res) {
+  const originalWriteHead = res.writeHead.bind(res);
+  res.writeHead = (statusCode, ...args) => {
+    console.log(`  → ${statusCode}`);
+    return originalWriteHead(statusCode, ...args);
+  };
+  return res;
+}
+
+const server = http.createServer((req, res) => {
+  if (req.method === "POST") {
+    let body = "";
+    req.on("data", (chunk) => (body += chunk));
+    req.on("end", () => {
+      logRequest(req, body);
+      const logged = withLogging(req, res);
+      if (req.url === "/auth/password") {
+        handleAuthPassword(body, logged);
+      } else if (req.url === "/ciba/notification") {
+        handleCibaNotification(body, req, logged);
+      } else {
+        logged.writeHead(404);
+        logged.end();
+      }
+    });
+  } else if (req.method === "GET") {
+    logRequest(req);
+    const logged = withLogging(req, res);
+    if (req.url === "/ciba/notifications") {
+      handleGetCibaNotifications(logged);
+    } else {
+      logged.writeHead(404);
+      logged.end();
+    }
+  } else if (req.method === "DELETE") {
+    logRequest(req);
+    const logged = withLogging(req, res);
+    if (req.url === "/ciba/notifications") {
+      handleDeleteCibaNotifications(logged);
+    } else {
+      logged.writeHead(404);
+      logged.end();
+    }
+  } else {
+    res.writeHead(404);
+    res.end();
+  }
+});
+
+const PORT = process.env.MOCK_PORT || 4007;
+server.listen(PORT, () =>
+  console.log(
+    `CIBA + External Auth mock server running on http://localhost:${PORT}`
+  )
+);

--- a/config/templates/use-cases/ciba_external-password-auth/onboarding-template.json
+++ b/config/templates/use-cases/ciba_external-password-auth/onboarding-template.json
@@ -1,0 +1,118 @@
+{
+  "organization": {
+    "id": "${ORGANIZATION_ID}",
+    "name": "${ORGANIZATION_NAME}",
+    "description": "CIBA + External Password Auth organization"
+  },
+  "tenant": {
+    "id": "${ORGANIZER_TENANT_ID}",
+    "name": "${ORGANIZATION_NAME} Organizer",
+    "type": "ORGANIZER",
+    "domain": "${BASE_URL}",
+    "authorization_provider": "idp-server",
+    "session_config": {
+      "cookie_name": "${COOKIE_NAME}_ADMIN",
+      "cookie_same_site": "Lax",
+      "use_secure_cookie": true,
+      "use_http_only_cookie": true,
+      "cookie_path": "/",
+      "timeout_seconds": 3600
+    },
+    "cors_config": {
+      "allow_origins": [
+        "${BASE_URL}"
+      ]
+    },
+    "security_event_log_config": {
+      "format": "structured_json",
+      "stage": "processed",
+      "include_user_id": true,
+      "include_user_ex_sub": true,
+      "include_client_id": true,
+      "include_ip_address": true,
+      "persistence_enabled": true,
+      "include_event_detail": true
+    }
+  },
+  "authorization_server": {
+    "issuer": "${BASE_URL}/${ORGANIZER_TENANT_ID}",
+    "authorization_endpoint": "${BASE_URL}/${ORGANIZER_TENANT_ID}/v1/authorizations",
+    "token_endpoint": "${BASE_URL}/${ORGANIZER_TENANT_ID}/v1/tokens",
+    "token_endpoint_auth_methods_supported": [
+      "client_secret_post",
+      "client_secret_basic"
+    ],
+    "token_endpoint_auth_signing_alg_values_supported": [
+      "RS256",
+      "ES256"
+    ],
+    "userinfo_endpoint": "${BASE_URL}/${ORGANIZER_TENANT_ID}/v1/userinfo",
+    "jwks_uri": "${BASE_URL}/${ORGANIZER_TENANT_ID}/v1/jwks",
+    "jwks": "${JWKS_CONTENT}",
+    "grant_types_supported": [
+      "authorization_code",
+      "refresh_token",
+      "password"
+    ],
+    "token_signed_key_id": "${TOKEN_SIGNING_KEY_ID}",
+    "id_token_signed_key_id": "${ID_TOKEN_SIGNING_KEY_ID}",
+    "scopes_supported": [
+      "openid",
+      "profile",
+      "email",
+      "management"
+    ],
+    "response_types_supported": [
+      "code"
+    ],
+    "response_modes_supported": [
+      "query"
+    ],
+    "subject_types_supported": [
+      "public"
+    ],
+    "id_token_signing_alg_values_supported": [
+      "RS256",
+      "ES256"
+    ],
+    "claims_parameter_supported": true,
+    "token_introspection_endpoint": "${BASE_URL}/${ORGANIZER_TENANT_ID}/v1/tokens/introspection",
+    "token_revocation_endpoint": "${BASE_URL}/${ORGANIZER_TENANT_ID}/v1/tokens/revocation",
+    "extension": {
+      "access_token_type": "JWT",
+      "token_signed_key_id": "${TOKEN_SIGNING_KEY_ID}",
+      "id_token_signed_key_id": "${ID_TOKEN_SIGNING_KEY_ID}",
+      "access_token_duration": 3600,
+      "id_token_duration": 3600,
+      "refresh_token_duration": 86400
+    }
+  },
+  "user": {
+    "sub": "${ADMIN_USER_SUB}",
+    "provider_id": "idp-server",
+    "name": "${ADMIN_EMAIL}",
+    "email": "${ADMIN_EMAIL}",
+    "email_verified": true,
+    "raw_password": "${ADMIN_PASSWORD}"
+  },
+  "client": {
+    "client_id": "${ADMIN_CLIENT_ID}",
+    "client_id_alias": "${ORGANIZATION_NAME}-admin-client",
+    "client_secret": "${ADMIN_CLIENT_SECRET}",
+    "redirect_uris": [
+      "${BASE_URL}/callback/"
+    ],
+    "response_types": [
+      "code"
+    ],
+    "grant_types": [
+      "authorization_code",
+      "refresh_token",
+      "password"
+    ],
+    "scope": "openid profile email management",
+    "client_name": "${ORGANIZATION_NAME} Admin Client",
+    "token_endpoint_auth_method": "client_secret_post",
+    "application_type": "web"
+  }
+}

--- a/config/templates/use-cases/ciba_external-password-auth/public-client-template.json
+++ b/config/templates/use-cases/ciba_external-password-auth/public-client-template.json
@@ -1,0 +1,26 @@
+{
+  "client_id": "${CLIENT_ID}",
+  "client_id_alias": "${CLIENT_ALIAS}",
+  "client_secret": "${CLIENT_SECRET}",
+  "redirect_uris": [
+    "${REDIRECT_URI}"
+  ],
+  "response_types": [
+    "code"
+  ],
+  "grant_types": [
+    "authorization_code",
+    "refresh_token",
+    "urn:openid:params:grant-type:ciba"
+  ],
+  "scope": "openid profile email claims:authentication_devices",
+  "client_name": "${CLIENT_NAME}",
+  "token_endpoint_auth_method": "client_secret_post",
+  "application_type": "web",
+  "backchannel_token_delivery_mode": "poll",
+  "backchannel_authentication_request_signing_alg": "ES256",
+  "backchannel_user_code_parameter": false,
+  "extension": {
+    "default_ciba_authentication_interaction_type": "authentication-device-notification-no-action"
+  }
+}

--- a/config/templates/use-cases/ciba_external-password-auth/public-tenant-template.json
+++ b/config/templates/use-cases/ciba_external-password-auth/public-tenant-template.json
@@ -1,0 +1,147 @@
+{
+  "tenant": {
+    "id": "${PUBLIC_TENANT_ID}",
+    "name": "${ORGANIZATION_NAME} Public Tenant",
+    "type": "PUBLIC",
+    "domain": "${BASE_URL}",
+    "authorization_provider": "idp-server",
+    "ui_config": {
+      "base_url": "${UI_BASE_URL}",
+      "signin_page": "/signin/",
+      "signup_page": "/signup/"
+    },
+    "session_config": {
+      "cookie_name": "${COOKIE_NAME}",
+      "cookie_same_site": "Lax",
+      "use_secure_cookie": true,
+      "use_http_only_cookie": true,
+      "cookie_path": "/",
+      "timeout_seconds": 86400
+    },
+    "cors_config": {
+      "allow_origins": [
+        "${BASE_URL}",
+        "${UI_BASE_URL}"
+      ]
+    },
+    "identity_policy_config": {
+      "identity_unique_key_type": "EMAIL_OR_EXTERNAL_USER_ID",
+      "password_policy": {
+        "min_length": 8,
+        "max_length": 72,
+        "require_uppercase": false,
+        "require_lowercase": false,
+        "require_number": false,
+        "require_special_char": false,
+        "max_history": 0,
+        "max_attempts": 5,
+        "lockout_duration_seconds": 900
+      },
+      "authentication_device_rule": {
+        "max_devices": 5,
+        "required_identity_verification": false,
+        "authentication_type": "none",
+        "issue_device_secret": false,
+        "device_secret_algorithm": "HS256",
+        "device_secret_expires_in_seconds": 31536000
+      }
+    },
+    "security_event_log_config": {
+      "format": "structured_json",
+      "stage": "processed",
+      "include_user_id": true,
+      "include_user_ex_sub": true,
+      "include_client_id": true,
+      "include_ip_address": true,
+      "persistence_enabled": true,
+      "include_event_detail": true
+    }
+  },
+  "authorization_server": {
+    "issuer": "${BASE_URL}/${PUBLIC_TENANT_ID}",
+    "authorization_endpoint": "${BASE_URL}/${PUBLIC_TENANT_ID}/v1/authorizations",
+    "token_endpoint": "${BASE_URL}/${PUBLIC_TENANT_ID}/v1/tokens",
+    "token_endpoint_auth_methods_supported": [
+      "client_secret_post",
+      "client_secret_basic"
+    ],
+    "token_endpoint_auth_signing_alg_values_supported": [
+      "RS256",
+      "ES256"
+    ],
+    "userinfo_endpoint": "${BASE_URL}/${PUBLIC_TENANT_ID}/v1/userinfo",
+    "jwks_uri": "${BASE_URL}/${PUBLIC_TENANT_ID}/v1/jwks",
+    "jwks": "${JWKS_CONTENT}",
+    "grant_types_supported": [
+      "authorization_code",
+      "refresh_token",
+      "urn:openid:params:grant-type:ciba"
+    ],
+    "token_signed_key_id": "${TOKEN_SIGNING_KEY_ID}",
+    "id_token_signed_key_id": "${ID_TOKEN_SIGNING_KEY_ID}",
+    "scopes_supported": [
+      "openid",
+      "profile",
+      "email",
+      "claims:authentication_devices"
+    ],
+    "response_types_supported": [
+      "code"
+    ],
+    "response_modes_supported": [
+      "query"
+    ],
+    "subject_types_supported": [
+      "public"
+    ],
+    "id_token_signing_alg_values_supported": [
+      "RS256",
+      "ES256"
+    ],
+    "claims_supported": [
+      "sub",
+      "iss",
+      "auth_time",
+      "acr",
+      "name",
+      "given_name",
+      "family_name",
+      "nickname",
+      "preferred_username",
+      "middle_name",
+      "profile",
+      "picture",
+      "website",
+      "email",
+      "email_verified",
+      "gender",
+      "birthdate",
+      "zoneinfo",
+      "locale",
+      "updated_at",
+      "address",
+      "phone_number",
+      "phone_number_verified",
+      "authentication_devices"
+    ],
+    "claims_parameter_supported": true,
+    "backchannel_authentication_endpoint": "${BASE_URL}/${PUBLIC_TENANT_ID}/v1/backchannel/authentications",
+    "backchannel_token_delivery_modes_supported": ["poll"],
+    "backchannel_authentication_request_signing_alg_values_supported": ["ES256"],
+    "backchannel_user_code_parameter_supported": false,
+    "token_introspection_endpoint": "${BASE_URL}/${PUBLIC_TENANT_ID}/v1/tokens/introspection",
+    "token_revocation_endpoint": "${BASE_URL}/${PUBLIC_TENANT_ID}/v1/tokens/revocation",
+    "extension": {
+      "access_token_type": "JWT",
+      "token_signed_key_id": "${TOKEN_SIGNING_KEY_ID}",
+      "id_token_signed_key_id": "${ID_TOKEN_SIGNING_KEY_ID}",
+      "access_token_duration": 3600,
+      "id_token_duration": 3600,
+      "refresh_token_duration": 86400,
+      "custom_claims_scope_mapping": true,
+      "backchannel_authentication_request_expires_in": 120,
+      "backchannel_authentication_polling_interval": 5,
+      "required_backchannel_auth_user_code": false
+    }
+  }
+}

--- a/config/templates/use-cases/ciba_external-password-auth/setup.sh
+++ b/config/templates/use-cases/ciba_external-password-auth/setup.sh
@@ -1,0 +1,429 @@
+#!/bin/bash
+set -e
+
+# CIBA + External Password Auth - Use Case Setup Script
+#
+# Combines external password authentication (user resolution with device mapping)
+# with CIBA backchannel authentication (no-action device notification mode).
+#
+# Flow:
+#   1. External password auth creates user with authentication_devices via mapping rules
+#   2. CIBA uses the mapped device for backchannel authentication notification
+#   3. No device credentials (no FIDO-UAF, no device_secret_jwt)
+#
+# Prerequisites:
+#   1. idp-server is running
+#   2. System administrator tenant exists (initial setup completed)
+#   3. .env file with admin credentials
+#   4. Mock server is running (node mock-server.js)
+#
+# Usage:
+#   ./setup.sh
+#   ./setup.sh --dry-run
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
+ENV_FILE="${PROJECT_ROOT}/.env"
+
+DRY_RUN=false
+[ "$1" = "--dry-run" ] && DRY_RUN=true
+
+echo "=========================================="
+echo "CIBA + External Password Auth Setup"
+echo "=========================================="
+echo ""
+
+# --- Load .env ---
+if [ ! -f "${ENV_FILE}" ]; then
+  echo "Error: .env file not found at ${ENV_FILE}"
+  exit 1
+fi
+
+set -a
+source "${ENV_FILE}"
+set +a
+
+: "${AUTHORIZATION_SERVER_URL:?AUTHORIZATION_SERVER_URL is required in .env}"
+: "${ADMIN_TENANT_ID:?ADMIN_TENANT_ID is required in .env}"
+: "${ADMIN_USER_EMAIL:?ADMIN_USER_EMAIL is required in .env}"
+: "${ADMIN_USER_PASSWORD:?ADMIN_USER_PASSWORD is required in .env}"
+: "${ADMIN_CLIENT_ID:?ADMIN_CLIENT_ID is required in .env}"
+: "${ADMIN_CLIENT_SECRET:?ADMIN_CLIENT_SECRET is required in .env}"
+
+echo "Server:  ${AUTHORIZATION_SERVER_URL}"
+echo "Admin:   ${ADMIN_USER_EMAIL}"
+echo ""
+
+# --- Helper: jq-based template substitution ---
+substitute_template() {
+  local template_file="$1"
+  shift
+  local result
+  result=$(cat "${template_file}")
+  while [ $# -gt 0 ]; do
+    local key="$1"
+    local value="$2"
+    shift 2
+    result=$(echo "${result}" | jq --arg k "\${${key}}" --arg v "${value}" '
+      walk(if type == "string" then split($k) | join($v) else . end)
+    ')
+  done
+  echo "${result}"
+}
+
+# --- Step 1: Get access token ---
+echo "Step 1: Getting system administrator access token..."
+
+TOKEN_RESPONSE=$(curl -s -X POST \
+  "${AUTHORIZATION_SERVER_URL}/${ADMIN_TENANT_ID}/v1/tokens" \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  --data-urlencode "grant_type=password" \
+  --data-urlencode "username=${ADMIN_USER_EMAIL}" \
+  --data-urlencode "password=${ADMIN_USER_PASSWORD}" \
+  --data-urlencode "client_id=${ADMIN_CLIENT_ID}" \
+  --data-urlencode "client_secret=${ADMIN_CLIENT_SECRET}" \
+  --data-urlencode "scope=account management")
+
+ACCESS_TOKEN=$(echo "${TOKEN_RESPONSE}" | jq -r '.access_token')
+
+if [ -z "${ACCESS_TOKEN}" ] || [ "${ACCESS_TOKEN}" = "null" ]; then
+  echo "  Failed to get access token"
+  echo "  ${TOKEN_RESPONSE}"
+  exit 1
+fi
+
+echo "  Access token obtained: ${ACCESS_TOKEN:0:20}..."
+echo ""
+
+# --- Step 2: Onboarding ---
+echo "Step 2: Executing onboarding..."
+
+ORGANIZATION_ID="${ORGANIZATION_ID:-$(uuidgen | tr '[:upper:]' '[:lower:]')}"
+ORGANIZER_TENANT_ID="${ORGANIZER_TENANT_ID:-$(uuidgen | tr '[:upper:]' '[:lower:]')}"
+NEW_ADMIN_USER_SUB="${NEW_ADMIN_USER_SUB:-$(uuidgen | tr '[:upper:]' '[:lower:]')}"
+NEW_ADMIN_CLIENT_ID="${NEW_ADMIN_CLIENT_ID:-$(uuidgen | tr '[:upper:]' '[:lower:]')}"
+NEW_ADMIN_CLIENT_SECRET="${NEW_ADMIN_CLIENT_SECRET:-$(uuidgen | tr '[:upper:]' '[:lower:]')}"
+ORGANIZATION_NAME="${ORGANIZATION_NAME:-ciba-ext-pw}"
+COOKIE_NAME="${COOKIE_NAME:-SESSION}"
+NEW_ADMIN_EMAIL="${NEW_ADMIN_EMAIL:-admin@example.com}"
+NEW_ADMIN_PASSWORD="${NEW_ADMIN_PASSWORD:-ChangeMe123}"
+TOKEN_SIGNING_KEY_ID="${TOKEN_SIGNING_KEY_ID:-signing_key_1}"
+ID_TOKEN_SIGNING_KEY_ID="${ID_TOKEN_SIGNING_KEY_ID:-signing_key_1}"
+
+# External authentication service settings
+EXTERNAL_AUTH_URL="${EXTERNAL_AUTH_URL:-http://host.docker.internal:4002/auth/password}"
+EXTERNAL_PROVIDER_ID="${EXTERNAL_PROVIDER_ID:-external-auth}"
+
+# Customizable policy values
+SESSION_TIMEOUT_SECONDS="${SESSION_TIMEOUT_SECONDS:-86400}"
+ACCESS_TOKEN_DURATION="${ACCESS_TOKEN_DURATION:-3600}"
+ID_TOKEN_DURATION="${ID_TOKEN_DURATION:-3600}"
+REFRESH_TOKEN_DURATION="${REFRESH_TOKEN_DURATION:-86400}"
+
+# CIBA configuration
+CIBA_REQUEST_EXPIRES_IN="${CIBA_REQUEST_EXPIRES_IN:-120}"
+CIBA_POLLING_INTERVAL="${CIBA_POLLING_INTERVAL:-5}"
+
+# Device configuration
+MAX_DEVICES="${MAX_DEVICES:-5}"
+
+OUTPUT_DIR="${PROJECT_ROOT}/config/generated/${ORGANIZATION_NAME}"
+mkdir -p "${OUTPUT_DIR}"
+echo "  Output directory: ${OUTPUT_DIR}"
+echo ""
+
+# Read JWKS
+JWKS_FILE="${SCRIPT_DIR}/jwks.json"
+if [ -f "${JWKS_FILE}" ]; then
+  JWKS_CONTENT=$(jq -c '.' "${JWKS_FILE}")
+else
+  echo "  Warning: jwks.json not found at ${JWKS_FILE}"
+  JWKS_CONTENT='{"keys":[]}'
+fi
+
+ONBOARDING_JSON=$(substitute_template "${SCRIPT_DIR}/onboarding-template.json" \
+  "ORGANIZATION_ID" "${ORGANIZATION_ID}" \
+  "ORGANIZATION_NAME" "${ORGANIZATION_NAME}" \
+  "ORGANIZER_TENANT_ID" "${ORGANIZER_TENANT_ID}" \
+  "BASE_URL" "${AUTHORIZATION_SERVER_URL}" \
+  "COOKIE_NAME" "${COOKIE_NAME}" \
+  "JWKS_CONTENT" "${JWKS_CONTENT}" \
+  "TOKEN_SIGNING_KEY_ID" "${TOKEN_SIGNING_KEY_ID}" \
+  "ID_TOKEN_SIGNING_KEY_ID" "${ID_TOKEN_SIGNING_KEY_ID}" \
+  "ADMIN_USER_SUB" "${NEW_ADMIN_USER_SUB}" \
+  "ADMIN_EMAIL" "${NEW_ADMIN_EMAIL}" \
+  "ADMIN_PASSWORD" "${NEW_ADMIN_PASSWORD}" \
+  "ADMIN_CLIENT_ID" "${NEW_ADMIN_CLIENT_ID}" \
+  "ADMIN_CLIENT_SECRET" "${NEW_ADMIN_CLIENT_SECRET}")
+
+echo "${ONBOARDING_JSON}" | jq '.' > "${OUTPUT_DIR}/onboarding.json"
+echo "  Saved: ${OUTPUT_DIR}/onboarding.json"
+
+ONBOARDING_RESPONSE=$(curl -s -w "\n%{http_code}" -X POST \
+  "${AUTHORIZATION_SERVER_URL}/v1/management/onboarding?dry_run=${DRY_RUN}" \
+  -H "Authorization: Bearer ${ACCESS_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d @"${OUTPUT_DIR}/onboarding.json")
+
+HTTP_CODE=$(echo "${ONBOARDING_RESPONSE}" | tail -n1)
+RESPONSE_BODY=$(echo "${ONBOARDING_RESPONSE}" | sed '$d')
+
+if [ "${HTTP_CODE}" = "201" ]; then
+  echo "  Onboarding successful"
+  echo "  Organization: ${ORGANIZATION_ID}"
+  echo "  Organizer Tenant: ${ORGANIZER_TENANT_ID}"
+else
+  echo "  Failed (HTTP ${HTTP_CODE})"
+  echo "  ${RESPONSE_BODY}" | jq '.' 2>/dev/null || echo "  ${RESPONSE_BODY}"
+  exit 1
+fi
+echo ""
+
+# --- Step 3: Get organizer admin token ---
+echo "Step 3: Getting organizer admin access token..."
+
+ORG_TOKEN_RESPONSE=$(curl -s -X POST \
+  "${AUTHORIZATION_SERVER_URL}/${ORGANIZER_TENANT_ID}/v1/tokens" \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  --data-urlencode "grant_type=password" \
+  --data-urlencode "username=${NEW_ADMIN_EMAIL}" \
+  --data-urlencode "password=${NEW_ADMIN_PASSWORD}" \
+  --data-urlencode "client_id=${NEW_ADMIN_CLIENT_ID}" \
+  --data-urlencode "client_secret=${NEW_ADMIN_CLIENT_SECRET}" \
+  --data-urlencode "scope=openid profile email management")
+
+ORG_ACCESS_TOKEN=$(echo "${ORG_TOKEN_RESPONSE}" | jq -r '.access_token')
+
+if [ -z "${ORG_ACCESS_TOKEN}" ] || [ "${ORG_ACCESS_TOKEN}" = "null" ]; then
+  echo "  Failed to get organizer admin token"
+  echo "  ${ORG_TOKEN_RESPONSE}"
+  exit 1
+fi
+
+echo "  Organizer admin token obtained: ${ORG_ACCESS_TOKEN:0:20}..."
+echo ""
+
+ORG_BASE_URL="${AUTHORIZATION_SERVER_URL}/v1/management/organizations/${ORGANIZATION_ID}/tenants"
+
+# --- Step 4: Create public tenant ---
+echo "Step 4: Creating public tenant (CIBA + external password auth)..."
+
+PUBLIC_TENANT_ID="${PUBLIC_TENANT_ID:-$(uuidgen | tr '[:upper:]' '[:lower:]')}"
+UI_BASE_URL="${UI_BASE_URL:-${AUTHORIZATION_SERVER_URL}}"
+
+PUBLIC_TENANT_JSON=$(substitute_template "${SCRIPT_DIR}/public-tenant-template.json" \
+  "PUBLIC_TENANT_ID" "${PUBLIC_TENANT_ID}" \
+  "ORGANIZATION_NAME" "${ORGANIZATION_NAME}" \
+  "BASE_URL" "${AUTHORIZATION_SERVER_URL}" \
+  "UI_BASE_URL" "${UI_BASE_URL}" \
+  "COOKIE_NAME" "${COOKIE_NAME}" \
+  "JWKS_CONTENT" "${JWKS_CONTENT}" \
+  "TOKEN_SIGNING_KEY_ID" "${TOKEN_SIGNING_KEY_ID}" \
+  "ID_TOKEN_SIGNING_KEY_ID" "${ID_TOKEN_SIGNING_KEY_ID}")
+
+PUBLIC_TENANT_JSON=$(echo "${PUBLIC_TENANT_JSON}" | jq \
+  --argjson session_timeout "${SESSION_TIMEOUT_SECONDS}" \
+  --argjson at_duration "${ACCESS_TOKEN_DURATION}" \
+  --argjson idt_duration "${ID_TOKEN_DURATION}" \
+  --argjson rt_duration "${REFRESH_TOKEN_DURATION}" \
+  --argjson ciba_expires "${CIBA_REQUEST_EXPIRES_IN}" \
+  --argjson ciba_interval "${CIBA_POLLING_INTERVAL}" \
+  --argjson max_devices "${MAX_DEVICES}" \
+  '
+  .tenant.session_config.timeout_seconds = $session_timeout |
+  .authorization_server.extension.access_token_duration = $at_duration |
+  .authorization_server.extension.id_token_duration = $idt_duration |
+  .authorization_server.extension.refresh_token_duration = $rt_duration |
+  .authorization_server.extension.backchannel_authentication_request_expires_in = $ciba_expires |
+  .authorization_server.extension.backchannel_authentication_polling_interval = $ciba_interval |
+  .tenant.identity_policy_config.authentication_device_rule.max_devices = $max_devices
+  ')
+
+echo "${PUBLIC_TENANT_JSON}" | jq '.' > "${OUTPUT_DIR}/public-tenant.json"
+echo "  Saved: ${OUTPUT_DIR}/public-tenant.json"
+
+TENANT_RESPONSE=$(curl -s -w "\n%{http_code}" -X POST \
+  "${ORG_BASE_URL}" \
+  -H "Authorization: Bearer ${ORG_ACCESS_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d @"${OUTPUT_DIR}/public-tenant.json")
+
+HTTP_CODE=$(echo "${TENANT_RESPONSE}" | tail -n1)
+RESPONSE_BODY=$(echo "${TENANT_RESPONSE}" | sed '$d')
+
+if [ "${HTTP_CODE}" = "200" ] || [ "${HTTP_CODE}" = "201" ]; then
+  echo "  Public tenant created: ${PUBLIC_TENANT_ID}"
+else
+  echo "  Failed (HTTP ${HTTP_CODE})"
+  echo "  ${RESPONSE_BODY}" | jq '.' 2>/dev/null || echo "  ${RESPONSE_BODY}"
+  exit 1
+fi
+echo ""
+
+# --- Step 5: Create authentication configuration (external password with device mapping) ---
+echo "Step 5: Creating authentication configuration (external password + device mapping)..."
+
+AUTH_CONFIG_ID=$(uuidgen | tr '[:upper:]' '[:lower:]')
+
+AUTH_CONFIG_JSON=$(substitute_template "${SCRIPT_DIR}/authentication-config-password-template.json" \
+  "EXTERNAL_AUTH_URL" "${EXTERNAL_AUTH_URL}" \
+  "EXTERNAL_PROVIDER_ID" "${EXTERNAL_PROVIDER_ID}")
+
+AUTH_CONFIG_JSON=$(echo "${AUTH_CONFIG_JSON}" | jq --arg id "${AUTH_CONFIG_ID}" '. + {id: $id}')
+
+echo "${AUTH_CONFIG_JSON}" | jq '.' > "${OUTPUT_DIR}/authentication-config-password.json"
+echo "  Saved: ${OUTPUT_DIR}/authentication-config-password.json"
+
+AUTH_CONFIG_RESPONSE=$(curl -s -w "\n%{http_code}" -X POST \
+  "${ORG_BASE_URL}/${PUBLIC_TENANT_ID}/authentication-configurations" \
+  -H "Authorization: Bearer ${ORG_ACCESS_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d @"${OUTPUT_DIR}/authentication-config-password.json")
+
+HTTP_CODE=$(echo "${AUTH_CONFIG_RESPONSE}" | tail -n1)
+RESPONSE_BODY=$(echo "${AUTH_CONFIG_RESPONSE}" | sed '$d')
+
+if [ "${HTTP_CODE}" = "200" ] || [ "${HTTP_CODE}" = "201" ]; then
+  echo "  Authentication configuration created: ${AUTH_CONFIG_ID}"
+  echo "  External URL: ${EXTERNAL_AUTH_URL}"
+  echo "  Provider ID:  ${EXTERNAL_PROVIDER_ID}"
+else
+  echo "  Failed (HTTP ${HTTP_CODE})"
+  echo "  ${RESPONSE_BODY}" | jq '.' 2>/dev/null || echo "  ${RESPONSE_BODY}"
+  exit 1
+fi
+echo ""
+
+# --- Step 6a: Create authentication policy (OAuth - external password) ---
+echo "Step 6a: Creating authentication policy (OAuth - external password)..."
+
+AUTH_POLICY_OAUTH_ID="${AUTH_POLICY_OAUTH_ID:-$(uuidgen | tr '[:upper:]' '[:lower:]')}"
+jq --arg id "${AUTH_POLICY_OAUTH_ID}" '. + {id: $id}' "${SCRIPT_DIR}/authentication-policy-oauth.json" > "${OUTPUT_DIR}/authentication-policy-oauth.json"
+echo "  Saved: ${OUTPUT_DIR}/authentication-policy-oauth.json"
+
+POLICY_OAUTH_RESPONSE=$(curl -s -w "\n%{http_code}" -X POST \
+  "${ORG_BASE_URL}/${PUBLIC_TENANT_ID}/authentication-policies" \
+  -H "Authorization: Bearer ${ORG_ACCESS_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d @"${OUTPUT_DIR}/authentication-policy-oauth.json")
+
+HTTP_CODE=$(echo "${POLICY_OAUTH_RESPONSE}" | tail -n1)
+RESPONSE_BODY=$(echo "${POLICY_OAUTH_RESPONSE}" | sed '$d')
+
+if [ "${HTTP_CODE}" = "200" ] || [ "${HTTP_CODE}" = "201" ]; then
+  echo "  OAuth authentication policy created"
+else
+  echo "  Failed (HTTP ${HTTP_CODE})"
+  echo "  ${RESPONSE_BODY}" | jq '.' 2>/dev/null || echo "  ${RESPONSE_BODY}"
+  exit 1
+fi
+echo ""
+
+# --- Step 6b: Create authentication policy (CIBA - no-action notification) ---
+echo "Step 6b: Creating authentication policy (CIBA - no-action notification)..."
+
+AUTH_POLICY_CIBA_ID="${AUTH_POLICY_CIBA_ID:-$(uuidgen | tr '[:upper:]' '[:lower:]')}"
+jq --arg id "${AUTH_POLICY_CIBA_ID}" '. + {id: $id}' "${SCRIPT_DIR}/authentication-policy-ciba.json" > "${OUTPUT_DIR}/authentication-policy-ciba.json"
+echo "  Saved: ${OUTPUT_DIR}/authentication-policy-ciba.json"
+
+POLICY_CIBA_RESPONSE=$(curl -s -w "\n%{http_code}" -X POST \
+  "${ORG_BASE_URL}/${PUBLIC_TENANT_ID}/authentication-policies" \
+  -H "Authorization: Bearer ${ORG_ACCESS_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d @"${OUTPUT_DIR}/authentication-policy-ciba.json")
+
+HTTP_CODE=$(echo "${POLICY_CIBA_RESPONSE}" | tail -n1)
+RESPONSE_BODY=$(echo "${POLICY_CIBA_RESPONSE}" | sed '$d')
+
+if [ "${HTTP_CODE}" = "200" ] || [ "${HTTP_CODE}" = "201" ]; then
+  echo "  CIBA authentication policy created"
+else
+  echo "  Failed (HTTP ${HTTP_CODE})"
+  echo "  ${RESPONSE_BODY}" | jq '.' 2>/dev/null || echo "  ${RESPONSE_BODY}"
+  exit 1
+fi
+echo ""
+
+# --- Step 7: Create application client ---
+echo "Step 7: Creating application client..."
+
+CLIENT_ID="${CLIENT_ID:-$(uuidgen | tr '[:upper:]' '[:lower:]')}"
+CLIENT_ALIAS="${CLIENT_ALIAS:-web-app}"
+CLIENT_SECRET="${CLIENT_SECRET_VALUE:-$(uuidgen | tr '[:upper:]' '[:lower:]')}"
+CLIENT_NAME="${CLIENT_NAME:-Web Application}"
+REDIRECT_URI="${REDIRECT_URI:-http://localhost:3000/callback/}"
+
+CLIENT_JSON=$(substitute_template "${SCRIPT_DIR}/public-client-template.json" \
+  "CLIENT_ID" "${CLIENT_ID}" \
+  "CLIENT_ALIAS" "${CLIENT_ALIAS}" \
+  "CLIENT_SECRET" "${CLIENT_SECRET}" \
+  "CLIENT_NAME" "${CLIENT_NAME}" \
+  "REDIRECT_URI" "${REDIRECT_URI}")
+
+echo "${CLIENT_JSON}" | jq '.' > "${OUTPUT_DIR}/public-client.json"
+echo "  Saved: ${OUTPUT_DIR}/public-client.json"
+
+CLIENT_RESPONSE=$(curl -s -w "\n%{http_code}" -X POST \
+  "${ORG_BASE_URL}/${PUBLIC_TENANT_ID}/clients" \
+  -H "Authorization: Bearer ${ORG_ACCESS_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d @"${OUTPUT_DIR}/public-client.json")
+
+HTTP_CODE=$(echo "${CLIENT_RESPONSE}" | tail -n1)
+RESPONSE_BODY=$(echo "${CLIENT_RESPONSE}" | sed '$d')
+
+if [ "${HTTP_CODE}" = "200" ] || [ "${HTTP_CODE}" = "201" ]; then
+  echo "  Client created: ${CLIENT_ID}"
+else
+  echo "  Failed (HTTP ${HTTP_CODE})"
+  echo "  ${RESPONSE_BODY}" | jq '.' 2>/dev/null || echo "  ${RESPONSE_BODY}"
+  exit 1
+fi
+echo ""
+
+# --- Summary ---
+echo "=========================================="
+echo "Setup Complete!"
+echo "=========================================="
+echo ""
+echo "Settings applied:"
+echo "  Authentication:   External password (${EXTERNAL_AUTH_URL})"
+echo "  Provider ID:      ${EXTERNAL_PROVIDER_ID}"
+echo "  Device mapping:   authentication_devices via user_mapping_rules"
+echo "  CIBA mode:        no-action (notification only, no device auth)"
+echo "  Session:          ${SESSION_TIMEOUT_SECONDS}s timeout"
+echo "  Token duration:   AT=${ACCESS_TOKEN_DURATION}s, IDT=${ID_TOKEN_DURATION}s, RT=${REFRESH_TOKEN_DURATION}s"
+echo "  CIBA config:      expires=${CIBA_REQUEST_EXPIRES_IN}s, interval=${CIBA_POLLING_INTERVAL}s"
+echo ""
+echo "Created Resources:"
+echo "  Organization ID:      ${ORGANIZATION_ID}"
+echo "  Organizer Tenant ID:  ${ORGANIZER_TENANT_ID}"
+echo "  Public Tenant ID:     ${PUBLIC_TENANT_ID}"
+echo ""
+echo "Admin User:"
+echo "  Email:    ${NEW_ADMIN_EMAIL}"
+echo "  Password: ${NEW_ADMIN_PASSWORD}"
+echo ""
+echo "Admin Client (Organizer Tenant):"
+echo "  Tenant ID:     ${ORGANIZER_TENANT_ID}"
+echo "  Client ID:     ${NEW_ADMIN_CLIENT_ID}"
+echo "  Client Secret: ${NEW_ADMIN_CLIENT_SECRET}"
+echo ""
+echo "Application Client (Public Tenant):"
+echo "  Tenant ID:     ${PUBLIC_TENANT_ID}"
+echo "  Client ID:     ${CLIENT_ID}"
+echo "  Client Secret: ${CLIENT_SECRET}"
+echo "  Redirect URI:  ${REDIRECT_URI}"
+echo ""
+echo "Generated JSON files:"
+echo "  ${OUTPUT_DIR}/onboarding.json"
+echo "  ${OUTPUT_DIR}/public-tenant.json"
+echo "  ${OUTPUT_DIR}/authentication-config-password.json"
+echo "  ${OUTPUT_DIR}/authentication-policy-oauth.json"
+echo "  ${OUTPUT_DIR}/authentication-policy-ciba.json"
+echo "  ${OUTPUT_DIR}/public-client.json"
+echo ""
+echo "Verification:"
+echo "  1. Ensure mock server is running: node mock-server.js"
+echo "  2. Run: cd config/templates/use-cases/ciba_external-password-auth && source helpers.sh && get_admin_token"
+echo "  3. Run: source verify.sh"

--- a/config/templates/use-cases/ciba_external-password-auth/verify.sh
+++ b/config/templates/use-cases/ciba_external-password-auth/verify.sh
@@ -1,0 +1,339 @@
+#!/bin/bash
+# CIBA + External Password Auth - Verification Script
+#
+# Tests:
+#   Phase 1: External password auth with device mapping
+#   Phase 2: CIBA backchannel authentication using mapped device
+#
+# Prerequisites:
+#   - setup.sh completed
+#   - mock-server.js running (port 4002)
+#   - source helpers.sh && get_admin_token
+
+PASS=0
+FAIL=0
+
+pass() { echo "  ✓ $1"; PASS=$((PASS + 1)); }
+fail() { echo "  ✗ $1"; FAIL=$((FAIL + 1)); }
+
+echo "=========================================="
+echo "CIBA + External Password Auth Verification"
+echo "=========================================="
+echo ""
+
+TEST_EMAIL="${TEST_EMAIL:-test-ciba-ext-$(date +%s)@example.com}"
+TEST_PASSWORD="${TEST_PASSWORD:-CorrectPassword123}"
+
+# ============================================================
+# Phase 1: External Password Auth + Device Mapping
+# ============================================================
+echo "--- Phase 1: External Password Auth + Device Mapping ---"
+echo ""
+
+# --- Step 1: Mock server connectivity ---
+echo "Step 1: Mock server connectivity check..."
+MOCK_STATUS=$(curl -s -o /dev/null -w "%{http_code}" -X POST "${MOCK_LOCAL_URL}/auth/password" \
+  -H "Content-Type: application/json" \
+  -d '{"username":"test@example.com","password":"test"}')
+
+if [ "${MOCK_STATUS}" = "200" ]; then
+  pass "Mock server reachable (HTTP ${MOCK_STATUS})"
+else
+  fail "Mock server unreachable (HTTP ${MOCK_STATUS})"
+  echo "  Start mock server: node mock-server.js"
+  echo ""
+  echo "Results: PASS=${PASS} FAIL=${FAIL}"
+  exit 1
+fi
+
+# Verify mock returns device info
+MOCK_RESPONSE=$(curl -s -X POST "${MOCK_LOCAL_URL}/auth/password" \
+  -H "Content-Type: application/json" \
+  -d "{\"username\":\"${TEST_EMAIL}\",\"password\":\"${TEST_PASSWORD}\"}")
+
+MOCK_DEVICE_ID=$(echo "${MOCK_RESPONSE}" | jq -r '.device.id // empty')
+if [ -n "${MOCK_DEVICE_ID}" ]; then
+  pass "Mock returns device info (device_id: ${MOCK_DEVICE_ID})"
+else
+  fail "Mock does not return device info"
+fi
+echo ""
+
+# --- Step 2: Discovery endpoint ---
+echo "Step 2: Discovery endpoint..."
+DISCO_STATUS=$(curl -s -o /dev/null -w "%{http_code}" "${TENANT_BASE}/.well-known/openid-configuration")
+if [ "${DISCO_STATUS}" = "200" ]; then
+  pass "Discovery endpoint (HTTP 200)"
+else
+  fail "Discovery endpoint (HTTP ${DISCO_STATUS})"
+fi
+
+# Check CIBA endpoint
+CIBA_ENDPOINT=$(curl -s "${TENANT_BASE}/.well-known/openid-configuration" | jq -r '.backchannel_authentication_endpoint // empty')
+if [ -n "${CIBA_ENDPOINT}" ]; then
+  pass "CIBA endpoint advertised"
+else
+  fail "CIBA endpoint not in discovery"
+fi
+echo ""
+
+# --- Step 3: External password login (creates user with device) ---
+echo "Step 3: External password login (user creation with device mapping)..."
+start_auth_flow
+password_login "${TEST_EMAIL}" "${TEST_PASSWORD}"
+complete_auth_flow
+
+if [ -n "${USER_ACCESS_TOKEN}" ] && [ "${USER_ACCESS_TOKEN}" != "null" ]; then
+  pass "External password auth + token obtained"
+else
+  fail "External password auth failed"
+fi
+echo ""
+
+# --- Step 4: Check UserInfo for authentication_devices ---
+echo "Step 4: Verify authentication_devices in UserInfo..."
+USERINFO=$(get_userinfo)
+echo "${USERINFO}"
+
+USER_SUB=$(echo "${USERINFO}" | jq -r '.sub // empty')
+DEVICE_COUNT=$(echo "${USERINFO}" | jq '.authentication_devices | length // 0' 2>/dev/null)
+
+if [ -n "${USER_SUB}" ] && [ "${USER_SUB}" != "null" ]; then
+  pass "UserInfo returned (sub: ${USER_SUB})"
+else
+  fail "UserInfo missing sub"
+fi
+
+if [ "${DEVICE_COUNT}" -gt 0 ] 2>/dev/null; then
+  DEVICE_ID=$(echo "${USERINFO}" | jq -r '.authentication_devices[0].id // empty')
+  DEVICE_NOTIFICATION=$(echo "${USERINFO}" | jq -r '.authentication_devices[0].notification_token // empty')
+  pass "authentication_devices mapped (count: ${DEVICE_COUNT}, id: ${DEVICE_ID})"
+  if [ -n "${DEVICE_NOTIFICATION}" ]; then
+    pass "notification_token present"
+  else
+    fail "notification_token missing"
+  fi
+else
+  fail "authentication_devices not mapped (count: ${DEVICE_COUNT:-0})"
+  echo "  This is the key test: ObjectCompositor array mapping for authentication_devices"
+fi
+echo ""
+
+# --- Step 5: Second login (verify existing user resolution) ---
+echo "Step 5: Second login (existing user resolution)..."
+start_auth_flow
+password_login "${TEST_EMAIL}" "${TEST_PASSWORD}"
+complete_auth_flow
+
+USERINFO2=$(get_userinfo)
+USER_SUB2=$(echo "${USERINFO2}" | jq -r '.sub // empty')
+
+if [ "${USER_SUB}" = "${USER_SUB2}" ]; then
+  pass "Same user resolved on second login (sub matches)"
+else
+  fail "Different user on second login (${USER_SUB} vs ${USER_SUB2})"
+fi
+echo ""
+
+# ============================================================
+# Phase 2: CIBA Backchannel Authentication (binding_message)
+# ============================================================
+echo "--- Phase 2: CIBA Backchannel Authentication ---"
+echo ""
+
+EXTERNAL_PROVIDER_ID="${EXTERNAL_PROVIDER_ID:-external-auth}"
+BINDING_MESSAGE="CIBA-$(date +%s | tail -c 5)"
+
+# --- Step 6: CIBA request with binding_message ---
+echo "Step 6: CIBA backchannel authentication request (binding_message: ${BINDING_MESSAGE})..."
+ciba_request "email:${TEST_EMAIL},idp:${EXTERNAL_PROVIDER_ID}" "${BINDING_MESSAGE}"
+
+if [ -n "${AUTH_REQ_ID}" ] && [ "${AUTH_REQ_ID}" != "null" ] && [ "${AUTH_REQ_ID}" != "" ]; then
+  pass "CIBA request accepted (auth_req_id: ${AUTH_REQ_ID:0:20}...)"
+else
+  fail "CIBA request failed"
+fi
+echo ""
+
+# --- Step 7: CIBA poll (before binding_message verification - expect authorization_pending) ---
+echo "Step 7: CIBA token poll (before verification, expect authorization_pending)..."
+ciba_poll
+
+if [ "${CIBA_ERROR}" = "authorization_pending" ]; then
+  pass "CIBA poll returns authorization_pending (expected)"
+else
+  fail "CIBA poll unexpected result (expected authorization_pending, got: ${CIBA_ERROR:-token})"
+fi
+echo ""
+
+# --- Step 8: Get authentication transaction (device side) ---
+echo "Step 8: Get authentication transaction for device..."
+TX_RESPONSE=$(curl -s -w "\n%{http_code}" \
+  "${TENANT_BASE}/v1/authentication-devices/${DEVICE_ID}/authentications?attributes.auth_req_id=${AUTH_REQ_ID}")
+
+TX_HTTP=$(echo "${TX_RESPONSE}" | tail -n1)
+TX_BODY=$(echo "${TX_RESPONSE}" | sed '$d')
+
+TRANSACTION_ID=$(echo "${TX_BODY}" | jq -r '.list[0].id // empty')
+TX_BINDING_MSG=$(echo "${TX_BODY}" | jq -r '.list[0].context.binding_message // empty')
+
+if [ -n "${TRANSACTION_ID}" ] && [ "${TRANSACTION_ID}" != "null" ]; then
+  pass "Authentication transaction found (id: ${TRANSACTION_ID:0:20}...)"
+  if [ -n "${TX_BINDING_MSG}" ]; then
+    echo "    binding_message in context: ${TX_BINDING_MSG}"
+  fi
+else
+  fail "Authentication transaction not found"
+  echo "  HTTP ${TX_HTTP}"
+  echo "  ${TX_BODY}" | jq '.' 2>/dev/null || echo "  ${TX_BODY}"
+fi
+echo ""
+
+# --- Step 9: Binding message verification (device side) ---
+echo "Step 9: Binding message verification..."
+BM_RESPONSE=$(curl -s -w "\n%{http_code}" -X POST \
+  "${TENANT_BASE}/v1/authentications/${TRANSACTION_ID}/authentication-device-binding-message" \
+  -H "Content-Type: application/json" \
+  -d "{\"binding_message\": \"${BINDING_MESSAGE}\"}")
+
+BM_HTTP=$(echo "${BM_RESPONSE}" | tail -n1)
+BM_BODY=$(echo "${BM_RESPONSE}" | sed '$d')
+
+if [ "${BM_HTTP}" = "200" ]; then
+  pass "Binding message verified successfully"
+else
+  fail "Binding message verification failed (HTTP ${BM_HTTP})"
+  echo "  ${BM_BODY}" | jq '.' 2>/dev/null || echo "  ${BM_BODY}"
+fi
+echo ""
+
+# --- Step 10: CIBA poll (after binding_message verification - expect token) ---
+echo "Step 10: CIBA token poll (after verification)..."
+ciba_poll
+
+if [ -n "${CIBA_ACCESS_TOKEN}" ] && [ "${CIBA_ACCESS_TOKEN}" != "null" ] && [ "${CIBA_ACCESS_TOKEN}" != "" ]; then
+  pass "CIBA token obtained"
+
+  # Verify CIBA token UserInfo
+  CIBA_USERINFO=$(get_userinfo "${CIBA_ACCESS_TOKEN}")
+  CIBA_SUB=$(echo "${CIBA_USERINFO}" | jq -r '.sub // empty')
+  if [ "${CIBA_SUB}" = "${USER_SUB}" ]; then
+    pass "CIBA token UserInfo matches original user (sub: ${CIBA_SUB})"
+  else
+    fail "CIBA UserInfo sub mismatch (${CIBA_SUB} vs ${USER_SUB})"
+  fi
+elif [ "${CIBA_ERROR}" = "authorization_pending" ]; then
+  fail "CIBA still authorization_pending after binding_message verification"
+else
+  fail "CIBA poll failed"
+fi
+echo ""
+
+# ============================================================
+# Phase 3: CIBA with device: login_hint
+# ============================================================
+echo "--- Phase 3: CIBA with device: login_hint ---"
+echo ""
+
+BINDING_MESSAGE_D="DEV-$(date +%s | tail -c 5)"
+
+# --- Step 11: CIBA request with device: login_hint ---
+echo "Step 11: CIBA request with device: login_hint (binding_message: ${BINDING_MESSAGE_D})..."
+ciba_request "device:${DEVICE_ID},idp:${EXTERNAL_PROVIDER_ID}" "${BINDING_MESSAGE_D}"
+
+if [ -n "${AUTH_REQ_ID}" ] && [ "${AUTH_REQ_ID}" != "null" ] && [ "${AUTH_REQ_ID}" != "" ]; then
+  pass "CIBA request accepted with device hint (auth_req_id: ${AUTH_REQ_ID:0:20}...)"
+else
+  fail "CIBA request with device hint failed"
+fi
+echo ""
+
+# --- Step 12: CIBA poll (before verification) ---
+echo "Step 12: CIBA token poll (before verification, expect authorization_pending)..."
+ciba_poll
+
+if [ "${CIBA_ERROR}" = "authorization_pending" ]; then
+  pass "CIBA poll returns authorization_pending (expected)"
+else
+  fail "CIBA poll unexpected result (expected authorization_pending, got: ${CIBA_ERROR:-token})"
+fi
+echo ""
+
+# --- Step 13: Get authentication transaction ---
+echo "Step 13: Get authentication transaction for device..."
+TX_RESPONSE_D=$(curl -s -w "\n%{http_code}" \
+  "${TENANT_BASE}/v1/authentication-devices/${DEVICE_ID}/authentications?attributes.auth_req_id=${AUTH_REQ_ID}")
+
+TX_HTTP_D=$(echo "${TX_RESPONSE_D}" | tail -n1)
+TX_BODY_D=$(echo "${TX_RESPONSE_D}" | sed '$d')
+
+TRANSACTION_ID_D=$(echo "${TX_BODY_D}" | jq -r '.list[0].id // empty')
+
+if [ -n "${TRANSACTION_ID_D}" ] && [ "${TRANSACTION_ID_D}" != "null" ]; then
+  pass "Authentication transaction found (id: ${TRANSACTION_ID_D:0:20}...)"
+else
+  fail "Authentication transaction not found"
+  echo "  HTTP ${TX_HTTP_D}"
+  echo "  ${TX_BODY_D}" | jq '.' 2>/dev/null || echo "  ${TX_BODY_D}"
+fi
+echo ""
+
+# --- Step 14: Binding message verification ---
+echo "Step 14: Binding message verification..."
+BM_RESPONSE_D=$(curl -s -w "\n%{http_code}" -X POST \
+  "${TENANT_BASE}/v1/authentications/${TRANSACTION_ID_D}/authentication-device-binding-message" \
+  -H "Content-Type: application/json" \
+  -d "{\"binding_message\": \"${BINDING_MESSAGE_D}\"}")
+
+BM_HTTP_D=$(echo "${BM_RESPONSE_D}" | tail -n1)
+BM_BODY_D=$(echo "${BM_RESPONSE_D}" | sed '$d')
+
+if [ "${BM_HTTP_D}" = "200" ]; then
+  pass "Binding message verified successfully"
+else
+  fail "Binding message verification failed (HTTP ${BM_HTTP_D})"
+  echo "  ${BM_BODY_D}" | jq '.' 2>/dev/null || echo "  ${BM_BODY_D}"
+fi
+echo ""
+
+# --- Step 15: CIBA poll (after verification) ---
+echo "Step 15: CIBA token poll (after verification)..."
+ciba_poll
+
+if [ -n "${CIBA_ACCESS_TOKEN}" ] && [ "${CIBA_ACCESS_TOKEN}" != "null" ] && [ "${CIBA_ACCESS_TOKEN}" != "" ]; then
+  pass "CIBA token obtained via device hint"
+
+  CIBA_USERINFO_D=$(get_userinfo "${CIBA_ACCESS_TOKEN}")
+  CIBA_SUB_D=$(echo "${CIBA_USERINFO_D}" | jq -r '.sub // empty')
+  if [ "${CIBA_SUB_D}" = "${USER_SUB}" ]; then
+    pass "CIBA token UserInfo matches original user (sub: ${CIBA_SUB_D})"
+  else
+    fail "CIBA UserInfo sub mismatch (${CIBA_SUB_D} vs ${USER_SUB})"
+  fi
+elif [ "${CIBA_ERROR}" = "authorization_pending" ]; then
+  fail "CIBA still authorization_pending after binding_message verification"
+else
+  fail "CIBA poll failed"
+fi
+echo ""
+
+# ============================================================
+# Summary
+# ============================================================
+echo "=========================================="
+echo "Verification Complete"
+echo "=========================================="
+echo ""
+echo "Results: PASS=${PASS} FAIL=${FAIL}"
+echo ""
+
+if [ ${FAIL} -gt 0 ]; then
+  echo "Some tests failed. Key areas to check:"
+  echo "  - authentication_devices mapping via ObjectCompositor"
+  echo "  - CIBA binding_message verification flow"
+  echo "  - authentication_device_rule.authentication_type setting"
+  echo "  - login_hint format (email: or device: with ,idp: suffix)"
+  exit 1
+else
+  echo "All tests passed!"
+fi

--- a/documentation/docs/content_05_how-to/phase-4-extensions/05-ciba-binding-message.md
+++ b/documentation/docs/content_05_how-to/phase-4-extensions/05-ciba-binding-message.md
@@ -84,7 +84,7 @@ sequenceDiagram
 認証デバイスからバインディングメッセージの一致を検証するAPIです。
 
 ```
-POST {tenant-id}/v1/authentications/{flow-type}/{transaction-id}/interactions/authentication-device-binding-message
+POST {tenant-id}/v1/authentications/{transaction-id}/authentication-device-binding-message
 Content-Type: application/json
 
 {
@@ -97,7 +97,6 @@ Content-Type: application/json
 | パラメータ | 型 | 説明 |
 |-----------|---|------|
 | `tenant-id` | `string` | テナント識別子 |
-| `flow-type` | `string` | 認証フロー種別（`ciba`等） |
 | `transaction-id` | `string` | 認証トランザクションID（UUID） |
 
 #### リクエストボディ
@@ -185,7 +184,7 @@ const userInput = await getUserInput(); // ユーザーが入力した値
 
 // 4. バインディングメッセージ検証API呼び出し
 const verifyResponse = await fetch(
-  `${baseUrl}/${tenantId}/v1/authentications/${transaction.flow}/${transaction.id}/interactions/authentication-device-binding-message`,
+  `${baseUrl}/${tenantId}/v1/authentications/${transaction.id}/authentication-device-binding-message`,
   {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },


### PR DESCRIPTION
## Summary

- 外部パスワード認証でユーザー作成時に `authentication_devices` を ObjectCompositor 配列マッピングで登録し、CIBA フローで `binding_message` 検証による認可を実現するユースケーステンプレートを追加
- binding_message 検証 API のドキュメントで、エンドポイントパスが Controller 実装と不一致だった箇所を修正

### 新規テンプレート (`config/templates/use-cases/ciba_external-password-auth/`)

| ファイル | 内容 |
|---------|------|
| `setup.sh` | 環境構築（オンボーディング → テナント → 認証設定 → ポリシー → クライアント） |
| `verify.sh` | 自動検証（全21テスト: Phase 1-3） |
| `VERIFY.md` | 手動動作確認ガイド |
| `mock-server.js` | 外部パスワード認証 + CIBA 通知モックサーバー（port 4002） |
| `helpers.sh` | OAuth/CIBA フローヘルパー関数 |
| `delete.sh` | クリーンアップスクリプト |
| `authentication-config-password-template.json` | 外部認証設定（`user_mapping_rules` でデバイスマッピング） |
| `authentication-policy-ciba.json` | CIBA 認証ポリシー（`binding_message` 検証） |
| `authentication-policy-oauth.json` | OAuth 認証ポリシー（外部パスワード） |
| `public-tenant-template.json` | テナント設定（`authentication_type: none`） |
| `public-client-template.json` | クライアント設定（CIBA poll モード） |

### 検証フロー（verify.sh: 21テスト）

- **Phase 1** (9テスト): 外部パスワード認証 → ユーザー作成 + `authentication_devices` マッピング → UserInfo 確認
- **Phase 2** (6テスト): CIBA `email:` login_hint + `binding_message` 検証 → トークン取得
- **Phase 3** (6テスト): CIBA `device:` login_hint + `binding_message` 検証 → トークン取得

### ドキュメント修正

- `05-ciba-binding-message.md`: API パス `{flow-type}/{transaction-id}/interactions/` → `{transaction-id}/` に修正（`AuthenticationV1Api.java` の `@PostMapping("/{id}/{interaction-type}")` と整合）

## Test plan

- [x] `setup.sh` でテンプレート環境構築
- [x] `node mock-server.js` でモックサーバー起動
- [x] `source helpers.sh && get_admin_token && source verify.sh` で全21テスト PASS 確認
- [x] `delete.sh` でクリーンアップ確認
- [ ] binding_message 検証ドキュメントの修正内容が正しいか確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)