### PR TITLE
feat: 身元確認申請管理API追加

### DIFF
--- a/documentation/docs/content_07_reference/api-reference.md
+++ b/documentation/docs/content_07_reference/api-reference.md
@@ -22,5 +22,6 @@
 - [認証設定管理API](cp-authentication-api-ja)
 - [身元確認設定管理API](cp-identity-verification-api-ja)
 - [身元確認申請管理API](cp-identity-verification-application-api-ja)
+- [身元確認結果管理API](cp-identity-verification-result-api-ja)
 - [フェデレーション設定管理API](cp-federation-api-ja)
 - [セキュリティイベント管理API](cp-security-event-api-ja)

--- a/documentation/docs/content_07_reference/api-reference.md
+++ b/documentation/docs/content_07_reference/api-reference.md
@@ -21,5 +21,6 @@
 - [ロール・権限管理API](cp-role-permission-api-ja)
 - [認証設定管理API](cp-authentication-api-ja)
 - [身元確認設定管理API](cp-identity-verification-api-ja)
+- [身元確認申請管理API](cp-identity-verification-application-api-ja)
 - [フェデレーション設定管理API](cp-federation-api-ja)
 - [セキュリティイベント管理API](cp-security-event-api-ja)

--- a/documentation/docusaurus.config.js
+++ b/documentation/docusaurus.config.js
@@ -130,6 +130,10 @@ const config = {
             route: '/docs/content_07_reference/cp-identity-verification-application-api-ja/',
           },
           {
+            spec: 'openapi/swagger-cp-identity-verification-result-ja.yaml',
+            route: '/docs/content_07_reference/cp-identity-verification-result-api-ja/',
+          },
+          {
             spec: 'openapi/swagger-cp-federation-ja.yaml',
             route: '/docs/content_07_reference/cp-federation-api-ja/',
           },

--- a/documentation/docusaurus.config.js
+++ b/documentation/docusaurus.config.js
@@ -126,6 +126,10 @@ const config = {
             route: '/docs/content_07_reference/cp-identity-verification-api-ja/',
           },
           {
+            spec: 'openapi/swagger-cp-identity-verification-application-ja.yaml',
+            route: '/docs/content_07_reference/cp-identity-verification-application-api-ja/',
+          },
+          {
             spec: 'openapi/swagger-cp-federation-ja.yaml',
             route: '/docs/content_07_reference/cp-federation-api-ja/',
           },

--- a/documentation/openapi/swagger-cp-identity-verification-application-ja.yaml
+++ b/documentation/openapi/swagger-cp-identity-verification-application-ja.yaml
@@ -1,0 +1,369 @@
+openapi: 3.0.3
+info:
+  title: idp-server コントロールプレーン 身元確認申請管理 API
+  description: 身元確認申請（Identity Verification Application）の管理API仕様書
+  version: 1.0.0
+  contact:
+    name: idp-server OSS
+servers:
+- url: http://localhost:8080
+tags:
+- name: organization-identity-verification-application
+  description: 組織レベル身元確認申請管理
+paths:
+  /v1/management/organizations/{organization-id}/tenants/{tenant-id}/identity-verification-applications:
+    parameters:
+    - $ref: '#/components/parameters/OrganizationId'
+    - $ref: '#/components/parameters/TenantId'
+    get:
+      summary: 組織内身元確認申請一覧取得
+      description: 指定した組織・テナント内の身元確認申請一覧を取得します。各種フィルタリングおよびページネーションに対応しています。
+      tags:
+      - organization-identity-verification-application
+      parameters:
+      - $ref: '#/components/parameters/Limit'
+      - $ref: '#/components/parameters/Offset'
+      - name: id
+        in: query
+        required: false
+        schema:
+          type: string
+          format: uuid
+        description: 申請IDでフィルタリング
+      - name: type
+        in: query
+        required: false
+        schema:
+          type: string
+        description: 検証タイプでフィルタリング
+      - name: client_id
+        in: query
+        required: false
+        schema:
+          type: string
+        description: クライアントIDでフィルタリング
+      - name: status
+        in: query
+        required: false
+        schema:
+          type: string
+          enum:
+          - requested
+          - applying
+          - applied
+          - examination_processing
+          - approved
+          - rejected
+          - expired
+          - cancelled
+        description: 申請ステータスでフィルタリング
+      - name: from
+        in: query
+        required: false
+        schema:
+          type: string
+          format: date-time
+        description: 作成日時の開始（ISO 8601形式）
+      - name: to
+        in: query
+        required: false
+        schema:
+          type: string
+          format: date-time
+        description: 作成日時の終了（ISO 8601形式）
+      responses:
+        '200':
+          description: 身元確認申請一覧
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IdentityVerificationApplicationListResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          description: 組織またはテナントが見つかりません
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /v1/management/organizations/{organization-id}/tenants/{tenant-id}/identity-verification-applications/{application-id}:
+    parameters:
+    - $ref: '#/components/parameters/OrganizationId'
+    - $ref: '#/components/parameters/TenantId'
+    - $ref: '#/components/parameters/ApplicationId'
+    get:
+      summary: 組織内身元確認申請詳細取得
+      description: 指定した組織・テナント内の特定の身元確認申請の詳細を取得します
+      tags:
+      - organization-identity-verification-application
+      responses:
+        '200':
+          description: 身元確認申請詳細
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IdentityVerificationApplication'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          description: 組織、テナント、または身元確認申請が見つかりません
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+    delete:
+      summary: 組織内身元確認申請削除
+      description: 指定した組織・テナント内の特定の身元確認申請を削除します
+      tags:
+      - organization-identity-verification-application
+      parameters:
+      - $ref: '#/components/parameters/DryRun'
+      responses:
+        '204':
+          description: 身元確認申請削除成功
+        '200':
+          description: dry_run=trueの場合の応答
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DryRunResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          description: 組織、テナント、または身元確認申請が見つかりません
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+components:
+  parameters:
+    TenantId:
+      name: tenant-id
+      in: path
+      required: true
+      schema:
+        type: string
+      description: テナントの識別子
+    OrganizationId:
+      name: organization-id
+      in: path
+      required: true
+      schema:
+        type: string
+        format: uuid
+      description: 組織の識別子
+    ApplicationId:
+      name: application-id
+      in: path
+      required: true
+      schema:
+        type: string
+        format: uuid
+      description: 身元確認申請の識別子
+    DryRun:
+      name: dry_run
+      in: query
+      required: false
+      schema:
+        type: boolean
+        default: false
+      description: trueの場合、リクエストの検証のみで実行はされません
+    Limit:
+      name: limit
+      in: query
+      required: false
+      schema:
+        type: integer
+        minimum: 1
+        maximum: 1000
+        default: 20
+      description: 返すアイテムの最大数
+    Offset:
+      name: offset
+      in: query
+      required: false
+      schema:
+        type: integer
+        minimum: 0
+        default: 0
+      description: アイテムを返す開始インデックス
+  schemas:
+    ErrorResponse:
+      type: object
+      properties:
+        error:
+          type: string
+          description: Error code
+        error_description:
+          type: string
+          description: Human-readable error description
+      required:
+      - error
+      - error_description
+    IdentityVerificationApplication:
+      type: object
+      description: 身元確認申請
+      properties:
+        id:
+          type: string
+          format: uuid
+          description: 申請ID
+          example: 8a3f2b1c-4d5e-6f7a-8b9c-0d1e2f3a4b5c
+        type:
+          type: string
+          description: 検証タイプ（身元確認設定のタイプに対応）
+          example: document_verification
+        tenant_id:
+          type: string
+          description: テナントID
+          example: 952f6906-3e95-4ed3-86b2-981f90f785f9
+        client_id:
+          type: string
+          description: リクエスト元クライアントID
+          example: my-client
+        user_id:
+          type: string
+          description: ユーザーID
+          example: 3ec055a8-8000-44a2-8677-e70ebff414e2
+        status:
+          type: string
+          description: 申請ステータス
+          enum:
+          - requested
+          - applying
+          - applied
+          - examination_processing
+          - approved
+          - rejected
+          - expired
+          - cancelled
+          example: approved
+        application_details:
+          type: object
+          description: 申請詳細データ（マッピングルールで生成された動的なキー・バリュー）
+          additionalProperties: true
+        processes:
+          type: object
+          description: プロセス別の実行結果
+          additionalProperties:
+            $ref: '#/components/schemas/ProcessResult'
+        attributes:
+          type: object
+          description: 申請属性（オプション、存在する場合のみ）
+          additionalProperties: true
+        requested_at:
+          type: string
+          format: date-time
+          description: 申請日時
+          example: "2026-03-18T10:30:00"
+      required:
+      - id
+      - type
+      - tenant_id
+      - client_id
+      - user_id
+      - status
+      - requested_at
+    ProcessResult:
+      type: object
+      description: プロセスの実行結果
+      properties:
+        call_count:
+          type: integer
+          description: 呼び出し回数
+          example: 3
+        success_count:
+          type: integer
+          description: 成功回数
+          example: 2
+        failure_count:
+          type: integer
+          description: 失敗回数
+          example: 1
+    IdentityVerificationApplicationListResponse:
+      type: object
+      description: 身元確認申請一覧レスポンス
+      properties:
+        list:
+          type: array
+          items:
+            $ref: '#/components/schemas/IdentityVerificationApplication'
+        total_count:
+          type: integer
+          description: フィルタ条件に一致する総件数
+          example: 42
+        limit:
+          type: integer
+          description: リクエストされたlimit値
+          example: 20
+        offset:
+          type: integer
+          description: リクエストされたoffset値
+          example: 0
+      required:
+      - list
+      - total_count
+      - limit
+      - offset
+    DryRunResponse:
+      type: object
+      description: dry_run=trueの場合のレスポンス
+      properties:
+        dry_run:
+          type: boolean
+          example: true
+  responses:
+    BadRequest:
+      description: Bad Request - Invalid input parameters
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              error:
+                type: string
+                example: invalid_request
+              error_description:
+                type: string
+                example: The request is missing required parameters
+            required:
+            - error
+            - error_description
+    Unauthorized:
+      description: Unauthorized - Authentication required or invalid
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              error:
+                type: string
+                example: unauthorized
+              error_description:
+                type: string
+                example: Authentication required
+            required:
+            - error
+            - error_description
+    Forbidden:
+      description: Forbidden - Insufficient permissions
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              error:
+                type: string
+                example: access_denied
+              error_description:
+                type: string
+                example: Insufficient permissions to access this resource
+            required:
+            - error
+            - error_description

--- a/documentation/openapi/swagger-cp-identity-verification-result-ja.yaml
+++ b/documentation/openapi/swagger-cp-identity-verification-result-ja.yaml
@@ -1,0 +1,309 @@
+openapi: 3.0.3
+info:
+  title: idp-server コントロールプレーン 身元確認結果管理 API
+  description: 身元確認結果（Identity Verification Result）の管理API仕様書
+  version: 1.0.0
+  contact:
+    name: idp-server OSS
+servers:
+- url: http://localhost:8080
+tags:
+- name: organization-identity-verification-result
+  description: 組織レベル身元確認結果管理
+paths:
+  /v1/management/organizations/{organization-id}/tenants/{tenant-id}/identity-verification-results:
+    parameters:
+    - $ref: '#/components/parameters/OrganizationId'
+    - $ref: '#/components/parameters/TenantId'
+    get:
+      summary: 組織内身元確認結果一覧取得
+      description: 指定した組織・テナント内の身元確認結果一覧を取得します。各種フィルタリングおよびページネーションに対応しています。
+      tags:
+      - organization-identity-verification-result
+      parameters:
+      - $ref: '#/components/parameters/Limit'
+      - $ref: '#/components/parameters/Offset'
+      - name: id
+        in: query
+        required: false
+        schema:
+          type: string
+          format: uuid
+        description: 結果IDでフィルタリング
+      - name: type
+        in: query
+        required: false
+        schema:
+          type: string
+        description: 検証タイプでフィルタリング
+      - name: application_id
+        in: query
+        required: false
+        schema:
+          type: string
+          format: uuid
+        description: 申請IDでフィルタリング
+      - name: source
+        in: query
+        required: false
+        schema:
+          type: string
+          enum:
+          - application
+          - direct
+          - manual
+          - import
+        description: ソースタイプでフィルタリング
+      - name: verified_at_from
+        in: query
+        required: false
+        schema:
+          type: string
+          format: date-time
+        description: 検証日時の開始（ISO 8601形式）
+      - name: verified_at_to
+        in: query
+        required: false
+        schema:
+          type: string
+          format: date-time
+        description: 検証日時の終了（ISO 8601形式）
+      - name: verified_until_from
+        in: query
+        required: false
+        schema:
+          type: string
+          format: date-time
+        description: 有効期限の開始（ISO 8601形式）
+      - name: verified_until_to
+        in: query
+        required: false
+        schema:
+          type: string
+          format: date-time
+        description: 有効期限の終了（ISO 8601形式）
+      responses:
+        '200':
+          description: 身元確認結果一覧
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IdentityVerificationResultListResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          description: 組織またはテナントが見つかりません
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /v1/management/organizations/{organization-id}/tenants/{tenant-id}/identity-verification-results/{result-id}:
+    parameters:
+    - $ref: '#/components/parameters/OrganizationId'
+    - $ref: '#/components/parameters/TenantId'
+    - $ref: '#/components/parameters/ResultId'
+    get:
+      summary: 組織内身元確認結果詳細取得
+      description: 指定した組織・テナント内の特定の身元確認結果の詳細を取得します
+      tags:
+      - organization-identity-verification-result
+      responses:
+        '200':
+          description: 身元確認結果詳細
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IdentityVerificationResult'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          description: 組織、テナント、または身元確認結果が見つかりません
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+components:
+  parameters:
+    TenantId:
+      name: tenant-id
+      in: path
+      required: true
+      schema:
+        type: string
+      description: テナントの識別子
+    OrganizationId:
+      name: organization-id
+      in: path
+      required: true
+      schema:
+        type: string
+        format: uuid
+      description: 組織の識別子
+    ResultId:
+      name: result-id
+      in: path
+      required: true
+      schema:
+        type: string
+        format: uuid
+      description: 身元確認結果の識別子
+    Limit:
+      name: limit
+      in: query
+      required: false
+      schema:
+        type: integer
+        minimum: 1
+        maximum: 1000
+        default: 20
+      description: 返すアイテムの最大数
+    Offset:
+      name: offset
+      in: query
+      required: false
+      schema:
+        type: integer
+        minimum: 0
+        default: 0
+      description: アイテムを返す開始インデックス
+  schemas:
+    ErrorResponse:
+      type: object
+      properties:
+        error:
+          type: string
+          description: Error code
+        error_description:
+          type: string
+          description: Human-readable error description
+      required:
+      - error
+      - error_description
+    IdentityVerificationResult:
+      type: object
+      description: 身元確認結果
+      properties:
+        id:
+          type: string
+          format: uuid
+          description: 結果ID
+          example: d02d9859-aad5-4672-bcc9-8fa42d5f2793
+        type:
+          type: string
+          description: 検証タイプ（身元確認設定のタイプに対応）
+          example: investment-account-opening
+        tenant_id:
+          type: string
+          description: テナントID
+          example: 67e7eae6-62b0-4500-9eff-87459f63fc66
+        user_id:
+          type: string
+          description: ユーザーID
+          example: 3ec055a8-8000-44a2-8677-e70ebff414e2
+        application_id:
+          type: string
+          format: uuid
+          description: 申請ID（オプション、ソースがapplicationの場合）
+          example: bd3b53e7-bcf2-490e-b1b7-416b086c9cee
+        verified_claims:
+          type: object
+          description: 検証済みクレーム
+          additionalProperties: true
+        verified_at:
+          type: string
+          format: date-time
+          description: 検証日時
+          example: "2026-03-18T10:30:00"
+        verified_until:
+          type: string
+          format: date-time
+          description: 有効期限（オプション）
+          example: "2027-03-18T10:30:00"
+          nullable: true
+        source:
+          type: string
+          description: ソースタイプ
+          enum:
+          - application
+          - direct
+          - manual
+          - import
+          example: application
+        source_details:
+          type: object
+          description: ソース詳細情報（オプション）
+          additionalProperties: true
+        attributes:
+          type: object
+          description: 属性（オプション）
+          additionalProperties: true
+      required:
+      - id
+      - type
+      - tenant_id
+      - user_id
+      - verified_claims
+      - verified_at
+      - source
+    IdentityVerificationResultListResponse:
+      type: object
+      description: 身元確認結果一覧レスポンス
+      properties:
+        list:
+          type: array
+          items:
+            $ref: '#/components/schemas/IdentityVerificationResult'
+        total_count:
+          type: integer
+          description: フィルタ条件に一致する総件数
+          example: 10
+        limit:
+          type: integer
+          description: リクエストされたlimit値
+          example: 20
+        offset:
+          type: integer
+          description: リクエストされたoffset値
+          example: 0
+      required:
+      - list
+      - total_count
+      - limit
+      - offset
+  responses:
+    Unauthorized:
+      description: Unauthorized - Authentication required or invalid
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              error:
+                type: string
+                example: unauthorized
+              error_description:
+                type: string
+                example: Authentication required
+            required:
+            - error
+            - error_description
+    Forbidden:
+      description: Forbidden - Insufficient permissions
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              error:
+                type: string
+                example: access_denied
+              error_description:
+                type: string
+                example: Insufficient permissions to access this resource
+            required:
+            - error
+            - error_description

--- a/e2e/src/lib/schemaValidation.js
+++ b/e2e/src/lib/schemaValidation.js
@@ -279,6 +279,85 @@ export const validateIdentityVerificationApplication = (application) => {
 };
 
 /**
+ * Identity Verification Result schema validation
+ * Based on OpenAPI spec: swagger-cp-identity-verification-result-ja.yaml
+ */
+export const validateIdentityVerificationResult = (result) => {
+  const errors = [];
+
+  const validSources = ["application", "direct", "manual", "import"];
+
+  // Required fields
+  if (!result.id || !isUUID(result.id)) {
+    errors.push("id must be a valid UUID");
+  }
+
+  if (!result.type || typeof result.type !== "string") {
+    errors.push("type must be a string");
+  }
+
+  if (!result.tenant_id || typeof result.tenant_id !== "string") {
+    errors.push("tenant_id must be a string");
+  }
+
+  if (!result.user_id || typeof result.user_id !== "string") {
+    errors.push("user_id must be a string");
+  }
+
+  if (!result.source || !validSources.includes(result.source)) {
+    errors.push(
+      `source must be one of: ${validSources.join(", ")}, got: ${result.source}`
+    );
+  }
+
+  if (!result.verified_at || !isISODateTime(result.verified_at)) {
+    errors.push("verified_at must be a valid ISO datetime");
+  }
+
+  if (
+    result.verified_claims === undefined ||
+    typeof result.verified_claims !== "object"
+  ) {
+    errors.push("verified_claims must be an object");
+  }
+
+  // Optional fields
+  if (
+    result.application_id !== undefined &&
+    typeof result.application_id !== "string"
+  ) {
+    errors.push("application_id must be a string when present");
+  }
+
+  if (
+    result.verified_until !== undefined &&
+    result.verified_until !== null &&
+    !isISODateTime(result.verified_until)
+  ) {
+    errors.push("verified_until must be a valid ISO datetime when present");
+  }
+
+  if (
+    result.source_details !== undefined &&
+    typeof result.source_details !== "object"
+  ) {
+    errors.push("source_details must be an object when present");
+  }
+
+  if (
+    result.attributes !== undefined &&
+    typeof result.attributes !== "object"
+  ) {
+    errors.push("attributes must be an object when present");
+  }
+
+  return {
+    valid: errors.length === 0,
+    errors,
+  };
+};
+
+/**
  * List response schema validation
  */
 export const validateListResponse = (response, itemValidator) => {

--- a/e2e/src/lib/schemaValidation.js
+++ b/e2e/src/lib/schemaValidation.js
@@ -180,6 +180,105 @@ export const validateAuthenticationConfig = (config) => {
 };
 
 /**
+ * Identity Verification Application schema validation
+ * Based on OpenAPI spec: swagger-cp-identity-verification-application-ja.yaml
+ */
+export const validateIdentityVerificationApplication = (application) => {
+  const errors = [];
+
+  const validStatuses = [
+    "requested",
+    "applying",
+    "applied",
+    "examination_processing",
+    "approved",
+    "rejected",
+    "expired",
+    "cancelled",
+  ];
+
+  // Required fields
+  if (!application.id || !isUUID(application.id)) {
+    errors.push("id must be a valid UUID");
+  }
+
+  if (!application.type || typeof application.type !== "string") {
+    errors.push("type must be a string");
+  }
+
+  if (!application.tenant_id || typeof application.tenant_id !== "string") {
+    errors.push("tenant_id must be a string");
+  }
+
+  if (!application.client_id || typeof application.client_id !== "string") {
+    errors.push("client_id must be a string");
+  }
+
+  if (!application.user_id || typeof application.user_id !== "string") {
+    errors.push("user_id must be a string");
+  }
+
+  if (!application.status || !validStatuses.includes(application.status)) {
+    errors.push(
+      `status must be one of: ${validStatuses.join(", ")}, got: ${application.status}`
+    );
+  }
+
+  if (
+    !application.requested_at ||
+    !isISODateTime(application.requested_at)
+  ) {
+    errors.push("requested_at must be a valid ISO datetime");
+  }
+
+  // Optional object fields
+  if (
+    application.application_details &&
+    typeof application.application_details !== "object"
+  ) {
+    errors.push("application_details must be an object when present");
+  }
+
+  if (application.processes && typeof application.processes !== "object") {
+    errors.push("processes must be an object when present");
+  }
+
+  // Validate process results structure
+  if (application.processes && typeof application.processes === "object") {
+    for (const [processName, result] of Object.entries(
+      application.processes
+    )) {
+      if (typeof result !== "object" || result === null) {
+        errors.push(`processes.${processName} must be an object`);
+        continue;
+      }
+      if (typeof result.call_count !== "number") {
+        errors.push(`processes.${processName}.call_count must be a number`);
+      }
+      if (typeof result.success_count !== "number") {
+        errors.push(
+          `processes.${processName}.success_count must be a number`
+        );
+      }
+      if (typeof result.failure_count !== "number") {
+        errors.push(
+          `processes.${processName}.failure_count must be a number`
+        );
+      }
+    }
+  }
+
+  if (application.attributes && typeof application.attributes !== "object") {
+    errors.push("attributes must be an object when present");
+  }
+
+  return {
+    valid: errors.length === 0,
+    errors,
+  };
+};
+
+/**
  * List response schema validation
  */
 export const validateListResponse = (response, itemValidator) => {

--- a/e2e/src/tests/scenario/control_plane/organization/organization_identity_verification_application_management.test.js
+++ b/e2e/src/tests/scenario/control_plane/organization/organization_identity_verification_application_management.test.js
@@ -61,7 +61,7 @@ describe("Organization Identity Verification Application Management API Test", (
 
   test("should support filtering by status", async () => {
     const listResponse = await get({
-      url: `${baseUrl}?status=completed&limit=10`,
+      url: `${baseUrl}?status=approved&limit=10`,
       headers: {
         Authorization: authHeader,
       },
@@ -73,7 +73,7 @@ describe("Organization Identity Verification Application Management API Test", (
 
     if (listResponse.data.list.length > 0) {
       listResponse.data.list.forEach(app => {
-        expect(app.status).toBe("completed");
+        expect(app.status).toBe("approved");
       });
     }
   });
@@ -116,7 +116,7 @@ describe("Organization Identity Verification Application Management API Test", (
     const fromDate = oneYearAgo.toISOString().substring(0, 19).replace("T", " ");
 
     const listResponse = await get({
-      url: `${baseUrl}?from=${encodeURIComponent(fromDate)}&status=completed&limit=5&offset=0`,
+      url: `${baseUrl}?from=${encodeURIComponent(fromDate)}&status=approved&limit=5&offset=0`,
       headers: {
         Authorization: authHeader,
       },

--- a/e2e/src/tests/scenario/control_plane/organization/organization_identity_verification_application_management.test.js
+++ b/e2e/src/tests/scenario/control_plane/organization/organization_identity_verification_application_management.test.js
@@ -1,0 +1,199 @@
+import { describe, expect, test, beforeAll } from "@jest/globals";
+import { deletion, get } from "../../../../lib/http";
+import { backendUrl } from "../../../testConfig";
+import { requestToken } from "../../../../api/oauthClient";
+
+describe("Organization Identity Verification Application Management API Test", () => {
+  const orgId = "72cf4a12-8da3-40fb-8ae4-a77e3cda95e2";
+  const tenantId = "952f6906-3e95-4ed3-86b2-981f90f785f9";
+
+  const baseUrl = `${backendUrl}/v1/management/organizations/${orgId}/tenants/${tenantId}/identity-verification-applications`;
+
+  let authHeader;
+
+  beforeAll(async () => {
+    const tokenResponse = await requestToken({
+      endpoint: `${backendUrl}/952f6906-3e95-4ed3-86b2-981f90f785f9/v1/tokens`,
+      grantType: "password",
+      username: "ito.ichiro@gmail.com",
+      password: "successUserCode001",
+      scope: "org-management account management",
+      clientId: "org-client",
+      clientSecret: "org-client-001"
+    });
+    authHeader = `Bearer ${tokenResponse.data.access_token}`;
+  });
+
+  test("should list identity verification applications with default pagination", async () => {
+    const listResponse = await get({
+      url: baseUrl,
+      headers: {
+        Authorization: authHeader,
+      },
+    });
+
+    console.log("List Response:", JSON.stringify(listResponse.data));
+    expect(listResponse.status).toBe(200);
+    expect(listResponse.data).toHaveProperty("list");
+    expect(listResponse.data).toHaveProperty("total_count");
+    expect(Array.isArray(listResponse.data.list)).toBe(true);
+    expect(typeof listResponse.data.total_count).toBe("number");
+  });
+
+  test("should support pagination with limit and offset", async () => {
+    const listResponse = await get({
+      url: `${baseUrl}?limit=5&offset=0`,
+      headers: {
+        Authorization: authHeader,
+      },
+    });
+
+    console.log("Pagination Response:", JSON.stringify(listResponse.data));
+    expect(listResponse.status).toBe(200);
+    expect(listResponse.data).toHaveProperty("list");
+    expect(listResponse.data).toHaveProperty("total_count");
+    expect(listResponse.data).toHaveProperty("limit");
+    expect(listResponse.data).toHaveProperty("offset");
+    expect(listResponse.data.limit).toBe(5);
+    expect(listResponse.data.offset).toBe(0);
+    expect(listResponse.data.list.length).toBeLessThanOrEqual(5);
+  });
+
+  test("should support filtering by status", async () => {
+    const listResponse = await get({
+      url: `${baseUrl}?status=completed&limit=10`,
+      headers: {
+        Authorization: authHeader,
+      },
+    });
+
+    console.log("Status Filter Response:", JSON.stringify(listResponse.data));
+    expect(listResponse.status).toBe(200);
+    expect(listResponse.data).toHaveProperty("total_count");
+
+    if (listResponse.data.list.length > 0) {
+      listResponse.data.list.forEach(app => {
+        expect(app.status).toBe("completed");
+      });
+    }
+  });
+
+  test("should support filtering by type", async () => {
+    const listResponse = await get({
+      url: `${baseUrl}?type=NonExistentType12345&limit=10&offset=0`,
+      headers: {
+        Authorization: authHeader,
+      },
+    });
+
+    console.log("Type Filter Response:", JSON.stringify(listResponse.data));
+    expect(listResponse.status).toBe(200);
+    expect(listResponse.data.list).toEqual([]);
+    expect(listResponse.data.total_count).toBe(0);
+  });
+
+  test("should support time range filtering", async () => {
+    const oneYearAgo = new Date();
+    oneYearAgo.setFullYear(oneYearAgo.getFullYear() - 1);
+    const fromDate = oneYearAgo.toISOString().substring(0, 19).replace("T", " ");
+
+    const listResponse = await get({
+      url: `${baseUrl}?from=${encodeURIComponent(fromDate)}&limit=10`,
+      headers: {
+        Authorization: authHeader,
+      },
+    });
+
+    console.log("Time Range Filter Response:", JSON.stringify(listResponse.data));
+    expect(listResponse.status).toBe(200);
+    expect(listResponse.data).toHaveProperty("total_count");
+    expect(listResponse.data).toHaveProperty("list");
+  });
+
+  test("should support multiple query parameters", async () => {
+    const oneYearAgo = new Date();
+    oneYearAgo.setFullYear(oneYearAgo.getFullYear() - 1);
+    const fromDate = oneYearAgo.toISOString().substring(0, 19).replace("T", " ");
+
+    const listResponse = await get({
+      url: `${baseUrl}?from=${encodeURIComponent(fromDate)}&status=completed&limit=5&offset=0`,
+      headers: {
+        Authorization: authHeader,
+      },
+    });
+
+    console.log("Multi Filter Response:", JSON.stringify(listResponse.data));
+    expect(listResponse.status).toBe(200);
+    expect(listResponse.data).toHaveProperty("total_count");
+    expect(listResponse.data.limit).toBe(5);
+    expect(listResponse.data.offset).toBe(0);
+  });
+
+  test("should get application detail when applications exist", async () => {
+    const listResponse = await get({
+      url: `${baseUrl}?limit=1`,
+      headers: {
+        Authorization: authHeader,
+      },
+    });
+    expect(listResponse.status).toBe(200);
+
+    if (listResponse.data.list.length > 0) {
+      const applicationId = listResponse.data.list[0].id;
+      const detailResponse = await get({
+        url: `${baseUrl}/${applicationId}`,
+        headers: {
+          Authorization: authHeader,
+        },
+      });
+      console.log("Detail Response:", JSON.stringify(detailResponse.data));
+      expect(detailResponse.status).toBe(200);
+      expect(detailResponse.data.id).toBe(applicationId);
+    }
+  });
+
+  test("should return 404 for non-existent application", async () => {
+    const response = await get({
+      url: `${baseUrl}/00000000-0000-0000-0000-000000000000`,
+      headers: {
+        Authorization: authHeader,
+      },
+    });
+
+    expect(response.status).toBe(404);
+  });
+
+  test("should support dry-run delete", async () => {
+    const listResponse = await get({
+      url: `${baseUrl}?limit=1`,
+      headers: {
+        Authorization: authHeader,
+      },
+    });
+    expect(listResponse.status).toBe(200);
+
+    if (listResponse.data.list.length > 0) {
+      const applicationId = listResponse.data.list[0].id;
+
+      // Dry-run delete
+      const dryRunResponse = await deletion({
+        url: `${baseUrl}/${applicationId}?dry_run=true`,
+        headers: {
+          Authorization: authHeader,
+        },
+      });
+      console.log("Dry-run Delete Response:", dryRunResponse.status, dryRunResponse.data);
+      expect(dryRunResponse.status).toBe(200);
+
+      // Verify application still exists
+      const verifyResponse = await get({
+        url: `${baseUrl}/${applicationId}`,
+        headers: {
+          Authorization: authHeader,
+        },
+      });
+      expect(verifyResponse.status).toBe(200);
+      expect(verifyResponse.data.id).toBe(applicationId);
+    }
+  });
+});

--- a/e2e/src/tests/scenario/control_plane/organization/organization_identity_verification_application_management_structured.test.js
+++ b/e2e/src/tests/scenario/control_plane/organization/organization_identity_verification_application_management_structured.test.js
@@ -1,0 +1,481 @@
+/*
+ * Organization Identity Verification Application Management API - Structured E2E Tests
+ *
+ * This test suite validates that actual API responses match the OpenAPI specification
+ * defined in swagger-cp-identity-verification-application-ja.yaml.
+ *
+ * - List Response Structure (IdentityVerificationApplicationListResponse)
+ * - Application Detail Structure (IdentityVerificationApplication)
+ * - ProcessResult Structure
+ * - Query Parameters (pagination, filtering)
+ * - Delete with dry_run
+ * - Error Responses
+ */
+
+import { describe, expect, it, beforeAll } from "@jest/globals";
+import { get, deletion } from "../../../../lib/http";
+import { requestToken } from "../../../../api/oauthClient";
+import { backendUrl } from "../../../testConfig";
+import {
+  isUUID,
+  isISODateTime,
+  validateIdentityVerificationApplication,
+  validateListResponse,
+} from "../../../../lib/schemaValidation";
+
+describe("Organization Identity Verification Application Management API - Schema Compliance Tests", () => {
+  const orgId = "72cf4a12-8da3-40fb-8ae4-a77e3cda95e2";
+  const tenantId = "952f6906-3e95-4ed3-86b2-981f90f785f9";
+  let accessToken;
+
+  const baseUrl = `${backendUrl}/v1/management/organizations/${orgId}/tenants/${tenantId}/identity-verification-applications`;
+
+  beforeAll(async () => {
+    const authResponse = await requestToken({
+      endpoint: `${backendUrl}/952f6906-3e95-4ed3-86b2-981f90f785f9/v1/tokens`,
+      grantType: "password",
+      username: "ito.ichiro@gmail.com",
+      password: "successUserCode001",
+      clientId: "org-client",
+      clientSecret: "org-client-001",
+      scope: "org-management account management",
+    });
+
+    expect(authResponse.status).toBe(200);
+    expect(authResponse.data).toHaveProperty("access_token");
+    accessToken = authResponse.data.access_token;
+  });
+
+  /**
+   * Layer 1: List Response Structure Validation
+   * Validates IdentityVerificationApplicationListResponse schema
+   */
+  describe("List Response Structure Validation", () => {
+    it("should match IdentityVerificationApplicationListResponse schema", async () => {
+      const response = await get({
+        url: `${baseUrl}?limit=10&offset=0`,
+        headers: { Authorization: `Bearer ${accessToken}` },
+      });
+
+      expect(response.status).toBe(200);
+
+      // Required fields per OpenAPI spec
+      expect(response.data).toHaveProperty("list");
+      expect(response.data).toHaveProperty("total_count");
+      expect(response.data).toHaveProperty("limit");
+      expect(response.data).toHaveProperty("offset");
+
+      // Type validation
+      expect(Array.isArray(response.data.list)).toBe(true);
+      expect(typeof response.data.total_count).toBe("number");
+      expect(typeof response.data.limit).toBe("number");
+      expect(typeof response.data.offset).toBe("number");
+
+      // Value validation
+      expect(response.data.limit).toBe(10);
+      expect(response.data.offset).toBe(0);
+      expect(response.data.total_count).toBeGreaterThanOrEqual(0);
+
+      // Schema validation using validator
+      const validation = validateListResponse(
+        response.data,
+        validateIdentityVerificationApplication
+      );
+      if (!validation.valid) {
+        console.log("Schema validation errors:", validation.errors);
+      }
+      expect(validation.valid).toBe(true);
+    });
+
+    it("should use default limit=20 and offset=0 when not specified", async () => {
+      const response = await get({
+        url: baseUrl,
+        headers: { Authorization: `Bearer ${accessToken}` },
+      });
+
+      expect(response.status).toBe(200);
+      expect(response.data.limit).toBe(20);
+      expect(response.data.offset).toBe(0);
+    });
+
+    it("should return empty list with correct structure when no results match", async () => {
+      const response = await get({
+        url: `${baseUrl}?type=NonExistentType_schema_test&limit=10&offset=0`,
+        headers: { Authorization: `Bearer ${accessToken}` },
+      });
+
+      expect(response.status).toBe(200);
+      expect(response.data.list).toEqual([]);
+      expect(response.data.total_count).toBe(0);
+      expect(response.data.limit).toBe(10);
+      expect(response.data.offset).toBe(0);
+    });
+  });
+
+  /**
+   * Layer 2: Individual Application Schema Validation
+   * Validates IdentityVerificationApplication schema when data exists
+   */
+  describe("Application Detail Schema Validation", () => {
+    it("should match IdentityVerificationApplication schema for each item in list", async () => {
+      const response = await get({
+        url: `${baseUrl}?limit=5`,
+        headers: { Authorization: `Bearer ${accessToken}` },
+      });
+
+      expect(response.status).toBe(200);
+
+      if (response.data.list.length === 0) {
+        console.log(
+          "⚠️ No identity verification applications found - skipping individual item validation. Run IDA integration tests first to create test data."
+        );
+        return;
+      }
+
+      for (const application of response.data.list) {
+        const validation =
+          validateIdentityVerificationApplication(application);
+        if (!validation.valid) {
+          console.log(
+            `Schema validation errors for application ${application.id}:`,
+            validation.errors
+          );
+        }
+        expect(validation.valid).toBe(true);
+
+        // Required fields per OpenAPI spec
+        expect(isUUID(application.id)).toBe(true);
+        expect(typeof application.type).toBe("string");
+        expect(typeof application.tenant_id).toBe("string");
+        expect(typeof application.client_id).toBe("string");
+        expect(typeof application.user_id).toBe("string");
+        expect(typeof application.status).toBe("string");
+        expect(isISODateTime(application.requested_at)).toBe(true);
+
+        // Status enum validation
+        expect([
+          "requested",
+          "applying",
+          "applied",
+          "examination_processing",
+          "approved",
+          "rejected",
+          "expired",
+          "cancelled",
+        ]).toContain(application.status);
+      }
+    });
+
+    it("should match IdentityVerificationApplication schema for single GET", async () => {
+      const listResponse = await get({
+        url: `${baseUrl}?limit=1`,
+        headers: { Authorization: `Bearer ${accessToken}` },
+      });
+
+      expect(listResponse.status).toBe(200);
+
+      if (listResponse.data.list.length === 0) {
+        console.log(
+          "⚠️ No identity verification applications found - skipping detail validation."
+        );
+        return;
+      }
+
+      const applicationId = listResponse.data.list[0].id;
+
+      const detailResponse = await get({
+        url: `${baseUrl}/${applicationId}`,
+        headers: { Authorization: `Bearer ${accessToken}` },
+      });
+
+      expect(detailResponse.status).toBe(200);
+
+      const application = detailResponse.data;
+
+      // Full schema validation
+      const validation = validateIdentityVerificationApplication(application);
+      if (!validation.valid) {
+        console.log("Detail schema validation errors:", validation.errors);
+      }
+      expect(validation.valid).toBe(true);
+
+      // Verify required fields
+      expect(application.id).toBe(applicationId);
+      expect(isUUID(application.id)).toBe(true);
+      expect(typeof application.type).toBe("string");
+      expect(typeof application.tenant_id).toBe("string");
+      expect(typeof application.client_id).toBe("string");
+      expect(typeof application.user_id).toBe("string");
+      expect(typeof application.status).toBe("string");
+      expect(isISODateTime(application.requested_at)).toBe(true);
+
+      // Verify optional fields type when present
+      if (application.application_details !== undefined) {
+        expect(typeof application.application_details).toBe("object");
+      }
+      if (application.processes !== undefined) {
+        expect(typeof application.processes).toBe("object");
+      }
+      if (application.attributes !== undefined) {
+        expect(typeof application.attributes).toBe("object");
+      }
+    });
+
+    it("should validate ProcessResult schema for each process", async () => {
+      const listResponse = await get({
+        url: `${baseUrl}?limit=10`,
+        headers: { Authorization: `Bearer ${accessToken}` },
+      });
+
+      expect(listResponse.status).toBe(200);
+
+      const appsWithProcesses = listResponse.data.list.filter(
+        (app) =>
+          app.processes &&
+          typeof app.processes === "object" &&
+          Object.keys(app.processes).length > 0
+      );
+
+      if (appsWithProcesses.length === 0) {
+        console.log(
+          "⚠️ No applications with process results found - skipping ProcessResult validation."
+        );
+        return;
+      }
+
+      for (const application of appsWithProcesses) {
+        for (const [processName, result] of Object.entries(
+          application.processes
+        )) {
+          expect(typeof result).toBe("object");
+          expect(typeof result.call_count).toBe("number");
+          expect(typeof result.success_count).toBe("number");
+          expect(typeof result.failure_count).toBe("number");
+          expect(result.call_count).toBeGreaterThanOrEqual(0);
+          expect(result.success_count).toBeGreaterThanOrEqual(0);
+          expect(result.failure_count).toBeGreaterThanOrEqual(0);
+          expect(result.call_count).toBeGreaterThanOrEqual(
+            result.success_count + result.failure_count
+          );
+          console.log(
+            `✅ ProcessResult validated: ${processName} (calls=${result.call_count}, success=${result.success_count}, failure=${result.failure_count})`
+          );
+        }
+      }
+    });
+  });
+
+  /**
+   * Layer 3: Query Parameter Validation
+   * Validates that query parameters produce correctly filtered results
+   */
+  describe("Query Parameter Validation", () => {
+    it("should filter by status and return only matching items", async () => {
+      const statuses = [
+        "requested",
+        "applying",
+        "applied",
+        "examination_processing",
+        "approved",
+        "rejected",
+        "expired",
+        "cancelled",
+      ];
+
+      for (const status of statuses) {
+        const response = await get({
+          url: `${baseUrl}?status=${status}&limit=5`,
+          headers: { Authorization: `Bearer ${accessToken}` },
+        });
+
+        expect(response.status).toBe(200);
+        expect(response.data).toHaveProperty("list");
+        expect(response.data).toHaveProperty("total_count");
+
+        for (const app of response.data.list) {
+          expect(app.status).toBe(status);
+        }
+      }
+    });
+
+    it("should filter by type and return only matching items", async () => {
+      // First get list to find existing types
+      const listResponse = await get({
+        url: `${baseUrl}?limit=1`,
+        headers: { Authorization: `Bearer ${accessToken}` },
+      });
+
+      if (listResponse.data.list.length === 0) {
+        console.log("⚠️ No data to test type filtering.");
+        return;
+      }
+
+      const existingType = listResponse.data.list[0].type;
+
+      const filteredResponse = await get({
+        url: `${baseUrl}?type=${encodeURIComponent(existingType)}&limit=10`,
+        headers: { Authorization: `Bearer ${accessToken}` },
+      });
+
+      expect(filteredResponse.status).toBe(200);
+      for (const app of filteredResponse.data.list) {
+        expect(app.type).toBe(existingType);
+      }
+    });
+
+    it("should filter by client_id and return only matching items", async () => {
+      const listResponse = await get({
+        url: `${baseUrl}?limit=1`,
+        headers: { Authorization: `Bearer ${accessToken}` },
+      });
+
+      if (listResponse.data.list.length === 0) {
+        console.log("⚠️ No data to test client_id filtering.");
+        return;
+      }
+
+      const existingClientId = listResponse.data.list[0].client_id;
+
+      const filteredResponse = await get({
+        url: `${baseUrl}?client_id=${encodeURIComponent(existingClientId)}&limit=10`,
+        headers: { Authorization: `Bearer ${accessToken}` },
+      });
+
+      expect(filteredResponse.status).toBe(200);
+      for (const app of filteredResponse.data.list) {
+        expect(app.client_id).toBe(existingClientId);
+      }
+    });
+
+    it("should respect pagination limit", async () => {
+      const response = await get({
+        url: `${baseUrl}?limit=2&offset=0`,
+        headers: { Authorization: `Bearer ${accessToken}` },
+      });
+
+      expect(response.status).toBe(200);
+      expect(response.data.list.length).toBeLessThanOrEqual(2);
+      expect(response.data.limit).toBe(2);
+      expect(response.data.offset).toBe(0);
+    });
+
+    it("should support time range filtering with from parameter", async () => {
+      const oneYearAgo = new Date();
+      oneYearAgo.setFullYear(oneYearAgo.getFullYear() - 1);
+      const fromDate = oneYearAgo
+        .toISOString()
+        .substring(0, 19)
+        .replace("T", " ");
+
+      const response = await get({
+        url: `${baseUrl}?from=${encodeURIComponent(fromDate)}&limit=10`,
+        headers: { Authorization: `Bearer ${accessToken}` },
+      });
+
+      expect(response.status).toBe(200);
+      expect(response.data).toHaveProperty("list");
+      expect(response.data).toHaveProperty("total_count");
+    });
+  });
+
+  /**
+   * Layer 4: Error Response Validation
+   * Validates error response structure matches OpenAPI spec
+   */
+  describe("Error Response Validation", () => {
+    it("should return 404 with ErrorResponse schema for non-existent application", async () => {
+      const response = await get({
+        url: `${baseUrl}/00000000-0000-0000-0000-000000000000`,
+        headers: { Authorization: `Bearer ${accessToken}` },
+      });
+
+      expect(response.status).toBe(404);
+      expect(response.data).toHaveProperty("error");
+      expect(response.data).toHaveProperty("error_description");
+      expect(typeof response.data.error).toBe("string");
+      expect(typeof response.data.error_description).toBe("string");
+    });
+  });
+
+  /**
+   * Layer 5: Delete with dry_run Validation
+   * Validates dry_run delete response matches OpenAPI spec
+   */
+  describe("Delete dry_run Response Validation", () => {
+    it("should return 200 with dry_run response when dry_run=true", async () => {
+      const listResponse = await get({
+        url: `${baseUrl}?limit=1`,
+        headers: { Authorization: `Bearer ${accessToken}` },
+      });
+
+      expect(listResponse.status).toBe(200);
+
+      if (listResponse.data.list.length === 0) {
+        console.log(
+          "⚠️ No applications found - skipping dry_run delete validation."
+        );
+        return;
+      }
+
+      const applicationId = listResponse.data.list[0].id;
+
+      const dryRunResponse = await deletion({
+        url: `${baseUrl}/${applicationId}?dry_run=true`,
+        headers: { Authorization: `Bearer ${accessToken}` },
+      });
+
+      expect(dryRunResponse.status).toBe(200);
+      expect(dryRunResponse.data).toHaveProperty("dry_run", true);
+
+      // Verify application still exists after dry_run
+      const verifyResponse = await get({
+        url: `${baseUrl}/${applicationId}`,
+        headers: { Authorization: `Bearer ${accessToken}` },
+      });
+      expect(verifyResponse.status).toBe(200);
+      expect(verifyResponse.data.id).toBe(applicationId);
+    });
+  });
+
+  /**
+   * Layer 6: Consistency between List and Detail
+   * Validates that list items and detail responses are consistent
+   */
+  describe("List and Detail Consistency", () => {
+    it("should return same data in list item and detail response", async () => {
+      const listResponse = await get({
+        url: `${baseUrl}?limit=3`,
+        headers: { Authorization: `Bearer ${accessToken}` },
+      });
+
+      expect(listResponse.status).toBe(200);
+
+      if (listResponse.data.list.length === 0) {
+        console.log(
+          "⚠️ No applications found - skipping consistency validation."
+        );
+        return;
+      }
+
+      for (const listItem of listResponse.data.list) {
+        const detailResponse = await get({
+          url: `${baseUrl}/${listItem.id}`,
+          headers: { Authorization: `Bearer ${accessToken}` },
+        });
+
+        expect(detailResponse.status).toBe(200);
+
+        const detail = detailResponse.data;
+
+        // Core fields must match
+        expect(detail.id).toBe(listItem.id);
+        expect(detail.type).toBe(listItem.type);
+        expect(detail.tenant_id).toBe(listItem.tenant_id);
+        expect(detail.client_id).toBe(listItem.client_id);
+        expect(detail.user_id).toBe(listItem.user_id);
+        expect(detail.status).toBe(listItem.status);
+        expect(detail.requested_at).toBe(listItem.requested_at);
+      }
+    });
+  });
+});

--- a/e2e/src/tests/scenario/control_plane/organization/organization_identity_verification_result_management.test.js
+++ b/e2e/src/tests/scenario/control_plane/organization/organization_identity_verification_result_management.test.js
@@ -1,0 +1,119 @@
+import { describe, expect, test, beforeAll } from "@jest/globals";
+import { get } from "../../../../lib/http";
+import { backendUrl } from "../../../testConfig";
+import { requestToken } from "../../../../api/oauthClient";
+import {
+  validateIdentityVerificationResult,
+  validateListResponse,
+} from "../../../../lib/schemaValidation";
+
+describe("Organization Identity Verification Result Management API Test", () => {
+  const orgId = "72cf4a12-8da3-40fb-8ae4-a77e3cda95e2";
+  const tenantId = "952f6906-3e95-4ed3-86b2-981f90f785f9";
+
+  const baseUrl = `${backendUrl}/v1/management/organizations/${orgId}/tenants/${tenantId}/identity-verification-results`;
+
+  let authHeader;
+
+  beforeAll(async () => {
+    const tokenResponse = await requestToken({
+      endpoint: `${backendUrl}/952f6906-3e95-4ed3-86b2-981f90f785f9/v1/tokens`,
+      grantType: "password",
+      username: "ito.ichiro@gmail.com",
+      password: "successUserCode001",
+      scope: "org-management account management",
+      clientId: "org-client",
+      clientSecret: "org-client-001",
+    });
+    authHeader = `Bearer ${tokenResponse.data.access_token}`;
+  });
+
+  test("should list results with default pagination", async () => {
+    const response = await get({
+      url: baseUrl,
+      headers: { Authorization: authHeader },
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.data).toHaveProperty("list");
+    expect(response.data).toHaveProperty("total_count");
+    expect(Array.isArray(response.data.list)).toBe(true);
+    expect(response.data.limit).toBe(20);
+    expect(response.data.offset).toBe(0);
+
+    const validation = validateListResponse(
+      response.data,
+      validateIdentityVerificationResult
+    );
+    if (!validation.valid) {
+      console.log("Schema validation errors:", validation.errors);
+    }
+    expect(validation.valid).toBe(true);
+  });
+
+  test("should support pagination with limit and offset", async () => {
+    const response = await get({
+      url: `${baseUrl}?limit=5&offset=0`,
+      headers: { Authorization: authHeader },
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.data.limit).toBe(5);
+    expect(response.data.offset).toBe(0);
+    expect(response.data.list.length).toBeLessThanOrEqual(5);
+  });
+
+  test("should return empty list for non-matching type filter", async () => {
+    const response = await get({
+      url: `${baseUrl}?type=NonExistentType12345&limit=10&offset=0`,
+      headers: { Authorization: authHeader },
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.data.list).toEqual([]);
+    expect(response.data.total_count).toBe(0);
+  });
+
+  test("should support filtering by source", async () => {
+    const response = await get({
+      url: `${baseUrl}?source=application&limit=10`,
+      headers: { Authorization: authHeader },
+    });
+
+    expect(response.status).toBe(200);
+    if (response.data.list.length > 0) {
+      response.data.list.forEach((result) => {
+        expect(result.source).toBe("application");
+      });
+    }
+  });
+
+  test("should return 404 for non-existent result", async () => {
+    const response = await get({
+      url: `${baseUrl}/00000000-0000-0000-0000-000000000000`,
+      headers: { Authorization: authHeader },
+    });
+
+    expect(response.status).toBe(404);
+    expect(response.data).toHaveProperty("error");
+    expect(response.data).toHaveProperty("error_description");
+  });
+
+  test("should get result detail when results exist", async () => {
+    const listResponse = await get({
+      url: `${baseUrl}?limit=1`,
+      headers: { Authorization: authHeader },
+    });
+    expect(listResponse.status).toBe(200);
+
+    if (listResponse.data.list.length > 0) {
+      const resultId = listResponse.data.list[0].id;
+      const detailResponse = await get({
+        url: `${baseUrl}/${resultId}`,
+        headers: { Authorization: authHeader },
+      });
+      expect(detailResponse.status).toBe(200);
+      expect(detailResponse.data.id).toBe(resultId);
+    }
+  });
+});

--- a/e2e/src/tests/scenario/control_plane/system/identity_verification_application_management.test.js
+++ b/e2e/src/tests/scenario/control_plane/system/identity_verification_application_management.test.js
@@ -1,0 +1,218 @@
+import { describe, expect, it } from "@jest/globals";
+import { get, deletion } from "../../../../lib/http";
+import { requestToken } from "../../../../api/oauthClient";
+import { adminServerConfig, backendUrl } from "../../../testConfig";
+
+describe("identity verification application management api", () => {
+
+  const baseUrl = `${backendUrl}/v1/management/tenants/${adminServerConfig.tenantId}/identity-verification-applications`;
+
+  const getAccessToken = async () => {
+    const tokenResponse = await requestToken({
+      endpoint: adminServerConfig.tokenEndpoint,
+      grantType: "password",
+      username: adminServerConfig.oauth.username,
+      password: adminServerConfig.oauth.password,
+      scope: adminServerConfig.adminClient.scope,
+      clientId: adminServerConfig.adminClient.clientId,
+      clientSecret: adminServerConfig.adminClient.clientSecret,
+    });
+    expect(tokenResponse.status).toBe(200);
+    return tokenResponse.data.access_token;
+  };
+
+  describe("list operations", () => {
+
+    it("should list identity verification applications with default pagination", async () => {
+      const accessToken = await getAccessToken();
+
+      const listResponse = await get({
+        url: baseUrl,
+        headers: {
+          Authorization: `Bearer ${accessToken}`
+        }
+      });
+      console.log("List Response:", JSON.stringify(listResponse.data));
+      expect(listResponse.status).toBe(200);
+      expect(listResponse.data).toHaveProperty("list");
+      expect(listResponse.data).toHaveProperty("total_count");
+      expect(Array.isArray(listResponse.data.list)).toBe(true);
+      expect(typeof listResponse.data.total_count).toBe("number");
+    });
+
+    it("should support pagination with limit and offset", async () => {
+      const accessToken = await getAccessToken();
+
+      const listResponse = await get({
+        url: `${baseUrl}?limit=5&offset=0`,
+        headers: {
+          Authorization: `Bearer ${accessToken}`
+        }
+      });
+      console.log("Pagination Response:", JSON.stringify(listResponse.data));
+      expect(listResponse.status).toBe(200);
+      expect(listResponse.data).toHaveProperty("list");
+      expect(listResponse.data).toHaveProperty("total_count");
+      expect(listResponse.data).toHaveProperty("limit");
+      expect(listResponse.data).toHaveProperty("offset");
+      expect(listResponse.data.limit).toBe(5);
+      expect(listResponse.data.offset).toBe(0);
+      expect(listResponse.data.list.length).toBeLessThanOrEqual(5);
+    });
+
+    it("should support filtering by status", async () => {
+      const accessToken = await getAccessToken();
+
+      const listResponse = await get({
+        url: `${baseUrl}?status=completed&limit=10`,
+        headers: {
+          Authorization: `Bearer ${accessToken}`
+        }
+      });
+      console.log("Status Filter Response:", JSON.stringify(listResponse.data));
+      expect(listResponse.status).toBe(200);
+      expect(listResponse.data).toHaveProperty("total_count");
+
+      if (listResponse.data.list.length > 0) {
+        listResponse.data.list.forEach(app => {
+          expect(app.status).toBe("completed");
+        });
+      }
+    });
+
+    it("should support filtering by type", async () => {
+      const accessToken = await getAccessToken();
+
+      const listResponse = await get({
+        url: `${baseUrl}?type=NonExistentType12345&limit=10&offset=0`,
+        headers: {
+          Authorization: `Bearer ${accessToken}`
+        }
+      });
+      console.log("Type Filter Response:", JSON.stringify(listResponse.data));
+      expect(listResponse.status).toBe(200);
+      expect(listResponse.data.list).toEqual([]);
+      expect(listResponse.data.total_count).toBe(0);
+    });
+
+    it("should support time range filtering", async () => {
+      const accessToken = await getAccessToken();
+
+      const oneYearAgo = new Date();
+      oneYearAgo.setFullYear(oneYearAgo.getFullYear() - 1);
+      const fromDate = oneYearAgo.toISOString().substring(0, 19).replace("T", " ");
+
+      const listResponse = await get({
+        url: `${baseUrl}?from=${encodeURIComponent(fromDate)}&limit=10`,
+        headers: {
+          Authorization: `Bearer ${accessToken}`
+        }
+      });
+      console.log("Time Range Filter Response:", JSON.stringify(listResponse.data));
+      expect(listResponse.status).toBe(200);
+      expect(listResponse.data).toHaveProperty("total_count");
+      expect(listResponse.data).toHaveProperty("list");
+    });
+
+    it("should support multiple query parameters", async () => {
+      const accessToken = await getAccessToken();
+
+      const oneYearAgo = new Date();
+      oneYearAgo.setFullYear(oneYearAgo.getFullYear() - 1);
+      const fromDate = oneYearAgo.toISOString().substring(0, 19).replace("T", " ");
+
+      const listResponse = await get({
+        url: `${baseUrl}?from=${encodeURIComponent(fromDate)}&status=completed&limit=5&offset=0`,
+        headers: {
+          Authorization: `Bearer ${accessToken}`
+        }
+      });
+      console.log("Multi Filter Response:", JSON.stringify(listResponse.data));
+      expect(listResponse.status).toBe(200);
+      expect(listResponse.data).toHaveProperty("total_count");
+      expect(listResponse.data.limit).toBe(5);
+      expect(listResponse.data.offset).toBe(0);
+    });
+  });
+
+  describe("get by id operations", () => {
+
+    it("should get application detail when applications exist", async () => {
+      const accessToken = await getAccessToken();
+
+      // First get the list to find an existing application
+      const listResponse = await get({
+        url: `${baseUrl}?limit=1`,
+        headers: {
+          Authorization: `Bearer ${accessToken}`
+        }
+      });
+      expect(listResponse.status).toBe(200);
+
+      if (listResponse.data.list.length > 0) {
+        const applicationId = listResponse.data.list[0].id;
+        const detailResponse = await get({
+          url: `${baseUrl}/${applicationId}`,
+          headers: {
+            Authorization: `Bearer ${accessToken}`
+          }
+        });
+        console.log("Detail Response:", JSON.stringify(detailResponse.data));
+        expect(detailResponse.status).toBe(200);
+        expect(detailResponse.data.id).toBe(applicationId);
+      }
+    });
+
+    it("should return 404 for non-existent application", async () => {
+      const accessToken = await getAccessToken();
+
+      const response = await get({
+        url: `${baseUrl}/00000000-0000-0000-0000-000000000000`,
+        headers: {
+          Authorization: `Bearer ${accessToken}`
+        }
+      });
+      expect(response.status).toBe(404);
+    });
+  });
+
+  describe("delete operations", () => {
+
+    it("should support dry-run delete", async () => {
+      const accessToken = await getAccessToken();
+
+      // First get the list to find an existing application
+      const listResponse = await get({
+        url: `${baseUrl}?limit=1`,
+        headers: {
+          Authorization: `Bearer ${accessToken}`
+        }
+      });
+      expect(listResponse.status).toBe(200);
+
+      if (listResponse.data.list.length > 0) {
+        const applicationId = listResponse.data.list[0].id;
+
+        // Dry-run delete
+        const dryRunResponse = await deletion({
+          url: `${baseUrl}/${applicationId}?dry_run=true`,
+          headers: {
+            Authorization: `Bearer ${accessToken}`
+          }
+        });
+        console.log("Dry-run Delete Response:", dryRunResponse.status, dryRunResponse.data);
+        expect(dryRunResponse.status).toBe(200);
+
+        // Verify application still exists
+        const verifyResponse = await get({
+          url: `${baseUrl}/${applicationId}`,
+          headers: {
+            Authorization: `Bearer ${accessToken}`
+          }
+        });
+        expect(verifyResponse.status).toBe(200);
+        expect(verifyResponse.data.id).toBe(applicationId);
+      }
+    });
+  });
+});

--- a/e2e/src/tests/scenario/control_plane/system/identity_verification_application_management.test.js
+++ b/e2e/src/tests/scenario/control_plane/system/identity_verification_application_management.test.js
@@ -64,7 +64,7 @@ describe("identity verification application management api", () => {
       const accessToken = await getAccessToken();
 
       const listResponse = await get({
-        url: `${baseUrl}?status=completed&limit=10`,
+        url: `${baseUrl}?status=approved&limit=10`,
         headers: {
           Authorization: `Bearer ${accessToken}`
         }
@@ -75,7 +75,7 @@ describe("identity verification application management api", () => {
 
       if (listResponse.data.list.length > 0) {
         listResponse.data.list.forEach(app => {
-          expect(app.status).toBe("completed");
+          expect(app.status).toBe("approved");
         });
       }
     });
@@ -122,7 +122,7 @@ describe("identity verification application management api", () => {
       const fromDate = oneYearAgo.toISOString().substring(0, 19).replace("T", " ");
 
       const listResponse = await get({
-        url: `${baseUrl}?from=${encodeURIComponent(fromDate)}&status=completed&limit=5&offset=0`,
+        url: `${baseUrl}?from=${encodeURIComponent(fromDate)}&status=approved&limit=5&offset=0`,
         headers: {
           Authorization: `Bearer ${accessToken}`
         }

--- a/e2e/src/tests/scenario/control_plane/system/identity_verification_application_management_structured.test.js
+++ b/e2e/src/tests/scenario/control_plane/system/identity_verification_application_management_structured.test.js
@@ -1,0 +1,468 @@
+/*
+ * Identity Verification Application Management API - Schema Compliance Tests (System Level)
+ *
+ * Validates that actual API responses match the OpenAPI specification
+ * defined in swagger-cp-identity-verification-application-ja.yaml.
+ *
+ * Uses the integration test tenant (67e7eae6-...) which has data created by IDA integration tests.
+ */
+
+import { describe, expect, it, beforeAll } from "@jest/globals";
+import { get, deletion } from "../../../../lib/http";
+import { requestToken } from "../../../../api/oauthClient";
+import { adminServerConfig, backendUrl, serverConfig } from "../../../testConfig";
+import {
+  isUUID,
+  isISODateTime,
+  validateIdentityVerificationApplication,
+  validateListResponse,
+} from "../../../../lib/schemaValidation";
+
+describe("Identity Verification Application Management API - Schema Compliance Tests", () => {
+  let accessToken;
+
+  // Use integration test tenant which has data from IDA integration tests
+  const tenantId = serverConfig.tenantId;
+  const baseUrl = `${backendUrl}/v1/management/tenants/${tenantId}/identity-verification-applications`;
+
+  beforeAll(async () => {
+    const tokenResponse = await requestToken({
+      endpoint: adminServerConfig.tokenEndpoint,
+      grantType: "password",
+      username: adminServerConfig.oauth.username,
+      password: adminServerConfig.oauth.password,
+      scope: adminServerConfig.adminClient.scope,
+      clientId: adminServerConfig.adminClient.clientId,
+      clientSecret: adminServerConfig.adminClient.clientSecret,
+    });
+
+    expect(tokenResponse.status).toBe(200);
+    expect(tokenResponse.data).toHaveProperty("access_token");
+    accessToken = tokenResponse.data.access_token;
+  });
+
+  /**
+   * Layer 1: List Response Structure Validation
+   * Validates IdentityVerificationApplicationListResponse schema
+   */
+  describe("List Response Structure (IdentityVerificationApplicationListResponse)", () => {
+    it("should have all required fields with correct types", async () => {
+      const response = await get({
+        url: `${baseUrl}?limit=10&offset=0`,
+        headers: { Authorization: `Bearer ${accessToken}` },
+      });
+
+      expect(response.status).toBe(200);
+
+      // Required fields
+      expect(response.data).toHaveProperty("list");
+      expect(response.data).toHaveProperty("total_count");
+      expect(response.data).toHaveProperty("limit");
+      expect(response.data).toHaveProperty("offset");
+
+      // Types
+      expect(Array.isArray(response.data.list)).toBe(true);
+      expect(typeof response.data.total_count).toBe("number");
+      expect(typeof response.data.limit).toBe("number");
+      expect(typeof response.data.offset).toBe("number");
+
+      // Values
+      expect(response.data.limit).toBe(10);
+      expect(response.data.offset).toBe(0);
+      expect(response.data.total_count).toBeGreaterThanOrEqual(0);
+
+      // Full list validation
+      const validation = validateListResponse(
+        response.data,
+        validateIdentityVerificationApplication
+      );
+      if (!validation.valid) {
+        console.log("Schema validation errors:", validation.errors);
+      }
+      expect(validation.valid).toBe(true);
+    });
+
+    it("should use default limit=20 and offset=0 when not specified", async () => {
+      const response = await get({
+        url: baseUrl,
+        headers: { Authorization: `Bearer ${accessToken}` },
+      });
+
+      expect(response.status).toBe(200);
+      expect(response.data.limit).toBe(20);
+      expect(response.data.offset).toBe(0);
+    });
+
+    it("should return empty list with correct structure for non-matching filter", async () => {
+      const response = await get({
+        url: `${baseUrl}?type=NonExistentType_schema_test&limit=10&offset=0`,
+        headers: { Authorization: `Bearer ${accessToken}` },
+      });
+
+      expect(response.status).toBe(200);
+      expect(response.data.list).toEqual([]);
+      expect(response.data.total_count).toBe(0);
+      expect(response.data.limit).toBe(10);
+      expect(response.data.offset).toBe(0);
+    });
+  });
+
+  /**
+   * Layer 2: Individual Application Schema Validation
+   * Validates IdentityVerificationApplication schema
+   */
+  describe("Application Schema (IdentityVerificationApplication)", () => {
+    it("should validate all required fields for each item in list", async () => {
+      const response = await get({
+        url: `${baseUrl}?limit=5`,
+        headers: { Authorization: `Bearer ${accessToken}` },
+      });
+
+      expect(response.status).toBe(200);
+
+      if (response.data.list.length === 0) {
+        console.log(
+          "⚠️ No data found. Run IDA integration tests first: npm test -- --testPathPattern='integration-0[1-4]-identity'"
+        );
+        return;
+      }
+
+      console.log(`Validating ${response.data.list.length} applications...`);
+
+      for (const application of response.data.list) {
+        const validation =
+          validateIdentityVerificationApplication(application);
+        if (!validation.valid) {
+          console.log(
+            `❌ Validation errors for ${application.id}:`,
+            validation.errors
+          );
+        }
+        expect(validation.valid).toBe(true);
+
+        // Required fields - type check
+        expect(isUUID(application.id)).toBe(true);
+        expect(typeof application.type).toBe("string");
+        expect(typeof application.tenant_id).toBe("string");
+        expect(typeof application.client_id).toBe("string");
+        expect(typeof application.user_id).toBe("string");
+        expect(typeof application.status).toBe("string");
+        expect(isISODateTime(application.requested_at)).toBe(true);
+
+        // Status enum
+        expect([
+          "requested",
+          "applying",
+          "applied",
+          "examination_processing",
+          "approved",
+          "rejected",
+          "expired",
+          "cancelled",
+        ]).toContain(application.status);
+
+        console.log(
+          `✅ ${application.id} (status=${application.status}, type=${application.type})`
+        );
+      }
+    });
+
+    it("should validate single GET response matches list item", async () => {
+      const listResponse = await get({
+        url: `${baseUrl}?limit=1`,
+        headers: { Authorization: `Bearer ${accessToken}` },
+      });
+
+      expect(listResponse.status).toBe(200);
+
+      if (listResponse.data.list.length === 0) {
+        console.log("⚠️ No data found - skipping detail validation.");
+        return;
+      }
+
+      const applicationId = listResponse.data.list[0].id;
+
+      const detailResponse = await get({
+        url: `${baseUrl}/${applicationId}`,
+        headers: { Authorization: `Bearer ${accessToken}` },
+      });
+
+      expect(detailResponse.status).toBe(200);
+
+      const application = detailResponse.data;
+      const validation = validateIdentityVerificationApplication(application);
+      if (!validation.valid) {
+        console.log("❌ Detail validation errors:", validation.errors);
+      }
+      expect(validation.valid).toBe(true);
+
+      // Verify same data as list
+      expect(application.id).toBe(applicationId);
+      expect(isUUID(application.id)).toBe(true);
+
+      // Optional fields type check
+      if (application.application_details !== undefined) {
+        expect(typeof application.application_details).toBe("object");
+      }
+      if (application.processes !== undefined) {
+        expect(typeof application.processes).toBe("object");
+      }
+      if (application.attributes !== undefined) {
+        expect(typeof application.attributes).toBe("object");
+      }
+    });
+  });
+
+  /**
+   * Layer 3: ProcessResult Schema Validation
+   */
+  describe("ProcessResult Schema", () => {
+    it("should validate call_count, success_count, failure_count as numbers", async () => {
+      const response = await get({
+        url: `${baseUrl}?limit=10`,
+        headers: { Authorization: `Bearer ${accessToken}` },
+      });
+
+      expect(response.status).toBe(200);
+
+      const appsWithProcesses = response.data.list.filter(
+        (app) =>
+          app.processes &&
+          typeof app.processes === "object" &&
+          Object.keys(app.processes).length > 0
+      );
+
+      if (appsWithProcesses.length === 0) {
+        console.log("⚠️ No applications with process results found.");
+        return;
+      }
+
+      console.log(
+        `Validating ProcessResult for ${appsWithProcesses.length} applications...`
+      );
+
+      for (const application of appsWithProcesses) {
+        for (const [processName, result] of Object.entries(
+          application.processes
+        )) {
+          // Type validation
+          expect(typeof result).toBe("object");
+          expect(typeof result.call_count).toBe("number");
+          expect(typeof result.success_count).toBe("number");
+          expect(typeof result.failure_count).toBe("number");
+
+          // Value constraints
+          expect(result.call_count).toBeGreaterThanOrEqual(0);
+          expect(result.success_count).toBeGreaterThanOrEqual(0);
+          expect(result.failure_count).toBeGreaterThanOrEqual(0);
+
+          console.log(
+            `✅ ${application.id}/${processName}: calls=${result.call_count}, success=${result.success_count}, failure=${result.failure_count}`
+          );
+        }
+      }
+    });
+  });
+
+  /**
+   * Layer 4: Query Parameter Filter Validation
+   */
+  describe("Query Parameter Filters", () => {
+    it("should filter by status correctly", async () => {
+      // Get all to find existing statuses
+      const allResponse = await get({
+        url: `${baseUrl}?limit=50`,
+        headers: { Authorization: `Bearer ${accessToken}` },
+      });
+
+      const existingStatuses = [
+        ...new Set(allResponse.data.list.map((app) => app.status)),
+      ];
+
+      for (const status of existingStatuses) {
+        const response = await get({
+          url: `${baseUrl}?status=${status}&limit=50`,
+          headers: { Authorization: `Bearer ${accessToken}` },
+        });
+
+        expect(response.status).toBe(200);
+
+        for (const app of response.data.list) {
+          expect(app.status).toBe(status);
+        }
+
+        console.log(
+          `✅ status=${status}: ${response.data.total_count} results`
+        );
+      }
+    });
+
+    it("should filter by client_id correctly", async () => {
+      const allResponse = await get({
+        url: `${baseUrl}?limit=5`,
+        headers: { Authorization: `Bearer ${accessToken}` },
+      });
+
+      if (allResponse.data.list.length === 0) {
+        console.log("⚠️ No data to test client_id filtering.");
+        return;
+      }
+
+      const clientId = allResponse.data.list[0].client_id;
+
+      const response = await get({
+        url: `${baseUrl}?client_id=${encodeURIComponent(clientId)}&limit=50`,
+        headers: { Authorization: `Bearer ${accessToken}` },
+      });
+
+      expect(response.status).toBe(200);
+
+      for (const app of response.data.list) {
+        expect(app.client_id).toBe(clientId);
+      }
+
+      console.log(
+        `✅ client_id=${clientId}: ${response.data.total_count} results`
+      );
+    });
+
+    it("should respect pagination limit", async () => {
+      const response = await get({
+        url: `${baseUrl}?limit=2&offset=0`,
+        headers: { Authorization: `Bearer ${accessToken}` },
+      });
+
+      expect(response.status).toBe(200);
+      expect(response.data.list.length).toBeLessThanOrEqual(2);
+      expect(response.data.limit).toBe(2);
+      expect(response.data.offset).toBe(0);
+    });
+
+    it("should support offset for pagination", async () => {
+      const firstPage = await get({
+        url: `${baseUrl}?limit=2&offset=0`,
+        headers: { Authorization: `Bearer ${accessToken}` },
+      });
+
+      const secondPage = await get({
+        url: `${baseUrl}?limit=2&offset=2`,
+        headers: { Authorization: `Bearer ${accessToken}` },
+      });
+
+      expect(firstPage.status).toBe(200);
+      expect(secondPage.status).toBe(200);
+      expect(firstPage.data.total_count).toBe(secondPage.data.total_count);
+
+      // Pages should not overlap
+      if (
+        firstPage.data.list.length > 0 &&
+        secondPage.data.list.length > 0
+      ) {
+        const firstIds = firstPage.data.list.map((app) => app.id);
+        const secondIds = secondPage.data.list.map((app) => app.id);
+        const overlap = firstIds.filter((id) => secondIds.includes(id));
+        expect(overlap).toEqual([]);
+      }
+    });
+  });
+
+  /**
+   * Layer 5: Error Response Validation
+   */
+  describe("Error Responses (ErrorResponse)", () => {
+    it("should return 404 with error and error_description for non-existent ID", async () => {
+      const response = await get({
+        url: `${baseUrl}/00000000-0000-0000-0000-000000000000`,
+        headers: { Authorization: `Bearer ${accessToken}` },
+      });
+
+      expect(response.status).toBe(404);
+      expect(response.data).toHaveProperty("error");
+      expect(response.data).toHaveProperty("error_description");
+      expect(typeof response.data.error).toBe("string");
+      expect(typeof response.data.error_description).toBe("string");
+    });
+  });
+
+  /**
+   * Layer 6: Delete dry_run Validation
+   */
+  describe("Delete with dry_run (DryRunResponse)", () => {
+    it("should return 200 with dry_run=true and not delete the resource", async () => {
+      const listResponse = await get({
+        url: `${baseUrl}?limit=1`,
+        headers: { Authorization: `Bearer ${accessToken}` },
+      });
+
+      expect(listResponse.status).toBe(200);
+
+      if (listResponse.data.list.length === 0) {
+        console.log("⚠️ No data for dry_run delete test.");
+        return;
+      }
+
+      const applicationId = listResponse.data.list[0].id;
+
+      // dry_run delete
+      const dryRunResponse = await deletion({
+        url: `${baseUrl}/${applicationId}?dry_run=true`,
+        headers: { Authorization: `Bearer ${accessToken}` },
+      });
+
+      expect(dryRunResponse.status).toBe(200);
+      expect(dryRunResponse.data).toHaveProperty("dry_run", true);
+
+      // Verify still exists
+      const verifyResponse = await get({
+        url: `${baseUrl}/${applicationId}`,
+        headers: { Authorization: `Bearer ${accessToken}` },
+      });
+      expect(verifyResponse.status).toBe(200);
+      expect(verifyResponse.data.id).toBe(applicationId);
+    });
+  });
+
+  /**
+   * Layer 7: List/Detail Consistency
+   */
+  describe("List and Detail Consistency", () => {
+    it("should return identical data in list and detail responses", async () => {
+      const listResponse = await get({
+        url: `${baseUrl}?limit=3`,
+        headers: { Authorization: `Bearer ${accessToken}` },
+      });
+
+      expect(listResponse.status).toBe(200);
+
+      if (listResponse.data.list.length === 0) {
+        console.log("⚠️ No data for consistency test.");
+        return;
+      }
+
+      for (const listItem of listResponse.data.list) {
+        const detailResponse = await get({
+          url: `${baseUrl}/${listItem.id}`,
+          headers: { Authorization: `Bearer ${accessToken}` },
+        });
+
+        expect(detailResponse.status).toBe(200);
+        const detail = detailResponse.data;
+
+        // All fields must match
+        expect(detail.id).toBe(listItem.id);
+        expect(detail.type).toBe(listItem.type);
+        expect(detail.tenant_id).toBe(listItem.tenant_id);
+        expect(detail.client_id).toBe(listItem.client_id);
+        expect(detail.user_id).toBe(listItem.user_id);
+        expect(detail.status).toBe(listItem.status);
+        expect(detail.requested_at).toBe(listItem.requested_at);
+        expect(JSON.stringify(detail.processes)).toBe(
+          JSON.stringify(listItem.processes)
+        );
+        expect(JSON.stringify(detail.application_details)).toBe(
+          JSON.stringify(listItem.application_details)
+        );
+      }
+    });
+  });
+});

--- a/e2e/src/tests/scenario/control_plane/system/identity_verification_result_management.test.js
+++ b/e2e/src/tests/scenario/control_plane/system/identity_verification_result_management.test.js
@@ -1,0 +1,216 @@
+import { describe, expect, it } from "@jest/globals";
+import { get } from "../../../../lib/http";
+import { requestToken } from "../../../../api/oauthClient";
+import { adminServerConfig, backendUrl, serverConfig } from "../../../testConfig";
+import {
+  isUUID,
+  isISODateTime,
+  validateIdentityVerificationResult,
+  validateListResponse,
+} from "../../../../lib/schemaValidation";
+
+describe("identity verification result management api", () => {
+
+  // Use integration test tenant which has data from IDA integration tests
+  const tenantId = serverConfig.tenantId;
+  const baseUrl = `${backendUrl}/v1/management/tenants/${tenantId}/identity-verification-results`;
+
+  const getAccessToken = async () => {
+    const tokenResponse = await requestToken({
+      endpoint: adminServerConfig.tokenEndpoint,
+      grantType: "password",
+      username: adminServerConfig.oauth.username,
+      password: adminServerConfig.oauth.password,
+      scope: adminServerConfig.adminClient.scope,
+      clientId: adminServerConfig.adminClient.clientId,
+      clientSecret: adminServerConfig.adminClient.clientSecret,
+    });
+    expect(tokenResponse.status).toBe(200);
+    return tokenResponse.data.access_token;
+  };
+
+  describe("list operations", () => {
+
+    it("should list results with default pagination", async () => {
+      const accessToken = await getAccessToken();
+
+      const response = await get({
+        url: baseUrl,
+        headers: { Authorization: `Bearer ${accessToken}` },
+      });
+      console.log("List Response:", JSON.stringify(response.data));
+      expect(response.status).toBe(200);
+      expect(response.data).toHaveProperty("list");
+      expect(response.data).toHaveProperty("total_count");
+      expect(Array.isArray(response.data.list)).toBe(true);
+      expect(typeof response.data.total_count).toBe("number");
+      expect(response.data.limit).toBe(20);
+      expect(response.data.offset).toBe(0);
+    });
+
+    it("should support pagination with limit and offset", async () => {
+      const accessToken = await getAccessToken();
+
+      const response = await get({
+        url: `${baseUrl}?limit=5&offset=0`,
+        headers: { Authorization: `Bearer ${accessToken}` },
+      });
+      expect(response.status).toBe(200);
+      expect(response.data.limit).toBe(5);
+      expect(response.data.offset).toBe(0);
+      expect(response.data.list.length).toBeLessThanOrEqual(5);
+    });
+
+    it("should support filtering by type", async () => {
+      const accessToken = await getAccessToken();
+
+      const response = await get({
+        url: `${baseUrl}?type=NonExistentType12345&limit=10&offset=0`,
+        headers: { Authorization: `Bearer ${accessToken}` },
+      });
+      expect(response.status).toBe(200);
+      expect(response.data.list).toEqual([]);
+      expect(response.data.total_count).toBe(0);
+    });
+
+    it("should support filtering by source", async () => {
+      const accessToken = await getAccessToken();
+
+      const response = await get({
+        url: `${baseUrl}?source=application&limit=10`,
+        headers: { Authorization: `Bearer ${accessToken}` },
+      });
+      expect(response.status).toBe(200);
+      expect(response.data).toHaveProperty("total_count");
+
+      if (response.data.list.length > 0) {
+        response.data.list.forEach(result => {
+          expect(result.source).toBe("application");
+        });
+      }
+    });
+
+    it("should support time range filtering", async () => {
+      const accessToken = await getAccessToken();
+
+      const oneYearAgo = new Date();
+      oneYearAgo.setFullYear(oneYearAgo.getFullYear() - 1);
+      const fromDate = oneYearAgo.toISOString().substring(0, 19).replace("T", " ");
+
+      const response = await get({
+        url: `${baseUrl}?verified_at_from=${encodeURIComponent(fromDate)}&limit=10`,
+        headers: { Authorization: `Bearer ${accessToken}` },
+      });
+      expect(response.status).toBe(200);
+      expect(response.data).toHaveProperty("total_count");
+      expect(response.data).toHaveProperty("list");
+    });
+  });
+
+  describe("get by id operations", () => {
+
+    it("should get result detail when results exist", async () => {
+      const accessToken = await getAccessToken();
+
+      const listResponse = await get({
+        url: `${baseUrl}?limit=1`,
+        headers: { Authorization: `Bearer ${accessToken}` },
+      });
+      expect(listResponse.status).toBe(200);
+
+      if (listResponse.data.list.length > 0) {
+        const resultId = listResponse.data.list[0].id;
+        const detailResponse = await get({
+          url: `${baseUrl}/${resultId}`,
+          headers: { Authorization: `Bearer ${accessToken}` },
+        });
+        expect(detailResponse.status).toBe(200);
+        expect(detailResponse.data.id).toBe(resultId);
+      }
+    });
+
+    it("should return 404 for non-existent result", async () => {
+      const accessToken = await getAccessToken();
+
+      const response = await get({
+        url: `${baseUrl}/00000000-0000-0000-0000-000000000000`,
+        headers: { Authorization: `Bearer ${accessToken}` },
+      });
+      expect(response.status).toBe(404);
+    });
+  });
+
+  describe("schema compliance", () => {
+
+    it("should validate IdentityVerificationResult schema for each item", async () => {
+      const accessToken = await getAccessToken();
+
+      const response = await get({
+        url: `${baseUrl}?limit=5`,
+        headers: { Authorization: `Bearer ${accessToken}` },
+      });
+      expect(response.status).toBe(200);
+
+      const validation = validateListResponse(
+        response.data,
+        validateIdentityVerificationResult
+      );
+      if (!validation.valid) {
+        console.log("Schema validation errors:", validation.errors);
+      }
+      expect(validation.valid).toBe(true);
+
+      if (response.data.list.length > 0) {
+        for (const result of response.data.list) {
+          expect(isUUID(result.id)).toBe(true);
+          expect(typeof result.type).toBe("string");
+          expect(typeof result.tenant_id).toBe("string");
+          expect(typeof result.user_id).toBe("string");
+          expect(typeof result.source).toBe("string");
+          expect(["application", "direct", "manual", "import"]).toContain(result.source);
+          expect(isISODateTime(result.verified_at)).toBe(true);
+          expect(typeof result.verified_claims).toBe("object");
+          console.log(`✅ ${result.id} (type=${result.type}, source=${result.source})`);
+        }
+      }
+    });
+
+    it("should validate list/detail consistency", async () => {
+      const accessToken = await getAccessToken();
+
+      const listResponse = await get({
+        url: `${baseUrl}?limit=3`,
+        headers: { Authorization: `Bearer ${accessToken}` },
+      });
+      expect(listResponse.status).toBe(200);
+
+      for (const listItem of listResponse.data.list) {
+        const detailResponse = await get({
+          url: `${baseUrl}/${listItem.id}`,
+          headers: { Authorization: `Bearer ${accessToken}` },
+        });
+        expect(detailResponse.status).toBe(200);
+        expect(detailResponse.data.id).toBe(listItem.id);
+        expect(detailResponse.data.type).toBe(listItem.type);
+        expect(detailResponse.data.tenant_id).toBe(listItem.tenant_id);
+        expect(detailResponse.data.user_id).toBe(listItem.user_id);
+        expect(detailResponse.data.source).toBe(listItem.source);
+        expect(detailResponse.data.verified_at).toBe(listItem.verified_at);
+      }
+    });
+
+    it("should return 404 with ErrorResponse schema", async () => {
+      const accessToken = await getAccessToken();
+
+      const response = await get({
+        url: `${baseUrl}/00000000-0000-0000-0000-000000000000`,
+        headers: { Authorization: `Bearer ${accessToken}` },
+      });
+      expect(response.status).toBe(404);
+      expect(response.data).toHaveProperty("error");
+      expect(response.data).toHaveProperty("error_description");
+      expect(typeof response.data.error).toBe("string");
+      expect(typeof response.data.error_description).toBe("string");
+    });
+  });
+});

--- a/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/base/definition/DefaultAdminPermission.java
+++ b/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/base/definition/DefaultAdminPermission.java
@@ -108,6 +108,13 @@ public enum DefaultAdminPermission {
   IDENTITY_VERIFICATION_CONFIG_DELETE(
       "idp:identity-verification-config:delete", "Admin Delete identity-verification-config"),
 
+  IDENTITY_VERIFICATION_APPLICATION_READ(
+      "idp:identity-verification-application:read",
+      "Admin Read identity-verification-application information"),
+  IDENTITY_VERIFICATION_APPLICATION_DELETE(
+      "idp:identity-verification-application:delete",
+      "Admin Delete identity-verification-application"),
+
   FEDERATION_CONFIG_CREATE("idp:federation-config:create", "Admin Create a federation-config"),
   FEDERATION_CONFIG_READ("idp:federation-config:read", "Admin Read federation-config information"),
   FEDERATION_CONFIG_UPDATE("idp:federation-config:update", "Admin Update federation-config"),

--- a/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/base/definition/DefaultAdminPermission.java
+++ b/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/base/definition/DefaultAdminPermission.java
@@ -115,6 +115,10 @@ public enum DefaultAdminPermission {
       "idp:identity-verification-application:delete",
       "Admin Delete identity-verification-application"),
 
+  IDENTITY_VERIFICATION_RESULT_READ(
+      "idp:identity-verification-result:read",
+      "Admin Read identity-verification-result information"),
+
   FEDERATION_CONFIG_CREATE("idp:federation-config:create", "Admin Create a federation-config"),
   FEDERATION_CONFIG_READ("idp:federation-config:read", "Admin Read federation-config information"),
   FEDERATION_CONFIG_UPDATE("idp:federation-config:update", "Admin Update federation-config"),

--- a/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/identity/verification/application/IdentityVerificationApplicationManagementApi.java
+++ b/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/identity/verification/application/IdentityVerificationApplicationManagementApi.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2025 Hirokazu Kobayashi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.idp.server.control_plane.management.identity.verification.application;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import org.idp.server.control_plane.base.AdminAuthenticationContext;
+import org.idp.server.control_plane.base.definition.AdminPermissions;
+import org.idp.server.control_plane.base.definition.DefaultAdminPermission;
+import org.idp.server.control_plane.management.identity.verification.application.io.IdentityVerificationApplicationManagementResponse;
+import org.idp.server.core.extension.identity.verification.application.model.IdentityVerificationApplicationIdentifier;
+import org.idp.server.core.extension.identity.verification.application.model.IdentityVerificationApplicationQueries;
+import org.idp.server.platform.exception.UnSupportedException;
+import org.idp.server.platform.multi_tenancy.tenant.TenantIdentifier;
+import org.idp.server.platform.type.RequestAttributes;
+
+public interface IdentityVerificationApplicationManagementApi {
+
+  default AdminPermissions getRequiredPermissions(String method) {
+    Map<String, AdminPermissions> map = new HashMap<>();
+    map.put(
+        "findList",
+        new AdminPermissions(
+            Set.of(DefaultAdminPermission.IDENTITY_VERIFICATION_APPLICATION_READ)));
+    map.put(
+        "get",
+        new AdminPermissions(
+            Set.of(DefaultAdminPermission.IDENTITY_VERIFICATION_APPLICATION_READ)));
+    map.put(
+        "delete",
+        new AdminPermissions(
+            Set.of(DefaultAdminPermission.IDENTITY_VERIFICATION_APPLICATION_DELETE)));
+    AdminPermissions adminPermissions = map.get(method);
+    if (adminPermissions == null) {
+      throw new UnSupportedException("Method " + method + " not supported");
+    }
+    return adminPermissions;
+  }
+
+  IdentityVerificationApplicationManagementResponse findList(
+      AdminAuthenticationContext authenticationContext,
+      TenantIdentifier tenantIdentifier,
+      IdentityVerificationApplicationQueries queries,
+      RequestAttributes requestAttributes);
+
+  IdentityVerificationApplicationManagementResponse get(
+      AdminAuthenticationContext authenticationContext,
+      TenantIdentifier tenantIdentifier,
+      IdentityVerificationApplicationIdentifier identifier,
+      RequestAttributes requestAttributes);
+
+  IdentityVerificationApplicationManagementResponse delete(
+      AdminAuthenticationContext authenticationContext,
+      TenantIdentifier tenantIdentifier,
+      IdentityVerificationApplicationIdentifier identifier,
+      RequestAttributes requestAttributes,
+      boolean dryRun);
+}

--- a/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/identity/verification/application/IdentityVerificationApplicationManagementContext.java
+++ b/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/identity/verification/application/IdentityVerificationApplicationManagementContext.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright 2025 Hirokazu Kobayashi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.idp.server.control_plane.management.identity.verification.application;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import org.idp.server.control_plane.base.AuditableContext;
+import org.idp.server.control_plane.management.exception.ManagementApiException;
+import org.idp.server.control_plane.management.identity.verification.application.io.IdentityVerificationApplicationManagementRequest;
+import org.idp.server.core.extension.identity.verification.application.model.IdentityVerificationApplication;
+import org.idp.server.core.openid.identity.User;
+import org.idp.server.core.openid.token.OAuthToken;
+import org.idp.server.platform.multi_tenancy.tenant.TenantIdentifier;
+import org.idp.server.platform.type.RequestAttributes;
+
+public class IdentityVerificationApplicationManagementContext implements AuditableContext {
+
+  TenantIdentifier tenantIdentifier;
+  User operator;
+  OAuthToken oAuthToken;
+  RequestAttributes requestAttributes;
+  IdentityVerificationApplication before;
+  IdentityVerificationApplicationManagementRequest request;
+  boolean dryRun;
+  ManagementApiException exception;
+
+  public IdentityVerificationApplicationManagementContext(
+      TenantIdentifier tenantIdentifier,
+      User operator,
+      OAuthToken oAuthToken,
+      RequestAttributes requestAttributes,
+      IdentityVerificationApplication before,
+      IdentityVerificationApplicationManagementRequest request,
+      boolean dryRun,
+      ManagementApiException exception) {
+    this.tenantIdentifier = tenantIdentifier;
+    this.operator = operator;
+    this.oAuthToken = oAuthToken;
+    this.requestAttributes = requestAttributes;
+    this.before = before;
+    this.request = request;
+    this.dryRun = dryRun;
+    this.exception = exception;
+  }
+
+  public IdentityVerificationApplication beforeApplication() {
+    return before;
+  }
+
+  public boolean hasException() {
+    return exception != null;
+  }
+
+  public ManagementApiException exception() {
+    return exception;
+  }
+
+  @Override
+  public String type() {
+    return "identity_verification_application";
+  }
+
+  @Override
+  public String description() {
+    return "identity verification application management api";
+  }
+
+  @Override
+  public String tenantId() {
+    return oAuthToken.tenantIdentifier().value();
+  }
+
+  @Override
+  public String clientId() {
+    return oAuthToken.requestedClientId().value();
+  }
+
+  @Override
+  public String userId() {
+    return operator.sub();
+  }
+
+  @Override
+  public String externalUserId() {
+    return operator.externalUserId();
+  }
+
+  @Override
+  public Map<String, Object> userPayload() {
+    return operator.toMap();
+  }
+
+  @Override
+  public String targetResource() {
+    return requestAttributes.resource().value();
+  }
+
+  @Override
+  public String targetResourceAction() {
+    return requestAttributes.action().value();
+  }
+
+  @Override
+  public String ipAddress() {
+    return requestAttributes.getIpAddress().value();
+  }
+
+  @Override
+  public String userAgent() {
+    return requestAttributes.getUserAgent().value();
+  }
+
+  @Override
+  public Map<String, Object> request() {
+    return request != null ? request.toMap() : Collections.emptyMap();
+  }
+
+  @Override
+  public Map<String, Object> before() {
+    return before != null ? before.toMap() : Collections.emptyMap();
+  }
+
+  @Override
+  public Map<String, Object> after() {
+    return Collections.emptyMap();
+  }
+
+  @Override
+  public String outcomeResult() {
+    return exception != null ? "failure" : "success";
+  }
+
+  @Override
+  public String outcomeReason() {
+    return exception != null ? exception.errorCode() : null;
+  }
+
+  @Override
+  public String targetTenantId() {
+    return tenantIdentifier.value();
+  }
+
+  @Override
+  public Map<String, Object> attributes() {
+    Map<String, Object> attributes = new HashMap<>();
+    if (exception != null) {
+      Map<String, Object> error = new HashMap<>();
+      error.put("error_code", exception.errorCode());
+      error.put("error_description", exception.errorDescription());
+
+      Map<String, Object> errorDetails = exception.errorDetails();
+      if (errorDetails != null && !errorDetails.isEmpty()) {
+        error.putAll(errorDetails);
+      }
+      attributes.put("error", error);
+    }
+
+    return attributes;
+  }
+
+  @Override
+  public boolean dryRun() {
+    return dryRun;
+  }
+}

--- a/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/identity/verification/application/IdentityVerificationApplicationManagementContextBuilder.java
+++ b/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/identity/verification/application/IdentityVerificationApplicationManagementContextBuilder.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2025 Hirokazu Kobayashi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.idp.server.control_plane.management.identity.verification.application;
+
+import org.idp.server.control_plane.base.AuditableContext;
+import org.idp.server.control_plane.management.exception.ManagementApiException;
+import org.idp.server.control_plane.management.identity.verification.application.io.IdentityVerificationApplicationManagementRequest;
+import org.idp.server.core.extension.identity.verification.application.model.IdentityVerificationApplication;
+import org.idp.server.core.openid.identity.User;
+import org.idp.server.core.openid.token.OAuthToken;
+import org.idp.server.platform.multi_tenancy.tenant.TenantIdentifier;
+import org.idp.server.platform.type.RequestAttributes;
+
+public class IdentityVerificationApplicationManagementContextBuilder {
+
+  private final User operator;
+  private final OAuthToken oAuthToken;
+  private final RequestAttributes requestAttributes;
+  private final IdentityVerificationApplicationManagementRequest request;
+  private final TenantIdentifier tenantIdentifier;
+  private final boolean dryRun;
+
+  private IdentityVerificationApplication before;
+
+  public IdentityVerificationApplicationManagementContextBuilder(
+      TenantIdentifier tenantIdentifier,
+      User operator,
+      OAuthToken oAuthToken,
+      RequestAttributes requestAttributes,
+      IdentityVerificationApplicationManagementRequest request,
+      boolean dryRun) {
+    this.tenantIdentifier = tenantIdentifier;
+    this.operator = operator;
+    this.oAuthToken = oAuthToken;
+    this.requestAttributes = requestAttributes;
+    this.request = request;
+    this.dryRun = dryRun;
+  }
+
+  public IdentityVerificationApplicationManagementContextBuilder withBefore(
+      IdentityVerificationApplication before) {
+    this.before = before;
+    return this;
+  }
+
+  public AuditableContext build() {
+    return new IdentityVerificationApplicationManagementContext(
+        tenantIdentifier, operator, oAuthToken, requestAttributes, before, request, dryRun, null);
+  }
+
+  public AuditableContext buildPartial(ManagementApiException exception) {
+    return new IdentityVerificationApplicationManagementContext(
+        tenantIdentifier,
+        operator,
+        oAuthToken,
+        requestAttributes,
+        before,
+        request,
+        dryRun,
+        exception);
+  }
+}

--- a/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/identity/verification/application/OrgIdentityVerificationApplicationManagementApi.java
+++ b/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/identity/verification/application/OrgIdentityVerificationApplicationManagementApi.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2025 Hirokazu Kobayashi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.idp.server.control_plane.management.identity.verification.application;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import org.idp.server.control_plane.base.OrganizationAuthenticationContext;
+import org.idp.server.control_plane.base.definition.AdminPermissions;
+import org.idp.server.control_plane.base.definition.DefaultAdminPermission;
+import org.idp.server.control_plane.management.identity.verification.application.io.IdentityVerificationApplicationManagementResponse;
+import org.idp.server.core.extension.identity.verification.application.model.IdentityVerificationApplicationIdentifier;
+import org.idp.server.core.extension.identity.verification.application.model.IdentityVerificationApplicationQueries;
+import org.idp.server.platform.exception.UnSupportedException;
+import org.idp.server.platform.multi_tenancy.tenant.TenantIdentifier;
+import org.idp.server.platform.type.RequestAttributes;
+
+public interface OrgIdentityVerificationApplicationManagementApi {
+
+  default AdminPermissions getRequiredPermissions(String method) {
+    Map<String, AdminPermissions> map = new HashMap<>();
+    map.put(
+        "findList",
+        new AdminPermissions(
+            Set.of(DefaultAdminPermission.IDENTITY_VERIFICATION_APPLICATION_READ)));
+    map.put(
+        "get",
+        new AdminPermissions(
+            Set.of(DefaultAdminPermission.IDENTITY_VERIFICATION_APPLICATION_READ)));
+    map.put(
+        "delete",
+        new AdminPermissions(
+            Set.of(DefaultAdminPermission.IDENTITY_VERIFICATION_APPLICATION_DELETE)));
+    AdminPermissions adminPermissions = map.get(method);
+    if (adminPermissions == null) {
+      throw new UnSupportedException("Method " + method + " not supported");
+    }
+    return adminPermissions;
+  }
+
+  IdentityVerificationApplicationManagementResponse findList(
+      OrganizationAuthenticationContext authenticationContext,
+      TenantIdentifier tenantIdentifier,
+      IdentityVerificationApplicationQueries queries,
+      RequestAttributes requestAttributes);
+
+  IdentityVerificationApplicationManagementResponse get(
+      OrganizationAuthenticationContext authenticationContext,
+      TenantIdentifier tenantIdentifier,
+      IdentityVerificationApplicationIdentifier identifier,
+      RequestAttributes requestAttributes);
+
+  IdentityVerificationApplicationManagementResponse delete(
+      OrganizationAuthenticationContext authenticationContext,
+      TenantIdentifier tenantIdentifier,
+      IdentityVerificationApplicationIdentifier identifier,
+      RequestAttributes requestAttributes,
+      boolean dryRun);
+}

--- a/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/identity/verification/application/handler/IdentityVerificationApplicationDeletionService.java
+++ b/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/identity/verification/application/handler/IdentityVerificationApplicationDeletionService.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2025 Hirokazu Kobayashi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.idp.server.control_plane.management.identity.verification.application.handler;
+
+import java.util.Map;
+import org.idp.server.control_plane.management.exception.ResourceNotFoundException;
+import org.idp.server.control_plane.management.identity.verification.application.IdentityVerificationApplicationManagementContextBuilder;
+import org.idp.server.control_plane.management.identity.verification.application.io.IdentityVerificationApplicationDeleteRequest;
+import org.idp.server.control_plane.management.identity.verification.application.io.IdentityVerificationApplicationManagementResponse;
+import org.idp.server.control_plane.management.identity.verification.application.io.IdentityVerificationApplicationManagementStatus;
+import org.idp.server.core.extension.identity.verification.application.model.IdentityVerificationApplication;
+import org.idp.server.core.extension.identity.verification.application.model.IdentityVerificationApplicationIdentifier;
+import org.idp.server.core.extension.identity.verification.repository.IdentityVerificationApplicationCommandRepository;
+import org.idp.server.core.extension.identity.verification.repository.IdentityVerificationApplicationQueryRepository;
+import org.idp.server.core.openid.identity.User;
+import org.idp.server.core.openid.token.OAuthToken;
+import org.idp.server.platform.multi_tenancy.tenant.Tenant;
+import org.idp.server.platform.type.RequestAttributes;
+
+public class IdentityVerificationApplicationDeletionService
+    implements IdentityVerificationApplicationManagementService<
+        IdentityVerificationApplicationDeleteRequest> {
+
+  private final IdentityVerificationApplicationQueryRepository queryRepository;
+  private final IdentityVerificationApplicationCommandRepository commandRepository;
+
+  public IdentityVerificationApplicationDeletionService(
+      IdentityVerificationApplicationQueryRepository queryRepository,
+      IdentityVerificationApplicationCommandRepository commandRepository) {
+    this.queryRepository = queryRepository;
+    this.commandRepository = commandRepository;
+  }
+
+  @Override
+  public IdentityVerificationApplicationManagementResponse execute(
+      IdentityVerificationApplicationManagementContextBuilder builder,
+      Tenant tenant,
+      User operator,
+      OAuthToken oAuthToken,
+      IdentityVerificationApplicationDeleteRequest request,
+      RequestAttributes requestAttributes,
+      boolean dryRun) {
+
+    IdentityVerificationApplicationIdentifier identifier = request.identifier();
+    IdentityVerificationApplication application = queryRepository.get(tenant, identifier);
+
+    if (!application.exists()) {
+      throw new ResourceNotFoundException(
+          "Identity verification application not found: " + identifier.value());
+    }
+
+    builder.withBefore(application);
+
+    if (dryRun) {
+      Map<String, Object> response =
+          Map.of(
+              "message",
+              "Deletion simulated successfully",
+              "id",
+              identifier.value(),
+              "dry_run",
+              true);
+      return new IdentityVerificationApplicationManagementResponse(
+          IdentityVerificationApplicationManagementStatus.OK, response);
+    }
+
+    commandRepository.delete(tenant, identifier);
+
+    return new IdentityVerificationApplicationManagementResponse(
+        IdentityVerificationApplicationManagementStatus.NO_CONTENT, Map.of());
+  }
+}

--- a/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/identity/verification/application/handler/IdentityVerificationApplicationFindListService.java
+++ b/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/identity/verification/application/handler/IdentityVerificationApplicationFindListService.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2025 Hirokazu Kobayashi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.idp.server.control_plane.management.identity.verification.application.handler;
+
+import java.util.List;
+import java.util.Map;
+import org.idp.server.control_plane.management.identity.verification.application.IdentityVerificationApplicationManagementContextBuilder;
+import org.idp.server.control_plane.management.identity.verification.application.io.IdentityVerificationApplicationFindListRequest;
+import org.idp.server.control_plane.management.identity.verification.application.io.IdentityVerificationApplicationManagementResponse;
+import org.idp.server.control_plane.management.identity.verification.application.io.IdentityVerificationApplicationManagementStatus;
+import org.idp.server.core.extension.identity.verification.application.model.IdentityVerificationApplication;
+import org.idp.server.core.extension.identity.verification.application.model.IdentityVerificationApplicationQueries;
+import org.idp.server.core.extension.identity.verification.application.model.IdentityVerificationApplications;
+import org.idp.server.core.extension.identity.verification.repository.IdentityVerificationApplicationQueryRepository;
+import org.idp.server.core.openid.identity.User;
+import org.idp.server.core.openid.token.OAuthToken;
+import org.idp.server.platform.multi_tenancy.tenant.Tenant;
+import org.idp.server.platform.type.RequestAttributes;
+
+public class IdentityVerificationApplicationFindListService
+    implements IdentityVerificationApplicationManagementService<
+        IdentityVerificationApplicationFindListRequest> {
+
+  private final IdentityVerificationApplicationQueryRepository queryRepository;
+
+  public IdentityVerificationApplicationFindListService(
+      IdentityVerificationApplicationQueryRepository queryRepository) {
+    this.queryRepository = queryRepository;
+  }
+
+  @Override
+  public IdentityVerificationApplicationManagementResponse execute(
+      IdentityVerificationApplicationManagementContextBuilder builder,
+      Tenant tenant,
+      User operator,
+      OAuthToken oAuthToken,
+      IdentityVerificationApplicationFindListRequest request,
+      RequestAttributes requestAttributes,
+      boolean dryRun) {
+
+    IdentityVerificationApplicationQueries queries = request.queries();
+    long totalCount = queryRepository.findTotalCount(tenant, queries);
+    if (totalCount == 0) {
+      Map<String, Object> response =
+          Map.of(
+              "list", List.of(),
+              "total_count", totalCount,
+              "limit", queries.limit(),
+              "offset", queries.offset());
+      return new IdentityVerificationApplicationManagementResponse(
+          IdentityVerificationApplicationManagementStatus.OK, response);
+    }
+
+    IdentityVerificationApplications applications = queryRepository.findList(tenant, queries);
+
+    List<Map<String, Object>> list = new java.util.ArrayList<>();
+    for (IdentityVerificationApplication application : applications) {
+      list.add(application.toMap());
+    }
+
+    Map<String, Object> response =
+        Map.of(
+            "list",
+            list,
+            "total_count",
+            totalCount,
+            "limit",
+            queries.limit(),
+            "offset",
+            queries.offset());
+
+    return new IdentityVerificationApplicationManagementResponse(
+        IdentityVerificationApplicationManagementStatus.OK, response);
+  }
+}

--- a/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/identity/verification/application/handler/IdentityVerificationApplicationFindService.java
+++ b/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/identity/verification/application/handler/IdentityVerificationApplicationFindService.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2025 Hirokazu Kobayashi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.idp.server.control_plane.management.identity.verification.application.handler;
+
+import org.idp.server.control_plane.management.exception.ResourceNotFoundException;
+import org.idp.server.control_plane.management.identity.verification.application.IdentityVerificationApplicationManagementContextBuilder;
+import org.idp.server.control_plane.management.identity.verification.application.io.IdentityVerificationApplicationFindRequest;
+import org.idp.server.control_plane.management.identity.verification.application.io.IdentityVerificationApplicationManagementResponse;
+import org.idp.server.control_plane.management.identity.verification.application.io.IdentityVerificationApplicationManagementStatus;
+import org.idp.server.core.extension.identity.verification.application.model.IdentityVerificationApplication;
+import org.idp.server.core.extension.identity.verification.application.model.IdentityVerificationApplicationIdentifier;
+import org.idp.server.core.extension.identity.verification.repository.IdentityVerificationApplicationQueryRepository;
+import org.idp.server.core.openid.identity.User;
+import org.idp.server.core.openid.token.OAuthToken;
+import org.idp.server.platform.multi_tenancy.tenant.Tenant;
+import org.idp.server.platform.type.RequestAttributes;
+
+public class IdentityVerificationApplicationFindService
+    implements IdentityVerificationApplicationManagementService<
+        IdentityVerificationApplicationFindRequest> {
+
+  private final IdentityVerificationApplicationQueryRepository queryRepository;
+
+  public IdentityVerificationApplicationFindService(
+      IdentityVerificationApplicationQueryRepository queryRepository) {
+    this.queryRepository = queryRepository;
+  }
+
+  @Override
+  public IdentityVerificationApplicationManagementResponse execute(
+      IdentityVerificationApplicationManagementContextBuilder builder,
+      Tenant tenant,
+      User operator,
+      OAuthToken oAuthToken,
+      IdentityVerificationApplicationFindRequest request,
+      RequestAttributes requestAttributes,
+      boolean dryRun) {
+
+    IdentityVerificationApplicationIdentifier identifier = request.identifier();
+    IdentityVerificationApplication application = queryRepository.get(tenant, identifier);
+
+    if (!application.exists()) {
+      throw new ResourceNotFoundException(
+          "Identity verification application not found: " + identifier.value());
+    }
+
+    builder.withBefore(application);
+
+    return new IdentityVerificationApplicationManagementResponse(
+        IdentityVerificationApplicationManagementStatus.OK, application.toMap());
+  }
+}

--- a/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/identity/verification/application/handler/IdentityVerificationApplicationManagementHandler.java
+++ b/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/identity/verification/application/handler/IdentityVerificationApplicationManagementHandler.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2025 Hirokazu Kobayashi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.idp.server.control_plane.management.identity.verification.application.handler;
+
+import java.util.Map;
+import org.idp.server.control_plane.base.AdminAuthenticationContext;
+import org.idp.server.control_plane.base.ApiPermissionVerifier;
+import org.idp.server.control_plane.base.AuditableContext;
+import org.idp.server.control_plane.base.definition.AdminPermissions;
+import org.idp.server.control_plane.management.exception.ManagementApiException;
+import org.idp.server.control_plane.management.exception.ResourceNotFoundException;
+import org.idp.server.control_plane.management.identity.verification.application.IdentityVerificationApplicationManagementApi;
+import org.idp.server.control_plane.management.identity.verification.application.IdentityVerificationApplicationManagementContextBuilder;
+import org.idp.server.control_plane.management.identity.verification.application.io.IdentityVerificationApplicationManagementRequest;
+import org.idp.server.control_plane.management.identity.verification.application.io.IdentityVerificationApplicationManagementResponse;
+import org.idp.server.core.openid.identity.User;
+import org.idp.server.core.openid.token.OAuthToken;
+import org.idp.server.platform.exception.NotFoundException;
+import org.idp.server.platform.exception.UnSupportedException;
+import org.idp.server.platform.log.LoggerWrapper;
+import org.idp.server.platform.multi_tenancy.tenant.Tenant;
+import org.idp.server.platform.multi_tenancy.tenant.TenantIdentifier;
+import org.idp.server.platform.multi_tenancy.tenant.TenantQueryRepository;
+import org.idp.server.platform.type.RequestAttributes;
+
+public class IdentityVerificationApplicationManagementHandler {
+
+  private final Map<String, IdentityVerificationApplicationManagementService<?>> services;
+  private final IdentityVerificationApplicationManagementApi api;
+  private final TenantQueryRepository tenantQueryRepository;
+  private final ApiPermissionVerifier apiPermissionVerifier;
+  LoggerWrapper log =
+      LoggerWrapper.getLogger(IdentityVerificationApplicationManagementHandler.class);
+
+  public IdentityVerificationApplicationManagementHandler(
+      Map<String, IdentityVerificationApplicationManagementService<?>> services,
+      IdentityVerificationApplicationManagementApi api,
+      TenantQueryRepository tenantQueryRepository) {
+    this.services = services;
+    this.api = api;
+    this.tenantQueryRepository = tenantQueryRepository;
+    this.apiPermissionVerifier = new ApiPermissionVerifier();
+  }
+
+  public IdentityVerificationApplicationManagementResult handle(
+      String method,
+      AdminAuthenticationContext authenticationContext,
+      TenantIdentifier tenantIdentifier,
+      IdentityVerificationApplicationManagementRequest request,
+      RequestAttributes requestAttributes,
+      boolean dryRun) {
+
+    User operator = authenticationContext.operator();
+    OAuthToken oAuthToken = authenticationContext.oAuthToken();
+
+    IdentityVerificationApplicationManagementService<?> service = services.get(method);
+    if (service == null) {
+      throw new UnSupportedException("Unsupported operation method: " + method);
+    }
+
+    IdentityVerificationApplicationManagementContextBuilder contextBuilder =
+        new IdentityVerificationApplicationManagementContextBuilder(
+            tenantIdentifier, operator, oAuthToken, requestAttributes, request, dryRun);
+
+    try {
+      Tenant tenant = tenantQueryRepository.get(tenantIdentifier);
+
+      AdminPermissions requiredPermissions = api.getRequiredPermissions(method);
+      apiPermissionVerifier.verify(operator, requiredPermissions);
+
+      IdentityVerificationApplicationManagementResponse response =
+          executeService(
+              service,
+              contextBuilder,
+              tenant,
+              operator,
+              oAuthToken,
+              request,
+              requestAttributes,
+              dryRun);
+
+      AuditableContext context = contextBuilder.build();
+      return IdentityVerificationApplicationManagementResult.success(context, response);
+    } catch (NotFoundException e) {
+
+      log.warn(e.getMessage());
+      ResourceNotFoundException notFound = new ResourceNotFoundException(e.getMessage());
+      AuditableContext context = contextBuilder.buildPartial(notFound);
+      return IdentityVerificationApplicationManagementResult.error(context, notFound);
+
+    } catch (ManagementApiException e) {
+
+      log.warn(e.getMessage());
+      AuditableContext errorContext = contextBuilder.buildPartial(e);
+      return IdentityVerificationApplicationManagementResult.error(errorContext, e);
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  private <T> IdentityVerificationApplicationManagementResponse executeService(
+      IdentityVerificationApplicationManagementService<T> service,
+      IdentityVerificationApplicationManagementContextBuilder builder,
+      Tenant tenant,
+      User operator,
+      OAuthToken oAuthToken,
+      Object request,
+      RequestAttributes requestAttributes,
+      boolean dryRun) {
+    T typedRequest = (T) request;
+    return service.execute(
+        builder, tenant, operator, oAuthToken, typedRequest, requestAttributes, dryRun);
+  }
+}

--- a/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/identity/verification/application/handler/IdentityVerificationApplicationManagementResult.java
+++ b/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/identity/verification/application/handler/IdentityVerificationApplicationManagementResult.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2025 Hirokazu Kobayashi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.idp.server.control_plane.management.identity.verification.application.handler;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.idp.server.control_plane.base.AuditableContext;
+import org.idp.server.control_plane.management.exception.ManagementApiException;
+import org.idp.server.control_plane.management.exception.OrganizationAccessDeniedException;
+import org.idp.server.control_plane.management.exception.PermissionDeniedException;
+import org.idp.server.control_plane.management.exception.ResourceNotFoundException;
+import org.idp.server.control_plane.management.identity.verification.application.io.IdentityVerificationApplicationManagementResponse;
+import org.idp.server.control_plane.management.identity.verification.application.io.IdentityVerificationApplicationManagementStatus;
+
+public class IdentityVerificationApplicationManagementResult {
+
+  private final AuditableContext context;
+  private final ManagementApiException exception;
+  private final IdentityVerificationApplicationManagementResponse response;
+
+  private IdentityVerificationApplicationManagementResult(
+      AuditableContext context,
+      ManagementApiException exception,
+      IdentityVerificationApplicationManagementResponse response) {
+    this.context = context;
+    this.exception = exception;
+    this.response = response;
+  }
+
+  public static IdentityVerificationApplicationManagementResult success(
+      AuditableContext context, IdentityVerificationApplicationManagementResponse response) {
+    return new IdentityVerificationApplicationManagementResult(context, null, response);
+  }
+
+  public static IdentityVerificationApplicationManagementResult error(
+      AuditableContext context, ManagementApiException exception) {
+    return new IdentityVerificationApplicationManagementResult(context, exception, null);
+  }
+
+  private static IdentityVerificationApplicationManagementStatus mapExceptionToStatus(
+      ManagementApiException exception) {
+    if (exception instanceof ResourceNotFoundException) {
+      return IdentityVerificationApplicationManagementStatus.NOT_FOUND;
+    }
+    if (exception instanceof PermissionDeniedException
+        || exception instanceof OrganizationAccessDeniedException) {
+      return IdentityVerificationApplicationManagementStatus.FORBIDDEN;
+    }
+    return IdentityVerificationApplicationManagementStatus.INVALID_REQUEST;
+  }
+
+  public AuditableContext context() {
+    return context;
+  }
+
+  public boolean hasException() {
+    return exception != null;
+  }
+
+  public ManagementApiException getException() {
+    return exception;
+  }
+
+  public IdentityVerificationApplicationManagementResponse toResponse(boolean dryRun) {
+    if (hasException()) {
+      IdentityVerificationApplicationManagementStatus status = mapExceptionToStatus(exception);
+      Map<String, Object> errorResponse = new HashMap<>();
+      errorResponse.put("dry_run", dryRun);
+      errorResponse.put("error", exception.errorCode());
+      errorResponse.put("error_description", exception.errorDescription());
+      errorResponse.putAll(exception.errorDetails());
+      return new IdentityVerificationApplicationManagementResponse(status, errorResponse);
+    }
+    return response;
+  }
+}

--- a/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/identity/verification/application/handler/IdentityVerificationApplicationManagementService.java
+++ b/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/identity/verification/application/handler/IdentityVerificationApplicationManagementService.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2025 Hirokazu Kobayashi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.idp.server.control_plane.management.identity.verification.application.handler;
+
+import org.idp.server.control_plane.management.identity.verification.application.IdentityVerificationApplicationManagementContextBuilder;
+import org.idp.server.control_plane.management.identity.verification.application.io.IdentityVerificationApplicationManagementResponse;
+import org.idp.server.core.openid.identity.User;
+import org.idp.server.core.openid.token.OAuthToken;
+import org.idp.server.platform.multi_tenancy.tenant.Tenant;
+import org.idp.server.platform.type.RequestAttributes;
+
+public interface IdentityVerificationApplicationManagementService<T> {
+
+  IdentityVerificationApplicationManagementResponse execute(
+      IdentityVerificationApplicationManagementContextBuilder builder,
+      Tenant tenant,
+      User operator,
+      OAuthToken oAuthToken,
+      T request,
+      RequestAttributes requestAttributes,
+      boolean dryRun);
+}

--- a/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/identity/verification/application/handler/OrgIdentityVerificationApplicationManagementHandler.java
+++ b/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/identity/verification/application/handler/OrgIdentityVerificationApplicationManagementHandler.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2025 Hirokazu Kobayashi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.idp.server.control_plane.management.identity.verification.application.handler;
+
+import java.util.Map;
+import org.idp.server.control_plane.base.AuditableContext;
+import org.idp.server.control_plane.base.OrganizationAccessVerifier;
+import org.idp.server.control_plane.base.OrganizationAuthenticationContext;
+import org.idp.server.control_plane.base.definition.AdminPermissions;
+import org.idp.server.control_plane.management.exception.ManagementApiException;
+import org.idp.server.control_plane.management.exception.ResourceNotFoundException;
+import org.idp.server.control_plane.management.identity.verification.application.IdentityVerificationApplicationManagementContextBuilder;
+import org.idp.server.control_plane.management.identity.verification.application.OrgIdentityVerificationApplicationManagementApi;
+import org.idp.server.control_plane.management.identity.verification.application.io.IdentityVerificationApplicationManagementRequest;
+import org.idp.server.control_plane.management.identity.verification.application.io.IdentityVerificationApplicationManagementResponse;
+import org.idp.server.core.openid.identity.User;
+import org.idp.server.core.openid.token.OAuthToken;
+import org.idp.server.platform.exception.NotFoundException;
+import org.idp.server.platform.exception.UnSupportedException;
+import org.idp.server.platform.log.LoggerWrapper;
+import org.idp.server.platform.multi_tenancy.organization.Organization;
+import org.idp.server.platform.multi_tenancy.organization.OrganizationRepository;
+import org.idp.server.platform.multi_tenancy.tenant.Tenant;
+import org.idp.server.platform.multi_tenancy.tenant.TenantIdentifier;
+import org.idp.server.platform.multi_tenancy.tenant.TenantQueryRepository;
+import org.idp.server.platform.type.RequestAttributes;
+
+public class OrgIdentityVerificationApplicationManagementHandler {
+
+  private final Map<String, IdentityVerificationApplicationManagementService<?>> services;
+  private final OrgIdentityVerificationApplicationManagementApi api;
+  private final TenantQueryRepository tenantQueryRepository;
+  private final OrganizationRepository organizationRepository;
+  private final OrganizationAccessVerifier organizationAccessVerifier;
+  LoggerWrapper log =
+      LoggerWrapper.getLogger(OrgIdentityVerificationApplicationManagementHandler.class);
+
+  public OrgIdentityVerificationApplicationManagementHandler(
+      Map<String, IdentityVerificationApplicationManagementService<?>> services,
+      OrgIdentityVerificationApplicationManagementApi api,
+      TenantQueryRepository tenantQueryRepository,
+      OrganizationRepository organizationRepository,
+      OrganizationAccessVerifier organizationAccessVerifier) {
+    this.services = services;
+    this.api = api;
+    this.tenantQueryRepository = tenantQueryRepository;
+    this.organizationRepository = organizationRepository;
+    this.organizationAccessVerifier = organizationAccessVerifier;
+  }
+
+  public IdentityVerificationApplicationManagementResult handle(
+      String method,
+      OrganizationAuthenticationContext authenticationContext,
+      TenantIdentifier tenantIdentifier,
+      IdentityVerificationApplicationManagementRequest request,
+      RequestAttributes requestAttributes,
+      boolean dryRun) {
+
+    Organization organization = authenticationContext.organization();
+    User operator = authenticationContext.operator();
+    OAuthToken oAuthToken = authenticationContext.oAuthToken();
+
+    IdentityVerificationApplicationManagementService<?> service = services.get(method);
+    if (service == null) {
+      throw new UnSupportedException("Unsupported operation method: " + method);
+    }
+
+    IdentityVerificationApplicationManagementContextBuilder contextBuilder =
+        new IdentityVerificationApplicationManagementContextBuilder(
+            tenantIdentifier, operator, oAuthToken, requestAttributes, request, dryRun);
+
+    try {
+      Tenant tenant = tenantQueryRepository.get(tenantIdentifier);
+
+      AdminPermissions permissions = api.getRequiredPermissions(method);
+      organizationAccessVerifier.verify(organization, tenantIdentifier, operator, permissions);
+
+      IdentityVerificationApplicationManagementResponse response =
+          executeService(
+              service,
+              contextBuilder,
+              tenant,
+              operator,
+              oAuthToken,
+              request,
+              requestAttributes,
+              dryRun);
+
+      AuditableContext context = contextBuilder.build();
+      return IdentityVerificationApplicationManagementResult.success(context, response);
+    } catch (NotFoundException e) {
+
+      log.warn(e.getMessage());
+      ResourceNotFoundException notFound = new ResourceNotFoundException(e.getMessage());
+      AuditableContext context = contextBuilder.buildPartial(notFound);
+      return IdentityVerificationApplicationManagementResult.error(context, notFound);
+
+    } catch (ManagementApiException e) {
+
+      log.warn(e.getMessage());
+      AuditableContext errorContext = contextBuilder.buildPartial(e);
+      return IdentityVerificationApplicationManagementResult.error(errorContext, e);
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  private <T> IdentityVerificationApplicationManagementResponse executeService(
+      IdentityVerificationApplicationManagementService<T> service,
+      IdentityVerificationApplicationManagementContextBuilder builder,
+      Tenant tenant,
+      User operator,
+      OAuthToken oAuthToken,
+      Object request,
+      RequestAttributes requestAttributes,
+      boolean dryRun) {
+    T typedRequest = (T) request;
+    return service.execute(
+        builder, tenant, operator, oAuthToken, typedRequest, requestAttributes, dryRun);
+  }
+}

--- a/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/identity/verification/application/io/IdentityVerificationApplicationDeleteRequest.java
+++ b/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/identity/verification/application/io/IdentityVerificationApplicationDeleteRequest.java
@@ -14,19 +14,17 @@
  * limitations under the License.
  */
 
-package org.idp.server.core.adapters.datasource.identity.verification.application.command;
+package org.idp.server.control_plane.management.identity.verification.application.io;
 
-import org.idp.server.core.extension.identity.verification.application.model.IdentityVerificationApplication;
+import java.util.Map;
 import org.idp.server.core.extension.identity.verification.application.model.IdentityVerificationApplicationIdentifier;
-import org.idp.server.core.openid.identity.User;
-import org.idp.server.platform.multi_tenancy.tenant.Tenant;
 
-public interface IdentityVerificationApplicationCommandSqlExecutor {
-  void insert(Tenant tenant, IdentityVerificationApplication application);
+public record IdentityVerificationApplicationDeleteRequest(
+    IdentityVerificationApplicationIdentifier identifier)
+    implements IdentityVerificationApplicationManagementRequest {
 
-  void update(Tenant tenant, IdentityVerificationApplication application);
-
-  void delete(Tenant tenant, User user, IdentityVerificationApplicationIdentifier identifier);
-
-  void delete(Tenant tenant, IdentityVerificationApplicationIdentifier identifier);
+  @Override
+  public Map<String, Object> toMap() {
+    return Map.of("id", identifier.value());
+  }
 }

--- a/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/identity/verification/application/io/IdentityVerificationApplicationFindListRequest.java
+++ b/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/identity/verification/application/io/IdentityVerificationApplicationFindListRequest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2025 Hirokazu Kobayashi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.idp.server.control_plane.management.identity.verification.application.io;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.idp.server.core.extension.identity.verification.application.model.IdentityVerificationApplicationQueries;
+
+public record IdentityVerificationApplicationFindListRequest(
+    IdentityVerificationApplicationQueries queries)
+    implements IdentityVerificationApplicationManagementRequest {
+
+  @Override
+  public Map<String, Object> toMap() {
+    Map<String, Object> map = new HashMap<>();
+    map.put("limit", queries.limit());
+    map.put("offset", queries.offset());
+    return map;
+  }
+}

--- a/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/identity/verification/application/io/IdentityVerificationApplicationFindRequest.java
+++ b/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/identity/verification/application/io/IdentityVerificationApplicationFindRequest.java
@@ -14,19 +14,17 @@
  * limitations under the License.
  */
 
-package org.idp.server.core.adapters.datasource.identity.verification.application.command;
+package org.idp.server.control_plane.management.identity.verification.application.io;
 
-import org.idp.server.core.extension.identity.verification.application.model.IdentityVerificationApplication;
+import java.util.Map;
 import org.idp.server.core.extension.identity.verification.application.model.IdentityVerificationApplicationIdentifier;
-import org.idp.server.core.openid.identity.User;
-import org.idp.server.platform.multi_tenancy.tenant.Tenant;
 
-public interface IdentityVerificationApplicationCommandSqlExecutor {
-  void insert(Tenant tenant, IdentityVerificationApplication application);
+public record IdentityVerificationApplicationFindRequest(
+    IdentityVerificationApplicationIdentifier identifier)
+    implements IdentityVerificationApplicationManagementRequest {
 
-  void update(Tenant tenant, IdentityVerificationApplication application);
-
-  void delete(Tenant tenant, User user, IdentityVerificationApplicationIdentifier identifier);
-
-  void delete(Tenant tenant, IdentityVerificationApplicationIdentifier identifier);
+  @Override
+  public Map<String, Object> toMap() {
+    return Map.of("id", identifier.value());
+  }
 }

--- a/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/identity/verification/application/io/IdentityVerificationApplicationManagementRequest.java
+++ b/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/identity/verification/application/io/IdentityVerificationApplicationManagementRequest.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2025 Hirokazu Kobayashi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.idp.server.control_plane.management.identity.verification.application.io;
+
+import java.util.Map;
+
+public interface IdentityVerificationApplicationManagementRequest {
+
+  Map<String, Object> toMap();
+}

--- a/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/identity/verification/application/io/IdentityVerificationApplicationManagementResponse.java
+++ b/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/identity/verification/application/io/IdentityVerificationApplicationManagementResponse.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2025 Hirokazu Kobayashi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.idp.server.control_plane.management.identity.verification.application.io;
+
+import java.util.Map;
+
+public class IdentityVerificationApplicationManagementResponse {
+  IdentityVerificationApplicationManagementStatus status;
+  Map<String, Object> contents;
+
+  public IdentityVerificationApplicationManagementResponse(
+      IdentityVerificationApplicationManagementStatus status, Map<String, Object> contents) {
+    this.status = status;
+    this.contents = contents;
+  }
+
+  public IdentityVerificationApplicationManagementStatus status() {
+    return status;
+  }
+
+  public int statusCode() {
+    return status.statusCode();
+  }
+
+  public Map<String, Object> contents() {
+    return contents;
+  }
+}

--- a/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/identity/verification/application/io/IdentityVerificationApplicationManagementStatus.java
+++ b/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/identity/verification/application/io/IdentityVerificationApplicationManagementStatus.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2025 Hirokazu Kobayashi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.idp.server.control_plane.management.identity.verification.application.io;
+
+public enum IdentityVerificationApplicationManagementStatus {
+  OK(200),
+  NO_CONTENT(204),
+  INVALID_REQUEST(400),
+  UNAUTHORIZED(401),
+  FORBIDDEN(403),
+  NOT_FOUND(404),
+  SERVER_ERROR(500);
+
+  int statusCode;
+
+  IdentityVerificationApplicationManagementStatus(int statusCode) {
+    this.statusCode = statusCode;
+  }
+
+  public int statusCode() {
+    return statusCode;
+  }
+
+  public boolean isOk() {
+    return this == OK;
+  }
+}

--- a/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/identity/verification/result/IdentityVerificationResultManagementApi.java
+++ b/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/identity/verification/result/IdentityVerificationResultManagementApi.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2025 Hirokazu Kobayashi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.idp.server.control_plane.management.identity.verification.result;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import org.idp.server.control_plane.base.AdminAuthenticationContext;
+import org.idp.server.control_plane.base.definition.AdminPermissions;
+import org.idp.server.control_plane.base.definition.DefaultAdminPermission;
+import org.idp.server.control_plane.management.identity.verification.result.io.IdentityVerificationResultManagementResponse;
+import org.idp.server.core.extension.identity.verification.result.IdentityVerificationResultIdentifier;
+import org.idp.server.core.extension.identity.verification.result.IdentityVerificationResultQueries;
+import org.idp.server.platform.exception.UnSupportedException;
+import org.idp.server.platform.multi_tenancy.tenant.TenantIdentifier;
+import org.idp.server.platform.type.RequestAttributes;
+
+public interface IdentityVerificationResultManagementApi {
+
+  default AdminPermissions getRequiredPermissions(String method) {
+    Map<String, AdminPermissions> map = new HashMap<>();
+    map.put(
+        "findList",
+        new AdminPermissions(Set.of(DefaultAdminPermission.IDENTITY_VERIFICATION_RESULT_READ)));
+    map.put(
+        "get",
+        new AdminPermissions(Set.of(DefaultAdminPermission.IDENTITY_VERIFICATION_RESULT_READ)));
+    AdminPermissions adminPermissions = map.get(method);
+    if (adminPermissions == null) {
+      throw new UnSupportedException("Method " + method + " not supported");
+    }
+    return adminPermissions;
+  }
+
+  IdentityVerificationResultManagementResponse findList(
+      AdminAuthenticationContext authenticationContext,
+      TenantIdentifier tenantIdentifier,
+      IdentityVerificationResultQueries queries,
+      RequestAttributes requestAttributes);
+
+  IdentityVerificationResultManagementResponse get(
+      AdminAuthenticationContext authenticationContext,
+      TenantIdentifier tenantIdentifier,
+      IdentityVerificationResultIdentifier identifier,
+      RequestAttributes requestAttributes);
+}

--- a/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/identity/verification/result/IdentityVerificationResultManagementContext.java
+++ b/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/identity/verification/result/IdentityVerificationResultManagementContext.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright 2025 Hirokazu Kobayashi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.idp.server.control_plane.management.identity.verification.result;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import org.idp.server.control_plane.base.AuditableContext;
+import org.idp.server.control_plane.management.exception.ManagementApiException;
+import org.idp.server.control_plane.management.identity.verification.result.io.IdentityVerificationResultManagementRequest;
+import org.idp.server.core.extension.identity.verification.result.IdentityVerificationResult;
+import org.idp.server.core.openid.identity.User;
+import org.idp.server.core.openid.token.OAuthToken;
+import org.idp.server.platform.multi_tenancy.tenant.TenantIdentifier;
+import org.idp.server.platform.type.RequestAttributes;
+
+public class IdentityVerificationResultManagementContext implements AuditableContext {
+
+  TenantIdentifier tenantIdentifier;
+  User operator;
+  OAuthToken oAuthToken;
+  RequestAttributes requestAttributes;
+  IdentityVerificationResult before;
+  IdentityVerificationResultManagementRequest request;
+  boolean dryRun;
+  ManagementApiException exception;
+
+  public IdentityVerificationResultManagementContext(
+      TenantIdentifier tenantIdentifier,
+      User operator,
+      OAuthToken oAuthToken,
+      RequestAttributes requestAttributes,
+      IdentityVerificationResult before,
+      IdentityVerificationResultManagementRequest request,
+      boolean dryRun,
+      ManagementApiException exception) {
+    this.tenantIdentifier = tenantIdentifier;
+    this.operator = operator;
+    this.oAuthToken = oAuthToken;
+    this.requestAttributes = requestAttributes;
+    this.before = before;
+    this.request = request;
+    this.dryRun = dryRun;
+    this.exception = exception;
+  }
+
+  public IdentityVerificationResult beforeResult() {
+    return before;
+  }
+
+  public boolean hasException() {
+    return exception != null;
+  }
+
+  public ManagementApiException exception() {
+    return exception;
+  }
+
+  @Override
+  public String type() {
+    return "identity_verification_result";
+  }
+
+  @Override
+  public String description() {
+    return "identity verification result management api";
+  }
+
+  @Override
+  public String tenantId() {
+    return oAuthToken.tenantIdentifier().value();
+  }
+
+  @Override
+  public String clientId() {
+    return oAuthToken.requestedClientId().value();
+  }
+
+  @Override
+  public String userId() {
+    return operator.sub();
+  }
+
+  @Override
+  public String externalUserId() {
+    return operator.externalUserId();
+  }
+
+  @Override
+  public Map<String, Object> userPayload() {
+    return operator.toMap();
+  }
+
+  @Override
+  public String targetResource() {
+    return requestAttributes.resource().value();
+  }
+
+  @Override
+  public String targetResourceAction() {
+    return requestAttributes.action().value();
+  }
+
+  @Override
+  public String ipAddress() {
+    return requestAttributes.getIpAddress().value();
+  }
+
+  @Override
+  public String userAgent() {
+    return requestAttributes.getUserAgent().value();
+  }
+
+  @Override
+  public Map<String, Object> request() {
+    return request != null ? request.toMap() : Collections.emptyMap();
+  }
+
+  @Override
+  public Map<String, Object> before() {
+    return before != null ? before.toMap() : Collections.emptyMap();
+  }
+
+  @Override
+  public Map<String, Object> after() {
+    return Collections.emptyMap();
+  }
+
+  @Override
+  public String outcomeResult() {
+    return exception != null ? "failure" : "success";
+  }
+
+  @Override
+  public String outcomeReason() {
+    return exception != null ? exception.errorCode() : null;
+  }
+
+  @Override
+  public String targetTenantId() {
+    return tenantIdentifier.value();
+  }
+
+  @Override
+  public Map<String, Object> attributes() {
+    Map<String, Object> attributes = new HashMap<>();
+    if (exception != null) {
+      Map<String, Object> error = new HashMap<>();
+      error.put("error_code", exception.errorCode());
+      error.put("error_description", exception.errorDescription());
+
+      Map<String, Object> errorDetails = exception.errorDetails();
+      if (errorDetails != null && !errorDetails.isEmpty()) {
+        error.putAll(errorDetails);
+      }
+      attributes.put("error", error);
+    }
+
+    return attributes;
+  }
+
+  @Override
+  public boolean dryRun() {
+    return dryRun;
+  }
+}

--- a/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/identity/verification/result/IdentityVerificationResultManagementContextBuilder.java
+++ b/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/identity/verification/result/IdentityVerificationResultManagementContextBuilder.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2025 Hirokazu Kobayashi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.idp.server.control_plane.management.identity.verification.result;
+
+import org.idp.server.control_plane.base.AuditableContext;
+import org.idp.server.control_plane.management.exception.ManagementApiException;
+import org.idp.server.control_plane.management.identity.verification.result.io.IdentityVerificationResultManagementRequest;
+import org.idp.server.core.extension.identity.verification.result.IdentityVerificationResult;
+import org.idp.server.core.openid.identity.User;
+import org.idp.server.core.openid.token.OAuthToken;
+import org.idp.server.platform.multi_tenancy.tenant.TenantIdentifier;
+import org.idp.server.platform.type.RequestAttributes;
+
+public class IdentityVerificationResultManagementContextBuilder {
+
+  private final User operator;
+  private final OAuthToken oAuthToken;
+  private final RequestAttributes requestAttributes;
+  private final IdentityVerificationResultManagementRequest request;
+  private final TenantIdentifier tenantIdentifier;
+  private final boolean dryRun;
+
+  private IdentityVerificationResult before;
+
+  public IdentityVerificationResultManagementContextBuilder(
+      TenantIdentifier tenantIdentifier,
+      User operator,
+      OAuthToken oAuthToken,
+      RequestAttributes requestAttributes,
+      IdentityVerificationResultManagementRequest request,
+      boolean dryRun) {
+    this.tenantIdentifier = tenantIdentifier;
+    this.operator = operator;
+    this.oAuthToken = oAuthToken;
+    this.requestAttributes = requestAttributes;
+    this.request = request;
+    this.dryRun = dryRun;
+  }
+
+  public IdentityVerificationResultManagementContextBuilder withBefore(
+      IdentityVerificationResult before) {
+    this.before = before;
+    return this;
+  }
+
+  public AuditableContext build() {
+    return new IdentityVerificationResultManagementContext(
+        tenantIdentifier, operator, oAuthToken, requestAttributes, before, request, dryRun, null);
+  }
+
+  public AuditableContext buildPartial(ManagementApiException exception) {
+    return new IdentityVerificationResultManagementContext(
+        tenantIdentifier,
+        operator,
+        oAuthToken,
+        requestAttributes,
+        before,
+        request,
+        dryRun,
+        exception);
+  }
+}

--- a/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/identity/verification/result/OrgIdentityVerificationResultManagementApi.java
+++ b/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/identity/verification/result/OrgIdentityVerificationResultManagementApi.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2025 Hirokazu Kobayashi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.idp.server.control_plane.management.identity.verification.result;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import org.idp.server.control_plane.base.OrganizationAuthenticationContext;
+import org.idp.server.control_plane.base.definition.AdminPermissions;
+import org.idp.server.control_plane.base.definition.DefaultAdminPermission;
+import org.idp.server.control_plane.management.identity.verification.result.io.IdentityVerificationResultManagementResponse;
+import org.idp.server.core.extension.identity.verification.result.IdentityVerificationResultIdentifier;
+import org.idp.server.core.extension.identity.verification.result.IdentityVerificationResultQueries;
+import org.idp.server.platform.exception.UnSupportedException;
+import org.idp.server.platform.multi_tenancy.tenant.TenantIdentifier;
+import org.idp.server.platform.type.RequestAttributes;
+
+public interface OrgIdentityVerificationResultManagementApi {
+
+  default AdminPermissions getRequiredPermissions(String method) {
+    Map<String, AdminPermissions> map = new HashMap<>();
+    map.put(
+        "findList",
+        new AdminPermissions(Set.of(DefaultAdminPermission.IDENTITY_VERIFICATION_RESULT_READ)));
+    map.put(
+        "get",
+        new AdminPermissions(Set.of(DefaultAdminPermission.IDENTITY_VERIFICATION_RESULT_READ)));
+    AdminPermissions adminPermissions = map.get(method);
+    if (adminPermissions == null) {
+      throw new UnSupportedException("Method " + method + " not supported");
+    }
+    return adminPermissions;
+  }
+
+  IdentityVerificationResultManagementResponse findList(
+      OrganizationAuthenticationContext authenticationContext,
+      TenantIdentifier tenantIdentifier,
+      IdentityVerificationResultQueries queries,
+      RequestAttributes requestAttributes);
+
+  IdentityVerificationResultManagementResponse get(
+      OrganizationAuthenticationContext authenticationContext,
+      TenantIdentifier tenantIdentifier,
+      IdentityVerificationResultIdentifier identifier,
+      RequestAttributes requestAttributes);
+}

--- a/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/identity/verification/result/handler/IdentityVerificationResultFindListService.java
+++ b/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/identity/verification/result/handler/IdentityVerificationResultFindListService.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2025 Hirokazu Kobayashi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.idp.server.control_plane.management.identity.verification.result.handler;
+
+import java.util.List;
+import java.util.Map;
+import org.idp.server.control_plane.management.identity.verification.result.IdentityVerificationResultManagementContextBuilder;
+import org.idp.server.control_plane.management.identity.verification.result.io.IdentityVerificationResultFindListRequest;
+import org.idp.server.control_plane.management.identity.verification.result.io.IdentityVerificationResultManagementResponse;
+import org.idp.server.control_plane.management.identity.verification.result.io.IdentityVerificationResultManagementStatus;
+import org.idp.server.core.extension.identity.verification.repository.IdentityVerificationResultQueryRepository;
+import org.idp.server.core.extension.identity.verification.result.IdentityVerificationResult;
+import org.idp.server.core.extension.identity.verification.result.IdentityVerificationResultQueries;
+import org.idp.server.core.openid.identity.User;
+import org.idp.server.core.openid.token.OAuthToken;
+import org.idp.server.platform.multi_tenancy.tenant.Tenant;
+import org.idp.server.platform.type.RequestAttributes;
+
+public class IdentityVerificationResultFindListService
+    implements IdentityVerificationResultManagementService<
+        IdentityVerificationResultFindListRequest> {
+
+  private final IdentityVerificationResultQueryRepository queryRepository;
+
+  public IdentityVerificationResultFindListService(
+      IdentityVerificationResultQueryRepository queryRepository) {
+    this.queryRepository = queryRepository;
+  }
+
+  @Override
+  public IdentityVerificationResultManagementResponse execute(
+      IdentityVerificationResultManagementContextBuilder builder,
+      Tenant tenant,
+      User operator,
+      OAuthToken oAuthToken,
+      IdentityVerificationResultFindListRequest request,
+      RequestAttributes requestAttributes,
+      boolean dryRun) {
+
+    IdentityVerificationResultQueries queries = request.queries();
+    long totalCount = queryRepository.findTotalCount(tenant, queries);
+    if (totalCount == 0) {
+      Map<String, Object> response =
+          Map.of(
+              "list", List.of(),
+              "total_count", totalCount,
+              "limit", queries.limit(),
+              "offset", queries.offset());
+      return new IdentityVerificationResultManagementResponse(
+          IdentityVerificationResultManagementStatus.OK, response);
+    }
+
+    List<IdentityVerificationResult> results = queryRepository.findList(tenant, queries);
+
+    List<Map<String, Object>> list = new java.util.ArrayList<>();
+    for (IdentityVerificationResult result : results) {
+      list.add(result.toMap());
+    }
+
+    Map<String, Object> response =
+        Map.of(
+            "list",
+            list,
+            "total_count",
+            totalCount,
+            "limit",
+            queries.limit(),
+            "offset",
+            queries.offset());
+
+    return new IdentityVerificationResultManagementResponse(
+        IdentityVerificationResultManagementStatus.OK, response);
+  }
+}

--- a/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/identity/verification/result/handler/IdentityVerificationResultFindService.java
+++ b/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/identity/verification/result/handler/IdentityVerificationResultFindService.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2025 Hirokazu Kobayashi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.idp.server.control_plane.management.identity.verification.result.handler;
+
+import org.idp.server.control_plane.management.exception.ResourceNotFoundException;
+import org.idp.server.control_plane.management.identity.verification.result.IdentityVerificationResultManagementContextBuilder;
+import org.idp.server.control_plane.management.identity.verification.result.io.IdentityVerificationResultFindRequest;
+import org.idp.server.control_plane.management.identity.verification.result.io.IdentityVerificationResultManagementResponse;
+import org.idp.server.control_plane.management.identity.verification.result.io.IdentityVerificationResultManagementStatus;
+import org.idp.server.core.extension.identity.verification.repository.IdentityVerificationResultQueryRepository;
+import org.idp.server.core.extension.identity.verification.result.IdentityVerificationResult;
+import org.idp.server.core.extension.identity.verification.result.IdentityVerificationResultIdentifier;
+import org.idp.server.core.openid.identity.User;
+import org.idp.server.core.openid.token.OAuthToken;
+import org.idp.server.platform.multi_tenancy.tenant.Tenant;
+import org.idp.server.platform.type.RequestAttributes;
+
+public class IdentityVerificationResultFindService
+    implements IdentityVerificationResultManagementService<IdentityVerificationResultFindRequest> {
+
+  private final IdentityVerificationResultQueryRepository queryRepository;
+
+  public IdentityVerificationResultFindService(
+      IdentityVerificationResultQueryRepository queryRepository) {
+    this.queryRepository = queryRepository;
+  }
+
+  @Override
+  public IdentityVerificationResultManagementResponse execute(
+      IdentityVerificationResultManagementContextBuilder builder,
+      Tenant tenant,
+      User operator,
+      OAuthToken oAuthToken,
+      IdentityVerificationResultFindRequest request,
+      RequestAttributes requestAttributes,
+      boolean dryRun) {
+
+    IdentityVerificationResultIdentifier identifier = request.identifier();
+    IdentityVerificationResult result = queryRepository.get(tenant, identifier);
+
+    if (!result.exists()) {
+      throw new ResourceNotFoundException(
+          "Identity verification result not found: " + identifier.value());
+    }
+
+    builder.withBefore(result);
+
+    return new IdentityVerificationResultManagementResponse(
+        IdentityVerificationResultManagementStatus.OK, result.toMap());
+  }
+}

--- a/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/identity/verification/result/handler/IdentityVerificationResultManagementHandler.java
+++ b/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/identity/verification/result/handler/IdentityVerificationResultManagementHandler.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2025 Hirokazu Kobayashi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.idp.server.control_plane.management.identity.verification.result.handler;
+
+import java.util.Map;
+import org.idp.server.control_plane.base.AdminAuthenticationContext;
+import org.idp.server.control_plane.base.ApiPermissionVerifier;
+import org.idp.server.control_plane.base.AuditableContext;
+import org.idp.server.control_plane.base.definition.AdminPermissions;
+import org.idp.server.control_plane.management.exception.ManagementApiException;
+import org.idp.server.control_plane.management.exception.ResourceNotFoundException;
+import org.idp.server.control_plane.management.identity.verification.result.IdentityVerificationResultManagementApi;
+import org.idp.server.control_plane.management.identity.verification.result.IdentityVerificationResultManagementContextBuilder;
+import org.idp.server.control_plane.management.identity.verification.result.io.IdentityVerificationResultManagementRequest;
+import org.idp.server.control_plane.management.identity.verification.result.io.IdentityVerificationResultManagementResponse;
+import org.idp.server.core.openid.identity.User;
+import org.idp.server.core.openid.token.OAuthToken;
+import org.idp.server.platform.exception.NotFoundException;
+import org.idp.server.platform.exception.UnSupportedException;
+import org.idp.server.platform.log.LoggerWrapper;
+import org.idp.server.platform.multi_tenancy.tenant.Tenant;
+import org.idp.server.platform.multi_tenancy.tenant.TenantIdentifier;
+import org.idp.server.platform.multi_tenancy.tenant.TenantQueryRepository;
+import org.idp.server.platform.type.RequestAttributes;
+
+public class IdentityVerificationResultManagementHandler {
+
+  private final Map<String, IdentityVerificationResultManagementService<?>> services;
+  private final IdentityVerificationResultManagementApi api;
+  private final TenantQueryRepository tenantQueryRepository;
+  private final ApiPermissionVerifier apiPermissionVerifier;
+  LoggerWrapper log = LoggerWrapper.getLogger(IdentityVerificationResultManagementHandler.class);
+
+  public IdentityVerificationResultManagementHandler(
+      Map<String, IdentityVerificationResultManagementService<?>> services,
+      IdentityVerificationResultManagementApi api,
+      TenantQueryRepository tenantQueryRepository) {
+    this.services = services;
+    this.api = api;
+    this.tenantQueryRepository = tenantQueryRepository;
+    this.apiPermissionVerifier = new ApiPermissionVerifier();
+  }
+
+  public IdentityVerificationResultManagementResult handle(
+      String method,
+      AdminAuthenticationContext authenticationContext,
+      TenantIdentifier tenantIdentifier,
+      IdentityVerificationResultManagementRequest request,
+      RequestAttributes requestAttributes,
+      boolean dryRun) {
+
+    User operator = authenticationContext.operator();
+    OAuthToken oAuthToken = authenticationContext.oAuthToken();
+
+    IdentityVerificationResultManagementService<?> service = services.get(method);
+    if (service == null) {
+      throw new UnSupportedException("Unsupported operation method: " + method);
+    }
+
+    IdentityVerificationResultManagementContextBuilder contextBuilder =
+        new IdentityVerificationResultManagementContextBuilder(
+            tenantIdentifier, operator, oAuthToken, requestAttributes, request, dryRun);
+
+    try {
+      Tenant tenant = tenantQueryRepository.get(tenantIdentifier);
+
+      AdminPermissions requiredPermissions = api.getRequiredPermissions(method);
+      apiPermissionVerifier.verify(operator, requiredPermissions);
+
+      IdentityVerificationResultManagementResponse response =
+          executeService(
+              service,
+              contextBuilder,
+              tenant,
+              operator,
+              oAuthToken,
+              request,
+              requestAttributes,
+              dryRun);
+
+      AuditableContext context = contextBuilder.build();
+      return IdentityVerificationResultManagementResult.success(context, response);
+    } catch (NotFoundException e) {
+
+      log.warn(e.getMessage());
+      ResourceNotFoundException notFound = new ResourceNotFoundException(e.getMessage());
+      AuditableContext context = contextBuilder.buildPartial(notFound);
+      return IdentityVerificationResultManagementResult.error(context, notFound);
+
+    } catch (ManagementApiException e) {
+
+      log.warn(e.getMessage());
+      AuditableContext errorContext = contextBuilder.buildPartial(e);
+      return IdentityVerificationResultManagementResult.error(errorContext, e);
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  private <T> IdentityVerificationResultManagementResponse executeService(
+      IdentityVerificationResultManagementService<T> service,
+      IdentityVerificationResultManagementContextBuilder builder,
+      Tenant tenant,
+      User operator,
+      OAuthToken oAuthToken,
+      Object request,
+      RequestAttributes requestAttributes,
+      boolean dryRun) {
+    T typedRequest = (T) request;
+    return service.execute(
+        builder, tenant, operator, oAuthToken, typedRequest, requestAttributes, dryRun);
+  }
+}

--- a/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/identity/verification/result/handler/IdentityVerificationResultManagementResult.java
+++ b/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/identity/verification/result/handler/IdentityVerificationResultManagementResult.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2025 Hirokazu Kobayashi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.idp.server.control_plane.management.identity.verification.result.handler;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.idp.server.control_plane.base.AuditableContext;
+import org.idp.server.control_plane.management.exception.ManagementApiException;
+import org.idp.server.control_plane.management.exception.OrganizationAccessDeniedException;
+import org.idp.server.control_plane.management.exception.PermissionDeniedException;
+import org.idp.server.control_plane.management.exception.ResourceNotFoundException;
+import org.idp.server.control_plane.management.identity.verification.result.io.IdentityVerificationResultManagementResponse;
+import org.idp.server.control_plane.management.identity.verification.result.io.IdentityVerificationResultManagementStatus;
+
+public class IdentityVerificationResultManagementResult {
+
+  private final AuditableContext context;
+  private final ManagementApiException exception;
+  private final IdentityVerificationResultManagementResponse response;
+
+  private IdentityVerificationResultManagementResult(
+      AuditableContext context,
+      ManagementApiException exception,
+      IdentityVerificationResultManagementResponse response) {
+    this.context = context;
+    this.exception = exception;
+    this.response = response;
+  }
+
+  public static IdentityVerificationResultManagementResult success(
+      AuditableContext context, IdentityVerificationResultManagementResponse response) {
+    return new IdentityVerificationResultManagementResult(context, null, response);
+  }
+
+  public static IdentityVerificationResultManagementResult error(
+      AuditableContext context, ManagementApiException exception) {
+    return new IdentityVerificationResultManagementResult(context, exception, null);
+  }
+
+  private static IdentityVerificationResultManagementStatus mapExceptionToStatus(
+      ManagementApiException exception) {
+    if (exception instanceof ResourceNotFoundException) {
+      return IdentityVerificationResultManagementStatus.NOT_FOUND;
+    }
+    if (exception instanceof PermissionDeniedException
+        || exception instanceof OrganizationAccessDeniedException) {
+      return IdentityVerificationResultManagementStatus.FORBIDDEN;
+    }
+    return IdentityVerificationResultManagementStatus.INVALID_REQUEST;
+  }
+
+  public AuditableContext context() {
+    return context;
+  }
+
+  public boolean hasException() {
+    return exception != null;
+  }
+
+  public ManagementApiException getException() {
+    return exception;
+  }
+
+  public IdentityVerificationResultManagementResponse toResponse(boolean dryRun) {
+    if (hasException()) {
+      IdentityVerificationResultManagementStatus status = mapExceptionToStatus(exception);
+      Map<String, Object> errorResponse = new HashMap<>();
+      errorResponse.put("dry_run", dryRun);
+      errorResponse.put("error", exception.errorCode());
+      errorResponse.put("error_description", exception.errorDescription());
+      errorResponse.putAll(exception.errorDetails());
+      return new IdentityVerificationResultManagementResponse(status, errorResponse);
+    }
+    return response;
+  }
+}

--- a/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/identity/verification/result/handler/IdentityVerificationResultManagementService.java
+++ b/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/identity/verification/result/handler/IdentityVerificationResultManagementService.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2025 Hirokazu Kobayashi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.idp.server.control_plane.management.identity.verification.result.handler;
+
+import org.idp.server.control_plane.management.identity.verification.result.IdentityVerificationResultManagementContextBuilder;
+import org.idp.server.control_plane.management.identity.verification.result.io.IdentityVerificationResultManagementResponse;
+import org.idp.server.core.openid.identity.User;
+import org.idp.server.core.openid.token.OAuthToken;
+import org.idp.server.platform.multi_tenancy.tenant.Tenant;
+import org.idp.server.platform.type.RequestAttributes;
+
+public interface IdentityVerificationResultManagementService<T> {
+
+  IdentityVerificationResultManagementResponse execute(
+      IdentityVerificationResultManagementContextBuilder builder,
+      Tenant tenant,
+      User operator,
+      OAuthToken oAuthToken,
+      T request,
+      RequestAttributes requestAttributes,
+      boolean dryRun);
+}

--- a/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/identity/verification/result/handler/OrgIdentityVerificationResultManagementHandler.java
+++ b/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/identity/verification/result/handler/OrgIdentityVerificationResultManagementHandler.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2025 Hirokazu Kobayashi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.idp.server.control_plane.management.identity.verification.result.handler;
+
+import java.util.Map;
+import org.idp.server.control_plane.base.AuditableContext;
+import org.idp.server.control_plane.base.OrganizationAccessVerifier;
+import org.idp.server.control_plane.base.OrganizationAuthenticationContext;
+import org.idp.server.control_plane.base.definition.AdminPermissions;
+import org.idp.server.control_plane.management.exception.ManagementApiException;
+import org.idp.server.control_plane.management.exception.ResourceNotFoundException;
+import org.idp.server.control_plane.management.identity.verification.result.IdentityVerificationResultManagementContextBuilder;
+import org.idp.server.control_plane.management.identity.verification.result.OrgIdentityVerificationResultManagementApi;
+import org.idp.server.control_plane.management.identity.verification.result.io.IdentityVerificationResultManagementRequest;
+import org.idp.server.control_plane.management.identity.verification.result.io.IdentityVerificationResultManagementResponse;
+import org.idp.server.core.openid.identity.User;
+import org.idp.server.core.openid.token.OAuthToken;
+import org.idp.server.platform.exception.NotFoundException;
+import org.idp.server.platform.exception.UnSupportedException;
+import org.idp.server.platform.log.LoggerWrapper;
+import org.idp.server.platform.multi_tenancy.organization.Organization;
+import org.idp.server.platform.multi_tenancy.organization.OrganizationRepository;
+import org.idp.server.platform.multi_tenancy.tenant.Tenant;
+import org.idp.server.platform.multi_tenancy.tenant.TenantIdentifier;
+import org.idp.server.platform.multi_tenancy.tenant.TenantQueryRepository;
+import org.idp.server.platform.type.RequestAttributes;
+
+public class OrgIdentityVerificationResultManagementHandler {
+
+  private final Map<String, IdentityVerificationResultManagementService<?>> services;
+  private final OrgIdentityVerificationResultManagementApi api;
+  private final TenantQueryRepository tenantQueryRepository;
+  private final OrganizationRepository organizationRepository;
+  private final OrganizationAccessVerifier organizationAccessVerifier;
+  LoggerWrapper log = LoggerWrapper.getLogger(OrgIdentityVerificationResultManagementHandler.class);
+
+  public OrgIdentityVerificationResultManagementHandler(
+      Map<String, IdentityVerificationResultManagementService<?>> services,
+      OrgIdentityVerificationResultManagementApi api,
+      TenantQueryRepository tenantQueryRepository,
+      OrganizationRepository organizationRepository,
+      OrganizationAccessVerifier organizationAccessVerifier) {
+    this.services = services;
+    this.api = api;
+    this.tenantQueryRepository = tenantQueryRepository;
+    this.organizationRepository = organizationRepository;
+    this.organizationAccessVerifier = organizationAccessVerifier;
+  }
+
+  public IdentityVerificationResultManagementResult handle(
+      String method,
+      OrganizationAuthenticationContext authenticationContext,
+      TenantIdentifier tenantIdentifier,
+      IdentityVerificationResultManagementRequest request,
+      RequestAttributes requestAttributes,
+      boolean dryRun) {
+
+    Organization organization = authenticationContext.organization();
+    User operator = authenticationContext.operator();
+    OAuthToken oAuthToken = authenticationContext.oAuthToken();
+
+    IdentityVerificationResultManagementService<?> service = services.get(method);
+    if (service == null) {
+      throw new UnSupportedException("Unsupported operation method: " + method);
+    }
+
+    IdentityVerificationResultManagementContextBuilder contextBuilder =
+        new IdentityVerificationResultManagementContextBuilder(
+            tenantIdentifier, operator, oAuthToken, requestAttributes, request, dryRun);
+
+    try {
+      Tenant tenant = tenantQueryRepository.get(tenantIdentifier);
+
+      AdminPermissions permissions = api.getRequiredPermissions(method);
+      organizationAccessVerifier.verify(organization, tenantIdentifier, operator, permissions);
+
+      IdentityVerificationResultManagementResponse response =
+          executeService(
+              service,
+              contextBuilder,
+              tenant,
+              operator,
+              oAuthToken,
+              request,
+              requestAttributes,
+              dryRun);
+
+      AuditableContext context = contextBuilder.build();
+      return IdentityVerificationResultManagementResult.success(context, response);
+    } catch (NotFoundException e) {
+
+      log.warn(e.getMessage());
+      ResourceNotFoundException notFound = new ResourceNotFoundException(e.getMessage());
+      AuditableContext context = contextBuilder.buildPartial(notFound);
+      return IdentityVerificationResultManagementResult.error(context, notFound);
+
+    } catch (ManagementApiException e) {
+
+      log.warn(e.getMessage());
+      AuditableContext errorContext = contextBuilder.buildPartial(e);
+      return IdentityVerificationResultManagementResult.error(errorContext, e);
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  private <T> IdentityVerificationResultManagementResponse executeService(
+      IdentityVerificationResultManagementService<T> service,
+      IdentityVerificationResultManagementContextBuilder builder,
+      Tenant tenant,
+      User operator,
+      OAuthToken oAuthToken,
+      Object request,
+      RequestAttributes requestAttributes,
+      boolean dryRun) {
+    T typedRequest = (T) request;
+    return service.execute(
+        builder, tenant, operator, oAuthToken, typedRequest, requestAttributes, dryRun);
+  }
+}

--- a/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/identity/verification/result/io/IdentityVerificationResultFindListRequest.java
+++ b/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/identity/verification/result/io/IdentityVerificationResultFindListRequest.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2025 Hirokazu Kobayashi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.idp.server.control_plane.management.identity.verification.result.io;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.idp.server.core.extension.identity.verification.result.IdentityVerificationResultQueries;
+
+public record IdentityVerificationResultFindListRequest(IdentityVerificationResultQueries queries)
+    implements IdentityVerificationResultManagementRequest {
+
+  @Override
+  public Map<String, Object> toMap() {
+    Map<String, Object> map = new HashMap<>();
+    map.put("limit", queries.limit());
+    map.put("offset", queries.offset());
+    return map;
+  }
+}

--- a/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/identity/verification/result/io/IdentityVerificationResultFindRequest.java
+++ b/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/identity/verification/result/io/IdentityVerificationResultFindRequest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2025 Hirokazu Kobayashi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.idp.server.control_plane.management.identity.verification.result.io;
+
+import java.util.Map;
+import org.idp.server.core.extension.identity.verification.result.IdentityVerificationResultIdentifier;
+
+public record IdentityVerificationResultFindRequest(IdentityVerificationResultIdentifier identifier)
+    implements IdentityVerificationResultManagementRequest {
+
+  @Override
+  public Map<String, Object> toMap() {
+    return Map.of("id", identifier.value());
+  }
+}

--- a/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/identity/verification/result/io/IdentityVerificationResultManagementRequest.java
+++ b/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/identity/verification/result/io/IdentityVerificationResultManagementRequest.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2025 Hirokazu Kobayashi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.idp.server.control_plane.management.identity.verification.result.io;
+
+import java.util.Map;
+
+public interface IdentityVerificationResultManagementRequest {
+  Map<String, Object> toMap();
+}

--- a/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/identity/verification/result/io/IdentityVerificationResultManagementResponse.java
+++ b/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/identity/verification/result/io/IdentityVerificationResultManagementResponse.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2025 Hirokazu Kobayashi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.idp.server.control_plane.management.identity.verification.result.io;
+
+import java.util.Map;
+
+public class IdentityVerificationResultManagementResponse {
+  IdentityVerificationResultManagementStatus status;
+  Map<String, Object> contents;
+
+  public IdentityVerificationResultManagementResponse(
+      IdentityVerificationResultManagementStatus status, Map<String, Object> contents) {
+    this.status = status;
+    this.contents = contents;
+  }
+
+  public IdentityVerificationResultManagementStatus status() {
+    return status;
+  }
+
+  public int statusCode() {
+    return status.statusCode();
+  }
+
+  public Map<String, Object> contents() {
+    return contents;
+  }
+}

--- a/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/identity/verification/result/io/IdentityVerificationResultManagementStatus.java
+++ b/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/identity/verification/result/io/IdentityVerificationResultManagementStatus.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2025 Hirokazu Kobayashi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.idp.server.control_plane.management.identity.verification.result.io;
+
+public enum IdentityVerificationResultManagementStatus {
+  OK(200),
+  INVALID_REQUEST(400),
+  UNAUTHORIZED(401),
+  FORBIDDEN(403),
+  NOT_FOUND(404),
+  SERVER_ERROR(500);
+
+  int statusCode;
+
+  IdentityVerificationResultManagementStatus(int statusCode) {
+    this.statusCode = statusCode;
+  }
+
+  public int statusCode() {
+    return statusCode;
+  }
+
+  public boolean isOk() {
+    return this == OK;
+  }
+}

--- a/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/identity/verification/application/command/IdentityVerificationApplicationCommandDataSource.java
+++ b/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/identity/verification/application/command/IdentityVerificationApplicationCommandDataSource.java
@@ -47,4 +47,9 @@ public class IdentityVerificationApplicationCommandDataSource
       Tenant tenant, User user, IdentityVerificationApplicationIdentifier identifier) {
     executor.delete(tenant, user, identifier);
   }
+
+  @Override
+  public void delete(Tenant tenant, IdentityVerificationApplicationIdentifier identifier) {
+    executor.delete(tenant, identifier);
+  }
 }

--- a/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/identity/verification/application/command/MysqlExecutor.java
+++ b/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/identity/verification/application/command/MysqlExecutor.java
@@ -126,4 +126,22 @@ public class MysqlExecutor implements IdentityVerificationApplicationCommandSqlE
 
     sqlExecutor.execute(sqlTemplate, params);
   }
+
+  @Override
+  public void delete(Tenant tenant, IdentityVerificationApplicationIdentifier identifier) {
+    SqlExecutor sqlExecutor = new SqlExecutor();
+
+    String sqlTemplate =
+        """
+            DELETE FROM identity_verification_application
+            WHERE tenant_id = ?
+            AND id = ?;
+            """;
+
+    List<Object> params = new ArrayList<>();
+    params.add(tenant.identifier().value());
+    params.add(identifier.value());
+
+    sqlExecutor.execute(sqlTemplate, params);
+  }
 }

--- a/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/identity/verification/application/command/PostgresqlExecutor.java
+++ b/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/identity/verification/application/command/PostgresqlExecutor.java
@@ -126,4 +126,22 @@ public class PostgresqlExecutor implements IdentityVerificationApplicationComman
 
     sqlExecutor.execute(sqlTemplate, params);
   }
+
+  @Override
+  public void delete(Tenant tenant, IdentityVerificationApplicationIdentifier identifier) {
+    SqlExecutor sqlExecutor = new SqlExecutor();
+
+    String sqlTemplate =
+        """
+            DELETE FROM identity_verification_application
+            WHERE tenant_id = ?::uuid
+            AND id = ?::uuid;
+            """;
+
+    List<Object> params = new ArrayList<>();
+    params.add(tenant.identifierUUID());
+    params.add(identifier.valueAsUuid());
+
+    sqlExecutor.execute(sqlTemplate, params);
+  }
 }

--- a/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/identity/verification/application/query/IdentityVerificationApplicationQueryDataSource.java
+++ b/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/identity/verification/application/query/IdentityVerificationApplicationQueryDataSource.java
@@ -126,4 +126,29 @@ public class IdentityVerificationApplicationQueryDataSource
 
     return Long.parseLong(result.get("count"));
   }
+
+  @Override
+  public IdentityVerificationApplications findList(
+      Tenant tenant, IdentityVerificationApplicationQueries queries) {
+    List<Map<String, String>> result = executor.selectList(tenant, queries);
+
+    if (result == null || result.isEmpty()) {
+      return new IdentityVerificationApplications();
+    }
+
+    List<IdentityVerificationApplication> applicationList =
+        result.stream().map(ModelConverter::convert).toList();
+    return new IdentityVerificationApplications(applicationList);
+  }
+
+  @Override
+  public long findTotalCount(Tenant tenant, IdentityVerificationApplicationQueries queries) {
+    Map<String, String> result = executor.selectCount(tenant, queries);
+
+    if (result == null || result.isEmpty()) {
+      return 0;
+    }
+
+    return Long.parseLong(result.get("count"));
+  }
 }

--- a/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/identity/verification/application/query/IdentityVerificationApplicationQuerySqlExecutor.java
+++ b/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/identity/verification/application/query/IdentityVerificationApplicationQuerySqlExecutor.java
@@ -39,4 +39,9 @@ public interface IdentityVerificationApplicationQuerySqlExecutor {
 
   Map<String, String> selectCount(
       Tenant tenant, User user, IdentityVerificationApplicationQueries queries);
+
+  List<Map<String, String>> selectList(
+      Tenant tenant, IdentityVerificationApplicationQueries queries);
+
+  Map<String, String> selectCount(Tenant tenant, IdentityVerificationApplicationQueries queries);
 }

--- a/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/identity/verification/application/query/MysqlExecutor.java
+++ b/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/identity/verification/application/query/MysqlExecutor.java
@@ -224,6 +224,123 @@ public class MysqlExecutor implements IdentityVerificationApplicationQuerySqlExe
     return sqlExecutor.selectOne(sql, params);
   }
 
+  @Override
+  public List<Map<String, String>> selectList(
+      Tenant tenant, IdentityVerificationApplicationQueries queries) {
+    SqlExecutor sqlExecutor = new SqlExecutor();
+
+    StringBuilder sqlBuilder = new StringBuilder();
+    sqlBuilder.append(selectSql);
+    sqlBuilder.append(" WHERE tenant_id = ?");
+
+    List<Object> params = new ArrayList<>();
+    params.add(tenant.identifier().value());
+
+    if (queries.hasFrom()) {
+      sqlBuilder.append(" AND created_at >= ?");
+      params.add(queries.from());
+    }
+
+    if (queries.hasTo()) {
+      sqlBuilder.append(" AND created_at <= ?");
+      params.add(queries.to());
+    }
+
+    if (queries.hasId()) {
+      sqlBuilder.append(" AND id = ?");
+      params.add(queries.id());
+    }
+
+    if (queries.hasType()) {
+      sqlBuilder.append(" AND verification_type = ?");
+      params.add(queries.type());
+    }
+
+    if (queries.hasClientId()) {
+      sqlBuilder.append(" AND client_id = ?");
+      params.add(queries.clientId());
+    }
+
+    if (queries.hasStatus()) {
+      sqlBuilder.append(" AND status = ?");
+      params.add(queries.status());
+    }
+
+    if (queries.hasApplicationDetails()) {
+      for (Map.Entry<String, String> entry : queries.applicationDetails().entrySet()) {
+        String key = entry.getKey();
+        String value = entry.getValue();
+        sqlBuilder.append(" AND JSON_EXTRACT(application_details, CONCAT('$.\"', ?, '\"')) = ?");
+        params.add(key);
+        params.add(value);
+      }
+    }
+
+    sqlBuilder.append(" ORDER BY created_at DESC");
+    sqlBuilder.append(" LIMIT ? OFFSET ?;");
+    params.add(queries.limit());
+    params.add(queries.offset());
+
+    String sql = sqlBuilder.toString();
+    return sqlExecutor.selectList(sql, params);
+  }
+
+  @Override
+  public Map<String, String> selectCount(
+      Tenant tenant, IdentityVerificationApplicationQueries queries) {
+    SqlExecutor sqlExecutor = new SqlExecutor();
+
+    StringBuilder sqlBuilder = new StringBuilder();
+    sqlBuilder.append("SELECT COUNT(*) as count FROM identity_verification_application");
+    sqlBuilder.append(" WHERE tenant_id = ?");
+
+    List<Object> params = new ArrayList<>();
+    params.add(tenant.identifier().value());
+
+    if (queries.hasFrom()) {
+      sqlBuilder.append(" AND created_at >= ?");
+      params.add(queries.from());
+    }
+
+    if (queries.hasTo()) {
+      sqlBuilder.append(" AND created_at <= ?");
+      params.add(queries.to());
+    }
+
+    if (queries.hasId()) {
+      sqlBuilder.append(" AND id = ?");
+      params.add(queries.id());
+    }
+
+    if (queries.hasType()) {
+      sqlBuilder.append(" AND verification_type = ?");
+      params.add(queries.type());
+    }
+
+    if (queries.hasClientId()) {
+      sqlBuilder.append(" AND client_id = ?");
+      params.add(queries.clientId());
+    }
+
+    if (queries.hasStatus()) {
+      sqlBuilder.append(" AND status = ?");
+      params.add(queries.status());
+    }
+
+    if (queries.hasApplicationDetails()) {
+      for (Map.Entry<String, String> entry : queries.applicationDetails().entrySet()) {
+        String key = entry.getKey();
+        String value = entry.getValue();
+        sqlBuilder.append(" AND JSON_EXTRACT(application_details, CONCAT('$.\"', ?, '\"')) = ?");
+        params.add(key);
+        params.add(value);
+      }
+    }
+
+    String sql = sqlBuilder.toString();
+    return sqlExecutor.selectOne(sql, params);
+  }
+
   String selectSql =
       """
           SELECT id,

--- a/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/identity/verification/application/query/PostgresqlExecutor.java
+++ b/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/identity/verification/application/query/PostgresqlExecutor.java
@@ -224,6 +224,123 @@ public class PostgresqlExecutor implements IdentityVerificationApplicationQueryS
     return sqlExecutor.selectOne(sql, params);
   }
 
+  @Override
+  public List<Map<String, String>> selectList(
+      Tenant tenant, IdentityVerificationApplicationQueries queries) {
+    SqlExecutor sqlExecutor = new SqlExecutor();
+
+    StringBuilder sqlBuilder = new StringBuilder();
+    sqlBuilder.append(selectSql);
+    sqlBuilder.append(" WHERE tenant_id = ?::uuid");
+
+    List<Object> params = new ArrayList<>();
+    params.add(tenant.identifierUUID());
+
+    if (queries.hasFrom()) {
+      sqlBuilder.append(" AND created_at >= ?");
+      params.add(queries.from());
+    }
+
+    if (queries.hasTo()) {
+      sqlBuilder.append(" AND created_at <= ?");
+      params.add(queries.to());
+    }
+
+    if (queries.hasId()) {
+      sqlBuilder.append(" AND id = ?::uuid");
+      params.add(queries.idAsUuid());
+    }
+
+    if (queries.hasType()) {
+      sqlBuilder.append(" AND verification_type = ?");
+      params.add(queries.type());
+    }
+
+    if (queries.hasClientId()) {
+      sqlBuilder.append(" AND client_id = ?");
+      params.add(queries.clientId());
+    }
+
+    if (queries.hasStatus()) {
+      sqlBuilder.append(" AND status = ?");
+      params.add(queries.status());
+    }
+
+    if (queries.hasApplicationDetails()) {
+      for (Map.Entry<String, String> entry : queries.applicationDetails().entrySet()) {
+        String key = entry.getKey();
+        String value = entry.getValue();
+        sqlBuilder.append(" AND application_details ->> ? = ?");
+        params.add(key);
+        params.add(value);
+      }
+    }
+
+    sqlBuilder.append(" ORDER BY created_at DESC");
+    sqlBuilder.append(" LIMIT ? OFFSET ?;");
+    params.add(queries.limit());
+    params.add(queries.offset());
+
+    String sql = sqlBuilder.toString();
+    return sqlExecutor.selectList(sql, params);
+  }
+
+  @Override
+  public Map<String, String> selectCount(
+      Tenant tenant, IdentityVerificationApplicationQueries queries) {
+    SqlExecutor sqlExecutor = new SqlExecutor();
+
+    StringBuilder sqlBuilder = new StringBuilder();
+    sqlBuilder.append("SELECT COUNT(*) FROM identity_verification_application");
+    sqlBuilder.append(" WHERE tenant_id = ?::uuid");
+
+    List<Object> params = new ArrayList<>();
+    params.add(tenant.identifierUUID());
+
+    if (queries.hasFrom()) {
+      sqlBuilder.append(" AND created_at >= ?");
+      params.add(queries.from());
+    }
+
+    if (queries.hasTo()) {
+      sqlBuilder.append(" AND created_at <= ?");
+      params.add(queries.to());
+    }
+
+    if (queries.hasId()) {
+      sqlBuilder.append(" AND id = ?::uuid");
+      params.add(queries.idAsUuid());
+    }
+
+    if (queries.hasType()) {
+      sqlBuilder.append(" AND verification_type = ?");
+      params.add(queries.type());
+    }
+
+    if (queries.hasClientId()) {
+      sqlBuilder.append(" AND client_id = ?");
+      params.add(queries.clientId());
+    }
+
+    if (queries.hasStatus()) {
+      sqlBuilder.append(" AND status = ?");
+      params.add(queries.status());
+    }
+
+    if (queries.hasApplicationDetails()) {
+      for (Map.Entry<String, String> entry : queries.applicationDetails().entrySet()) {
+        String key = entry.getKey();
+        String value = entry.getValue();
+        sqlBuilder.append(" AND application_details ->> ? = ?");
+        params.add(key);
+        params.add(value);
+      }
+    }
+
+    String sql = sqlBuilder.toString();
+    return sqlExecutor.selectOne(sql, params);
+  }
+
   String selectSql =
       """
           SELECT id,

--- a/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/identity/verification/result/query/IdentityVerificationResultQueryDataSource.java
+++ b/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/identity/verification/result/query/IdentityVerificationResultQueryDataSource.java
@@ -71,4 +71,40 @@ public class IdentityVerificationResultQueryDataSource
 
     return ModelConverter.convert(result);
   }
+
+  @Override
+  public IdentityVerificationResult get(
+      Tenant tenant, IdentityVerificationResultIdentifier identifier) {
+    Map<String, String> result = executor.selectOne(tenant, identifier);
+
+    if (result == null || result.isEmpty()) {
+      throw new IdentityVerificationApplicationNotFoundException(
+          String.format("IdentityVerificationResult not found (%s)", identifier.value()));
+    }
+
+    return ModelConverter.convert(result);
+  }
+
+  @Override
+  public List<IdentityVerificationResult> findList(
+      Tenant tenant, IdentityVerificationResultQueries queries) {
+    List<Map<String, String>> result = executor.selectList(tenant, queries);
+
+    if (result == null || result.isEmpty()) {
+      return new ArrayList<>();
+    }
+
+    return result.stream().map(ModelConverter::convert).toList();
+  }
+
+  @Override
+  public long findTotalCount(Tenant tenant, IdentityVerificationResultQueries queries) {
+    Map<String, String> result = executor.selectCount(tenant, queries);
+
+    if (result == null || result.isEmpty()) {
+      return 0;
+    }
+
+    return Long.parseLong(result.get("count"));
+  }
 }

--- a/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/identity/verification/result/query/IdentityVerificationResultSqlExecutor.java
+++ b/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/identity/verification/result/query/IdentityVerificationResultSqlExecutor.java
@@ -32,4 +32,10 @@ public interface IdentityVerificationResultSqlExecutor {
 
   Map<String, String> selectCount(
       Tenant tenant, User user, IdentityVerificationResultQueries queries);
+
+  Map<String, String> selectOne(Tenant tenant, IdentityVerificationResultIdentifier identifier);
+
+  List<Map<String, String>> selectList(Tenant tenant, IdentityVerificationResultQueries queries);
+
+  Map<String, String> selectCount(Tenant tenant, IdentityVerificationResultQueries queries);
 }

--- a/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/identity/verification/result/query/MysqlExecutor.java
+++ b/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/identity/verification/result/query/MysqlExecutor.java
@@ -185,6 +185,159 @@ public class MysqlExecutor implements IdentityVerificationResultSqlExecutor {
     return sqlExecutor.selectOne(sql, params);
   }
 
+  @Override
+  public Map<String, String> selectOne(
+      Tenant tenant, IdentityVerificationResultIdentifier identifier) {
+    SqlExecutor sqlExecutor = new SqlExecutor();
+    String sqlTemplate =
+        selectSql
+            + " "
+            + """
+                 WHERE id = ?
+                 AND tenant_id = ?;
+                """;
+
+    List<Object> params = new ArrayList<>();
+    params.add(identifier.value());
+    params.add(tenant.identifier().value());
+
+    return sqlExecutor.selectOne(sqlTemplate, params);
+  }
+
+  @Override
+  public List<Map<String, String>> selectList(
+      Tenant tenant, IdentityVerificationResultQueries queries) {
+    SqlExecutor sqlExecutor = new SqlExecutor();
+
+    StringBuilder sqlBuilder = new StringBuilder();
+    sqlBuilder.append(selectSql);
+    sqlBuilder.append(" WHERE tenant_id = ?");
+
+    List<Object> params = new ArrayList<>();
+    params.add(tenant.identifier().value());
+
+    if (queries.hasVerifiedAtFrom()) {
+      sqlBuilder.append(" AND verified_at >= ?");
+      params.add(queries.verifiedAtFrom());
+    }
+
+    if (queries.hasVerifiedAtTo()) {
+      sqlBuilder.append(" AND verified_at <= ?");
+      params.add(queries.verifiedAtTo());
+    }
+
+    if (queries.hasVerifiedUntilFrom()) {
+      sqlBuilder.append(" AND valid_until >= ?");
+      params.add(queries.verifiedUntilFrom());
+    }
+
+    if (queries.hasVerifiedUntilTo()) {
+      sqlBuilder.append(" AND valid_until <= ?");
+      params.add(queries.verifiedUntilTo());
+    }
+
+    if (queries.hasId()) {
+      sqlBuilder.append(" AND id = ?");
+      params.add(queries.id());
+    }
+    if (queries.hasType()) {
+      sqlBuilder.append(" AND verification_type = ?");
+      params.add(queries.type());
+    }
+
+    if (queries.hasApplicationId()) {
+      sqlBuilder.append(" AND application_id = ?");
+      params.add(queries.applicationId());
+    }
+
+    if (queries.hasSource()) {
+      sqlBuilder.append(" AND source = ?");
+      params.add(queries.source());
+    }
+
+    if (queries.hasVerifiedClaims()) {
+      for (Map.Entry<String, String> entry : queries.verifiedClaims().entrySet()) {
+        String key = entry.getKey();
+        String value = entry.getValue();
+        sqlBuilder.append(" AND JSON_EXTRACT(verified_claims, CONCAT('$.\"', ?, '\"')) = ?");
+        params.add(key);
+        params.add(value);
+      }
+    }
+
+    sqlBuilder.append(" ORDER BY created_at DESC");
+    sqlBuilder.append(" LIMIT ? OFFSET ?;");
+    params.add(queries.limit());
+    params.add(queries.offset());
+
+    String sql = sqlBuilder.toString();
+    return sqlExecutor.selectList(sql, params);
+  }
+
+  @Override
+  public Map<String, String> selectCount(Tenant tenant, IdentityVerificationResultQueries queries) {
+    SqlExecutor sqlExecutor = new SqlExecutor();
+
+    StringBuilder sqlBuilder = new StringBuilder();
+    sqlBuilder.append("SELECT COUNT(*) as count FROM identity_verification_result");
+    sqlBuilder.append(" WHERE tenant_id = ?");
+
+    List<Object> params = new ArrayList<>();
+    params.add(tenant.identifier().value());
+
+    if (queries.hasVerifiedAtFrom()) {
+      sqlBuilder.append(" AND verified_at >= ?");
+      params.add(queries.verifiedAtFrom());
+    }
+
+    if (queries.hasVerifiedAtTo()) {
+      sqlBuilder.append(" AND verified_at <= ?");
+      params.add(queries.verifiedAtTo());
+    }
+
+    if (queries.hasVerifiedUntilFrom()) {
+      sqlBuilder.append(" AND valid_until >= ?");
+      params.add(queries.verifiedUntilFrom());
+    }
+
+    if (queries.hasVerifiedUntilTo()) {
+      sqlBuilder.append(" AND valid_until <= ?");
+      params.add(queries.verifiedUntilTo());
+    }
+
+    if (queries.hasId()) {
+      sqlBuilder.append(" AND id = ?");
+      params.add(queries.id());
+    }
+    if (queries.hasType()) {
+      sqlBuilder.append(" AND verification_type = ?");
+      params.add(queries.type());
+    }
+
+    if (queries.hasApplicationId()) {
+      sqlBuilder.append(" AND application_id = ?");
+      params.add(queries.applicationId());
+    }
+
+    if (queries.hasSource()) {
+      sqlBuilder.append(" AND source = ?");
+      params.add(queries.source());
+    }
+
+    if (queries.hasVerifiedClaims()) {
+      for (Map.Entry<String, String> entry : queries.verifiedClaims().entrySet()) {
+        String key = entry.getKey();
+        String value = entry.getValue();
+        sqlBuilder.append(" AND JSON_EXTRACT(verified_claims, CONCAT('$.\"', ?, '\"')) = ?");
+        params.add(key);
+        params.add(value);
+      }
+    }
+
+    String sql = sqlBuilder.toString();
+    return sqlExecutor.selectOne(sql, params);
+  }
+
   String selectSql =
       """
           SELECT id,

--- a/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/identity/verification/result/query/PostgresqlExecutor.java
+++ b/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/identity/verification/result/query/PostgresqlExecutor.java
@@ -185,6 +185,159 @@ public class PostgresqlExecutor implements IdentityVerificationResultSqlExecutor
     return sqlExecutor.selectOne(sql, params);
   }
 
+  @Override
+  public Map<String, String> selectOne(
+      Tenant tenant, IdentityVerificationResultIdentifier identifier) {
+    SqlExecutor sqlExecutor = new SqlExecutor();
+    String sqlTemplate =
+        selectSql
+            + " "
+            + """
+                 WHERE id = ?::uuid
+                 AND tenant_id = ?::uuid;
+                """;
+
+    List<Object> params = new ArrayList<>();
+    params.add(identifier.valueAsUuid());
+    params.add(tenant.identifierUUID());
+
+    return sqlExecutor.selectOne(sqlTemplate, params);
+  }
+
+  @Override
+  public List<Map<String, String>> selectList(
+      Tenant tenant, IdentityVerificationResultQueries queries) {
+    SqlExecutor sqlExecutor = new SqlExecutor();
+
+    StringBuilder sqlBuilder = new StringBuilder();
+    sqlBuilder.append(selectSql);
+    sqlBuilder.append(" WHERE tenant_id = ?::uuid");
+
+    List<Object> params = new ArrayList<>();
+    params.add(tenant.identifierUUID());
+
+    if (queries.hasVerifiedAtFrom()) {
+      sqlBuilder.append(" AND verified_at >= ?");
+      params.add(queries.verifiedAtFrom());
+    }
+
+    if (queries.hasVerifiedAtTo()) {
+      sqlBuilder.append(" AND verified_at <= ?");
+      params.add(queries.verifiedAtTo());
+    }
+
+    if (queries.hasVerifiedUntilFrom()) {
+      sqlBuilder.append(" AND valid_until >= ?");
+      params.add(queries.verifiedUntilFrom());
+    }
+
+    if (queries.hasVerifiedUntilTo()) {
+      sqlBuilder.append(" AND valid_until <= ?");
+      params.add(queries.verifiedUntilTo());
+    }
+
+    if (queries.hasId()) {
+      sqlBuilder.append(" AND id = ?::uuid");
+      params.add(queries.idAsUuid());
+    }
+    if (queries.hasType()) {
+      sqlBuilder.append(" AND verification_type = ?");
+      params.add(queries.type());
+    }
+
+    if (queries.hasApplicationId()) {
+      sqlBuilder.append(" AND application_id = ?::uuid");
+      params.add(queries.applicationIdAsUuid());
+    }
+
+    if (queries.hasSource()) {
+      sqlBuilder.append(" AND source = ?");
+      params.add(queries.source());
+    }
+
+    if (queries.hasVerifiedClaims()) {
+      for (Map.Entry<String, String> entry : queries.verifiedClaims().entrySet()) {
+        String key = entry.getKey();
+        String value = entry.getValue();
+        sqlBuilder.append(" AND verified_claims ->> ? = ?");
+        params.add(key);
+        params.add(value);
+      }
+    }
+
+    sqlBuilder.append(" ORDER BY created_at DESC");
+    sqlBuilder.append(" LIMIT ? OFFSET ?;");
+    params.add(queries.limit());
+    params.add(queries.offset());
+
+    String sql = sqlBuilder.toString();
+    return sqlExecutor.selectList(sql, params);
+  }
+
+  @Override
+  public Map<String, String> selectCount(Tenant tenant, IdentityVerificationResultQueries queries) {
+    SqlExecutor sqlExecutor = new SqlExecutor();
+
+    StringBuilder sqlBuilder = new StringBuilder();
+    sqlBuilder.append("SELECT COUNT(*) FROM identity_verification_result");
+    sqlBuilder.append(" WHERE tenant_id = ?::uuid");
+
+    List<Object> params = new ArrayList<>();
+    params.add(tenant.identifierUUID());
+
+    if (queries.hasVerifiedAtFrom()) {
+      sqlBuilder.append(" AND verified_at >= ?");
+      params.add(queries.verifiedAtFrom());
+    }
+
+    if (queries.hasVerifiedAtTo()) {
+      sqlBuilder.append(" AND verified_at <= ?");
+      params.add(queries.verifiedAtTo());
+    }
+
+    if (queries.hasVerifiedUntilFrom()) {
+      sqlBuilder.append(" AND valid_until >= ?");
+      params.add(queries.verifiedUntilFrom());
+    }
+
+    if (queries.hasVerifiedUntilTo()) {
+      sqlBuilder.append(" AND valid_until <= ?");
+      params.add(queries.verifiedUntilTo());
+    }
+
+    if (queries.hasId()) {
+      sqlBuilder.append(" AND id = ?::uuid");
+      params.add(queries.idAsUuid());
+    }
+    if (queries.hasType()) {
+      sqlBuilder.append(" AND verification_type = ?");
+      params.add(queries.type());
+    }
+
+    if (queries.hasApplicationId()) {
+      sqlBuilder.append(" AND application_id = ?::uuid");
+      params.add(queries.applicationIdAsUuid());
+    }
+
+    if (queries.hasSource()) {
+      sqlBuilder.append(" AND source = ?");
+      params.add(queries.source());
+    }
+
+    if (queries.hasVerifiedClaims()) {
+      for (Map.Entry<String, String> entry : queries.verifiedClaims().entrySet()) {
+        String key = entry.getKey();
+        String value = entry.getValue();
+        sqlBuilder.append(" AND verified_claims ->> ? = ?");
+        params.add(key);
+        params.add(value);
+      }
+    }
+
+    String sql = sqlBuilder.toString();
+    return sqlExecutor.selectOne(sql, params);
+  }
+
   String selectSql =
       """
           SELECT id,

--- a/libs/idp-server-core-extension-ida/src/main/java/org/idp/server/core/extension/identity/verification/repository/IdentityVerificationApplicationCommandRepository.java
+++ b/libs/idp-server-core-extension-ida/src/main/java/org/idp/server/core/extension/identity/verification/repository/IdentityVerificationApplicationCommandRepository.java
@@ -28,4 +28,6 @@ public interface IdentityVerificationApplicationCommandRepository {
   void update(Tenant tenant, IdentityVerificationApplication application);
 
   void delete(Tenant tenant, User user, IdentityVerificationApplicationIdentifier identifier);
+
+  void delete(Tenant tenant, IdentityVerificationApplicationIdentifier identifier);
 }

--- a/libs/idp-server-core-extension-ida/src/main/java/org/idp/server/core/extension/identity/verification/repository/IdentityVerificationApplicationQueryRepository.java
+++ b/libs/idp-server-core-extension-ida/src/main/java/org/idp/server/core/extension/identity/verification/repository/IdentityVerificationApplicationQueryRepository.java
@@ -39,4 +39,9 @@ public interface IdentityVerificationApplicationQueryRepository {
       Tenant tenant, User user, IdentityVerificationApplicationQueries queries);
 
   long findTotalCount(Tenant tenant, User user, IdentityVerificationApplicationQueries queries);
+
+  IdentityVerificationApplications findList(
+      Tenant tenant, IdentityVerificationApplicationQueries queries);
+
+  long findTotalCount(Tenant tenant, IdentityVerificationApplicationQueries queries);
 }

--- a/libs/idp-server-core-extension-ida/src/main/java/org/idp/server/core/extension/identity/verification/repository/IdentityVerificationResultQueryRepository.java
+++ b/libs/idp-server-core-extension-ida/src/main/java/org/idp/server/core/extension/identity/verification/repository/IdentityVerificationResultQueryRepository.java
@@ -32,4 +32,11 @@ public interface IdentityVerificationResultQueryRepository {
 
   IdentityVerificationResult get(
       Tenant tenant, User user, IdentityVerificationResultIdentifier identifier);
+
+  IdentityVerificationResult get(Tenant tenant, IdentityVerificationResultIdentifier identifier);
+
+  List<IdentityVerificationResult> findList(
+      Tenant tenant, IdentityVerificationResultQueries queries);
+
+  long findTotalCount(Tenant tenant, IdentityVerificationResultQueries queries);
 }

--- a/libs/idp-server-springboot-adapter/src/main/java/org/idp/server/adapters/springboot/control_plane/restapi/management/IdentityVerificationApplicationManagementV1Api.java
+++ b/libs/idp-server-springboot-adapter/src/main/java/org/idp/server/adapters/springboot/control_plane/restapi/management/IdentityVerificationApplicationManagementV1Api.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2025 Hirokazu Kobayashi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.idp.server.adapters.springboot.control_plane.restapi.management;
+
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.Map;
+import org.idp.server.adapters.springboot.application.restapi.ParameterTransformable;
+import org.idp.server.adapters.springboot.control_plane.model.OperatorPrincipal;
+import org.idp.server.control_plane.management.identity.verification.application.IdentityVerificationApplicationManagementApi;
+import org.idp.server.control_plane.management.identity.verification.application.io.IdentityVerificationApplicationManagementResponse;
+import org.idp.server.core.extension.identity.verification.application.model.IdentityVerificationApplicationIdentifier;
+import org.idp.server.core.extension.identity.verification.application.model.IdentityVerificationApplicationQueries;
+import org.idp.server.platform.multi_tenancy.tenant.TenantIdentifier;
+import org.idp.server.platform.type.RequestAttributes;
+import org.idp.server.usecases.IdpServerApplication;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/v1/management/tenants/{tenant-id}/identity-verification-applications")
+public class IdentityVerificationApplicationManagementV1Api implements ParameterTransformable {
+
+  IdentityVerificationApplicationManagementApi identityVerificationApplicationManagementApi;
+
+  public IdentityVerificationApplicationManagementV1Api(IdpServerApplication idpServerApplication) {
+    this.identityVerificationApplicationManagementApi =
+        idpServerApplication.identityVerificationApplicationManagementApi();
+  }
+
+  @GetMapping
+  public ResponseEntity<?> getList(
+      @AuthenticationPrincipal OperatorPrincipal operatorPrincipal,
+      @PathVariable("tenant-id") TenantIdentifier tenantIdentifier,
+      @RequestParam Map<String, String> queryParams,
+      HttpServletRequest httpServletRequest) {
+
+    RequestAttributes requestAttributes = transform(httpServletRequest);
+
+    IdentityVerificationApplicationManagementResponse response =
+        identityVerificationApplicationManagementApi.findList(
+            operatorPrincipal.authenticationContext(),
+            tenantIdentifier,
+            new IdentityVerificationApplicationQueries(queryParams),
+            requestAttributes);
+
+    HttpHeaders httpHeaders = new HttpHeaders();
+    httpHeaders.add("content-type", "application/json");
+    return new ResponseEntity<>(
+        response.contents(), httpHeaders, HttpStatus.valueOf(response.statusCode()));
+  }
+
+  @GetMapping("/{id}")
+  public ResponseEntity<?> get(
+      @AuthenticationPrincipal OperatorPrincipal operatorPrincipal,
+      @PathVariable("tenant-id") TenantIdentifier tenantIdentifier,
+      @PathVariable("id") IdentityVerificationApplicationIdentifier identifier,
+      HttpServletRequest httpServletRequest) {
+
+    RequestAttributes requestAttributes = transform(httpServletRequest);
+
+    IdentityVerificationApplicationManagementResponse response =
+        identityVerificationApplicationManagementApi.get(
+            operatorPrincipal.authenticationContext(),
+            tenantIdentifier,
+            identifier,
+            requestAttributes);
+
+    HttpHeaders httpHeaders = new HttpHeaders();
+    httpHeaders.add("content-type", "application/json");
+    return new ResponseEntity<>(
+        response.contents(), httpHeaders, HttpStatus.valueOf(response.statusCode()));
+  }
+
+  @DeleteMapping("/{id}")
+  public ResponseEntity<?> delete(
+      @AuthenticationPrincipal OperatorPrincipal operatorPrincipal,
+      @PathVariable("tenant-id") TenantIdentifier tenantIdentifier,
+      @PathVariable("id") IdentityVerificationApplicationIdentifier identifier,
+      @RequestParam(value = "dry_run", required = false, defaultValue = "false") boolean dryRun,
+      HttpServletRequest httpServletRequest) {
+
+    RequestAttributes requestAttributes = transform(httpServletRequest);
+
+    IdentityVerificationApplicationManagementResponse response =
+        identityVerificationApplicationManagementApi.delete(
+            operatorPrincipal.authenticationContext(),
+            tenantIdentifier,
+            identifier,
+            requestAttributes,
+            dryRun);
+
+    HttpHeaders httpHeaders = new HttpHeaders();
+    httpHeaders.add("content-type", "application/json");
+    return new ResponseEntity<>(
+        response.contents(), httpHeaders, HttpStatus.valueOf(response.statusCode()));
+  }
+}

--- a/libs/idp-server-springboot-adapter/src/main/java/org/idp/server/adapters/springboot/control_plane/restapi/management/IdentityVerificationResultManagementV1Api.java
+++ b/libs/idp-server-springboot-adapter/src/main/java/org/idp/server/adapters/springboot/control_plane/restapi/management/IdentityVerificationResultManagementV1Api.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2025 Hirokazu Kobayashi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.idp.server.adapters.springboot.control_plane.restapi.management;
+
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.Map;
+import org.idp.server.adapters.springboot.application.restapi.ParameterTransformable;
+import org.idp.server.adapters.springboot.control_plane.model.OperatorPrincipal;
+import org.idp.server.control_plane.management.identity.verification.result.IdentityVerificationResultManagementApi;
+import org.idp.server.control_plane.management.identity.verification.result.io.IdentityVerificationResultManagementResponse;
+import org.idp.server.core.extension.identity.verification.result.IdentityVerificationResultIdentifier;
+import org.idp.server.core.extension.identity.verification.result.IdentityVerificationResultQueries;
+import org.idp.server.platform.multi_tenancy.tenant.TenantIdentifier;
+import org.idp.server.platform.type.RequestAttributes;
+import org.idp.server.usecases.IdpServerApplication;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/v1/management/tenants/{tenant-id}/identity-verification-results")
+public class IdentityVerificationResultManagementV1Api implements ParameterTransformable {
+
+  IdentityVerificationResultManagementApi identityVerificationResultManagementApi;
+
+  public IdentityVerificationResultManagementV1Api(IdpServerApplication idpServerApplication) {
+    this.identityVerificationResultManagementApi =
+        idpServerApplication.identityVerificationResultManagementApi();
+  }
+
+  @GetMapping
+  public ResponseEntity<?> getList(
+      @AuthenticationPrincipal OperatorPrincipal operatorPrincipal,
+      @PathVariable("tenant-id") TenantIdentifier tenantIdentifier,
+      @RequestParam Map<String, String> queryParams,
+      HttpServletRequest httpServletRequest) {
+
+    RequestAttributes requestAttributes = transform(httpServletRequest);
+
+    IdentityVerificationResultManagementResponse response =
+        identityVerificationResultManagementApi.findList(
+            operatorPrincipal.authenticationContext(),
+            tenantIdentifier,
+            new IdentityVerificationResultQueries(queryParams),
+            requestAttributes);
+
+    HttpHeaders httpHeaders = new HttpHeaders();
+    httpHeaders.add("content-type", "application/json");
+    return new ResponseEntity<>(
+        response.contents(), httpHeaders, HttpStatus.valueOf(response.statusCode()));
+  }
+
+  @GetMapping("/{id}")
+  public ResponseEntity<?> get(
+      @AuthenticationPrincipal OperatorPrincipal operatorPrincipal,
+      @PathVariable("tenant-id") TenantIdentifier tenantIdentifier,
+      @PathVariable("id") IdentityVerificationResultIdentifier identifier,
+      HttpServletRequest httpServletRequest) {
+
+    RequestAttributes requestAttributes = transform(httpServletRequest);
+
+    IdentityVerificationResultManagementResponse response =
+        identityVerificationResultManagementApi.get(
+            operatorPrincipal.authenticationContext(),
+            tenantIdentifier,
+            identifier,
+            requestAttributes);
+
+    HttpHeaders httpHeaders = new HttpHeaders();
+    httpHeaders.add("content-type", "application/json");
+    return new ResponseEntity<>(
+        response.contents(), httpHeaders, HttpStatus.valueOf(response.statusCode()));
+  }
+}

--- a/libs/idp-server-springboot-adapter/src/main/java/org/idp/server/adapters/springboot/control_plane/restapi/organization/OrganizationIdentityVerificationApplicationManagementV1Api.java
+++ b/libs/idp-server-springboot-adapter/src/main/java/org/idp/server/adapters/springboot/control_plane/restapi/organization/OrganizationIdentityVerificationApplicationManagementV1Api.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2025 Hirokazu Kobayashi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.idp.server.adapters.springboot.control_plane.restapi.organization;
+
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.Map;
+import org.idp.server.adapters.springboot.application.restapi.ParameterTransformable;
+import org.idp.server.adapters.springboot.control_plane.model.OrganizationOperatorPrincipal;
+import org.idp.server.control_plane.management.identity.verification.application.OrgIdentityVerificationApplicationManagementApi;
+import org.idp.server.control_plane.management.identity.verification.application.io.IdentityVerificationApplicationManagementResponse;
+import org.idp.server.core.extension.identity.verification.application.model.IdentityVerificationApplicationIdentifier;
+import org.idp.server.core.extension.identity.verification.application.model.IdentityVerificationApplicationQueries;
+import org.idp.server.platform.multi_tenancy.tenant.TenantIdentifier;
+import org.idp.server.platform.type.RequestAttributes;
+import org.idp.server.usecases.IdpServerApplication;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping(
+    "/v1/management/organizations/{organizationId}/tenants/{tenantId}/identity-verification-applications")
+public class OrganizationIdentityVerificationApplicationManagementV1Api
+    implements ParameterTransformable {
+
+  OrgIdentityVerificationApplicationManagementApi orgIdentityVerificationApplicationManagementApi;
+
+  public OrganizationIdentityVerificationApplicationManagementV1Api(
+      IdpServerApplication idpServerApplication) {
+    this.orgIdentityVerificationApplicationManagementApi =
+        idpServerApplication.orgIdentityVerificationApplicationManagementApi();
+  }
+
+  @GetMapping
+  public ResponseEntity<?> get(
+      @AuthenticationPrincipal OrganizationOperatorPrincipal organizationOperatorPrincipal,
+      @PathVariable String organizationId,
+      @PathVariable String tenantId,
+      @RequestParam Map<String, String> queryParams,
+      HttpServletRequest httpServletRequest) {
+
+    RequestAttributes requestAttributes = transform(httpServletRequest);
+
+    IdentityVerificationApplicationManagementResponse response =
+        orgIdentityVerificationApplicationManagementApi.findList(
+            organizationOperatorPrincipal.authenticationContext(),
+            new TenantIdentifier(tenantId),
+            new IdentityVerificationApplicationQueries(queryParams),
+            requestAttributes);
+
+    HttpHeaders httpHeaders = new HttpHeaders();
+    httpHeaders.add("content-type", "application/json");
+    return new ResponseEntity<>(
+        response.contents(), httpHeaders, HttpStatus.valueOf(response.statusCode()));
+  }
+
+  @GetMapping("/{applicationId}")
+  public ResponseEntity<?> get(
+      @AuthenticationPrincipal OrganizationOperatorPrincipal organizationOperatorPrincipal,
+      @PathVariable String organizationId,
+      @PathVariable String tenantId,
+      @PathVariable String applicationId,
+      HttpServletRequest httpServletRequest) {
+
+    RequestAttributes requestAttributes = transform(httpServletRequest);
+
+    IdentityVerificationApplicationManagementResponse response =
+        orgIdentityVerificationApplicationManagementApi.get(
+            organizationOperatorPrincipal.authenticationContext(),
+            new TenantIdentifier(tenantId),
+            new IdentityVerificationApplicationIdentifier(applicationId),
+            requestAttributes);
+
+    HttpHeaders httpHeaders = new HttpHeaders();
+    httpHeaders.add("content-type", "application/json");
+    return new ResponseEntity<>(
+        response.contents(), httpHeaders, HttpStatus.valueOf(response.statusCode()));
+  }
+
+  @DeleteMapping("/{applicationId}")
+  public ResponseEntity<?> delete(
+      @AuthenticationPrincipal OrganizationOperatorPrincipal organizationOperatorPrincipal,
+      @PathVariable String organizationId,
+      @PathVariable String tenantId,
+      @PathVariable String applicationId,
+      @RequestParam(value = "dry_run", required = false, defaultValue = "false") boolean dryRun,
+      HttpServletRequest httpServletRequest) {
+
+    RequestAttributes requestAttributes = transform(httpServletRequest);
+
+    IdentityVerificationApplicationManagementResponse response =
+        orgIdentityVerificationApplicationManagementApi.delete(
+            organizationOperatorPrincipal.authenticationContext(),
+            new TenantIdentifier(tenantId),
+            new IdentityVerificationApplicationIdentifier(applicationId),
+            requestAttributes,
+            dryRun);
+
+    HttpHeaders httpHeaders = new HttpHeaders();
+    httpHeaders.add("content-type", "application/json");
+    return new ResponseEntity<>(
+        response.contents(), httpHeaders, HttpStatus.valueOf(response.statusCode()));
+  }
+}

--- a/libs/idp-server-springboot-adapter/src/main/java/org/idp/server/adapters/springboot/control_plane/restapi/organization/OrganizationIdentityVerificationResultManagementV1Api.java
+++ b/libs/idp-server-springboot-adapter/src/main/java/org/idp/server/adapters/springboot/control_plane/restapi/organization/OrganizationIdentityVerificationResultManagementV1Api.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2025 Hirokazu Kobayashi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.idp.server.adapters.springboot.control_plane.restapi.organization;
+
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.Map;
+import org.idp.server.adapters.springboot.application.restapi.ParameterTransformable;
+import org.idp.server.adapters.springboot.control_plane.model.OrganizationOperatorPrincipal;
+import org.idp.server.control_plane.management.identity.verification.result.OrgIdentityVerificationResultManagementApi;
+import org.idp.server.control_plane.management.identity.verification.result.io.IdentityVerificationResultManagementResponse;
+import org.idp.server.core.extension.identity.verification.result.IdentityVerificationResultIdentifier;
+import org.idp.server.core.extension.identity.verification.result.IdentityVerificationResultQueries;
+import org.idp.server.platform.multi_tenancy.tenant.TenantIdentifier;
+import org.idp.server.platform.type.RequestAttributes;
+import org.idp.server.usecases.IdpServerApplication;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping(
+    "/v1/management/organizations/{organizationId}/tenants/{tenantId}/identity-verification-results")
+public class OrganizationIdentityVerificationResultManagementV1Api
+    implements ParameterTransformable {
+
+  OrgIdentityVerificationResultManagementApi orgIdentityVerificationResultManagementApi;
+
+  public OrganizationIdentityVerificationResultManagementV1Api(
+      IdpServerApplication idpServerApplication) {
+    this.orgIdentityVerificationResultManagementApi =
+        idpServerApplication.orgIdentityVerificationResultManagementApi();
+  }
+
+  @GetMapping
+  public ResponseEntity<?> get(
+      @AuthenticationPrincipal OrganizationOperatorPrincipal organizationOperatorPrincipal,
+      @PathVariable String organizationId,
+      @PathVariable String tenantId,
+      @RequestParam Map<String, String> queryParams,
+      HttpServletRequest httpServletRequest) {
+
+    RequestAttributes requestAttributes = transform(httpServletRequest);
+
+    IdentityVerificationResultManagementResponse response =
+        orgIdentityVerificationResultManagementApi.findList(
+            organizationOperatorPrincipal.authenticationContext(),
+            new TenantIdentifier(tenantId),
+            new IdentityVerificationResultQueries(queryParams),
+            requestAttributes);
+
+    HttpHeaders httpHeaders = new HttpHeaders();
+    httpHeaders.add("content-type", "application/json");
+    return new ResponseEntity<>(
+        response.contents(), httpHeaders, HttpStatus.valueOf(response.statusCode()));
+  }
+
+  @GetMapping("/{resultId}")
+  public ResponseEntity<?> get(
+      @AuthenticationPrincipal OrganizationOperatorPrincipal organizationOperatorPrincipal,
+      @PathVariable String organizationId,
+      @PathVariable String tenantId,
+      @PathVariable String resultId,
+      HttpServletRequest httpServletRequest) {
+
+    RequestAttributes requestAttributes = transform(httpServletRequest);
+
+    IdentityVerificationResultManagementResponse response =
+        orgIdentityVerificationResultManagementApi.get(
+            organizationOperatorPrincipal.authenticationContext(),
+            new TenantIdentifier(tenantId),
+            new IdentityVerificationResultIdentifier(resultId),
+            requestAttributes);
+
+    HttpHeaders httpHeaders = new HttpHeaders();
+    httpHeaders.add("content-type", "application/json");
+    return new ResponseEntity<>(
+        response.contents(), httpHeaders, HttpStatus.valueOf(response.statusCode()));
+  }
+}

--- a/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/IdpServerApplication.java
+++ b/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/IdpServerApplication.java
@@ -48,6 +48,8 @@ import org.idp.server.control_plane.management.identity.user.OrgUserManagementAp
 import org.idp.server.control_plane.management.identity.user.UserManagementApi;
 import org.idp.server.control_plane.management.identity.verification.IdentityVerificationConfigManagementApi;
 import org.idp.server.control_plane.management.identity.verification.OrgIdentityVerificationConfigManagementApi;
+import org.idp.server.control_plane.management.identity.verification.application.IdentityVerificationApplicationManagementApi;
+import org.idp.server.control_plane.management.identity.verification.application.OrgIdentityVerificationApplicationManagementApi;
 import org.idp.server.control_plane.management.oidc.authorization.AuthorizationServerManagementApi;
 import org.idp.server.control_plane.management.oidc.authorization.OrgAuthorizationServerManagementApi;
 import org.idp.server.control_plane.management.oidc.client.ClientManagementApi;
@@ -241,6 +243,7 @@ public class IdpServerApplication {
   AuthenticationPolicyConfigurationManagementApi authenticationPolicyConfigurationManagementApi;
   FederationConfigurationManagementApi federationConfigurationManagementApi;
   IdentityVerificationConfigManagementApi identityVerificationConfigManagementApi;
+  IdentityVerificationApplicationManagementApi identityVerificationApplicationManagementApi;
   SecurityEventHookConfigurationManagementApi securityEventHookConfigurationManagementApi;
   SecurityEventManagementApi securityEventManagementApi;
   SecurityEventHookManagementApi securityEventHookManagementApi;
@@ -262,6 +265,7 @@ public class IdpServerApplication {
   OrgAuthenticationConfigManagementApi orgAuthenticationConfigManagementApi;
   OrgAuthenticationPolicyConfigManagementApi orgAuthenticationPolicyConfigManagementApi;
   OrgIdentityVerificationConfigManagementApi orgIdentityVerificationConfigManagementApi;
+  OrgIdentityVerificationApplicationManagementApi orgIdentityVerificationApplicationManagementApi;
   OrgFederationConfigManagementApi orgFederationConfigManagementApi;
   OrgSecurityEventHookConfigManagementApi orgSecurityEventHookConfigManagementApi;
   OrgAuthenticationInteractionManagementApi orgAuthenticationInteractionManagementApi;
@@ -997,6 +1001,16 @@ public class IdpServerApplication {
             IdentityVerificationConfigManagementApi.class,
             databaseTypeProvider);
 
+    this.identityVerificationApplicationManagementApi =
+        ManagementTypeEntryServiceProxy.createProxy(
+            new IdentityVerificationApplicationManagementEntryService(
+                identityVerificationApplicationQueryRepository,
+                identityVerificationApplicationCommandRepository,
+                tenantQueryRepository,
+                auditLogPublisher),
+            IdentityVerificationApplicationManagementApi.class,
+            databaseTypeProvider);
+
     this.securityEventManagementApi =
         ManagementTypeEntryServiceProxy.createProxy(
             new SecurityEventManagementEntryService(
@@ -1248,6 +1262,17 @@ public class IdpServerApplication {
             OrgIdentityVerificationConfigManagementApi.class,
             databaseTypeProvider);
 
+    this.orgIdentityVerificationApplicationManagementApi =
+        ManagementTypeEntryServiceProxy.createProxy(
+            new OrgIdentityVerificationApplicationManagementEntryService(
+                tenantQueryRepository,
+                organizationRepository,
+                identityVerificationApplicationQueryRepository,
+                identityVerificationApplicationCommandRepository,
+                auditLogPublisher),
+            OrgIdentityVerificationApplicationManagementApi.class,
+            databaseTypeProvider);
+
     this.orgAuditLogManagementApi =
         ManagementTypeEntryServiceProxy.createProxy(
             new OrgAuditLogManagementEntryService(
@@ -1402,6 +1427,11 @@ public class IdpServerApplication {
     return identityVerificationConfigManagementApi;
   }
 
+  public IdentityVerificationApplicationManagementApi
+      identityVerificationApplicationManagementApi() {
+    return identityVerificationApplicationManagementApi;
+  }
+
   public UserAuthenticationApi operatorAuthenticationApi() {
     return userAuthenticationApi;
   }
@@ -1520,6 +1550,11 @@ public class IdpServerApplication {
 
   public OrgIdentityVerificationConfigManagementApi orgIdentityVerificationConfigManagementApi() {
     return orgIdentityVerificationConfigManagementApi;
+  }
+
+  public OrgIdentityVerificationApplicationManagementApi
+      orgIdentityVerificationApplicationManagementApi() {
+    return orgIdentityVerificationApplicationManagementApi;
   }
 
   public OrgAuditLogManagementApi orgAuditLogManagementApi() {

--- a/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/IdpServerApplication.java
+++ b/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/IdpServerApplication.java
@@ -50,6 +50,8 @@ import org.idp.server.control_plane.management.identity.verification.IdentityVer
 import org.idp.server.control_plane.management.identity.verification.OrgIdentityVerificationConfigManagementApi;
 import org.idp.server.control_plane.management.identity.verification.application.IdentityVerificationApplicationManagementApi;
 import org.idp.server.control_plane.management.identity.verification.application.OrgIdentityVerificationApplicationManagementApi;
+import org.idp.server.control_plane.management.identity.verification.result.IdentityVerificationResultManagementApi;
+import org.idp.server.control_plane.management.identity.verification.result.OrgIdentityVerificationResultManagementApi;
 import org.idp.server.control_plane.management.oidc.authorization.AuthorizationServerManagementApi;
 import org.idp.server.control_plane.management.oidc.authorization.OrgAuthorizationServerManagementApi;
 import org.idp.server.control_plane.management.oidc.client.ClientManagementApi;
@@ -244,6 +246,7 @@ public class IdpServerApplication {
   FederationConfigurationManagementApi federationConfigurationManagementApi;
   IdentityVerificationConfigManagementApi identityVerificationConfigManagementApi;
   IdentityVerificationApplicationManagementApi identityVerificationApplicationManagementApi;
+  IdentityVerificationResultManagementApi identityVerificationResultManagementApi;
   SecurityEventHookConfigurationManagementApi securityEventHookConfigurationManagementApi;
   SecurityEventManagementApi securityEventManagementApi;
   SecurityEventHookManagementApi securityEventHookManagementApi;
@@ -266,6 +269,7 @@ public class IdpServerApplication {
   OrgAuthenticationPolicyConfigManagementApi orgAuthenticationPolicyConfigManagementApi;
   OrgIdentityVerificationConfigManagementApi orgIdentityVerificationConfigManagementApi;
   OrgIdentityVerificationApplicationManagementApi orgIdentityVerificationApplicationManagementApi;
+  OrgIdentityVerificationResultManagementApi orgIdentityVerificationResultManagementApi;
   OrgFederationConfigManagementApi orgFederationConfigManagementApi;
   OrgSecurityEventHookConfigManagementApi orgSecurityEventHookConfigManagementApi;
   OrgAuthenticationInteractionManagementApi orgAuthenticationInteractionManagementApi;
@@ -1011,6 +1015,15 @@ public class IdpServerApplication {
             IdentityVerificationApplicationManagementApi.class,
             databaseTypeProvider);
 
+    this.identityVerificationResultManagementApi =
+        ManagementTypeEntryServiceProxy.createProxy(
+            new IdentityVerificationResultManagementEntryService(
+                identityVerificationResultQueryRepository,
+                tenantQueryRepository,
+                auditLogPublisher),
+            IdentityVerificationResultManagementApi.class,
+            databaseTypeProvider);
+
     this.securityEventManagementApi =
         ManagementTypeEntryServiceProxy.createProxy(
             new SecurityEventManagementEntryService(
@@ -1273,6 +1286,16 @@ public class IdpServerApplication {
             OrgIdentityVerificationApplicationManagementApi.class,
             databaseTypeProvider);
 
+    this.orgIdentityVerificationResultManagementApi =
+        ManagementTypeEntryServiceProxy.createProxy(
+            new OrgIdentityVerificationResultManagementEntryService(
+                tenantQueryRepository,
+                organizationRepository,
+                identityVerificationResultQueryRepository,
+                auditLogPublisher),
+            OrgIdentityVerificationResultManagementApi.class,
+            databaseTypeProvider);
+
     this.orgAuditLogManagementApi =
         ManagementTypeEntryServiceProxy.createProxy(
             new OrgAuditLogManagementEntryService(
@@ -1432,6 +1455,10 @@ public class IdpServerApplication {
     return identityVerificationApplicationManagementApi;
   }
 
+  public IdentityVerificationResultManagementApi identityVerificationResultManagementApi() {
+    return identityVerificationResultManagementApi;
+  }
+
   public UserAuthenticationApi operatorAuthenticationApi() {
     return userAuthenticationApi;
   }
@@ -1555,6 +1582,10 @@ public class IdpServerApplication {
   public OrgIdentityVerificationApplicationManagementApi
       orgIdentityVerificationApplicationManagementApi() {
     return orgIdentityVerificationApplicationManagementApi;
+  }
+
+  public OrgIdentityVerificationResultManagementApi orgIdentityVerificationResultManagementApi() {
+    return orgIdentityVerificationResultManagementApi;
   }
 
   public OrgAuditLogManagementApi orgAuditLogManagementApi() {

--- a/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/control_plane/organization_manager/OrgIdentityVerificationApplicationManagementEntryService.java
+++ b/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/control_plane/organization_manager/OrgIdentityVerificationApplicationManagementEntryService.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2025 Hirokazu Kobayashi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.idp.server.usecases.control_plane.organization_manager;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.idp.server.control_plane.base.AuditLogCreator;
+import org.idp.server.control_plane.base.OrganizationAccessVerifier;
+import org.idp.server.control_plane.base.OrganizationAuthenticationContext;
+import org.idp.server.control_plane.management.identity.verification.application.OrgIdentityVerificationApplicationManagementApi;
+import org.idp.server.control_plane.management.identity.verification.application.handler.*;
+import org.idp.server.control_plane.management.identity.verification.application.io.*;
+import org.idp.server.core.extension.identity.verification.application.model.IdentityVerificationApplicationIdentifier;
+import org.idp.server.core.extension.identity.verification.application.model.IdentityVerificationApplicationQueries;
+import org.idp.server.core.extension.identity.verification.repository.IdentityVerificationApplicationCommandRepository;
+import org.idp.server.core.extension.identity.verification.repository.IdentityVerificationApplicationQueryRepository;
+import org.idp.server.platform.audit.AuditLog;
+import org.idp.server.platform.audit.AuditLogPublisher;
+import org.idp.server.platform.datasource.Transaction;
+import org.idp.server.platform.multi_tenancy.organization.OrganizationRepository;
+import org.idp.server.platform.multi_tenancy.tenant.TenantIdentifier;
+import org.idp.server.platform.multi_tenancy.tenant.TenantQueryRepository;
+import org.idp.server.platform.type.RequestAttributes;
+
+@Transaction
+public class OrgIdentityVerificationApplicationManagementEntryService
+    implements OrgIdentityVerificationApplicationManagementApi {
+
+  private final OrgIdentityVerificationApplicationManagementHandler handler;
+  private final AuditLogPublisher auditLogPublisher;
+
+  public OrgIdentityVerificationApplicationManagementEntryService(
+      TenantQueryRepository tenantQueryRepository,
+      OrganizationRepository organizationRepository,
+      IdentityVerificationApplicationQueryRepository identityVerificationApplicationQueryRepository,
+      IdentityVerificationApplicationCommandRepository
+          identityVerificationApplicationCommandRepository,
+      AuditLogPublisher auditLogPublisher) {
+
+    Map<String, IdentityVerificationApplicationManagementService<?>> services = new HashMap<>();
+    services.put(
+        "findList",
+        new IdentityVerificationApplicationFindListService(
+            identityVerificationApplicationQueryRepository));
+    services.put(
+        "get",
+        new IdentityVerificationApplicationFindService(
+            identityVerificationApplicationQueryRepository));
+    services.put(
+        "delete",
+        new IdentityVerificationApplicationDeletionService(
+            identityVerificationApplicationQueryRepository,
+            identityVerificationApplicationCommandRepository));
+
+    this.handler =
+        new OrgIdentityVerificationApplicationManagementHandler(
+            services,
+            this,
+            tenantQueryRepository,
+            organizationRepository,
+            new OrganizationAccessVerifier());
+    this.auditLogPublisher = auditLogPublisher;
+  }
+
+  @Override
+  @Transaction(readOnly = true)
+  public IdentityVerificationApplicationManagementResponse findList(
+      OrganizationAuthenticationContext authenticationContext,
+      TenantIdentifier tenantIdentifier,
+      IdentityVerificationApplicationQueries queries,
+      RequestAttributes requestAttributes) {
+
+    IdentityVerificationApplicationFindListRequest findListRequest =
+        new IdentityVerificationApplicationFindListRequest(queries);
+    IdentityVerificationApplicationManagementResult result =
+        handler.handle(
+            "findList",
+            authenticationContext,
+            tenantIdentifier,
+            findListRequest,
+            requestAttributes,
+            false);
+
+    AuditLog auditLog = AuditLogCreator.create(result.context());
+    auditLogPublisher.publish(auditLog);
+
+    return result.toResponse(false);
+  }
+
+  @Override
+  @Transaction(readOnly = true)
+  public IdentityVerificationApplicationManagementResponse get(
+      OrganizationAuthenticationContext authenticationContext,
+      TenantIdentifier tenantIdentifier,
+      IdentityVerificationApplicationIdentifier identifier,
+      RequestAttributes requestAttributes) {
+
+    IdentityVerificationApplicationFindRequest findRequest =
+        new IdentityVerificationApplicationFindRequest(identifier);
+    IdentityVerificationApplicationManagementResult result =
+        handler.handle(
+            "get", authenticationContext, tenantIdentifier, findRequest, requestAttributes, false);
+
+    AuditLog auditLog = AuditLogCreator.create(result.context());
+    auditLogPublisher.publish(auditLog);
+
+    return result.toResponse(false);
+  }
+
+  @Override
+  public IdentityVerificationApplicationManagementResponse delete(
+      OrganizationAuthenticationContext authenticationContext,
+      TenantIdentifier tenantIdentifier,
+      IdentityVerificationApplicationIdentifier identifier,
+      RequestAttributes requestAttributes,
+      boolean dryRun) {
+
+    IdentityVerificationApplicationDeleteRequest deleteRequest =
+        new IdentityVerificationApplicationDeleteRequest(identifier);
+    IdentityVerificationApplicationManagementResult result =
+        handler.handle(
+            "delete",
+            authenticationContext,
+            tenantIdentifier,
+            deleteRequest,
+            requestAttributes,
+            dryRun);
+
+    AuditLog auditLog = AuditLogCreator.create(result.context());
+    auditLogPublisher.publish(auditLog);
+
+    return result.toResponse(dryRun);
+  }
+}

--- a/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/control_plane/organization_manager/OrgIdentityVerificationResultManagementEntryService.java
+++ b/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/control_plane/organization_manager/OrgIdentityVerificationResultManagementEntryService.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2025 Hirokazu Kobayashi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.idp.server.usecases.control_plane.organization_manager;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.idp.server.control_plane.base.AuditLogCreator;
+import org.idp.server.control_plane.base.OrganizationAccessVerifier;
+import org.idp.server.control_plane.base.OrganizationAuthenticationContext;
+import org.idp.server.control_plane.management.identity.verification.result.OrgIdentityVerificationResultManagementApi;
+import org.idp.server.control_plane.management.identity.verification.result.handler.*;
+import org.idp.server.control_plane.management.identity.verification.result.io.*;
+import org.idp.server.core.extension.identity.verification.repository.IdentityVerificationResultQueryRepository;
+import org.idp.server.core.extension.identity.verification.result.IdentityVerificationResultIdentifier;
+import org.idp.server.core.extension.identity.verification.result.IdentityVerificationResultQueries;
+import org.idp.server.platform.audit.AuditLog;
+import org.idp.server.platform.audit.AuditLogPublisher;
+import org.idp.server.platform.datasource.Transaction;
+import org.idp.server.platform.multi_tenancy.organization.OrganizationRepository;
+import org.idp.server.platform.multi_tenancy.tenant.TenantIdentifier;
+import org.idp.server.platform.multi_tenancy.tenant.TenantQueryRepository;
+import org.idp.server.platform.type.RequestAttributes;
+
+@Transaction
+public class OrgIdentityVerificationResultManagementEntryService
+    implements OrgIdentityVerificationResultManagementApi {
+
+  private final OrgIdentityVerificationResultManagementHandler handler;
+  private final AuditLogPublisher auditLogPublisher;
+
+  public OrgIdentityVerificationResultManagementEntryService(
+      TenantQueryRepository tenantQueryRepository,
+      OrganizationRepository organizationRepository,
+      IdentityVerificationResultQueryRepository identityVerificationResultQueryRepository,
+      AuditLogPublisher auditLogPublisher) {
+
+    Map<String, IdentityVerificationResultManagementService<?>> services = new HashMap<>();
+    services.put(
+        "findList",
+        new IdentityVerificationResultFindListService(identityVerificationResultQueryRepository));
+    services.put(
+        "get",
+        new IdentityVerificationResultFindService(identityVerificationResultQueryRepository));
+
+    this.handler =
+        new OrgIdentityVerificationResultManagementHandler(
+            services,
+            this,
+            tenantQueryRepository,
+            organizationRepository,
+            new OrganizationAccessVerifier());
+    this.auditLogPublisher = auditLogPublisher;
+  }
+
+  @Override
+  @Transaction(readOnly = true)
+  public IdentityVerificationResultManagementResponse findList(
+      OrganizationAuthenticationContext authenticationContext,
+      TenantIdentifier tenantIdentifier,
+      IdentityVerificationResultQueries queries,
+      RequestAttributes requestAttributes) {
+
+    IdentityVerificationResultFindListRequest findListRequest =
+        new IdentityVerificationResultFindListRequest(queries);
+    IdentityVerificationResultManagementResult result =
+        handler.handle(
+            "findList",
+            authenticationContext,
+            tenantIdentifier,
+            findListRequest,
+            requestAttributes,
+            false);
+
+    AuditLog auditLog = AuditLogCreator.create(result.context());
+    auditLogPublisher.publish(auditLog);
+
+    return result.toResponse(false);
+  }
+
+  @Override
+  @Transaction(readOnly = true)
+  public IdentityVerificationResultManagementResponse get(
+      OrganizationAuthenticationContext authenticationContext,
+      TenantIdentifier tenantIdentifier,
+      IdentityVerificationResultIdentifier identifier,
+      RequestAttributes requestAttributes) {
+
+    IdentityVerificationResultFindRequest findRequest =
+        new IdentityVerificationResultFindRequest(identifier);
+    IdentityVerificationResultManagementResult result =
+        handler.handle(
+            "get", authenticationContext, tenantIdentifier, findRequest, requestAttributes, false);
+
+    AuditLog auditLog = AuditLogCreator.create(result.context());
+    auditLogPublisher.publish(auditLog);
+
+    return result.toResponse(false);
+  }
+}

--- a/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/control_plane/system_manager/IdentityVerificationApplicationManagementEntryService.java
+++ b/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/control_plane/system_manager/IdentityVerificationApplicationManagementEntryService.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2025 Hirokazu Kobayashi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.idp.server.usecases.control_plane.system_manager;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.idp.server.control_plane.base.AdminAuthenticationContext;
+import org.idp.server.control_plane.base.AuditLogCreator;
+import org.idp.server.control_plane.management.identity.verification.application.IdentityVerificationApplicationManagementApi;
+import org.idp.server.control_plane.management.identity.verification.application.handler.*;
+import org.idp.server.control_plane.management.identity.verification.application.io.*;
+import org.idp.server.core.extension.identity.verification.application.model.IdentityVerificationApplicationIdentifier;
+import org.idp.server.core.extension.identity.verification.application.model.IdentityVerificationApplicationQueries;
+import org.idp.server.core.extension.identity.verification.repository.IdentityVerificationApplicationCommandRepository;
+import org.idp.server.core.extension.identity.verification.repository.IdentityVerificationApplicationQueryRepository;
+import org.idp.server.platform.audit.AuditLog;
+import org.idp.server.platform.audit.AuditLogPublisher;
+import org.idp.server.platform.datasource.Transaction;
+import org.idp.server.platform.multi_tenancy.tenant.TenantIdentifier;
+import org.idp.server.platform.multi_tenancy.tenant.TenantQueryRepository;
+import org.idp.server.platform.type.RequestAttributes;
+
+@Transaction
+public class IdentityVerificationApplicationManagementEntryService
+    implements IdentityVerificationApplicationManagementApi {
+
+  private final IdentityVerificationApplicationManagementHandler handler;
+  private final AuditLogPublisher auditLogPublisher;
+
+  public IdentityVerificationApplicationManagementEntryService(
+      IdentityVerificationApplicationQueryRepository identityVerificationApplicationQueryRepository,
+      IdentityVerificationApplicationCommandRepository
+          identityVerificationApplicationCommandRepository,
+      TenantQueryRepository tenantQueryRepository,
+      AuditLogPublisher auditLogPublisher) {
+
+    Map<String, IdentityVerificationApplicationManagementService<?>> services = new HashMap<>();
+    services.put(
+        "findList",
+        new IdentityVerificationApplicationFindListService(
+            identityVerificationApplicationQueryRepository));
+    services.put(
+        "get",
+        new IdentityVerificationApplicationFindService(
+            identityVerificationApplicationQueryRepository));
+    services.put(
+        "delete",
+        new IdentityVerificationApplicationDeletionService(
+            identityVerificationApplicationQueryRepository,
+            identityVerificationApplicationCommandRepository));
+
+    this.handler =
+        new IdentityVerificationApplicationManagementHandler(services, this, tenantQueryRepository);
+    this.auditLogPublisher = auditLogPublisher;
+  }
+
+  @Override
+  @Transaction(readOnly = true)
+  public IdentityVerificationApplicationManagementResponse findList(
+      AdminAuthenticationContext authenticationContext,
+      TenantIdentifier tenantIdentifier,
+      IdentityVerificationApplicationQueries queries,
+      RequestAttributes requestAttributes) {
+
+    IdentityVerificationApplicationFindListRequest findListRequest =
+        new IdentityVerificationApplicationFindListRequest(queries);
+    IdentityVerificationApplicationManagementResult result =
+        handler.handle(
+            "findList",
+            authenticationContext,
+            tenantIdentifier,
+            findListRequest,
+            requestAttributes,
+            false);
+
+    AuditLog auditLog = AuditLogCreator.create(result.context());
+    auditLogPublisher.publish(auditLog);
+
+    return result.toResponse(false);
+  }
+
+  @Override
+  @Transaction(readOnly = true)
+  public IdentityVerificationApplicationManagementResponse get(
+      AdminAuthenticationContext authenticationContext,
+      TenantIdentifier tenantIdentifier,
+      IdentityVerificationApplicationIdentifier identifier,
+      RequestAttributes requestAttributes) {
+
+    IdentityVerificationApplicationFindRequest findRequest =
+        new IdentityVerificationApplicationFindRequest(identifier);
+    IdentityVerificationApplicationManagementResult result =
+        handler.handle(
+            "get", authenticationContext, tenantIdentifier, findRequest, requestAttributes, false);
+
+    AuditLog auditLog = AuditLogCreator.create(result.context());
+    auditLogPublisher.publish(auditLog);
+
+    return result.toResponse(false);
+  }
+
+  @Override
+  public IdentityVerificationApplicationManagementResponse delete(
+      AdminAuthenticationContext authenticationContext,
+      TenantIdentifier tenantIdentifier,
+      IdentityVerificationApplicationIdentifier identifier,
+      RequestAttributes requestAttributes,
+      boolean dryRun) {
+
+    IdentityVerificationApplicationDeleteRequest deleteRequest =
+        new IdentityVerificationApplicationDeleteRequest(identifier);
+    IdentityVerificationApplicationManagementResult result =
+        handler.handle(
+            "delete",
+            authenticationContext,
+            tenantIdentifier,
+            deleteRequest,
+            requestAttributes,
+            dryRun);
+
+    AuditLog auditLog = AuditLogCreator.create(result.context());
+    auditLogPublisher.publish(auditLog);
+
+    return result.toResponse(dryRun);
+  }
+}

--- a/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/control_plane/system_manager/IdentityVerificationResultManagementEntryService.java
+++ b/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/control_plane/system_manager/IdentityVerificationResultManagementEntryService.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2025 Hirokazu Kobayashi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.idp.server.usecases.control_plane.system_manager;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.idp.server.control_plane.base.AdminAuthenticationContext;
+import org.idp.server.control_plane.base.AuditLogCreator;
+import org.idp.server.control_plane.management.identity.verification.result.IdentityVerificationResultManagementApi;
+import org.idp.server.control_plane.management.identity.verification.result.handler.*;
+import org.idp.server.control_plane.management.identity.verification.result.io.*;
+import org.idp.server.core.extension.identity.verification.repository.IdentityVerificationResultQueryRepository;
+import org.idp.server.core.extension.identity.verification.result.IdentityVerificationResultIdentifier;
+import org.idp.server.core.extension.identity.verification.result.IdentityVerificationResultQueries;
+import org.idp.server.platform.audit.AuditLog;
+import org.idp.server.platform.audit.AuditLogPublisher;
+import org.idp.server.platform.datasource.Transaction;
+import org.idp.server.platform.multi_tenancy.tenant.TenantIdentifier;
+import org.idp.server.platform.multi_tenancy.tenant.TenantQueryRepository;
+import org.idp.server.platform.type.RequestAttributes;
+
+@Transaction
+public class IdentityVerificationResultManagementEntryService
+    implements IdentityVerificationResultManagementApi {
+
+  private final IdentityVerificationResultManagementHandler handler;
+  private final AuditLogPublisher auditLogPublisher;
+
+  public IdentityVerificationResultManagementEntryService(
+      IdentityVerificationResultQueryRepository identityVerificationResultQueryRepository,
+      TenantQueryRepository tenantQueryRepository,
+      AuditLogPublisher auditLogPublisher) {
+
+    Map<String, IdentityVerificationResultManagementService<?>> services = new HashMap<>();
+    services.put(
+        "findList",
+        new IdentityVerificationResultFindListService(identityVerificationResultQueryRepository));
+    services.put(
+        "get",
+        new IdentityVerificationResultFindService(identityVerificationResultQueryRepository));
+
+    this.handler =
+        new IdentityVerificationResultManagementHandler(services, this, tenantQueryRepository);
+    this.auditLogPublisher = auditLogPublisher;
+  }
+
+  @Override
+  @Transaction(readOnly = true)
+  public IdentityVerificationResultManagementResponse findList(
+      AdminAuthenticationContext authenticationContext,
+      TenantIdentifier tenantIdentifier,
+      IdentityVerificationResultQueries queries,
+      RequestAttributes requestAttributes) {
+
+    IdentityVerificationResultFindListRequest findListRequest =
+        new IdentityVerificationResultFindListRequest(queries);
+    IdentityVerificationResultManagementResult result =
+        handler.handle(
+            "findList",
+            authenticationContext,
+            tenantIdentifier,
+            findListRequest,
+            requestAttributes,
+            false);
+
+    AuditLog auditLog = AuditLogCreator.create(result.context());
+    auditLogPublisher.publish(auditLog);
+
+    return result.toResponse(false);
+  }
+
+  @Override
+  @Transaction(readOnly = true)
+  public IdentityVerificationResultManagementResponse get(
+      AdminAuthenticationContext authenticationContext,
+      TenantIdentifier tenantIdentifier,
+      IdentityVerificationResultIdentifier identifier,
+      RequestAttributes requestAttributes) {
+
+    IdentityVerificationResultFindRequest findRequest =
+        new IdentityVerificationResultFindRequest(identifier);
+    IdentityVerificationResultManagementResult result =
+        handler.handle(
+            "get", authenticationContext, tenantIdentifier, findRequest, requestAttributes, false);
+
+    AuditLog auditLog = AuditLogCreator.create(result.context());
+    auditLogPublisher.publish(auditLog);
+
+    return result.toResponse(false);
+  }
+}


### PR DESCRIPTION
## Summary

- 身元確認申請（Identity Verification Application）の管理APIをシステムレベル・組織レベルで追加
- E2Eテスト（基本テスト + OpenAPIスキーマ検証テスト）追加
- OpenAPI仕様書・Docusaurusドキュメントリンク追加

## 変更内容

### 管理API（GET list / GET detail / DELETE with dry_run）

| エンドポイント | 概要 |
|---|---|
| `GET /v1/management/tenants/{id}/identity-verification-applications` | 一覧取得 |
| `GET /v1/management/tenants/{id}/identity-verification-applications/{id}` | 詳細取得 |
| `DELETE /v1/management/tenants/{id}/identity-verification-applications/{id}` | 削除 |
| 上記の組織レベル版（`/organizations/{orgId}/tenants/{tenantId}/...`） | 同上 |

### E2Eテスト（45テスト全パス）
- 基本テスト: ページネーション、フィルタ（status/type/client_id/from/to）、404、dry_run
- スキーマ検証: OpenAPI仕様書とレスポンスの型・構造・enum・一貫性を検証

### ドキュメント
- `swagger-cp-identity-verification-application-ja.yaml` 追加
- Docusaurusビルド設定・APIリファレンスリンク追加

## Test plan
- [x] E2E基本テスト（system / organization）パス
- [x] E2Eスキーマ検証テスト（実データで全フィールド検証）パス
- [x] `./gradlew compileJava` ビルド成功

Closes #1403

🤖 Generated with [Claude Code](https://claude.com/claude-code)