### PR TITLE
[DDL]feat: トークン管理API追加

### DIFF
--- a/documentation/docs/content_03_concepts/04-tokens-claims/concept-02-token-management.md
+++ b/documentation/docs/content_03_concepts/04-tokens-claims/concept-02-token-management.md
@@ -113,6 +113,7 @@ idp-serverでは、Refresh Tokenを使用のたびに新しいトークンを発
 
 ## 関連ドキュメント
 
+- [トークン管理API運用ガイド](../../content_05_how-to/phase-2-security/06-token-management-api.md) - 管理APIの使い方とGrant管理APIとの使い分け
 - [トークン有効期限パターン](../../content_05_how-to/phase-2-security/02-token-strategy.md) - 具体的な設定例
 - [イントロスペクション](../../content_04_protocols/protocol-03-introspection.md) - イントロスペクション仕様
 - [セッション管理](../03-authentication-authorization/concept-03-session-management.md) - セッションとトークンの関係

--- a/documentation/docs/content_05_how-to/phase-2-security/06-token-management-api.md
+++ b/documentation/docs/content_05_how-to/phase-2-security/06-token-management-api.md
@@ -1,0 +1,239 @@
+# トークン管理API運用ガイド
+
+## このドキュメントの目的
+
+**トークン管理APIとGrant管理APIの違いを理解し、運用シーンに応じた使い分けができるようになる**ことが目標です。
+
+### 学べること
+
+✅ **トークン管理API vs Grant管理API**
+- 操作対象と粒度の違い
+- 副作用の違い（何が削除されるか）
+- 運用シーンごとの使い分け
+
+✅ **トークン管理APIの実践的な使い方**
+- 不正アクセス時の即座失効
+- ユーザー退職時の全トークン削除
+- dry_runによる事前確認
+
+### 所要時間
+⏱️ **約10分**
+
+### 前提条件
+- [トークン管理の概念](../../content_03_concepts/04-tokens-claims/concept-02-token-management.md)を理解している
+- 管理API（Control Plane）の基本的な認証・認可を理解している
+
+---
+
+## トークン管理API vs Grant管理API
+
+idp-serverには、トークンに関連する2つの管理APIがあります。
+
+### 操作対象の違い
+
+| 観点 | トークン管理API | Grant管理API |
+|:---|:---|:---|
+| **操作対象** | `oauth_token`テーブルの個別レコード | `authorization_granted`テーブルのGrantレコード |
+| **粒度** | トークン単位（1発行 = 1レコード） | ユーザー×クライアント単位の認可記録 |
+| **参照できる情報** | トークンメタデータ（ID、client_id、scopes、有効期限等） | 同意済みスコープ、認可日時等 |
+| **トークン値の公開** | しない（セキュリティ上非公開） | N/A |
+
+### 削除時の副作用
+
+```
+トークン管理API: DELETE /tokens/{id}
+└─→ 対象のoauth_tokenレコードを物理削除
+    ├─ アクセストークン → 即座に無効化（introspectionでactive=false）
+    └─ リフレッシュトークン → 同レコード内のため同時に無効化
+    ※ Grantは削除されない（ユーザーの認可同意は維持）
+
+Grant管理API: DELETE /grants/{id}
+└─→ 対象のGrant + 関連する全トークンを削除
+    ├─ authorization_grantedレコードを削除
+    └─ 該当ユーザー×クライアントの全oauth_tokenレコードを一括削除
+    ※ ユーザーの認可同意が取り消されるため、再ログイン時に同意画面が表示される
+```
+
+### 使い分けの判断基準
+
+| 運用シーン | 推奨API | 理由 |
+|:---|:---|:---|
+| **特定トークンの即座失効** | トークン管理API | 対象を絞って最小限の影響で失効できる |
+| **ユーザーの全トークン一括失効** | トークン管理API | Grant（認可同意）を維持したまま全セッションを切れる |
+| **ユーザーのアプリ連携解除** | Grant管理API | 認可同意ごと削除し、再認可を要求する |
+| **不正クライアントの全アクセス遮断** | Grant管理API | 該当クライアントへのGrant削除で関連トークンも一括削除 |
+| **トークン発行状況の監査** | トークン管理API | 一覧取得でフィルタリング・ページネーション対応 |
+| **トークン棚卸し（有効期限確認）** | トークン管理API | 有効期限付きメタデータを確認できる |
+
+---
+
+## エンドポイント一覧
+
+### システムレベル
+
+| メソッド | パス | 概要 |
+|:---|:---|:---|
+| GET | `/v1/management/tenants/{id}/tokens` | トークン一覧取得 |
+| GET | `/v1/management/tenants/{id}/tokens/{id}` | トークン詳細取得 |
+| DELETE | `/v1/management/tenants/{id}/tokens/{id}` | トークン個別失効 |
+| DELETE | `/v1/management/tenants/{id}/users/{id}/tokens` | ユーザー全トークン失効 |
+
+### 組織レベル
+
+上記のシステムレベルAPIと同じ操作を、組織スコープで提供します。
+
+パス: `/v1/management/organizations/{orgId}/tenants/{tenantId}/...`
+
+### 必要な権限
+
+| 権限 | 操作 |
+|:---|:---|
+| `idp:token:read` | 一覧取得、詳細取得 |
+| `idp:token:delete` | 個別失効、ユーザー全トークン失効 |
+
+---
+
+## フィルタリング
+
+一覧取得APIでは **`user_id` または `client_id` のどちらか1つ以上のフィルタが必須**です。大量データでのパフォーマンス劣化を防ぐため、フィルタなしのリクエストは `400 Bad Request` を返します。
+
+| パラメータ | 型 | 説明 | 例 |
+|:---|:---|:---|:---|
+| `user_id` | UUID | ユーザーIDで絞り込み | `?user_id=3ec055a8-...` |
+| `client_id` | string | クライアントIDで絞り込み | `?client_id=my-app` |
+| `grant_type` | string | grant_typeで絞り込み | `?grant_type=authorization_code` |
+| `from` | datetime | 作成日時の開始 | `?from=2026-03-01 00:00:00` |
+| `to` | datetime | 作成日時の終了 | `?to=2026-03-31 23:59:59` |
+| `expired` | boolean | 期限切れトークンを含める（デフォルト: false） | `?expired=true` |
+| `limit` | integer | 最大件数（デフォルト: 20、最大: 1000） | `?limit=50` |
+| `offset` | integer | 開始位置（デフォルト: 0） | `?offset=20` |
+
+---
+
+## 運用ユースケース
+
+### 1. 不正アクセスの検知と対応
+
+特定ユーザーのアカウントが侵害された疑いがある場合：
+
+```bash
+# Step 1: 該当ユーザーのトークン一覧を確認
+GET /v1/management/tenants/{tenantId}/tokens?user_id={userId}
+
+# Step 2: dry_runで影響範囲を確認
+DELETE /v1/management/tenants/{tenantId}/users/{userId}/tokens?dry_run=true
+# → {"dry_run": true, "user_id": "...", "affected_count": 5}
+
+# Step 3: 全トークンを失効
+DELETE /v1/management/tenants/{tenantId}/users/{userId}/tokens
+```
+
+### 2. 従業員退職時のアクセス剥奪
+
+```bash
+# Step 1: ユーザーの全トークンを即座に失効（セッション切断）
+DELETE /v1/management/tenants/{tenantId}/users/{userId}/tokens
+
+# Step 2: 認可同意も取り消す場合はGrant管理APIも使用
+DELETE /v1/management/tenants/{tenantId}/grants/{grantId}
+```
+
+### 3. 特定クライアントのトークン調査
+
+```bash
+# 特定クライアントが発行したトークンの一覧
+GET /v1/management/tenants/{tenantId}/tokens?client_id=suspicious-app&limit=100
+
+# 期限切れを含めて全履歴を確認
+GET /v1/management/tenants/{tenantId}/tokens?client_id=suspicious-app&expired=true&limit=100
+```
+
+### 4. トークン棚卸し
+
+```bash
+# 直近1ヶ月に発行されたトークンを確認
+GET /v1/management/tenants/{tenantId}/tokens?from=2026-02-18 00:00:00&limit=100
+
+# client_credentials（M2M）トークンの一覧
+GET /v1/management/tenants/{tenantId}/tokens?grant_type=client_credentials
+```
+
+---
+
+## レスポンス例
+
+### トークン一覧
+
+```json
+{
+  "list": [
+    {
+      "id": "283d1547-f8c4-4c50-9d33-188bb4e93bca",
+      "tenant_id": "4c4ee0fd-bcb2-4a3c-9fcf-ffc2da535e37",
+      "user_id": "b48b908c-6f48-4e43-9418-3378dd389c5a",
+      "client_id": "my-web-app",
+      "grant_type": "authorization_code",
+      "scopes": "openid profile email",
+      "token_type": "Bearer",
+      "access_token_expires_at": "2026-03-18T07:19:39",
+      "has_refresh_token": true,
+      "refresh_token_expires_at": "2026-03-19T06:19:39",
+      "created_at": "2026-03-18T06:19:39"
+    }
+  ],
+  "total_count": 1,
+  "limit": 20,
+  "offset": 0
+}
+```
+
+### dry_run削除（個別）
+
+```json
+{
+  "dry_run": true,
+  "target": {
+    "id": "283d1547-f8c4-4c50-9d33-188bb4e93bca",
+    "tenant_id": "4c4ee0fd-bcb2-4a3c-9fcf-ffc2da535e37",
+    "user_id": "b48b908c-6f48-4e43-9418-3378dd389c5a",
+    "client_id": "my-web-app",
+    "grant_type": "authorization_code",
+    "scopes": "openid profile email",
+    "token_type": "Bearer",
+    "access_token_expires_at": "2026-03-18T07:19:39",
+    "has_refresh_token": true,
+    "created_at": "2026-03-18T06:19:39"
+  }
+}
+```
+
+### dry_run削除（ユーザー全トークン）
+
+```json
+{
+  "dry_run": true,
+  "user_id": "b48b908c-6f48-4e43-9418-3378dd389c5a",
+  "affected_count": 5
+}
+```
+
+---
+
+## 大量データに関する注意事項
+
+- **`total_count`の上限**: 一覧取得APIの`total_count`は最大**1,000,001**で打ち止めになります。100万件を超えるレコードが存在する場合、厳密な件数は返しません。これはCOUNTクエリのパフォーマンス劣化を防ぐための設計です（セキュリティイベントAPIと同じ方式）
+- **フィルタの活用**: 大量のトークンが存在するテナントでは、`user_id`や`client_id`でフィルタリングして対象を絞り込むことを推奨します
+- **期限切れトークン**: デフォルトでは期限切れトークンは一覧に含まれません（`expired=false`）。期限切れトークンは定期バッチで削除されるため、通常は有効なトークンのみ確認すれば十分です
+
+## セキュリティに関する注意事項
+
+- **トークン値は非公開**: 管理APIのレスポンスにアクセストークン値・リフレッシュトークン値は含まれません。`has_refresh_token`フラグで有無のみ確認できます
+- **物理削除**: トークン管理APIの削除は論理削除ではなく物理削除です。削除後は復元できません
+- **キャッシュ**: `TOKEN_CACHE_ENABLED=true`の環境では、トークン削除後もキャッシュTTL（デフォルト60秒）の間はイントロスペクションで`active=true`が返る可能性があります。管理APIによる削除はキャッシュを削除しないため、即座失効が必要な場合は識別子型トークンの利用を推奨します
+
+## 関連ドキュメント
+
+- [トークン管理の概念](../../content_03_concepts/04-tokens-claims/concept-02-token-management.md) - トークンの種類・形式・ライフサイクル
+- [トークン有効期限パターン](02-token-strategy.md) - 有効期限の設計と設定
+- [トークン管理API仕様書（OpenAPI）](../../content_07_reference/cp-token-api-ja) - エンドポイント詳細仕様
+- [Grant管理API仕様書（OpenAPI）](../../content_07_reference/api-grant-management-ja) - Grant管理エンドポイント詳細仕様

--- a/documentation/docs/content_07_reference/api-reference.md
+++ b/documentation/docs/content_07_reference/api-reference.md
@@ -23,5 +23,6 @@
 - [身元確認設定管理API](cp-identity-verification-api-ja)
 - [身元確認申請管理API](cp-identity-verification-application-api-ja)
 - [身元確認結果管理API](cp-identity-verification-result-api-ja)
+- [トークン管理API](cp-token-api-ja)
 - [フェデレーション設定管理API](cp-federation-api-ja)
 - [セキュリティイベント管理API](cp-security-event-api-ja)

--- a/documentation/docusaurus.config.js
+++ b/documentation/docusaurus.config.js
@@ -134,6 +134,10 @@ const config = {
             route: '/docs/content_07_reference/cp-identity-verification-result-api-ja/',
           },
           {
+            spec: 'openapi/swagger-cp-token-ja.yaml',
+            route: '/docs/content_07_reference/cp-token-api-ja/',
+          },
+          {
             spec: 'openapi/swagger-cp-federation-ja.yaml',
             route: '/docs/content_07_reference/cp-federation-api-ja/',
           },

--- a/documentation/openapi/swagger-cp-token-ja.yaml
+++ b/documentation/openapi/swagger-cp-token-ja.yaml
@@ -17,7 +17,10 @@ paths:
     - $ref: '#/components/parameters/TenantId'
     get:
       summary: 組織内トークン一覧取得
-      description: 指定した組織・テナント内のOAuthトークン一覧を取得します。各種フィルタリングおよびページネーションに対応しています。
+      description: |
+        指定した組織・テナント内のOAuthトークン一覧を取得します。
+        各種フィルタリングおよびページネーションに対応しています。
+        **user_id または client_id のどちらか1つ以上のフィルタが必須です。**
       tags:
       - organization-token
       parameters:

--- a/documentation/openapi/swagger-cp-token-ja.yaml
+++ b/documentation/openapi/swagger-cp-token-ja.yaml
@@ -1,0 +1,394 @@
+openapi: 3.0.3
+info:
+  title: idp-server コントロールプレーン トークン管理 API
+  description: OAuthトークンの管理API仕様書。管理者がテナント内のトークンを一覧取得・詳細取得・強制失効できます。
+  version: 1.0.0
+  contact:
+    name: idp-server OSS
+servers:
+- url: http://localhost:8080
+tags:
+- name: organization-token
+  description: 組織レベルトークン管理
+paths:
+  /v1/management/organizations/{organization-id}/tenants/{tenant-id}/tokens:
+    parameters:
+    - $ref: '#/components/parameters/OrganizationId'
+    - $ref: '#/components/parameters/TenantId'
+    get:
+      summary: 組織内トークン一覧取得
+      description: 指定した組織・テナント内のOAuthトークン一覧を取得します。各種フィルタリングおよびページネーションに対応しています。
+      tags:
+      - organization-token
+      parameters:
+      - $ref: '#/components/parameters/Limit'
+      - $ref: '#/components/parameters/Offset'
+      - name: user_id
+        in: query
+        required: false
+        schema:
+          type: string
+          format: uuid
+        description: ユーザーIDでフィルタリング
+      - name: client_id
+        in: query
+        required: false
+        schema:
+          type: string
+        description: クライアントIDでフィルタリング
+      - name: grant_type
+        in: query
+        required: false
+        schema:
+          type: string
+          enum:
+          - authorization_code
+          - client_credentials
+          - password
+          - refresh_token
+          - urn:ietf:params:oauth:grant-type:jwt-bearer
+          - urn:ietf:params:oauth:grant-type:device_code
+          - urn:openid:params:grant-type:ciba
+        description: grant_typeでフィルタリング
+      - name: from
+        in: query
+        required: false
+        schema:
+          type: string
+          format: date-time
+        description: 作成日時の開始（ISO 8601形式）
+      - name: to
+        in: query
+        required: false
+        schema:
+          type: string
+          format: date-time
+        description: 作成日時の終了（ISO 8601形式）
+      - name: expired
+        in: query
+        required: false
+        schema:
+          type: boolean
+          default: false
+        description: 期限切れトークンを含めるか
+      responses:
+        '200':
+          description: トークン一覧
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TokenListResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          description: 組織またはテナントが見つかりません
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /v1/management/organizations/{organization-id}/tenants/{tenant-id}/tokens/{token-id}:
+    parameters:
+    - $ref: '#/components/parameters/OrganizationId'
+    - $ref: '#/components/parameters/TenantId'
+    - $ref: '#/components/parameters/TokenId'
+    get:
+      summary: 組織内トークン詳細取得
+      description: 指定した組織・テナント内の特定のトークンの詳細を取得します
+      tags:
+      - organization-token
+      responses:
+        '200':
+          description: トークン詳細
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TokenDetail'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          description: トークンが見つかりません
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+    delete:
+      summary: 組織内トークン失効
+      description: 指定した組織・テナント内の特定のトークンを強制失効します
+      tags:
+      - organization-token
+      parameters:
+      - $ref: '#/components/parameters/DryRun'
+      responses:
+        '204':
+          description: トークン失効成功
+        '200':
+          description: dry_run=trueの場合の応答
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TokenDryRunDeleteResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          description: トークンが見つかりません
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /v1/management/organizations/{organization-id}/tenants/{tenant-id}/users/{user-id}/tokens:
+    parameters:
+    - $ref: '#/components/parameters/OrganizationId'
+    - $ref: '#/components/parameters/TenantId'
+    - $ref: '#/components/parameters/UserId'
+    delete:
+      summary: 組織内ユーザー全トークン失効
+      description: 指定したユーザーの全トークンを強制失効します。不可逆な操作のため、dry_runでの事前確認を推奨します。
+      tags:
+      - organization-token
+      parameters:
+      - $ref: '#/components/parameters/DryRun'
+      responses:
+        '204':
+          description: ユーザー全トークン失効成功
+        '200':
+          description: dry_run=trueの場合の応答
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TokenUserDryRunDeleteResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+components:
+  parameters:
+    TenantId:
+      name: tenant-id
+      in: path
+      required: true
+      schema:
+        type: string
+      description: テナントの識別子
+    OrganizationId:
+      name: organization-id
+      in: path
+      required: true
+      schema:
+        type: string
+        format: uuid
+      description: 組織の識別子
+    TokenId:
+      name: token-id
+      in: path
+      required: true
+      schema:
+        type: string
+        format: uuid
+      description: トークンの識別子
+    UserId:
+      name: user-id
+      in: path
+      required: true
+      schema:
+        type: string
+        format: uuid
+      description: ユーザーの識別子
+    DryRun:
+      name: dry_run
+      in: query
+      required: false
+      schema:
+        type: boolean
+        default: false
+      description: trueの場合、リクエストの検証のみで実行はされません
+    Limit:
+      name: limit
+      in: query
+      required: false
+      schema:
+        type: integer
+        minimum: 1
+        maximum: 1000
+        default: 20
+      description: 返すアイテムの最大数
+    Offset:
+      name: offset
+      in: query
+      required: false
+      schema:
+        type: integer
+        minimum: 0
+        default: 0
+      description: アイテムを返す開始インデックス
+  schemas:
+    ErrorResponse:
+      type: object
+      properties:
+        error:
+          type: string
+          description: エラーコード
+        error_description:
+          type: string
+          description: エラーの説明
+      required:
+      - error
+      - error_description
+    TokenDetail:
+      type: object
+      description: OAuthトークン詳細（トークン値は含まない）
+      properties:
+        id:
+          type: string
+          format: uuid
+          description: トークンID
+          example: 8a3f2b1c-4d5e-6f7a-8b9c-0d1e2f3a4b5c
+        tenant_id:
+          type: string
+          description: テナントID
+          example: 952f6906-3e95-4ed3-86b2-981f90f785f9
+        user_id:
+          type: string
+          format: uuid
+          description: ユーザーID（client_credentialsの場合はnull）
+          example: 3ec055a8-8000-44a2-8677-e70ebff414e2
+        client_id:
+          type: string
+          description: クライアントID
+          example: my-client
+        grant_type:
+          type: string
+          description: グラントタイプ
+          example: authorization_code
+        scopes:
+          type: string
+          description: 付与されたスコープ（スペース区切り）
+          example: openid profile email
+        token_type:
+          type: string
+          description: トークンタイプ
+          example: Bearer
+        access_token_expires_at:
+          type: string
+          format: date-time
+          description: アクセストークンの有効期限
+          example: "2026-03-18T10:30:00"
+        has_refresh_token:
+          type: boolean
+          description: リフレッシュトークンの有無
+          example: true
+        refresh_token_expires_at:
+          type: string
+          format: date-time
+          description: リフレッシュトークンの有効期限（存在する場合のみ）
+          example: "2026-04-17T10:30:00"
+        created_at:
+          type: string
+          format: date-time
+          description: トークン作成日時
+          example: "2026-03-17T10:30:00"
+      required:
+      - id
+      - tenant_id
+      - client_id
+      - grant_type
+      - scopes
+      - token_type
+      - access_token_expires_at
+      - has_refresh_token
+      - created_at
+    TokenListResponse:
+      type: object
+      description: トークン一覧レスポンス
+      properties:
+        list:
+          type: array
+          items:
+            $ref: '#/components/schemas/TokenDetail'
+        total_count:
+          type: integer
+          description: フィルタ条件に一致する総件数
+          example: 42
+        limit:
+          type: integer
+          description: リクエストされたlimit値
+          example: 20
+        offset:
+          type: integer
+          description: リクエストされたoffset値
+          example: 0
+      required:
+      - list
+      - total_count
+      - limit
+      - offset
+    TokenDryRunDeleteResponse:
+      type: object
+      description: トークン個別削除のdry_runレスポンス
+      properties:
+        dry_run:
+          type: boolean
+          example: true
+        target:
+          $ref: '#/components/schemas/TokenDetail'
+      required:
+      - dry_run
+      - target
+    TokenUserDryRunDeleteResponse:
+      type: object
+      description: ユーザー全トークン削除のdry_runレスポンス
+      properties:
+        dry_run:
+          type: boolean
+          example: true
+        user_id:
+          type: string
+          format: uuid
+          description: 対象ユーザーID
+          example: 3ec055a8-8000-44a2-8677-e70ebff414e2
+        affected_count:
+          type: integer
+          description: 削除対象のトークン数
+          example: 12
+      required:
+      - dry_run
+      - user_id
+      - affected_count
+  responses:
+    Unauthorized:
+      description: Unauthorized - 認証が必要です
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              error:
+                type: string
+                example: unauthorized
+              error_description:
+                type: string
+                example: Authentication required
+            required:
+            - error
+            - error_description
+    Forbidden:
+      description: Forbidden - 権限が不足しています
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              error:
+                type: string
+                example: access_denied
+              error_description:
+                type: string
+                example: Insufficient permissions to access this resource
+            required:
+            - error
+            - error_description

--- a/e2e/src/tests/scenario/control_plane/organization/organization_token_management.test.js
+++ b/e2e/src/tests/scenario/control_plane/organization/organization_token_management.test.js
@@ -24,7 +24,7 @@ describe("Organization Token Management API Test", () => {
     authHeader = `Bearer ${tokenResponse.data.access_token}`;
   });
 
-  test("should list tokens with default pagination", async () => {
+  test("should require user_id or client_id filter", async () => {
     const listResponse = await get({
       url: baseUrl,
       headers: {
@@ -32,17 +32,14 @@ describe("Organization Token Management API Test", () => {
       },
     });
 
-    console.log("List Response:", JSON.stringify(listResponse.data));
-    expect(listResponse.status).toBe(200);
-    expect(listResponse.data).toHaveProperty("list");
-    expect(listResponse.data).toHaveProperty("total_count");
-    expect(Array.isArray(listResponse.data.list)).toBe(true);
-    expect(typeof listResponse.data.total_count).toBe("number");
+    console.log("No filter Response:", JSON.stringify(listResponse.data));
+    expect(listResponse.status).toBe(400);
+    expect(listResponse.data).toHaveProperty("error", "invalid_request");
   });
 
-  test("should support pagination with limit and offset", async () => {
+  test("should list tokens with client_id filter and pagination", async () => {
     const listResponse = await get({
-      url: `${baseUrl}?limit=5&offset=0`,
+      url: `${baseUrl}?client_id=org-client&limit=5&offset=0`,
       headers: {
         Authorization: authHeader,
       },
@@ -59,9 +56,9 @@ describe("Organization Token Management API Test", () => {
     expect(listResponse.data.list.length).toBeLessThanOrEqual(5);
   });
 
-  test("should support filtering by grant_type", async () => {
+  test("should support filtering by client_id and grant_type", async () => {
     const listResponse = await get({
-      url: `${baseUrl}?grant_type=password&limit=10`,
+      url: `${baseUrl}?client_id=org-client&grant_type=password&limit=10`,
       headers: {
         Authorization: authHeader,
       },
@@ -81,7 +78,7 @@ describe("Organization Token Management API Test", () => {
     }
   });
 
-  test("should support time range filtering", async () => {
+  test("should support time range filtering with client_id", async () => {
     const oneYearAgo = new Date();
     oneYearAgo.setFullYear(oneYearAgo.getFullYear() - 1);
     const fromDate = oneYearAgo
@@ -90,7 +87,7 @@ describe("Organization Token Management API Test", () => {
       .replace("T", " ");
 
     const listResponse = await get({
-      url: `${baseUrl}?from=${encodeURIComponent(fromDate)}&limit=10`,
+      url: `${baseUrl}?client_id=org-client&from=${encodeURIComponent(fromDate)}&limit=10`,
       headers: {
         Authorization: authHeader,
       },
@@ -107,7 +104,7 @@ describe("Organization Token Management API Test", () => {
 
   test("should return correct token fields in list", async () => {
     const listResponse = await get({
-      url: `${baseUrl}?limit=1`,
+      url: `${baseUrl}?client_id=org-client&limit=1`,
       headers: {
         Authorization: authHeader,
       },
@@ -133,7 +130,7 @@ describe("Organization Token Management API Test", () => {
 
   test("should get token detail when tokens exist", async () => {
     const listResponse = await get({
-      url: `${baseUrl}?limit=1`,
+      url: `${baseUrl}?client_id=org-client&limit=1`,
       headers: {
         Authorization: authHeader,
       },
@@ -167,7 +164,7 @@ describe("Organization Token Management API Test", () => {
 
   test("should support dry-run delete", async () => {
     const listResponse = await get({
-      url: `${baseUrl}?limit=1`,
+      url: `${baseUrl}?client_id=org-client&limit=1`,
       headers: {
         Authorization: authHeader,
       },
@@ -207,7 +204,7 @@ describe("Organization Token Management API Test", () => {
 
   test("should support dry-run delete user tokens", async () => {
     const listResponse = await get({
-      url: `${baseUrl}?limit=1`,
+      url: `${baseUrl}?client_id=org-client&limit=1`,
       headers: {
         Authorization: authHeader,
       },

--- a/e2e/src/tests/scenario/control_plane/organization/organization_token_management.test.js
+++ b/e2e/src/tests/scenario/control_plane/organization/organization_token_management.test.js
@@ -1,0 +1,241 @@
+import { describe, expect, test, beforeAll } from "@jest/globals";
+import { deletion, get } from "../../../../lib/http";
+import { backendUrl } from "../../../testConfig";
+import { requestToken } from "../../../../api/oauthClient";
+
+describe("Organization Token Management API Test", () => {
+  const orgId = "72cf4a12-8da3-40fb-8ae4-a77e3cda95e2";
+  const tenantId = "952f6906-3e95-4ed3-86b2-981f90f785f9";
+
+  const baseUrl = `${backendUrl}/v1/management/organizations/${orgId}/tenants/${tenantId}/tokens`;
+
+  let authHeader;
+
+  beforeAll(async () => {
+    const tokenResponse = await requestToken({
+      endpoint: `${backendUrl}/952f6906-3e95-4ed3-86b2-981f90f785f9/v1/tokens`,
+      grantType: "password",
+      username: "ito.ichiro@gmail.com",
+      password: "successUserCode001",
+      scope: "org-management account management",
+      clientId: "org-client",
+      clientSecret: "org-client-001",
+    });
+    authHeader = `Bearer ${tokenResponse.data.access_token}`;
+  });
+
+  test("should list tokens with default pagination", async () => {
+    const listResponse = await get({
+      url: baseUrl,
+      headers: {
+        Authorization: authHeader,
+      },
+    });
+
+    console.log("List Response:", JSON.stringify(listResponse.data));
+    expect(listResponse.status).toBe(200);
+    expect(listResponse.data).toHaveProperty("list");
+    expect(listResponse.data).toHaveProperty("total_count");
+    expect(Array.isArray(listResponse.data.list)).toBe(true);
+    expect(typeof listResponse.data.total_count).toBe("number");
+  });
+
+  test("should support pagination with limit and offset", async () => {
+    const listResponse = await get({
+      url: `${baseUrl}?limit=5&offset=0`,
+      headers: {
+        Authorization: authHeader,
+      },
+    });
+
+    console.log("Pagination Response:", JSON.stringify(listResponse.data));
+    expect(listResponse.status).toBe(200);
+    expect(listResponse.data).toHaveProperty("list");
+    expect(listResponse.data).toHaveProperty("total_count");
+    expect(listResponse.data).toHaveProperty("limit");
+    expect(listResponse.data).toHaveProperty("offset");
+    expect(listResponse.data.limit).toBe(5);
+    expect(listResponse.data.offset).toBe(0);
+    expect(listResponse.data.list.length).toBeLessThanOrEqual(5);
+  });
+
+  test("should support filtering by grant_type", async () => {
+    const listResponse = await get({
+      url: `${baseUrl}?grant_type=password&limit=10`,
+      headers: {
+        Authorization: authHeader,
+      },
+    });
+
+    console.log(
+      "Grant Type Filter Response:",
+      JSON.stringify(listResponse.data)
+    );
+    expect(listResponse.status).toBe(200);
+    expect(listResponse.data).toHaveProperty("total_count");
+
+    if (listResponse.data.list.length > 0) {
+      listResponse.data.list.forEach((token) => {
+        expect(token.grant_type).toBe("password");
+      });
+    }
+  });
+
+  test("should support time range filtering", async () => {
+    const oneYearAgo = new Date();
+    oneYearAgo.setFullYear(oneYearAgo.getFullYear() - 1);
+    const fromDate = oneYearAgo
+      .toISOString()
+      .substring(0, 19)
+      .replace("T", " ");
+
+    const listResponse = await get({
+      url: `${baseUrl}?from=${encodeURIComponent(fromDate)}&limit=10`,
+      headers: {
+        Authorization: authHeader,
+      },
+    });
+
+    console.log(
+      "Time Range Filter Response:",
+      JSON.stringify(listResponse.data)
+    );
+    expect(listResponse.status).toBe(200);
+    expect(listResponse.data).toHaveProperty("total_count");
+    expect(listResponse.data).toHaveProperty("list");
+  });
+
+  test("should return correct token fields in list", async () => {
+    const listResponse = await get({
+      url: `${baseUrl}?limit=1`,
+      headers: {
+        Authorization: authHeader,
+      },
+    });
+    expect(listResponse.status).toBe(200);
+
+    if (listResponse.data.list.length > 0) {
+      const token = listResponse.data.list[0];
+      expect(token).toHaveProperty("id");
+      expect(token).toHaveProperty("tenant_id");
+      expect(token).toHaveProperty("client_id");
+      expect(token).toHaveProperty("grant_type");
+      expect(token).toHaveProperty("scopes");
+      expect(token).toHaveProperty("token_type");
+      expect(token).toHaveProperty("access_token_expires_at");
+      expect(token).toHaveProperty("has_refresh_token");
+      expect(token).toHaveProperty("created_at");
+      // token values must NOT be exposed
+      expect(token).not.toHaveProperty("encrypted_access_token");
+      expect(token).not.toHaveProperty("encrypted_refresh_token");
+    }
+  });
+
+  test("should get token detail when tokens exist", async () => {
+    const listResponse = await get({
+      url: `${baseUrl}?limit=1`,
+      headers: {
+        Authorization: authHeader,
+      },
+    });
+    expect(listResponse.status).toBe(200);
+
+    if (listResponse.data.list.length > 0) {
+      const tokenId = listResponse.data.list[0].id;
+      const detailResponse = await get({
+        url: `${baseUrl}/${tokenId}`,
+        headers: {
+          Authorization: authHeader,
+        },
+      });
+      console.log("Detail Response:", JSON.stringify(detailResponse.data));
+      expect(detailResponse.status).toBe(200);
+      expect(detailResponse.data.id).toBe(tokenId);
+    }
+  });
+
+  test("should return 404 for non-existent token", async () => {
+    const response = await get({
+      url: `${baseUrl}/00000000-0000-0000-0000-000000000000`,
+      headers: {
+        Authorization: authHeader,
+      },
+    });
+
+    expect(response.status).toBe(404);
+  });
+
+  test("should support dry-run delete", async () => {
+    const listResponse = await get({
+      url: `${baseUrl}?limit=1`,
+      headers: {
+        Authorization: authHeader,
+      },
+    });
+    expect(listResponse.status).toBe(200);
+
+    if (listResponse.data.list.length > 0) {
+      const tokenId = listResponse.data.list[0].id;
+
+      // Dry-run delete
+      const dryRunResponse = await deletion({
+        url: `${baseUrl}/${tokenId}?dry_run=true`,
+        headers: {
+          Authorization: authHeader,
+        },
+      });
+      console.log(
+        "Dry-run Delete Response:",
+        dryRunResponse.status,
+        dryRunResponse.data
+      );
+      expect(dryRunResponse.status).toBe(200);
+      expect(dryRunResponse.data).toHaveProperty("dry_run", true);
+      expect(dryRunResponse.data).toHaveProperty("target");
+
+      // Verify token still exists
+      const verifyResponse = await get({
+        url: `${baseUrl}/${tokenId}`,
+        headers: {
+          Authorization: authHeader,
+        },
+      });
+      expect(verifyResponse.status).toBe(200);
+      expect(verifyResponse.data.id).toBe(tokenId);
+    }
+  });
+
+  test("should support dry-run delete user tokens", async () => {
+    const listResponse = await get({
+      url: `${baseUrl}?limit=1`,
+      headers: {
+        Authorization: authHeader,
+      },
+    });
+    expect(listResponse.status).toBe(200);
+
+    if (listResponse.data.list.length > 0) {
+      const userId = listResponse.data.list[0].user_id;
+      if (userId) {
+        const userTokensUrl = `${backendUrl}/v1/management/organizations/${orgId}/tenants/${tenantId}/users/${userId}/tokens`;
+
+        const dryRunResponse = await deletion({
+          url: `${userTokensUrl}?dry_run=true`,
+          headers: {
+            Authorization: authHeader,
+          },
+        });
+        console.log(
+          "Dry-run Delete User Tokens Response:",
+          dryRunResponse.status,
+          dryRunResponse.data
+        );
+        expect(dryRunResponse.status).toBe(200);
+        expect(dryRunResponse.data).toHaveProperty("dry_run", true);
+        expect(dryRunResponse.data).toHaveProperty("user_id", userId);
+        expect(dryRunResponse.data).toHaveProperty("affected_count");
+        expect(typeof dryRunResponse.data.affected_count).toBe("number");
+      }
+    }
+  });
+});

--- a/e2e/src/tests/scenario/control_plane/system/token_management.test.js
+++ b/e2e/src/tests/scenario/control_plane/system/token_management.test.js
@@ -1,0 +1,284 @@
+import { describe, expect, it } from "@jest/globals";
+import { get, deletion } from "../../../../lib/http";
+import { requestToken } from "../../../../api/oauthClient";
+import { adminServerConfig, backendUrl } from "../../../testConfig";
+
+describe("token management api", () => {
+  const baseUrl = `${backendUrl}/v1/management/tenants/${adminServerConfig.tenantId}/tokens`;
+
+  const getAccessToken = async () => {
+    const tokenResponse = await requestToken({
+      endpoint: adminServerConfig.tokenEndpoint,
+      grantType: "password",
+      username: adminServerConfig.oauth.username,
+      password: adminServerConfig.oauth.password,
+      scope: adminServerConfig.adminClient.scope,
+      clientId: adminServerConfig.adminClient.clientId,
+      clientSecret: adminServerConfig.adminClient.clientSecret,
+    });
+    expect(tokenResponse.status).toBe(200);
+    return tokenResponse.data.access_token;
+  };
+
+  describe("list operations", () => {
+    it("should list tokens with default pagination", async () => {
+      const accessToken = await getAccessToken();
+
+      const listResponse = await get({
+        url: baseUrl,
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+        },
+      });
+      console.log("List Response:", JSON.stringify(listResponse.data));
+      expect(listResponse.status).toBe(200);
+      expect(listResponse.data).toHaveProperty("list");
+      expect(listResponse.data).toHaveProperty("total_count");
+      expect(Array.isArray(listResponse.data.list)).toBe(true);
+      expect(typeof listResponse.data.total_count).toBe("number");
+    });
+
+    it("should support pagination with limit and offset", async () => {
+      const accessToken = await getAccessToken();
+
+      const listResponse = await get({
+        url: `${baseUrl}?limit=5&offset=0`,
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+        },
+      });
+      console.log("Pagination Response:", JSON.stringify(listResponse.data));
+      expect(listResponse.status).toBe(200);
+      expect(listResponse.data).toHaveProperty("list");
+      expect(listResponse.data).toHaveProperty("total_count");
+      expect(listResponse.data).toHaveProperty("limit");
+      expect(listResponse.data).toHaveProperty("offset");
+      expect(listResponse.data.limit).toBe(5);
+      expect(listResponse.data.offset).toBe(0);
+      expect(listResponse.data.list.length).toBeLessThanOrEqual(5);
+    });
+
+    it("should support filtering by grant_type", async () => {
+      const accessToken = await getAccessToken();
+
+      const listResponse = await get({
+        url: `${baseUrl}?grant_type=password&limit=10`,
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+        },
+      });
+      console.log(
+        "Grant Type Filter Response:",
+        JSON.stringify(listResponse.data)
+      );
+      expect(listResponse.status).toBe(200);
+      expect(listResponse.data).toHaveProperty("total_count");
+
+      if (listResponse.data.list.length > 0) {
+        listResponse.data.list.forEach((token) => {
+          expect(token.grant_type).toBe("password");
+        });
+      }
+    });
+
+    it("should support filtering by client_id", async () => {
+      const accessToken = await getAccessToken();
+
+      const listResponse = await get({
+        url: `${baseUrl}?client_id=${adminServerConfig.adminClient.clientId}&limit=10`,
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+        },
+      });
+      console.log(
+        "Client ID Filter Response:",
+        JSON.stringify(listResponse.data)
+      );
+      expect(listResponse.status).toBe(200);
+
+      if (listResponse.data.list.length > 0) {
+        listResponse.data.list.forEach((token) => {
+          expect(token.client_id).toBe(
+            adminServerConfig.adminClient.clientId
+          );
+        });
+      }
+    });
+
+    it("should support time range filtering", async () => {
+      const accessToken = await getAccessToken();
+
+      const oneYearAgo = new Date();
+      oneYearAgo.setFullYear(oneYearAgo.getFullYear() - 1);
+      const fromDate = oneYearAgo
+        .toISOString()
+        .substring(0, 19)
+        .replace("T", " ");
+
+      const listResponse = await get({
+        url: `${baseUrl}?from=${encodeURIComponent(fromDate)}&limit=10`,
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+        },
+      });
+      console.log(
+        "Time Range Filter Response:",
+        JSON.stringify(listResponse.data)
+      );
+      expect(listResponse.status).toBe(200);
+      expect(listResponse.data).toHaveProperty("total_count");
+      expect(listResponse.data).toHaveProperty("list");
+    });
+
+    it("should return correct token fields in list response", async () => {
+      const accessToken = await getAccessToken();
+
+      const listResponse = await get({
+        url: `${baseUrl}?limit=1`,
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+        },
+      });
+      expect(listResponse.status).toBe(200);
+
+      if (listResponse.data.list.length > 0) {
+        const token = listResponse.data.list[0];
+        expect(token).toHaveProperty("id");
+        expect(token).toHaveProperty("tenant_id");
+        expect(token).toHaveProperty("client_id");
+        expect(token).toHaveProperty("grant_type");
+        expect(token).toHaveProperty("scopes");
+        expect(token).toHaveProperty("token_type");
+        expect(token).toHaveProperty("access_token_expires_at");
+        expect(token).toHaveProperty("has_refresh_token");
+        expect(token).toHaveProperty("created_at");
+        // token value should NOT be exposed
+        expect(token).not.toHaveProperty("encrypted_access_token");
+        expect(token).not.toHaveProperty("hashed_access_token");
+        expect(token).not.toHaveProperty("encrypted_refresh_token");
+        expect(token).not.toHaveProperty("hashed_refresh_token");
+        console.log("Token fields:", JSON.stringify(token));
+      }
+    });
+  });
+
+  describe("get by id operations", () => {
+    it("should get token detail when tokens exist", async () => {
+      const accessToken = await getAccessToken();
+
+      const listResponse = await get({
+        url: `${baseUrl}?limit=1`,
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+        },
+      });
+      expect(listResponse.status).toBe(200);
+
+      if (listResponse.data.list.length > 0) {
+        const tokenId = listResponse.data.list[0].id;
+        const detailResponse = await get({
+          url: `${baseUrl}/${tokenId}`,
+          headers: {
+            Authorization: `Bearer ${accessToken}`,
+          },
+        });
+        console.log("Detail Response:", JSON.stringify(detailResponse.data));
+        expect(detailResponse.status).toBe(200);
+        expect(detailResponse.data.id).toBe(tokenId);
+      }
+    });
+
+    it("should return 404 for non-existent token", async () => {
+      const accessToken = await getAccessToken();
+
+      const response = await get({
+        url: `${baseUrl}/00000000-0000-0000-0000-000000000000`,
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+        },
+      });
+      expect(response.status).toBe(404);
+    });
+  });
+
+  describe("delete operations", () => {
+    it("should support dry-run delete", async () => {
+      const accessToken = await getAccessToken();
+
+      const listResponse = await get({
+        url: `${baseUrl}?limit=1`,
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+        },
+      });
+      expect(listResponse.status).toBe(200);
+
+      if (listResponse.data.list.length > 0) {
+        const tokenId = listResponse.data.list[0].id;
+
+        const dryRunResponse = await deletion({
+          url: `${baseUrl}/${tokenId}?dry_run=true`,
+          headers: {
+            Authorization: `Bearer ${accessToken}`,
+          },
+        });
+        console.log(
+          "Dry-run Delete Response:",
+          dryRunResponse.status,
+          dryRunResponse.data
+        );
+        expect(dryRunResponse.status).toBe(200);
+        expect(dryRunResponse.data).toHaveProperty("dry_run", true);
+        expect(dryRunResponse.data).toHaveProperty("target");
+        expect(dryRunResponse.data.target).toHaveProperty("id", tokenId);
+
+        // Verify token still exists
+        const verifyResponse = await get({
+          url: `${baseUrl}/${tokenId}`,
+          headers: {
+            Authorization: `Bearer ${accessToken}`,
+          },
+        });
+        expect(verifyResponse.status).toBe(200);
+        expect(verifyResponse.data.id).toBe(tokenId);
+      }
+    });
+
+    it("should support dry-run delete user tokens", async () => {
+      const accessToken = await getAccessToken();
+
+      const listResponse = await get({
+        url: `${baseUrl}?limit=1`,
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+        },
+      });
+      expect(listResponse.status).toBe(200);
+
+      if (listResponse.data.list.length > 0) {
+        const userId = listResponse.data.list[0].user_id;
+        if (userId) {
+          const userTokensUrl = `${backendUrl}/v1/management/tenants/${adminServerConfig.tenantId}/users/${userId}/tokens`;
+
+          const dryRunResponse = await deletion({
+            url: `${userTokensUrl}?dry_run=true`,
+            headers: {
+              Authorization: `Bearer ${accessToken}`,
+            },
+          });
+          console.log(
+            "Dry-run Delete User Tokens Response:",
+            dryRunResponse.status,
+            dryRunResponse.data
+          );
+          expect(dryRunResponse.status).toBe(200);
+          expect(dryRunResponse.data).toHaveProperty("dry_run", true);
+          expect(dryRunResponse.data).toHaveProperty("user_id", userId);
+          expect(dryRunResponse.data).toHaveProperty("affected_count");
+          expect(typeof dryRunResponse.data.affected_count).toBe("number");
+          expect(dryRunResponse.data.affected_count).toBeGreaterThan(0);
+        }
+      }
+    });
+  });
+});

--- a/e2e/src/tests/scenario/control_plane/system/token_management.test.js
+++ b/e2e/src/tests/scenario/control_plane/system/token_management.test.js
@@ -21,7 +21,7 @@ describe("token management api", () => {
   };
 
   describe("list operations", () => {
-    it("should list tokens with default pagination", async () => {
+    it("should require user_id or client_id filter", async () => {
       const accessToken = await getAccessToken();
 
       const listResponse = await get({
@@ -30,19 +30,16 @@ describe("token management api", () => {
           Authorization: `Bearer ${accessToken}`,
         },
       });
-      console.log("List Response:", JSON.stringify(listResponse.data));
-      expect(listResponse.status).toBe(200);
-      expect(listResponse.data).toHaveProperty("list");
-      expect(listResponse.data).toHaveProperty("total_count");
-      expect(Array.isArray(listResponse.data.list)).toBe(true);
-      expect(typeof listResponse.data.total_count).toBe("number");
+      console.log("No filter Response:", JSON.stringify(listResponse.data));
+      expect(listResponse.status).toBe(400);
+      expect(listResponse.data).toHaveProperty("error", "invalid_request");
     });
 
-    it("should support pagination with limit and offset", async () => {
+    it("should list tokens with client_id filter and pagination", async () => {
       const accessToken = await getAccessToken();
 
       const listResponse = await get({
-        url: `${baseUrl}?limit=5&offset=0`,
+        url: `${baseUrl}?client_id=${adminServerConfig.adminClient.clientId}&limit=5&offset=0`,
         headers: {
           Authorization: `Bearer ${accessToken}`,
         },
@@ -58,11 +55,11 @@ describe("token management api", () => {
       expect(listResponse.data.list.length).toBeLessThanOrEqual(5);
     });
 
-    it("should support filtering by grant_type", async () => {
+    it("should support filtering by client_id and grant_type", async () => {
       const accessToken = await getAccessToken();
 
       const listResponse = await get({
-        url: `${baseUrl}?grant_type=password&limit=10`,
+        url: `${baseUrl}?client_id=${adminServerConfig.adminClient.clientId}&grant_type=password&limit=10`,
         headers: {
           Authorization: `Bearer ${accessToken}`,
         },
@@ -105,7 +102,7 @@ describe("token management api", () => {
       }
     });
 
-    it("should support time range filtering", async () => {
+    it("should support time range filtering with client_id", async () => {
       const accessToken = await getAccessToken();
 
       const oneYearAgo = new Date();
@@ -116,7 +113,7 @@ describe("token management api", () => {
         .replace("T", " ");
 
       const listResponse = await get({
-        url: `${baseUrl}?from=${encodeURIComponent(fromDate)}&limit=10`,
+        url: `${baseUrl}?client_id=${adminServerConfig.adminClient.clientId}&from=${encodeURIComponent(fromDate)}&limit=10`,
         headers: {
           Authorization: `Bearer ${accessToken}`,
         },
@@ -134,7 +131,7 @@ describe("token management api", () => {
       const accessToken = await getAccessToken();
 
       const listResponse = await get({
-        url: `${baseUrl}?limit=1`,
+        url: `${baseUrl}?client_id=${adminServerConfig.adminClient.clientId}&limit=1`,
         headers: {
           Authorization: `Bearer ${accessToken}`,
         },
@@ -167,7 +164,7 @@ describe("token management api", () => {
       const accessToken = await getAccessToken();
 
       const listResponse = await get({
-        url: `${baseUrl}?limit=1`,
+        url: `${baseUrl}?client_id=${adminServerConfig.adminClient.clientId}&limit=1`,
         headers: {
           Authorization: `Bearer ${accessToken}`,
         },
@@ -206,7 +203,7 @@ describe("token management api", () => {
       const accessToken = await getAccessToken();
 
       const listResponse = await get({
-        url: `${baseUrl}?limit=1`,
+        url: `${baseUrl}?client_id=${adminServerConfig.adminClient.clientId}&limit=1`,
         headers: {
           Authorization: `Bearer ${accessToken}`,
         },
@@ -248,7 +245,7 @@ describe("token management api", () => {
       const accessToken = await getAccessToken();
 
       const listResponse = await get({
-        url: `${baseUrl}?limit=1`,
+        url: `${baseUrl}?client_id=${adminServerConfig.adminClient.clientId}&limit=1`,
         headers: {
           Authorization: `Bearer ${accessToken}`,
         },

--- a/e2e/src/tests/usecase/standard/standard-06-token-management.test.js
+++ b/e2e/src/tests/usecase/standard/standard-06-token-management.test.js
@@ -460,4 +460,385 @@ describe("Standard Use Case: Token Management", () => {
       "Verified: User-level token deletion removes all user tokens"
     );
   });
+
+  it("should create token via management API and verify full lifecycle", async () => {
+    // キャッシュTTL待ち（61秒）があるためタイムアウトを延長
+    jest.setTimeout(120000);
+    const timestamp = Date.now();
+    const organizationId = uuidv4();
+    const tenantId = uuidv4();
+    const adminUserId = uuidv4();
+    const testUserId = uuidv4();
+    const clientId = uuidv4();
+    const adminEmail = `admin-${timestamp}@token-create-test.example.com`;
+    const adminPassword = `AdminPass${timestamp}!`;
+    const testUserEmail = `user-${timestamp}@token-create-test.example.com`;
+    const clientSecret = `client-secret-${crypto.randomBytes(16).toString("hex")}`;
+    const jwksContent = await generateECP256JWKS();
+
+    console.log("\n=== Create Test: Step 1 - Setup Organization ===");
+
+    const onboardingRequest = {
+      organization: {
+        id: organizationId,
+        name: `Token Create Test Org ${timestamp}`,
+        description: "E2E test for token creation via management API",
+      },
+      tenant: {
+        id: tenantId,
+        name: `Token Create Tenant ${timestamp}`,
+        domain: backendUrl,
+        authorization_provider: "idp-server",
+        session_config: {
+          cookie_name: `CREATE_SESSION_${organizationId.substring(0, 8)}`,
+          use_secure_cookie: false,
+        },
+        cors_config: {
+          allow_origins: [backendUrl],
+        },
+      },
+      authorization_server: {
+        issuer: `${backendUrl}/${tenantId}`,
+        authorization_endpoint: `${backendUrl}/${tenantId}/v1/authorizations`,
+        token_endpoint: `${backendUrl}/${tenantId}/v1/tokens`,
+        token_endpoint_auth_methods_supported: [
+          "client_secret_post",
+          "client_secret_basic",
+        ],
+        userinfo_endpoint: `${backendUrl}/${tenantId}/v1/userinfo`,
+        jwks_uri: `${backendUrl}/${tenantId}/v1/jwks`,
+        jwks: jwksContent,
+        grant_types_supported: [
+          "authorization_code",
+          "refresh_token",
+          "password",
+        ],
+        token_signed_key_id: "signing_key_1",
+        id_token_signed_key_id: "signing_key_1",
+        scopes_supported: [
+          "openid",
+          "profile",
+          "email",
+          "org-management",
+          "management",
+        ],
+        response_types_supported: ["code"],
+        response_modes_supported: ["query"],
+        subject_types_supported: ["public"],
+        id_token_signing_alg_values_supported: ["ES256"],
+        token_introspection_endpoint: `${backendUrl}/${tenantId}/v1/tokens/introspection`,
+        extension: {
+          access_token_type: "JWT",
+          access_token_duration: 3600,
+          id_token_duration: 3600,
+          refresh_token_duration: 86400,
+        },
+      },
+      user: {
+        sub: adminUserId,
+        provider_id: "idp-server",
+        name: "Token Create Admin",
+        email: adminEmail,
+        email_verified: true,
+        raw_password: adminPassword,
+      },
+      client: {
+        client_id: clientId,
+        client_secret: clientSecret,
+        redirect_uris: ["http://localhost:3000/callback"],
+        response_types: ["code"],
+        grant_types: ["authorization_code", "refresh_token", "password"],
+        scope: "openid profile email org-management management",
+        client_name: `Token Create Test Client`,
+        token_endpoint_auth_method: "client_secret_post",
+        application_type: "web",
+      },
+    };
+
+    const createOrgResponse = await postWithJson({
+      url: `${backendUrl}/v1/management/onboarding`,
+      headers: { Authorization: `Bearer ${systemAccessToken}` },
+      body: onboardingRequest,
+    });
+    expect(createOrgResponse.status).toBe(201);
+    console.log(`Organization created: ${organizationId}`);
+
+    // Register test user (separate from admin)
+    const registerUserResponse = await postWithJson({
+      url: `${backendUrl}/v1/management/tenants/${tenantId}/users`,
+      headers: { Authorization: `Bearer ${systemAccessToken}` },
+      body: {
+        sub: testUserId,
+        provider_id: "idp-server",
+        name: "Test User for Token Create",
+        email: testUserEmail,
+        email_verified: true,
+        raw_password: `TestPass${timestamp}!`,
+      },
+    });
+    expect(registerUserResponse.status).toBe(201);
+    console.log(`Test user created: ${testUserId}`);
+
+    // Get management token via normal flow
+    const mgmtTokenResponse = await requestToken({
+      endpoint: `${backendUrl}/${tenantId}/v1/tokens`,
+      grantType: "password",
+      username: adminEmail,
+      password: adminPassword,
+      scope: "org-management management",
+      clientId: clientId,
+      clientSecret: clientSecret,
+    });
+    expect(mgmtTokenResponse.status).toBe(200);
+    const managementAccessToken = mgmtTokenResponse.data.access_token;
+    console.log("Management token obtained via password grant");
+
+    const tokenMgmtUrl = `${backendUrl}/v1/management/organizations/${organizationId}/tenants/${tenantId}/tokens`;
+
+    console.log(
+      "\n=== Create Test: Step 2 - Create Token with Custom Claims (JWT) ==="
+    );
+
+    const createJwtResponse = await postWithJson({
+      url: tokenMgmtUrl,
+      headers: { Authorization: `Bearer ${managementAccessToken}` },
+      body: {
+        client_id: clientId,
+        scopes: "openid profile email",
+        user_id: testUserId,
+        token_format: "jwt",
+        access_token_duration: 1800,
+        refresh_token_duration: 43200,
+        custom_claims: {
+          role: "tester",
+          department: "qa",
+          test_id: timestamp,
+        },
+      },
+    });
+
+    console.log(
+      "Create JWT Response:",
+      createJwtResponse.status,
+      JSON.stringify(createJwtResponse.data).substring(0, 200)
+    );
+    expect(createJwtResponse.status).toBe(201);
+    expect(createJwtResponse.data).toHaveProperty("id");
+    expect(createJwtResponse.data).toHaveProperty("access_token");
+    expect(createJwtResponse.data).toHaveProperty("token_type", "Bearer");
+    expect(createJwtResponse.data).toHaveProperty("expires_in", 1800);
+    expect(createJwtResponse.data).toHaveProperty("refresh_token");
+    expect(createJwtResponse.data).toHaveProperty("scopes");
+
+    const createdJwtToken = createJwtResponse.data.access_token;
+    const createdTokenId = createJwtResponse.data.id;
+    const createdRefreshToken = createJwtResponse.data.refresh_token;
+
+    // Verify JWT structure (header.payload.signature)
+    const jwtParts = createdJwtToken.split(".");
+    expect(jwtParts.length).toBe(3);
+    console.log("JWT token created with 3 parts (header.payload.signature)");
+
+    // Decode and verify JWT payload
+    const payload = JSON.parse(
+      Buffer.from(jwtParts[1], "base64url").toString()
+    );
+    expect(payload.iss).toBe(`${backendUrl}/${tenantId}`);
+    expect(payload.client_id).toBe(clientId);
+    expect(payload.sub).toBe(testUserId);
+    expect(payload.scope).toBe("openid profile email");
+    expect(payload.role).toBe("tester");
+    expect(payload.department).toBe("qa");
+    expect(payload.test_id).toBe(timestamp);
+    console.log("JWT payload verified: standard claims + custom claims present");
+
+    // Verify standard claims cannot be overwritten by custom claims
+    expect(payload.iss).not.toBe("evil-issuer");
+    console.log("Security: standard claims not overwritable by custom claims");
+
+    console.log(
+      "\n=== Create Test: Step 3 - Introspection Verifies Token Active ==="
+    );
+
+    const introspectResponse = await post({
+      url: `${backendUrl}/${tenantId}/v1/tokens/introspection`,
+      body: {
+        token: createdJwtToken,
+        client_id: clientId,
+        client_secret: clientSecret,
+      },
+    });
+
+    expect(introspectResponse.status).toBe(200);
+    expect(introspectResponse.data.active).toBe(true);
+    expect(introspectResponse.data.client_id).toBe(clientId);
+    expect(introspectResponse.data.sub).toBe(testUserId);
+    // Custom claims should be in introspection response
+    expect(introspectResponse.data.role).toBe("tester");
+    expect(introspectResponse.data.department).toBe("qa");
+    console.log(
+      "Introspection: active=true, custom claims included in response"
+    );
+
+    console.log(
+      "\n=== Create Test: Step 4 - Token Visible in List API ==="
+    );
+
+    const listResponse = await get({
+      url: `${tokenMgmtUrl}?user_id=${testUserId}&limit=10`,
+      headers: { Authorization: `Bearer ${managementAccessToken}` },
+    });
+
+    expect(listResponse.status).toBe(200);
+    const createdTokenInList = listResponse.data.list.find(
+      (t) => t.id === createdTokenId
+    );
+    expect(createdTokenInList).toBeDefined();
+    expect(createdTokenInList.client_id).toBe(clientId);
+    expect(createdTokenInList.has_refresh_token).toBe(true);
+    console.log("Token visible in list API with correct metadata");
+
+    console.log(
+      "\n=== Create Test: Step 5 - Create Opaque Token (no user) ==="
+    );
+
+    const createOpaqueResponse = await postWithJson({
+      url: tokenMgmtUrl,
+      headers: { Authorization: `Bearer ${managementAccessToken}` },
+      body: {
+        client_id: clientId,
+        scopes: "management",
+        token_format: "opaque",
+        access_token_duration: 600,
+      },
+    });
+
+    expect(createOpaqueResponse.status).toBe(201);
+    expect(createOpaqueResponse.data).toHaveProperty("access_token");
+    expect(createOpaqueResponse.data).toHaveProperty("expires_in", 600);
+    // No refresh token for client_credentials-like token
+    expect(createOpaqueResponse.data.refresh_token).toBeUndefined();
+
+    const opaqueToken = createOpaqueResponse.data.access_token;
+    // Opaque token should NOT be a JWT
+    expect(opaqueToken.split(".").length).not.toBe(3);
+    console.log("Opaque token created (not JWT format, no refresh token)");
+
+    // Introspect opaque token
+    const introspectOpaqueResponse = await post({
+      url: `${backendUrl}/${tenantId}/v1/tokens/introspection`,
+      body: {
+        token: opaqueToken,
+        client_id: clientId,
+        client_secret: clientSecret,
+      },
+    });
+    expect(introspectOpaqueResponse.status).toBe(200);
+    expect(introspectOpaqueResponse.data.active).toBe(true);
+    console.log("Opaque token active via introspection");
+
+    console.log(
+      "\n=== Create Test: Step 6 - Dry-run Create ==="
+    );
+
+    const dryRunCreateResponse = await postWithJson({
+      url: `${tokenMgmtUrl}?dry_run=true`,
+      headers: { Authorization: `Bearer ${managementAccessToken}` },
+      body: {
+        client_id: clientId,
+        scopes: "openid profile",
+        user_id: testUserId,
+        token_format: "jwt",
+      },
+    });
+
+    expect(dryRunCreateResponse.status).toBe(200);
+    expect(dryRunCreateResponse.data).toHaveProperty("dry_run", true);
+    expect(dryRunCreateResponse.data).toHaveProperty("access_token");
+    console.log("Dry-run create: token returned but not persisted");
+
+    // Dry-run token should NOT be active via introspection
+    const introspectDryRunResponse = await post({
+      url: `${backendUrl}/${tenantId}/v1/tokens/introspection`,
+      body: {
+        token: dryRunCreateResponse.data.access_token,
+        client_id: clientId,
+        client_secret: clientSecret,
+      },
+    });
+    expect(introspectDryRunResponse.status).toBe(200);
+    expect(introspectDryRunResponse.data.active).toBe(false);
+    console.log("Dry-run token inactive via introspection (not persisted)");
+
+    console.log(
+      "\n=== Create Test: Step 7 - Delete Created Token and Verify Lifecycle ==="
+    );
+
+    // Delete the JWT token
+    const deleteResponse = await deletion({
+      url: `${tokenMgmtUrl}/${createdTokenId}`,
+      headers: { Authorization: `Bearer ${managementAccessToken}` },
+    });
+    expect(deleteResponse.status).toBe(204);
+    console.log("Created token deleted");
+
+    // Wait for token cache to expire (TOKEN_CACHE_ENABLED=true の場合、TTL 60秒)
+    // 管理APIの削除はDBレコードを物理削除するが、キャッシュは削除しない
+    await sleep(61000);
+
+    // Introspection should return active=false
+    const introspectAfterDelete = await post({
+      url: `${backendUrl}/${tenantId}/v1/tokens/introspection`,
+      body: {
+        token: createdJwtToken,
+        client_id: clientId,
+        client_secret: clientSecret,
+      },
+    });
+    expect(introspectAfterDelete.status).toBe(200);
+    expect(introspectAfterDelete.data.active).toBe(false);
+    console.log("Deleted token inactive via introspection");
+
+    // Refresh token should also be invalidated
+    const refreshAfterDelete = await requestToken({
+      endpoint: `${backendUrl}/${tenantId}/v1/tokens`,
+      grantType: "refresh_token",
+      refreshToken: createdRefreshToken,
+      clientId: clientId,
+      clientSecret: clientSecret,
+    });
+    expect(refreshAfterDelete.status).toBe(400);
+    console.log("Refresh token invalidated after token deletion");
+
+    console.log("\n=== Cleanup ===");
+
+    await deletion({
+      url: `${backendUrl}/v1/management/organizations/${organizationId}/tenants/${tenantId}`,
+      headers: { Authorization: `Bearer ${managementAccessToken}` },
+    }).catch(() => {});
+    console.log("Tenant deleted");
+
+    await deletion({
+      url: `${backendUrl}/v1/management/orgs/${organizationId}`,
+      headers: { Authorization: `Bearer ${systemAccessToken}` },
+    }).catch(() => {});
+    console.log("Organization deleted");
+
+    console.log("\n=== Token Create Lifecycle Test Completed ===");
+    console.log(
+      "Verified: JWT token with custom claims created via management API"
+    );
+    console.log(
+      "Verified: Custom claims present in JWT payload and introspection"
+    );
+    console.log(
+      "Verified: Opaque token created without user (no refresh token)"
+    );
+    console.log(
+      "Verified: Dry-run creates token but does not persist"
+    );
+    console.log(
+      "Verified: Full lifecycle: create → introspect → list → delete → inactive"
+    );
+  });
 });

--- a/e2e/src/tests/usecase/standard/standard-06-token-management.test.js
+++ b/e2e/src/tests/usecase/standard/standard-06-token-management.test.js
@@ -1,0 +1,463 @@
+import { describe, expect, it, beforeAll } from "@jest/globals";
+import { deletion, get, post, postWithJson } from "../../../lib/http";
+import { requestToken } from "../../../api/oauthClient";
+import { generateECP256JWKS } from "../../../lib/jose";
+import { adminServerConfig, backendUrl } from "../../testConfig";
+import { v4 as uuidv4 } from "uuid";
+import crypto from "crypto";
+import { sleep } from "../../../lib/util";
+
+/**
+ * Standard Use Case: Token Management API
+ *
+ * This test demonstrates the token management workflow:
+ * 1. Create organization via Onboarding API
+ * 2. Create tokens via password grant
+ * 3. List tokens via Token Management API (filtering, pagination)
+ * 4. Get token detail
+ * 5. Dry-run delete (verify token is NOT deleted)
+ * 6. Delete token (verify token IS deleted)
+ * 7. Delete all user tokens with dry-run (verify affected_count)
+ * 8. Delete all user tokens (verify all tokens deleted)
+ *
+ * Key behavior verified:
+ * - Token list returns metadata without token values (security)
+ * - Filtering by client_id, grant_type works correctly
+ * - Dry-run returns target info without actual deletion
+ * - User-level token deletion removes all tokens for that user
+ * - Deleted tokens cannot be used for refresh
+ */
+describe("Standard Use Case: Token Management", () => {
+  let systemAccessToken;
+
+  beforeAll(async () => {
+    const tokenResponse = await requestToken({
+      endpoint: adminServerConfig.tokenEndpoint,
+      grantType: "password",
+      username: adminServerConfig.oauth.username,
+      password: adminServerConfig.oauth.password,
+      scope: adminServerConfig.adminClient.scope,
+      clientId: adminServerConfig.adminClient.clientId,
+      clientSecret: adminServerConfig.adminClient.clientSecret,
+    });
+    expect(tokenResponse.status).toBe(200);
+    systemAccessToken = tokenResponse.data.access_token;
+  });
+
+  it("should manage tokens through full lifecycle", async () => {
+    const timestamp = Date.now();
+    const organizationId = uuidv4();
+    const tenantId = uuidv4();
+    const adminUserId = uuidv4();
+    const clientId = uuidv4();
+    const adminEmail = `admin-${timestamp}@token-mgmt-test.example.com`;
+    const adminPassword = `AdminPass${timestamp}!`;
+    const clientSecret = `client-secret-${crypto.randomBytes(16).toString("hex")}`;
+    const jwksContent = await generateECP256JWKS();
+
+    console.log("\n=== Step 1: Create Organization via Onboarding API ===");
+
+    const onboardingRequest = {
+      organization: {
+        id: organizationId,
+        name: `Token Mgmt Test Org ${timestamp}`,
+        description: `E2E test organization for token management created at ${new Date().toISOString()}`,
+      },
+      tenant: {
+        id: tenantId,
+        name: `Token Mgmt Tenant ${timestamp}`,
+        domain: backendUrl,
+        authorization_provider: "idp-server",
+        session_config: {
+          cookie_name: `TOKEN_SESSION_${organizationId.substring(0, 8)}`,
+          use_secure_cookie: false,
+        },
+        cors_config: {
+          allow_origins: [backendUrl],
+        },
+        security_event_log_config: {
+          format: "structured_json",
+          stage: "processed",
+          include_user_id: true,
+          include_client_id: true,
+          persistence_enabled: true,
+          include_detail: true,
+        },
+      },
+      authorization_server: {
+        issuer: `${backendUrl}/${tenantId}`,
+        authorization_endpoint: `${backendUrl}/${tenantId}/v1/authorizations`,
+        token_endpoint: `${backendUrl}/${tenantId}/v1/tokens`,
+        token_endpoint_auth_methods_supported: [
+          "client_secret_post",
+          "client_secret_basic",
+        ],
+        userinfo_endpoint: `${backendUrl}/${tenantId}/v1/userinfo`,
+        jwks_uri: `${backendUrl}/${tenantId}/v1/jwks`,
+        jwks: jwksContent,
+        grant_types_supported: [
+          "authorization_code",
+          "refresh_token",
+          "password",
+        ],
+        token_signed_key_id: "signing_key_1",
+        id_token_signed_key_id: "signing_key_1",
+        scopes_supported: [
+          "openid",
+          "profile",
+          "email",
+          "org-management",
+          "management",
+        ],
+        response_types_supported: ["code"],
+        response_modes_supported: ["query"],
+        subject_types_supported: ["public"],
+        id_token_signing_alg_values_supported: ["RS256", "ES256"],
+        token_introspection_endpoint: `${backendUrl}/${tenantId}/v1/tokens/introspection`,
+        token_revocation_endpoint: `${backendUrl}/${tenantId}/v1/tokens/revocation`,
+        extension: {
+          access_token_type: "JWT",
+          access_token_duration: 3600,
+          id_token_duration: 3600,
+          refresh_token_duration: 86400,
+        },
+      },
+      user: {
+        sub: adminUserId,
+        provider_id: "idp-server",
+        name: "Token Mgmt Test Admin",
+        email: adminEmail,
+        email_verified: true,
+        raw_password: adminPassword,
+      },
+      client: {
+        client_id: clientId,
+        client_secret: clientSecret,
+        redirect_uris: ["http://localhost:3000/callback"],
+        response_types: ["code"],
+        grant_types: ["authorization_code", "refresh_token", "password"],
+        scope: "openid profile email org-management management",
+        client_name: `Token Mgmt Test Client ${timestamp}`,
+        token_endpoint_auth_method: "client_secret_post",
+        application_type: "web",
+      },
+    };
+
+    const createResponse = await postWithJson({
+      url: `${backendUrl}/v1/management/onboarding`,
+      headers: {
+        Authorization: `Bearer ${systemAccessToken}`,
+      },
+      body: onboardingRequest,
+    });
+
+    if (createResponse.status !== 201) {
+      console.error(
+        "Onboarding failed:",
+        JSON.stringify(createResponse.data, null, 2)
+      );
+    }
+    expect(createResponse.status).toBe(201);
+    console.log(`Organization created: ${organizationId}`);
+
+    console.log("\n=== Step 2: Create Multiple Tokens via Password Grant ===");
+
+    // Token 1: management scope
+    const mgmtTokenResponse = await requestToken({
+      endpoint: `${backendUrl}/${tenantId}/v1/tokens`,
+      grantType: "password",
+      username: adminEmail,
+      password: adminPassword,
+      scope: "org-management management",
+      clientId: clientId,
+      clientSecret: clientSecret,
+    });
+    expect(mgmtTokenResponse.status).toBe(200);
+    const managementAccessToken = mgmtTokenResponse.data.access_token;
+    console.log("Management token created");
+
+    // Token 2: openid scope (creates another token record)
+    const userTokenResponse = await requestToken({
+      endpoint: `${backendUrl}/${tenantId}/v1/tokens`,
+      grantType: "password",
+      username: adminEmail,
+      password: adminPassword,
+      scope: "openid profile email",
+      clientId: clientId,
+      clientSecret: clientSecret,
+    });
+    expect(userTokenResponse.status).toBe(200);
+    const userAccessToken = userTokenResponse.data.access_token;
+    const userRefreshToken = userTokenResponse.data.refresh_token;
+    expect(userAccessToken).toBeDefined();
+    expect(userRefreshToken).toBeDefined();
+    console.log("User token with refresh token created");
+
+    await sleep(500);
+
+    console.log("\n=== Step 3: List Tokens via Management API ===");
+
+    const tokenListUrl = `${backendUrl}/v1/management/organizations/${organizationId}/tenants/${tenantId}/tokens`;
+
+    const listResponse = await get({
+      url: `${tokenListUrl}?user_id=${adminUserId}&limit=10`,
+      headers: {
+        Authorization: `Bearer ${managementAccessToken}`,
+      },
+    });
+
+    console.log("Token list response:", JSON.stringify(listResponse.data));
+    expect(listResponse.status).toBe(200);
+    expect(listResponse.data.list).toBeDefined();
+    expect(listResponse.data.total_count).toBe(2);
+    expect(listResponse.data.limit).toBe(10);
+    expect(listResponse.data.offset).toBe(0);
+
+    // Verify all tokens belong to the user
+    listResponse.data.list.forEach((token) => {
+      expect(token.user_id).toBe(adminUserId);
+    });
+
+    // Verify token metadata fields
+    const firstToken = listResponse.data.list[0];
+    expect(firstToken.id).toBeDefined();
+    expect(firstToken.tenant_id).toBe(tenantId);
+    expect(firstToken.client_id).toBe(clientId);
+    expect(firstToken.grant_type).toBe("password");
+    expect(firstToken.token_type).toBeDefined();
+    expect(firstToken.access_token_expires_at).toBeDefined();
+    expect(firstToken.created_at).toBeDefined();
+    expect(typeof firstToken.has_refresh_token).toBe("boolean");
+
+    // Security: token values must NOT be exposed
+    expect(firstToken.encrypted_access_token).toBeUndefined();
+    expect(firstToken.hashed_access_token).toBeUndefined();
+    expect(firstToken.encrypted_refresh_token).toBeUndefined();
+    console.log("Token list verified: metadata only, no token values exposed");
+
+    console.log("\n=== Step 4: Filter Tokens by client_id ===");
+
+    const filteredResponse = await get({
+      url: `${tokenListUrl}?client_id=${clientId}&limit=10`,
+      headers: {
+        Authorization: `Bearer ${managementAccessToken}`,
+      },
+    });
+
+    expect(filteredResponse.status).toBe(200);
+    filteredResponse.data.list.forEach((token) => {
+      expect(token.client_id).toBe(clientId);
+    });
+    console.log(
+      `Filtered by client_id: ${filteredResponse.data.total_count} tokens`
+    );
+
+    console.log("\n=== Step 5: Get Token Detail ===");
+
+    const tokenId = listResponse.data.list[0].id;
+
+    const detailResponse = await get({
+      url: `${tokenListUrl}/${tokenId}`,
+      headers: {
+        Authorization: `Bearer ${managementAccessToken}`,
+      },
+    });
+
+    expect(detailResponse.status).toBe(200);
+    expect(detailResponse.data.id).toBe(tokenId);
+    expect(detailResponse.data.tenant_id).toBe(tenantId);
+    console.log("Token detail retrieved:", detailResponse.data.id);
+
+    console.log("\n=== Step 6: Dry-Run Delete Single Token ===");
+
+    // Find the user token (not the management token we're using)
+    const userToken = listResponse.data.list.find(
+      (t) => t.scopes && t.scopes.includes("openid")
+    );
+    expect(userToken).toBeDefined();
+
+    const dryRunResponse = await deletion({
+      url: `${tokenListUrl}/${userToken.id}?dry_run=true`,
+      headers: {
+        Authorization: `Bearer ${managementAccessToken}`,
+      },
+    });
+
+    expect(dryRunResponse.status).toBe(200);
+    expect(dryRunResponse.data.dry_run).toBe(true);
+    expect(dryRunResponse.data.target).toBeDefined();
+    expect(dryRunResponse.data.target.id).toBe(userToken.id);
+    console.log("Dry-run delete: target info returned without deletion");
+
+    // Verify token still exists
+    const verifyExists = await get({
+      url: `${tokenListUrl}/${userToken.id}`,
+      headers: {
+        Authorization: `Bearer ${managementAccessToken}`,
+      },
+    });
+    expect(verifyExists.status).toBe(200);
+    console.log("Token still exists after dry-run");
+
+    console.log("\n=== Step 7: Actually Delete Single Token ===");
+
+    const deleteResponse = await deletion({
+      url: `${tokenListUrl}/${userToken.id}`,
+      headers: {
+        Authorization: `Bearer ${managementAccessToken}`,
+      },
+    });
+
+    expect(deleteResponse.status).toBe(204);
+    console.log("Token deleted successfully (204 No Content)");
+
+    // Verify token no longer exists
+    const verifyDeleted = await get({
+      url: `${tokenListUrl}/${userToken.id}`,
+      headers: {
+        Authorization: `Bearer ${managementAccessToken}`,
+      },
+    });
+    expect(verifyDeleted.status).toBe(404);
+    console.log("Deleted token returns 404");
+
+    // Verify access token is no longer active via introspection
+    const introspectionResponse = await post({
+      url: `${backendUrl}/${tenantId}/v1/tokens/introspection`,
+      body: {
+        token: userAccessToken,
+        client_id: clientId,
+        client_secret: clientSecret,
+      },
+    });
+    expect(introspectionResponse.status).toBe(200);
+    expect(introspectionResponse.data.active).toBe(false);
+    console.log("Access token inactive via introspection after deletion");
+
+    // Verify refresh token is also invalidated (record physically deleted)
+    const refreshAfterDelete = await requestToken({
+      endpoint: `${backendUrl}/${tenantId}/v1/tokens`,
+      grantType: "refresh_token",
+      refreshToken: userRefreshToken,
+      clientId: clientId,
+      clientSecret: clientSecret,
+    });
+    expect(refreshAfterDelete.status).toBe(400);
+    console.log("Refresh token invalidated after token deletion");
+
+    console.log("\n=== Step 8: Create More Tokens for User Deletion Test ===");
+
+    // Create a few more tokens
+    for (let i = 0; i < 2; i++) {
+      const extraToken = await requestToken({
+        endpoint: `${backendUrl}/${tenantId}/v1/tokens`,
+        grantType: "password",
+        username: adminEmail,
+        password: adminPassword,
+        scope: "openid profile",
+        clientId: clientId,
+        clientSecret: clientSecret,
+      });
+      expect(extraToken.status).toBe(200);
+    }
+
+    await sleep(500);
+
+    console.log(
+      "\n=== Step 9: Dry-Run Delete All User Tokens ==="
+    );
+
+    const userTokensUrl = `${backendUrl}/v1/management/organizations/${organizationId}/tenants/${tenantId}/users/${adminUserId}/tokens`;
+
+    const userDryRunResponse = await deletion({
+      url: `${userTokensUrl}?dry_run=true`,
+      headers: {
+        Authorization: `Bearer ${managementAccessToken}`,
+      },
+    });
+
+    expect(userDryRunResponse.status).toBe(200);
+    expect(userDryRunResponse.data.dry_run).toBe(true);
+    expect(userDryRunResponse.data.user_id).toBe(adminUserId);
+    expect(typeof userDryRunResponse.data.affected_count).toBe("number");
+    expect(userDryRunResponse.data.affected_count).toBeGreaterThanOrEqual(2);
+    console.log(
+      `Dry-run user token deletion: ${userDryRunResponse.data.affected_count} tokens would be affected`
+    );
+
+    console.log(
+      "\n=== Step 10: Actually Delete All User Tokens ==="
+    );
+
+    const userDeleteResponse = await deletion({
+      url: `${userTokensUrl}`,
+      headers: {
+        Authorization: `Bearer ${managementAccessToken}`,
+      },
+    });
+
+    // Management token itself was also deleted, so this may return 204 or 401
+    console.log(
+      `User token deletion response: ${userDeleteResponse.status}`
+    );
+    expect([204, 401].includes(userDeleteResponse.status)).toBe(true);
+
+    // Need fresh token - all previous tokens were deleted
+    const freshTokenResponse = await requestToken({
+      endpoint: `${backendUrl}/${tenantId}/v1/tokens`,
+      grantType: "password",
+      username: adminEmail,
+      password: adminPassword,
+      scope: "org-management management",
+      clientId: clientId,
+      clientSecret: clientSecret,
+    });
+    expect(freshTokenResponse.status).toBe(200);
+    const freshToken = freshTokenResponse.data.access_token;
+
+    // Verify no old tokens remain (only the fresh one)
+    const afterDeleteList = await get({
+      url: `${tokenListUrl}?user_id=${adminUserId}&limit=10`,
+      headers: {
+        Authorization: `Bearer ${freshToken}`,
+      },
+    });
+    expect(afterDeleteList.status).toBe(200);
+    // Only the fresh token should exist
+    expect(afterDeleteList.data.total_count).toBe(1);
+    console.log(
+      "All old user tokens deleted, only fresh token remains"
+    );
+
+    console.log("\n=== Cleanup ===");
+
+    await deletion({
+      url: `${backendUrl}/v1/management/organizations/${organizationId}/tenants/${tenantId}`,
+      headers: { Authorization: `Bearer ${freshToken}` },
+    }).catch(() => {});
+    console.log("Tenant deleted");
+
+    await deletion({
+      url: `${backendUrl}/v1/management/orgs/${organizationId}`,
+      headers: { Authorization: `Bearer ${systemAccessToken}` },
+    }).catch(() => {});
+    console.log("Organization deleted");
+
+    console.log("\n=== Test Completed Successfully ===");
+    console.log(
+      "Verified: Token list returns metadata without token values"
+    );
+    console.log(
+      "Verified: Filtering by client_id/grant_type works"
+    );
+    console.log(
+      "Verified: Dry-run returns target info without actual deletion"
+    );
+    console.log(
+      "Verified: Token deletion invalidates associated refresh tokens"
+    );
+    console.log(
+      "Verified: User-level token deletion removes all user tokens"
+    );
+  });
+});

--- a/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/base/definition/DefaultAdminPermission.java
+++ b/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/base/definition/DefaultAdminPermission.java
@@ -119,6 +119,9 @@ public enum DefaultAdminPermission {
       "idp:identity-verification-result:read",
       "Admin Read identity-verification-result information"),
 
+  TOKEN_READ("idp:token:read", "Admin Read token information"),
+  TOKEN_DELETE("idp:token:delete", "Admin Delete token"),
+
   FEDERATION_CONFIG_CREATE("idp:federation-config:create", "Admin Create a federation-config"),
   FEDERATION_CONFIG_READ("idp:federation-config:read", "Admin Read federation-config information"),
   FEDERATION_CONFIG_UPDATE("idp:federation-config:update", "Admin Update federation-config"),

--- a/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/base/definition/DefaultAdminPermission.java
+++ b/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/base/definition/DefaultAdminPermission.java
@@ -119,6 +119,7 @@ public enum DefaultAdminPermission {
       "idp:identity-verification-result:read",
       "Admin Read identity-verification-result information"),
 
+  TOKEN_CREATE("idp:token:create", "Admin Create token"),
   TOKEN_READ("idp:token:read", "Admin Read token information"),
   TOKEN_DELETE("idp:token:delete", "Admin Delete token"),
 

--- a/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/token/OrgTokenManagementApi.java
+++ b/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/token/OrgTokenManagementApi.java
@@ -33,6 +33,7 @@ public interface OrgTokenManagementApi {
 
   default AdminPermissions getRequiredPermissions(String method) {
     Map<String, AdminPermissions> map = new HashMap<>();
+    map.put("create", new AdminPermissions(Set.of(DefaultAdminPermission.TOKEN_CREATE)));
     map.put("findList", new AdminPermissions(Set.of(DefaultAdminPermission.TOKEN_READ)));
     map.put("get", new AdminPermissions(Set.of(DefaultAdminPermission.TOKEN_READ)));
     map.put("delete", new AdminPermissions(Set.of(DefaultAdminPermission.TOKEN_DELETE)));
@@ -43,6 +44,13 @@ public interface OrgTokenManagementApi {
     }
     return adminPermissions;
   }
+
+  TokenManagementResponse create(
+      OrganizationAuthenticationContext authenticationContext,
+      TenantIdentifier tenantIdentifier,
+      Map<String, Object> body,
+      RequestAttributes requestAttributes,
+      boolean dryRun);
 
   TokenManagementResponse findList(
       OrganizationAuthenticationContext authenticationContext,

--- a/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/token/OrgTokenManagementApi.java
+++ b/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/token/OrgTokenManagementApi.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2025 Hirokazu Kobayashi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.idp.server.control_plane.management.token;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import org.idp.server.control_plane.base.OrganizationAuthenticationContext;
+import org.idp.server.control_plane.base.definition.AdminPermissions;
+import org.idp.server.control_plane.base.definition.DefaultAdminPermission;
+import org.idp.server.control_plane.management.token.io.TokenManagementResponse;
+import org.idp.server.core.openid.token.OAuthTokenIdentifier;
+import org.idp.server.core.openid.token.OAuthTokenQueries;
+import org.idp.server.platform.exception.UnSupportedException;
+import org.idp.server.platform.multi_tenancy.tenant.TenantIdentifier;
+import org.idp.server.platform.type.RequestAttributes;
+
+public interface OrgTokenManagementApi {
+
+  default AdminPermissions getRequiredPermissions(String method) {
+    Map<String, AdminPermissions> map = new HashMap<>();
+    map.put("findList", new AdminPermissions(Set.of(DefaultAdminPermission.TOKEN_READ)));
+    map.put("get", new AdminPermissions(Set.of(DefaultAdminPermission.TOKEN_READ)));
+    map.put("delete", new AdminPermissions(Set.of(DefaultAdminPermission.TOKEN_DELETE)));
+    map.put("deleteUserTokens", new AdminPermissions(Set.of(DefaultAdminPermission.TOKEN_DELETE)));
+    AdminPermissions adminPermissions = map.get(method);
+    if (adminPermissions == null) {
+      throw new UnSupportedException("Method " + method + " not supported");
+    }
+    return adminPermissions;
+  }
+
+  TokenManagementResponse findList(
+      OrganizationAuthenticationContext authenticationContext,
+      TenantIdentifier tenantIdentifier,
+      OAuthTokenQueries queries,
+      RequestAttributes requestAttributes);
+
+  TokenManagementResponse get(
+      OrganizationAuthenticationContext authenticationContext,
+      TenantIdentifier tenantIdentifier,
+      OAuthTokenIdentifier identifier,
+      RequestAttributes requestAttributes);
+
+  TokenManagementResponse delete(
+      OrganizationAuthenticationContext authenticationContext,
+      TenantIdentifier tenantIdentifier,
+      OAuthTokenIdentifier identifier,
+      RequestAttributes requestAttributes,
+      boolean dryRun);
+
+  TokenManagementResponse deleteUserTokens(
+      OrganizationAuthenticationContext authenticationContext,
+      TenantIdentifier tenantIdentifier,
+      String userId,
+      RequestAttributes requestAttributes,
+      boolean dryRun);
+}

--- a/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/token/TokenManagementApi.java
+++ b/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/token/TokenManagementApi.java
@@ -33,6 +33,7 @@ public interface TokenManagementApi {
 
   default AdminPermissions getRequiredPermissions(String method) {
     Map<String, AdminPermissions> map = new HashMap<>();
+    map.put("create", new AdminPermissions(Set.of(DefaultAdminPermission.TOKEN_CREATE)));
     map.put("findList", new AdminPermissions(Set.of(DefaultAdminPermission.TOKEN_READ)));
     map.put("get", new AdminPermissions(Set.of(DefaultAdminPermission.TOKEN_READ)));
     map.put("delete", new AdminPermissions(Set.of(DefaultAdminPermission.TOKEN_DELETE)));
@@ -43,6 +44,13 @@ public interface TokenManagementApi {
     }
     return adminPermissions;
   }
+
+  TokenManagementResponse create(
+      AdminAuthenticationContext authenticationContext,
+      TenantIdentifier tenantIdentifier,
+      Map<String, Object> body,
+      RequestAttributes requestAttributes,
+      boolean dryRun);
 
   TokenManagementResponse findList(
       AdminAuthenticationContext authenticationContext,

--- a/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/token/TokenManagementApi.java
+++ b/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/token/TokenManagementApi.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2025 Hirokazu Kobayashi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.idp.server.control_plane.management.token;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import org.idp.server.control_plane.base.AdminAuthenticationContext;
+import org.idp.server.control_plane.base.definition.AdminPermissions;
+import org.idp.server.control_plane.base.definition.DefaultAdminPermission;
+import org.idp.server.control_plane.management.token.io.TokenManagementResponse;
+import org.idp.server.core.openid.token.OAuthTokenIdentifier;
+import org.idp.server.core.openid.token.OAuthTokenQueries;
+import org.idp.server.platform.exception.UnSupportedException;
+import org.idp.server.platform.multi_tenancy.tenant.TenantIdentifier;
+import org.idp.server.platform.type.RequestAttributes;
+
+public interface TokenManagementApi {
+
+  default AdminPermissions getRequiredPermissions(String method) {
+    Map<String, AdminPermissions> map = new HashMap<>();
+    map.put("findList", new AdminPermissions(Set.of(DefaultAdminPermission.TOKEN_READ)));
+    map.put("get", new AdminPermissions(Set.of(DefaultAdminPermission.TOKEN_READ)));
+    map.put("delete", new AdminPermissions(Set.of(DefaultAdminPermission.TOKEN_DELETE)));
+    map.put("deleteUserTokens", new AdminPermissions(Set.of(DefaultAdminPermission.TOKEN_DELETE)));
+    AdminPermissions adminPermissions = map.get(method);
+    if (adminPermissions == null) {
+      throw new UnSupportedException("Method " + method + " not supported");
+    }
+    return adminPermissions;
+  }
+
+  TokenManagementResponse findList(
+      AdminAuthenticationContext authenticationContext,
+      TenantIdentifier tenantIdentifier,
+      OAuthTokenQueries queries,
+      RequestAttributes requestAttributes);
+
+  TokenManagementResponse get(
+      AdminAuthenticationContext authenticationContext,
+      TenantIdentifier tenantIdentifier,
+      OAuthTokenIdentifier identifier,
+      RequestAttributes requestAttributes);
+
+  TokenManagementResponse delete(
+      AdminAuthenticationContext authenticationContext,
+      TenantIdentifier tenantIdentifier,
+      OAuthTokenIdentifier identifier,
+      RequestAttributes requestAttributes,
+      boolean dryRun);
+
+  TokenManagementResponse deleteUserTokens(
+      AdminAuthenticationContext authenticationContext,
+      TenantIdentifier tenantIdentifier,
+      String userId,
+      RequestAttributes requestAttributes,
+      boolean dryRun);
+}

--- a/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/token/TokenManagementContext.java
+++ b/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/token/TokenManagementContext.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright 2025 Hirokazu Kobayashi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.idp.server.control_plane.management.token;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import org.idp.server.control_plane.base.AuditableContext;
+import org.idp.server.control_plane.management.exception.ManagementApiException;
+import org.idp.server.control_plane.management.token.io.TokenManagementRequest;
+import org.idp.server.core.openid.identity.User;
+import org.idp.server.platform.multi_tenancy.tenant.TenantIdentifier;
+import org.idp.server.platform.type.RequestAttributes;
+
+public class TokenManagementContext implements AuditableContext {
+
+  TenantIdentifier tenantIdentifier;
+  User operator;
+  org.idp.server.core.openid.token.OAuthToken oAuthToken;
+  RequestAttributes requestAttributes;
+  TokenManagementRequest request;
+  boolean dryRun;
+  ManagementApiException exception;
+
+  public TokenManagementContext(
+      TenantIdentifier tenantIdentifier,
+      User operator,
+      org.idp.server.core.openid.token.OAuthToken oAuthToken,
+      RequestAttributes requestAttributes,
+      TokenManagementRequest request,
+      boolean dryRun,
+      ManagementApiException exception) {
+    this.tenantIdentifier = tenantIdentifier;
+    this.operator = operator;
+    this.oAuthToken = oAuthToken;
+    this.requestAttributes = requestAttributes;
+    this.request = request;
+    this.dryRun = dryRun;
+    this.exception = exception;
+  }
+
+  public boolean hasException() {
+    return exception != null;
+  }
+
+  public ManagementApiException exception() {
+    return exception;
+  }
+
+  @Override
+  public String type() {
+    return "token";
+  }
+
+  @Override
+  public String description() {
+    return "token management api";
+  }
+
+  @Override
+  public String tenantId() {
+    return tenantIdentifier.value();
+  }
+
+  @Override
+  public String clientId() {
+    return oAuthToken != null ? oAuthToken.requestedClientId().value() : "";
+  }
+
+  @Override
+  public String userId() {
+    return operator.sub();
+  }
+
+  @Override
+  public String externalUserId() {
+    return operator.externalUserId();
+  }
+
+  @Override
+  public Map<String, Object> userPayload() {
+    return operator.toMap();
+  }
+
+  @Override
+  public String targetResource() {
+    return requestAttributes.resource().value();
+  }
+
+  @Override
+  public String targetResourceAction() {
+    return requestAttributes.action().value();
+  }
+
+  @Override
+  public String ipAddress() {
+    return requestAttributes.getIpAddress().value();
+  }
+
+  @Override
+  public String userAgent() {
+    return requestAttributes.getUserAgent().value();
+  }
+
+  @Override
+  public Map<String, Object> request() {
+    return request != null ? request.toMap() : Collections.emptyMap();
+  }
+
+  @Override
+  public Map<String, Object> before() {
+    return Collections.emptyMap();
+  }
+
+  @Override
+  public Map<String, Object> after() {
+    return Collections.emptyMap();
+  }
+
+  @Override
+  public String outcomeResult() {
+    return exception != null ? "failure" : "success";
+  }
+
+  @Override
+  public String outcomeReason() {
+    return exception != null ? exception.errorCode() : null;
+  }
+
+  @Override
+  public String targetTenantId() {
+    return tenantIdentifier.value();
+  }
+
+  @Override
+  public Map<String, Object> attributes() {
+    Map<String, Object> attributes = new HashMap<>();
+    if (exception != null) {
+      Map<String, Object> error = new HashMap<>();
+      error.put("error_code", exception.errorCode());
+      error.put("error_description", exception.errorDescription());
+      Map<String, Object> errorDetails = exception.errorDetails();
+      if (errorDetails != null && !errorDetails.isEmpty()) {
+        error.putAll(errorDetails);
+      }
+      attributes.put("error", error);
+    }
+    return attributes;
+  }
+
+  @Override
+  public boolean dryRun() {
+    return dryRun;
+  }
+}

--- a/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/token/TokenManagementContextBuilder.java
+++ b/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/token/TokenManagementContextBuilder.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2025 Hirokazu Kobayashi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.idp.server.control_plane.management.token;
+
+import org.idp.server.control_plane.base.AuditableContext;
+import org.idp.server.control_plane.management.exception.ManagementApiException;
+import org.idp.server.control_plane.management.token.io.TokenManagementRequest;
+import org.idp.server.core.openid.identity.User;
+import org.idp.server.core.openid.token.OAuthToken;
+import org.idp.server.platform.multi_tenancy.tenant.TenantIdentifier;
+import org.idp.server.platform.type.RequestAttributes;
+
+public class TokenManagementContextBuilder {
+
+  private final TenantIdentifier tenantIdentifier;
+  private final User operator;
+  private final RequestAttributes requestAttributes;
+  private final TokenManagementRequest request;
+  private final boolean dryRun;
+
+  private OAuthToken oAuthToken;
+
+  public TokenManagementContextBuilder(
+      TenantIdentifier tenantIdentifier,
+      User operator,
+      RequestAttributes requestAttributes,
+      TokenManagementRequest request,
+      boolean dryRun) {
+    this.tenantIdentifier = tenantIdentifier;
+    this.operator = operator;
+    this.requestAttributes = requestAttributes;
+    this.request = request;
+    this.dryRun = dryRun;
+  }
+
+  public TokenManagementContextBuilder withOAuthToken(OAuthToken oAuthToken) {
+    this.oAuthToken = oAuthToken;
+    return this;
+  }
+
+  public AuditableContext build() {
+    return new TokenManagementContext(
+        tenantIdentifier, operator, oAuthToken, requestAttributes, request, dryRun, null);
+  }
+
+  public AuditableContext buildPartial(ManagementApiException exception) {
+    return new TokenManagementContext(
+        tenantIdentifier, operator, oAuthToken, requestAttributes, request, dryRun, exception);
+  }
+}

--- a/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/token/handler/AdminTokenFactory.java
+++ b/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/token/handler/AdminTokenFactory.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright 2025 Hirokazu Kobayashi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.idp.server.control_plane.management.token.handler;
+
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.UUID;
+import org.idp.server.control_plane.management.exception.InvalidRequestException;
+import org.idp.server.control_plane.management.token.io.TokenCreateRequest;
+import org.idp.server.core.openid.identity.User;
+import org.idp.server.core.openid.oauth.configuration.AuthorizationServerConfiguration;
+import org.idp.server.core.openid.oauth.configuration.client.ClientConfiguration;
+import org.idp.server.core.openid.oauth.type.extension.CreatedAt;
+import org.idp.server.core.openid.oauth.type.extension.ExpiresAt;
+import org.idp.server.core.openid.oauth.type.oauth.AccessTokenEntity;
+import org.idp.server.core.openid.oauth.type.oauth.RefreshTokenEntity;
+import org.idp.server.core.openid.token.RefreshToken;
+import org.idp.server.platform.jose.JsonWebSignature;
+import org.idp.server.platform.jose.JsonWebSignatureFactory;
+import org.idp.server.platform.random.RandomStringGenerator;
+
+/**
+ * Factory for creating tokens via management API.
+ *
+ * <p>This class is independent from the Application Plane OAuth flow (AccessTokenCreator / plugin
+ * pipeline). All methods are pure functions with no repository dependencies, making them easily
+ * testable.
+ */
+public class AdminTokenFactory {
+
+  public boolean resolveUseJwt(
+      TokenCreateRequest request, AuthorizationServerConfiguration serverConfig) {
+    if (request.hasTokenFormat()) {
+      return request.isJwtFormat();
+    }
+    return !serverConfig.isIdentifierAccessTokenType();
+  }
+
+  public long resolveAccessTokenDuration(
+      TokenCreateRequest request,
+      ClientConfiguration clientConfig,
+      AuthorizationServerConfiguration serverConfig) {
+    if (request.hasAccessTokenDuration()) {
+      return request.accessTokenDuration();
+    }
+    if (clientConfig.hasAccessTokenDuration()) {
+      return clientConfig.accessTokenDuration();
+    }
+    return serverConfig.accessTokenDuration();
+  }
+
+  public long resolveRefreshTokenDuration(
+      TokenCreateRequest request,
+      ClientConfiguration clientConfig,
+      AuthorizationServerConfiguration serverConfig) {
+    if (request.hasRefreshTokenDuration()) {
+      return request.refreshTokenDuration();
+    }
+    if (clientConfig.hasRefreshTokenDuration()) {
+      return clientConfig.refreshTokenDuration();
+    }
+    return serverConfig.refreshTokenDuration();
+  }
+
+  public boolean shouldCreateRefreshToken(TokenCreateRequest request) {
+    if (request.hasRefreshTokenDuration() && request.refreshTokenDuration() == 0) {
+      return false;
+    }
+    return request.hasUserId();
+  }
+
+  public Map<String, Object> buildJwtPayload(
+      TokenCreateRequest request,
+      AuthorizationServerConfiguration serverConfig,
+      String clientId,
+      String scopes,
+      User user,
+      CreatedAt createdAt,
+      ExpiresAt expiresAt) {
+
+    Map<String, Object> payload = new HashMap<>();
+
+    // Custom claims first (can be overwritten by standard claims)
+    if (request.hasCustomClaims()) {
+      payload.putAll(request.customClaims());
+    }
+
+    // Standard claims (override custom claims for security)
+    payload.put("iss", serverConfig.tokenIssuer().value());
+    payload.put("client_id", clientId);
+    payload.put("scope", scopes);
+    payload.put("jti", UUID.randomUUID().toString());
+    payload.put("iat", createdAt.toEpochSecondWithUtc());
+    payload.put("exp", expiresAt.toEpochSecondWithUtc());
+    if (user.exists()) {
+      payload.put("sub", user.sub());
+    }
+
+    return payload;
+  }
+
+  public AccessTokenEntity createAccessTokenEntity(
+      boolean useJwt,
+      Map<String, Object> jwtPayload,
+      AuthorizationServerConfiguration serverConfig) {
+
+    if (!useJwt) {
+      RandomStringGenerator generator = new RandomStringGenerator(32);
+      return new AccessTokenEntity(generator.generate());
+    }
+
+    try {
+      JsonWebSignatureFactory factory = new JsonWebSignatureFactory();
+      JsonWebSignature jws =
+          factory.createWithAsymmetricKey(
+              jwtPayload,
+              Map.of("typ", "at+jwt"),
+              serverConfig.jwks(),
+              serverConfig.tokenSignedKeyId());
+      return new AccessTokenEntity(jws.serialize());
+    } catch (Exception e) {
+      throw new InvalidRequestException("Failed to create JWT access token: " + e.getMessage());
+    }
+  }
+
+  public RefreshToken createRefreshToken(long duration, LocalDateTime now) {
+    RandomStringGenerator generator = new RandomStringGenerator(32);
+    RefreshTokenEntity refreshTokenEntity = new RefreshTokenEntity(generator.generate());
+    CreatedAt createdAt = new CreatedAt(now);
+    ExpiresAt expiresAt = new ExpiresAt(now.plusSeconds(duration));
+    return new RefreshToken(refreshTokenEntity, createdAt, expiresAt);
+  }
+
+  public Map<String, Object> buildResponse(
+      String tokenId,
+      String accessTokenValue,
+      String tokenType,
+      long expiresIn,
+      String refreshTokenValue,
+      String scopes) {
+
+    Map<String, Object> response = new LinkedHashMap<>();
+    response.put("id", tokenId);
+    response.put("access_token", accessTokenValue);
+    response.put("token_type", tokenType);
+    response.put("expires_in", expiresIn);
+    if (refreshTokenValue != null) {
+      response.put("refresh_token", refreshTokenValue);
+    }
+    response.put("scopes", scopes);
+    return response;
+  }
+}

--- a/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/token/handler/OrgTokenManagementHandler.java
+++ b/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/token/handler/OrgTokenManagementHandler.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2025 Hirokazu Kobayashi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.idp.server.control_plane.management.token.handler;
+
+import java.util.Map;
+import org.idp.server.control_plane.base.AuditableContext;
+import org.idp.server.control_plane.base.OrganizationAccessVerifier;
+import org.idp.server.control_plane.base.OrganizationAuthenticationContext;
+import org.idp.server.control_plane.base.definition.AdminPermissions;
+import org.idp.server.control_plane.management.exception.ManagementApiException;
+import org.idp.server.control_plane.management.exception.ResourceNotFoundException;
+import org.idp.server.control_plane.management.token.OrgTokenManagementApi;
+import org.idp.server.control_plane.management.token.TokenManagementContextBuilder;
+import org.idp.server.control_plane.management.token.io.TokenManagementRequest;
+import org.idp.server.control_plane.management.token.io.TokenManagementResponse;
+import org.idp.server.core.openid.identity.User;
+import org.idp.server.platform.exception.NotFoundException;
+import org.idp.server.platform.exception.UnSupportedException;
+import org.idp.server.platform.log.LoggerWrapper;
+import org.idp.server.platform.multi_tenancy.organization.Organization;
+import org.idp.server.platform.multi_tenancy.organization.OrganizationRepository;
+import org.idp.server.platform.multi_tenancy.tenant.Tenant;
+import org.idp.server.platform.multi_tenancy.tenant.TenantIdentifier;
+import org.idp.server.platform.multi_tenancy.tenant.TenantQueryRepository;
+import org.idp.server.platform.type.RequestAttributes;
+
+public class OrgTokenManagementHandler {
+
+  private final Map<String, TokenManagementService<?>> services;
+  private final OrgTokenManagementApi api;
+  private final TenantQueryRepository tenantQueryRepository;
+  private final OrganizationRepository organizationRepository;
+  private final OrganizationAccessVerifier organizationAccessVerifier;
+  LoggerWrapper log = LoggerWrapper.getLogger(OrgTokenManagementHandler.class);
+
+  public OrgTokenManagementHandler(
+      Map<String, TokenManagementService<?>> services,
+      OrgTokenManagementApi api,
+      TenantQueryRepository tenantQueryRepository,
+      OrganizationRepository organizationRepository,
+      OrganizationAccessVerifier organizationAccessVerifier) {
+    this.services = services;
+    this.api = api;
+    this.tenantQueryRepository = tenantQueryRepository;
+    this.organizationRepository = organizationRepository;
+    this.organizationAccessVerifier = organizationAccessVerifier;
+  }
+
+  public TokenManagementResult handle(
+      String method,
+      OrganizationAuthenticationContext authenticationContext,
+      TenantIdentifier tenantIdentifier,
+      TokenManagementRequest request,
+      RequestAttributes requestAttributes,
+      boolean dryRun) {
+
+    Organization organization = authenticationContext.organization();
+    User operator = authenticationContext.operator();
+
+    TokenManagementService<?> service = services.get(method);
+    if (service == null) {
+      throw new UnSupportedException("Unsupported operation method: " + method);
+    }
+
+    TokenManagementContextBuilder contextBuilder =
+        new TokenManagementContextBuilder(
+            tenantIdentifier, operator, requestAttributes, request, dryRun);
+
+    try {
+      Tenant tenant = tenantQueryRepository.get(tenantIdentifier);
+
+      AdminPermissions permissions = api.getRequiredPermissions(method);
+      organizationAccessVerifier.verify(organization, tenantIdentifier, operator, permissions);
+
+      TokenManagementResponse response =
+          executeService(
+              service, contextBuilder, tenant, operator, request, requestAttributes, dryRun);
+
+      AuditableContext context = contextBuilder.build();
+      return TokenManagementResult.success(context, response);
+    } catch (NotFoundException e) {
+
+      log.warn(e.getMessage());
+      ResourceNotFoundException notFound = new ResourceNotFoundException(e.getMessage());
+      AuditableContext context = contextBuilder.buildPartial(notFound);
+      return TokenManagementResult.error(context, notFound);
+
+    } catch (ManagementApiException e) {
+
+      log.warn(e.getMessage());
+      AuditableContext errorContext = contextBuilder.buildPartial(e);
+      return TokenManagementResult.error(errorContext, e);
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  private <T> TokenManagementResponse executeService(
+      TokenManagementService<T> service,
+      TokenManagementContextBuilder builder,
+      Tenant tenant,
+      User operator,
+      Object request,
+      RequestAttributes requestAttributes,
+      boolean dryRun) {
+    T typedRequest = (T) request;
+    return service.execute(builder, tenant, operator, typedRequest, requestAttributes, dryRun);
+  }
+}

--- a/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/token/handler/TokenCreationService.java
+++ b/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/token/handler/TokenCreationService.java
@@ -1,0 +1,197 @@
+/*
+ * Copyright 2025 Hirokazu Kobayashi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.idp.server.control_plane.management.token.handler;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+import java.util.UUID;
+import org.idp.server.control_plane.management.exception.InvalidRequestException;
+import org.idp.server.control_plane.management.exception.ResourceNotFoundException;
+import org.idp.server.control_plane.management.token.TokenManagementContextBuilder;
+import org.idp.server.control_plane.management.token.io.TokenCreateRequest;
+import org.idp.server.control_plane.management.token.io.TokenManagementResponse;
+import org.idp.server.control_plane.management.token.io.TokenManagementStatus;
+import org.idp.server.core.openid.authentication.Authentication;
+import org.idp.server.core.openid.grant_management.grant.AuthorizationGrant;
+import org.idp.server.core.openid.grant_management.grant.AuthorizationGrantBuilder;
+import org.idp.server.core.openid.identity.User;
+import org.idp.server.core.openid.identity.UserIdentifier;
+import org.idp.server.core.openid.identity.repository.UserQueryRepository;
+import org.idp.server.core.openid.oauth.clientauthenticator.mtls.ClientCertificationThumbprint;
+import org.idp.server.core.openid.oauth.configuration.AuthorizationServerConfiguration;
+import org.idp.server.core.openid.oauth.configuration.AuthorizationServerConfigurationQueryRepository;
+import org.idp.server.core.openid.oauth.configuration.client.ClientConfiguration;
+import org.idp.server.core.openid.oauth.configuration.client.ClientConfigurationQueryRepository;
+import org.idp.server.core.openid.oauth.type.extension.CreatedAt;
+import org.idp.server.core.openid.oauth.type.extension.ExpiresAt;
+import org.idp.server.core.openid.oauth.type.oauth.*;
+import org.idp.server.core.openid.token.*;
+import org.idp.server.core.openid.token.repository.OAuthTokenCommandRepository;
+import org.idp.server.platform.date.SystemDateTime;
+import org.idp.server.platform.multi_tenancy.tenant.Tenant;
+import org.idp.server.platform.type.RequestAttributes;
+
+public class TokenCreationService implements TokenManagementService<TokenCreateRequest> {
+
+  private final AuthorizationServerConfigurationQueryRepository serverConfigRepository;
+  private final ClientConfigurationQueryRepository clientConfigRepository;
+  private final UserQueryRepository userQueryRepository;
+  private final OAuthTokenCommandRepository oAuthTokenCommandRepository;
+  private final AdminTokenFactory adminTokenFactory;
+
+  public TokenCreationService(
+      AuthorizationServerConfigurationQueryRepository serverConfigRepository,
+      ClientConfigurationQueryRepository clientConfigRepository,
+      UserQueryRepository userQueryRepository,
+      OAuthTokenCommandRepository oAuthTokenCommandRepository) {
+    this.serverConfigRepository = serverConfigRepository;
+    this.clientConfigRepository = clientConfigRepository;
+    this.userQueryRepository = userQueryRepository;
+    this.oAuthTokenCommandRepository = oAuthTokenCommandRepository;
+    this.adminTokenFactory = new AdminTokenFactory();
+  }
+
+  @Override
+  public TokenManagementResponse execute(
+      TokenManagementContextBuilder builder,
+      Tenant tenant,
+      User operator,
+      TokenCreateRequest request,
+      RequestAttributes requestAttributes,
+      boolean dryRun) {
+
+    validateRequest(request);
+
+    AuthorizationServerConfiguration serverConfig = serverConfigRepository.get(tenant);
+    ClientConfiguration clientConfig =
+        clientConfigRepository.get(tenant, new RequestedClientId(request.clientId()));
+
+    if (!clientConfig.exists()) {
+      throw new ResourceNotFoundException("Client not found: " + request.clientId());
+    }
+
+    Scopes scopes = new Scopes(clientConfig.filteredScope(request.scopes()));
+    GrantType grantType = request.hasUserId() ? GrantType.password : GrantType.client_credentials;
+
+    AuthorizationGrantBuilder grantBuilder =
+        new AuthorizationGrantBuilder(
+            tenant.identifier(), new RequestedClientId(request.clientId()), grantType, scopes);
+    grantBuilder.add(clientConfig.clientAttributes());
+
+    User tokenUser = new User();
+    if (request.hasUserId()) {
+      tokenUser = userQueryRepository.get(tenant, new UserIdentifier(request.userId()));
+      if (!tokenUser.exists()) {
+        throw new ResourceNotFoundException("User not found: " + request.userId());
+      }
+      grantBuilder.add(tokenUser);
+      grantBuilder.add(new Authentication());
+    }
+
+    AuthorizationGrant authorizationGrant = grantBuilder.build();
+
+    LocalDateTime now = SystemDateTime.now();
+    CreatedAt createdAt = new CreatedAt(now);
+
+    long accessTokenDuration =
+        adminTokenFactory.resolveAccessTokenDuration(request, clientConfig, serverConfig);
+    ExpiresIn expiresIn = new ExpiresIn(accessTokenDuration);
+    ExpiresAt expiresAt = new ExpiresAt(now.plusSeconds(accessTokenDuration));
+
+    boolean useJwt = adminTokenFactory.resolveUseJwt(request, serverConfig);
+    Map<String, Object> jwtPayload =
+        adminTokenFactory.buildJwtPayload(
+            request,
+            serverConfig,
+            request.clientId(),
+            scopes.toStringValues(),
+            tokenUser,
+            createdAt,
+            expiresAt);
+
+    AccessTokenEntity accessTokenEntity =
+        adminTokenFactory.createAccessTokenEntity(useJwt, jwtPayload, serverConfig);
+
+    AccessTokenCustomClaims customClaims =
+        request.hasCustomClaims()
+            ? new AccessTokenCustomClaims(request.customClaims())
+            : new AccessTokenCustomClaims();
+
+    AccessToken accessToken =
+        new AccessToken(
+            tenant.identifier(),
+            serverConfig.tokenIssuer(),
+            TokenType.Bearer,
+            accessTokenEntity,
+            authorizationGrant,
+            new ClientCertificationThumbprint(),
+            customClaims,
+            createdAt,
+            expiresIn,
+            expiresAt);
+
+    OAuthTokenBuilder tokenBuilder =
+        new OAuthTokenBuilder(new OAuthTokenIdentifier(UUID.randomUUID().toString()));
+    tokenBuilder.add(accessToken);
+
+    if (adminTokenFactory.shouldCreateRefreshToken(request)) {
+      long refreshDuration =
+          adminTokenFactory.resolveRefreshTokenDuration(request, clientConfig, serverConfig);
+      RefreshToken refreshToken = adminTokenFactory.createRefreshToken(refreshDuration, now);
+      tokenBuilder.add(refreshToken);
+    }
+
+    OAuthToken oAuthToken = tokenBuilder.build();
+
+    String refreshTokenValue =
+        oAuthToken.hasRefreshToken() ? oAuthToken.refreshTokenEntity().value() : null;
+
+    if (dryRun) {
+      Map<String, Object> response =
+          adminTokenFactory.buildResponse(
+              oAuthToken.identifier().value(),
+              oAuthToken.accessTokenEntity().value(),
+              oAuthToken.tokenType().name(),
+              oAuthToken.expiresIn().value(),
+              refreshTokenValue,
+              oAuthToken.scopes().toStringValues());
+      response.put("dry_run", true);
+      return new TokenManagementResponse(TokenManagementStatus.OK, response);
+    }
+
+    oAuthTokenCommandRepository.register(tenant, oAuthToken);
+
+    Map<String, Object> response =
+        adminTokenFactory.buildResponse(
+            oAuthToken.identifier().value(),
+            oAuthToken.accessTokenEntity().value(),
+            oAuthToken.tokenType().name(),
+            oAuthToken.expiresIn().value(),
+            refreshTokenValue,
+            oAuthToken.scopes().toStringValues());
+    return new TokenManagementResponse(TokenManagementStatus.CREATED, response);
+  }
+
+  private void validateRequest(TokenCreateRequest request) {
+    if (request.clientId() == null || request.clientId().isEmpty()) {
+      throw new InvalidRequestException("client_id is required");
+    }
+    if (request.scopes() == null || request.scopes().isEmpty()) {
+      throw new InvalidRequestException("scopes is required");
+    }
+  }
+}

--- a/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/token/handler/TokenDeletionService.java
+++ b/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/token/handler/TokenDeletionService.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2025 Hirokazu Kobayashi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.idp.server.control_plane.management.token.handler;
+
+import java.util.Map;
+import org.idp.server.control_plane.management.exception.ResourceNotFoundException;
+import org.idp.server.control_plane.management.token.TokenManagementContextBuilder;
+import org.idp.server.control_plane.management.token.io.TokenDeleteRequest;
+import org.idp.server.control_plane.management.token.io.TokenManagementResponse;
+import org.idp.server.control_plane.management.token.io.TokenManagementStatus;
+import org.idp.server.core.openid.identity.User;
+import org.idp.server.core.openid.token.OAuthTokenIdentifier;
+import org.idp.server.core.openid.token.repository.OAuthTokenManagementCommandRepository;
+import org.idp.server.core.openid.token.repository.OAuthTokenManagementQueryRepository;
+import org.idp.server.platform.multi_tenancy.tenant.Tenant;
+import org.idp.server.platform.type.RequestAttributes;
+
+public class TokenDeletionService implements TokenManagementService<TokenDeleteRequest> {
+
+  private final OAuthTokenManagementQueryRepository queryRepository;
+  private final OAuthTokenManagementCommandRepository commandRepository;
+
+  public TokenDeletionService(
+      OAuthTokenManagementQueryRepository queryRepository,
+      OAuthTokenManagementCommandRepository commandRepository) {
+    this.queryRepository = queryRepository;
+    this.commandRepository = commandRepository;
+  }
+
+  @Override
+  public TokenManagementResponse execute(
+      TokenManagementContextBuilder builder,
+      Tenant tenant,
+      User operator,
+      TokenDeleteRequest request,
+      RequestAttributes requestAttributes,
+      boolean dryRun) {
+
+    OAuthTokenIdentifier identifier = request.identifier();
+    Map<String, String> row = queryRepository.get(tenant, identifier);
+
+    if (row == null || row.isEmpty()) {
+      throw new ResourceNotFoundException("Token not found: " + identifier.value());
+    }
+
+    if (dryRun) {
+      Map<String, Object> response =
+          Map.of("dry_run", true, "target", TokenFindListService.toTokenSummary(row));
+      return new TokenManagementResponse(TokenManagementStatus.OK, response);
+    }
+
+    commandRepository.delete(tenant, identifier);
+
+    return new TokenManagementResponse(TokenManagementStatus.NO_CONTENT, Map.of());
+  }
+}

--- a/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/token/handler/TokenFindListService.java
+++ b/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/token/handler/TokenFindListService.java
@@ -21,6 +21,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import org.idp.server.control_plane.management.exception.InvalidRequestException;
 import org.idp.server.control_plane.management.token.TokenManagementContextBuilder;
 import org.idp.server.control_plane.management.token.io.TokenFindListRequest;
 import org.idp.server.control_plane.management.token.io.TokenManagementResponse;
@@ -49,6 +50,11 @@ public class TokenFindListService implements TokenManagementService<TokenFindLis
       boolean dryRun) {
 
     OAuthTokenQueries queries = request.queries();
+
+    if (!queries.hasUserId() && !queries.hasClientId()) {
+      throw new InvalidRequestException("Either user_id or client_id query parameter is required");
+    }
+
     long totalCount = queryRepository.findTotalCount(tenant, queries);
     if (totalCount == 0) {
       Map<String, Object> response =

--- a/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/token/handler/TokenFindListService.java
+++ b/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/token/handler/TokenFindListService.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2025 Hirokazu Kobayashi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.idp.server.control_plane.management.token.handler;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import org.idp.server.control_plane.management.token.TokenManagementContextBuilder;
+import org.idp.server.control_plane.management.token.io.TokenFindListRequest;
+import org.idp.server.control_plane.management.token.io.TokenManagementResponse;
+import org.idp.server.control_plane.management.token.io.TokenManagementStatus;
+import org.idp.server.core.openid.identity.User;
+import org.idp.server.core.openid.token.OAuthTokenQueries;
+import org.idp.server.core.openid.token.repository.OAuthTokenManagementQueryRepository;
+import org.idp.server.platform.multi_tenancy.tenant.Tenant;
+import org.idp.server.platform.type.RequestAttributes;
+
+public class TokenFindListService implements TokenManagementService<TokenFindListRequest> {
+
+  private final OAuthTokenManagementQueryRepository queryRepository;
+
+  public TokenFindListService(OAuthTokenManagementQueryRepository queryRepository) {
+    this.queryRepository = queryRepository;
+  }
+
+  @Override
+  public TokenManagementResponse execute(
+      TokenManagementContextBuilder builder,
+      Tenant tenant,
+      User operator,
+      TokenFindListRequest request,
+      RequestAttributes requestAttributes,
+      boolean dryRun) {
+
+    OAuthTokenQueries queries = request.queries();
+    long totalCount = queryRepository.findTotalCount(tenant, queries);
+    if (totalCount == 0) {
+      Map<String, Object> response =
+          Map.of(
+              "list", List.of(),
+              "total_count", totalCount,
+              "limit", queries.limit(),
+              "offset", queries.offset());
+      return new TokenManagementResponse(TokenManagementStatus.OK, response);
+    }
+
+    List<Map<String, String>> results = queryRepository.findList(tenant, queries);
+
+    List<Map<String, Object>> list = new ArrayList<>();
+    for (Map<String, String> row : results) {
+      list.add(toTokenSummary(row));
+    }
+
+    Map<String, Object> response =
+        Map.of(
+            "list",
+            list,
+            "total_count",
+            totalCount,
+            "limit",
+            queries.limit(),
+            "offset",
+            queries.offset());
+
+    return new TokenManagementResponse(TokenManagementStatus.OK, response);
+  }
+
+  static Map<String, Object> toTokenSummary(Map<String, String> row) {
+    Map<String, Object> summary = new LinkedHashMap<>();
+    summary.put("id", row.get("id"));
+    summary.put("tenant_id", row.get("tenant_id"));
+    summary.put("user_id", row.get("user_id"));
+    summary.put("client_id", row.get("client_id"));
+    summary.put("grant_type", row.get("grant_type"));
+    summary.put("scopes", row.get("scopes"));
+    summary.put("token_type", row.get("token_type"));
+    summary.put("access_token_expires_at", row.get("access_token_expires_at"));
+    summary.put(
+        "has_refresh_token",
+        Objects.nonNull(row.get("hashed_refresh_token"))
+            && !row.get("hashed_refresh_token").isEmpty());
+    if (Objects.nonNull(row.get("refresh_token_expires_at"))
+        && !row.get("refresh_token_expires_at").isEmpty()) {
+      summary.put("refresh_token_expires_at", row.get("refresh_token_expires_at"));
+    }
+    summary.put("created_at", row.get("access_token_created_at"));
+    return summary;
+  }
+}

--- a/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/token/handler/TokenFindService.java
+++ b/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/token/handler/TokenFindService.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2025 Hirokazu Kobayashi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.idp.server.control_plane.management.token.handler;
+
+import java.util.Map;
+import org.idp.server.control_plane.management.exception.ResourceNotFoundException;
+import org.idp.server.control_plane.management.token.TokenManagementContextBuilder;
+import org.idp.server.control_plane.management.token.io.TokenFindRequest;
+import org.idp.server.control_plane.management.token.io.TokenManagementResponse;
+import org.idp.server.control_plane.management.token.io.TokenManagementStatus;
+import org.idp.server.core.openid.identity.User;
+import org.idp.server.core.openid.token.OAuthTokenIdentifier;
+import org.idp.server.core.openid.token.repository.OAuthTokenManagementQueryRepository;
+import org.idp.server.platform.multi_tenancy.tenant.Tenant;
+import org.idp.server.platform.type.RequestAttributes;
+
+public class TokenFindService implements TokenManagementService<TokenFindRequest> {
+
+  private final OAuthTokenManagementQueryRepository queryRepository;
+
+  public TokenFindService(OAuthTokenManagementQueryRepository queryRepository) {
+    this.queryRepository = queryRepository;
+  }
+
+  @Override
+  public TokenManagementResponse execute(
+      TokenManagementContextBuilder builder,
+      Tenant tenant,
+      User operator,
+      TokenFindRequest request,
+      RequestAttributes requestAttributes,
+      boolean dryRun) {
+
+    OAuthTokenIdentifier identifier = request.identifier();
+    Map<String, String> row = queryRepository.get(tenant, identifier);
+
+    if (row == null || row.isEmpty()) {
+      throw new ResourceNotFoundException("Token not found: " + identifier.value());
+    }
+
+    Map<String, Object> tokenDetail = TokenFindListService.toTokenSummary(row);
+
+    return new TokenManagementResponse(TokenManagementStatus.OK, tokenDetail);
+  }
+}

--- a/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/token/handler/TokenManagementHandler.java
+++ b/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/token/handler/TokenManagementHandler.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2025 Hirokazu Kobayashi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.idp.server.control_plane.management.token.handler;
+
+import java.util.Map;
+import org.idp.server.control_plane.base.AdminAuthenticationContext;
+import org.idp.server.control_plane.base.ApiPermissionVerifier;
+import org.idp.server.control_plane.base.AuditableContext;
+import org.idp.server.control_plane.base.definition.AdminPermissions;
+import org.idp.server.control_plane.management.exception.ManagementApiException;
+import org.idp.server.control_plane.management.exception.ResourceNotFoundException;
+import org.idp.server.control_plane.management.token.TokenManagementApi;
+import org.idp.server.control_plane.management.token.TokenManagementContextBuilder;
+import org.idp.server.control_plane.management.token.io.TokenManagementRequest;
+import org.idp.server.control_plane.management.token.io.TokenManagementResponse;
+import org.idp.server.core.openid.identity.User;
+import org.idp.server.platform.exception.NotFoundException;
+import org.idp.server.platform.exception.UnSupportedException;
+import org.idp.server.platform.log.LoggerWrapper;
+import org.idp.server.platform.multi_tenancy.tenant.Tenant;
+import org.idp.server.platform.multi_tenancy.tenant.TenantIdentifier;
+import org.idp.server.platform.multi_tenancy.tenant.TenantQueryRepository;
+import org.idp.server.platform.type.RequestAttributes;
+
+public class TokenManagementHandler {
+
+  private final Map<String, TokenManagementService<?>> services;
+  private final TokenManagementApi api;
+  private final TenantQueryRepository tenantQueryRepository;
+  private final ApiPermissionVerifier apiPermissionVerifier;
+  LoggerWrapper log = LoggerWrapper.getLogger(TokenManagementHandler.class);
+
+  public TokenManagementHandler(
+      Map<String, TokenManagementService<?>> services,
+      TokenManagementApi api,
+      TenantQueryRepository tenantQueryRepository) {
+    this.services = services;
+    this.api = api;
+    this.tenantQueryRepository = tenantQueryRepository;
+    this.apiPermissionVerifier = new ApiPermissionVerifier();
+  }
+
+  public TokenManagementResult handle(
+      String method,
+      AdminAuthenticationContext authenticationContext,
+      TenantIdentifier tenantIdentifier,
+      TokenManagementRequest request,
+      RequestAttributes requestAttributes,
+      boolean dryRun) {
+
+    User operator = authenticationContext.operator();
+
+    TokenManagementService<?> service = services.get(method);
+    if (service == null) {
+      throw new UnSupportedException("Unsupported operation method: " + method);
+    }
+
+    TokenManagementContextBuilder contextBuilder =
+        new TokenManagementContextBuilder(
+            tenantIdentifier, operator, requestAttributes, request, dryRun);
+
+    try {
+      Tenant tenant = tenantQueryRepository.get(tenantIdentifier);
+
+      AdminPermissions requiredPermissions = api.getRequiredPermissions(method);
+      apiPermissionVerifier.verify(operator, requiredPermissions);
+
+      TokenManagementResponse response =
+          executeService(
+              service, contextBuilder, tenant, operator, request, requestAttributes, dryRun);
+
+      AuditableContext context = contextBuilder.build();
+      return TokenManagementResult.success(context, response);
+    } catch (NotFoundException e) {
+
+      log.warn(e.getMessage());
+      ResourceNotFoundException notFound = new ResourceNotFoundException(e.getMessage());
+      AuditableContext context = contextBuilder.buildPartial(notFound);
+      return TokenManagementResult.error(context, notFound);
+
+    } catch (ManagementApiException e) {
+
+      log.warn(e.getMessage());
+      AuditableContext errorContext = contextBuilder.buildPartial(e);
+      return TokenManagementResult.error(errorContext, e);
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  private <T> TokenManagementResponse executeService(
+      TokenManagementService<T> service,
+      TokenManagementContextBuilder builder,
+      Tenant tenant,
+      User operator,
+      Object request,
+      RequestAttributes requestAttributes,
+      boolean dryRun) {
+    T typedRequest = (T) request;
+    return service.execute(builder, tenant, operator, typedRequest, requestAttributes, dryRun);
+  }
+}

--- a/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/token/handler/TokenManagementResult.java
+++ b/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/token/handler/TokenManagementResult.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2025 Hirokazu Kobayashi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.idp.server.control_plane.management.token.handler;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.idp.server.control_plane.base.AuditableContext;
+import org.idp.server.control_plane.management.exception.ManagementApiException;
+import org.idp.server.control_plane.management.exception.OrganizationAccessDeniedException;
+import org.idp.server.control_plane.management.exception.PermissionDeniedException;
+import org.idp.server.control_plane.management.exception.ResourceNotFoundException;
+import org.idp.server.control_plane.management.token.io.TokenManagementResponse;
+import org.idp.server.control_plane.management.token.io.TokenManagementStatus;
+
+public class TokenManagementResult {
+
+  private final AuditableContext context;
+  private final ManagementApiException exception;
+  private final TokenManagementResponse response;
+
+  private TokenManagementResult(
+      AuditableContext context,
+      ManagementApiException exception,
+      TokenManagementResponse response) {
+    this.context = context;
+    this.exception = exception;
+    this.response = response;
+  }
+
+  public static TokenManagementResult success(
+      AuditableContext context, TokenManagementResponse response) {
+    return new TokenManagementResult(context, null, response);
+  }
+
+  public static TokenManagementResult error(
+      AuditableContext context, ManagementApiException exception) {
+    return new TokenManagementResult(context, exception, null);
+  }
+
+  private static TokenManagementStatus mapExceptionToStatus(ManagementApiException exception) {
+    if (exception instanceof ResourceNotFoundException) {
+      return TokenManagementStatus.NOT_FOUND;
+    }
+    if (exception instanceof PermissionDeniedException
+        || exception instanceof OrganizationAccessDeniedException) {
+      return TokenManagementStatus.FORBIDDEN;
+    }
+    return TokenManagementStatus.INVALID_REQUEST;
+  }
+
+  public AuditableContext context() {
+    return context;
+  }
+
+  public boolean hasException() {
+    return exception != null;
+  }
+
+  public ManagementApiException getException() {
+    return exception;
+  }
+
+  public TokenManagementResponse toResponse(boolean dryRun) {
+    if (hasException()) {
+      TokenManagementStatus status = mapExceptionToStatus(exception);
+      Map<String, Object> errorResponse = new HashMap<>();
+      errorResponse.put("error", exception.errorCode());
+      errorResponse.put("error_description", exception.errorDescription());
+      errorResponse.putAll(exception.errorDetails());
+      return new TokenManagementResponse(status, errorResponse);
+    }
+    return response;
+  }
+}

--- a/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/token/handler/TokenManagementResult.java
+++ b/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/token/handler/TokenManagementResult.java
@@ -80,7 +80,10 @@ public class TokenManagementResult {
       Map<String, Object> errorResponse = new HashMap<>();
       errorResponse.put("error", exception.errorCode());
       errorResponse.put("error_description", exception.errorDescription());
-      errorResponse.putAll(exception.errorDetails());
+      Map<String, Object> errorDetails = exception.errorDetails();
+      if (errorDetails != null && !errorDetails.isEmpty()) {
+        errorResponse.putAll(errorDetails);
+      }
       return new TokenManagementResponse(status, errorResponse);
     }
     return response;

--- a/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/token/handler/TokenManagementService.java
+++ b/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/token/handler/TokenManagementService.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2025 Hirokazu Kobayashi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.idp.server.control_plane.management.token.handler;
+
+import org.idp.server.control_plane.management.token.TokenManagementContextBuilder;
+import org.idp.server.control_plane.management.token.io.TokenManagementResponse;
+import org.idp.server.core.openid.identity.User;
+import org.idp.server.platform.multi_tenancy.tenant.Tenant;
+import org.idp.server.platform.type.RequestAttributes;
+
+public interface TokenManagementService<T> {
+
+  TokenManagementResponse execute(
+      TokenManagementContextBuilder builder,
+      Tenant tenant,
+      User operator,
+      T request,
+      RequestAttributes requestAttributes,
+      boolean dryRun);
+}

--- a/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/token/handler/TokenUserDeletionService.java
+++ b/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/token/handler/TokenUserDeletionService.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2025 Hirokazu Kobayashi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.idp.server.control_plane.management.token.handler;
+
+import java.util.Map;
+import org.idp.server.control_plane.management.token.TokenManagementContextBuilder;
+import org.idp.server.control_plane.management.token.io.TokenManagementResponse;
+import org.idp.server.control_plane.management.token.io.TokenManagementStatus;
+import org.idp.server.control_plane.management.token.io.TokenUserDeleteRequest;
+import org.idp.server.core.openid.identity.User;
+import org.idp.server.core.openid.token.repository.OAuthTokenManagementCommandRepository;
+import org.idp.server.core.openid.token.repository.OAuthTokenManagementQueryRepository;
+import org.idp.server.platform.multi_tenancy.tenant.Tenant;
+import org.idp.server.platform.type.RequestAttributes;
+
+public class TokenUserDeletionService implements TokenManagementService<TokenUserDeleteRequest> {
+
+  private final OAuthTokenManagementQueryRepository queryRepository;
+  private final OAuthTokenManagementCommandRepository commandRepository;
+
+  public TokenUserDeletionService(
+      OAuthTokenManagementQueryRepository queryRepository,
+      OAuthTokenManagementCommandRepository commandRepository) {
+    this.queryRepository = queryRepository;
+    this.commandRepository = commandRepository;
+  }
+
+  @Override
+  public TokenManagementResponse execute(
+      TokenManagementContextBuilder builder,
+      Tenant tenant,
+      User operator,
+      TokenUserDeleteRequest request,
+      RequestAttributes requestAttributes,
+      boolean dryRun) {
+
+    String userId = request.userId();
+    long affectedCount = queryRepository.countByUser(tenant, userId);
+
+    if (dryRun) {
+      Map<String, Object> response =
+          Map.of(
+              "dry_run", true,
+              "user_id", userId,
+              "affected_count", affectedCount);
+      return new TokenManagementResponse(TokenManagementStatus.OK, response);
+    }
+
+    commandRepository.deleteAllByUser(tenant, userId);
+
+    return new TokenManagementResponse(TokenManagementStatus.NO_CONTENT, Map.of());
+  }
+}

--- a/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/token/io/TokenCreateRequest.java
+++ b/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/token/io/TokenCreateRequest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2025 Hirokazu Kobayashi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.idp.server.control_plane.management.token.io;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class TokenCreateRequest implements TokenManagementRequest {
+
+  private final Map<String, Object> body;
+
+  public TokenCreateRequest(Map<String, Object> body) {
+    this.body = body;
+  }
+
+  public String clientId() {
+    return (String) body.get("client_id");
+  }
+
+  public String scopes() {
+    return (String) body.get("scopes");
+  }
+
+  public boolean hasUserId() {
+    return body.containsKey("user_id") && body.get("user_id") != null;
+  }
+
+  public String userId() {
+    return (String) body.get("user_id");
+  }
+
+  public boolean hasAccessTokenDuration() {
+    return body.containsKey("access_token_duration") && body.get("access_token_duration") != null;
+  }
+
+  public long accessTokenDuration() {
+    Object value = body.get("access_token_duration");
+    if (value instanceof Number) {
+      return ((Number) value).longValue();
+    }
+    return Long.parseLong(value.toString());
+  }
+
+  public boolean hasRefreshTokenDuration() {
+    return body.containsKey("refresh_token_duration") && body.get("refresh_token_duration") != null;
+  }
+
+  public long refreshTokenDuration() {
+    Object value = body.get("refresh_token_duration");
+    if (value instanceof Number) {
+      return ((Number) value).longValue();
+    }
+    return Long.parseLong(value.toString());
+  }
+
+  public boolean hasTokenFormat() {
+    return body.containsKey("token_format") && body.get("token_format") != null;
+  }
+
+  public String tokenFormat() {
+    return (String) body.get("token_format");
+  }
+
+  public boolean isJwtFormat() {
+    return "jwt".equalsIgnoreCase(tokenFormat());
+  }
+
+  public boolean isOpaqueFormat() {
+    return "opaque".equalsIgnoreCase(tokenFormat());
+  }
+
+  public boolean hasCustomClaims() {
+    return body.containsKey("custom_claims") && body.get("custom_claims") instanceof Map;
+  }
+
+  @SuppressWarnings("unchecked")
+  public Map<String, Object> customClaims() {
+    return (Map<String, Object>) body.get("custom_claims");
+  }
+
+  @Override
+  public Map<String, Object> toMap() {
+    Map<String, Object> map = new HashMap<>();
+    map.put("client_id", clientId());
+    map.put("scopes", scopes());
+    if (hasUserId()) {
+      map.put("user_id", userId());
+    }
+    return map;
+  }
+}

--- a/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/token/io/TokenDeleteRequest.java
+++ b/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/token/io/TokenDeleteRequest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2025 Hirokazu Kobayashi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.idp.server.control_plane.management.token.io;
+
+import java.util.Map;
+import org.idp.server.core.openid.token.OAuthTokenIdentifier;
+
+public record TokenDeleteRequest(OAuthTokenIdentifier identifier)
+    implements TokenManagementRequest {
+
+  @Override
+  public Map<String, Object> toMap() {
+    return Map.of("id", identifier.value());
+  }
+}

--- a/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/token/io/TokenFindListRequest.java
+++ b/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/token/io/TokenFindListRequest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2025 Hirokazu Kobayashi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.idp.server.control_plane.management.token.io;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.idp.server.core.openid.token.OAuthTokenQueries;
+
+public record TokenFindListRequest(OAuthTokenQueries queries) implements TokenManagementRequest {
+
+  @Override
+  public Map<String, Object> toMap() {
+    Map<String, Object> map = new HashMap<>();
+    map.put("limit", queries.limit());
+    map.put("offset", queries.offset());
+    return map;
+  }
+}

--- a/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/token/io/TokenFindRequest.java
+++ b/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/token/io/TokenFindRequest.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2025 Hirokazu Kobayashi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.idp.server.control_plane.management.token.io;
+
+import java.util.Map;
+import org.idp.server.core.openid.token.OAuthTokenIdentifier;
+
+public record TokenFindRequest(OAuthTokenIdentifier identifier) implements TokenManagementRequest {
+
+  @Override
+  public Map<String, Object> toMap() {
+    return Map.of("id", identifier.value());
+  }
+}

--- a/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/token/io/TokenManagementRequest.java
+++ b/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/token/io/TokenManagementRequest.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2025 Hirokazu Kobayashi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.idp.server.control_plane.management.token.io;
+
+import java.util.Map;
+
+public interface TokenManagementRequest {
+
+  Map<String, Object> toMap();
+}

--- a/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/token/io/TokenManagementResponse.java
+++ b/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/token/io/TokenManagementResponse.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2025 Hirokazu Kobayashi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.idp.server.control_plane.management.token.io;
+
+import java.util.Map;
+
+public class TokenManagementResponse {
+  TokenManagementStatus status;
+  Map<String, Object> contents;
+
+  public TokenManagementResponse(TokenManagementStatus status, Map<String, Object> contents) {
+    this.status = status;
+    this.contents = contents;
+  }
+
+  public TokenManagementStatus status() {
+    return status;
+  }
+
+  public int statusCode() {
+    return status.statusCode();
+  }
+
+  public Map<String, Object> contents() {
+    return contents;
+  }
+}

--- a/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/token/io/TokenManagementStatus.java
+++ b/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/token/io/TokenManagementStatus.java
@@ -18,6 +18,7 @@ package org.idp.server.control_plane.management.token.io;
 
 public enum TokenManagementStatus {
   OK(200),
+  CREATED(201),
   NO_CONTENT(204),
   INVALID_REQUEST(400),
   UNAUTHORIZED(401),

--- a/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/token/io/TokenManagementStatus.java
+++ b/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/token/io/TokenManagementStatus.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2025 Hirokazu Kobayashi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.idp.server.control_plane.management.token.io;
+
+public enum TokenManagementStatus {
+  OK(200),
+  NO_CONTENT(204),
+  INVALID_REQUEST(400),
+  UNAUTHORIZED(401),
+  FORBIDDEN(403),
+  NOT_FOUND(404),
+  SERVER_ERROR(500);
+
+  int statusCode;
+
+  TokenManagementStatus(int statusCode) {
+    this.statusCode = statusCode;
+  }
+
+  public int statusCode() {
+    return statusCode;
+  }
+
+  public boolean isOk() {
+    return this == OK;
+  }
+}

--- a/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/token/io/TokenUserDeleteRequest.java
+++ b/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/token/io/TokenUserDeleteRequest.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2025 Hirokazu Kobayashi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.idp.server.control_plane.management.token.io;
+
+import java.util.Map;
+
+public record TokenUserDeleteRequest(String userId) implements TokenManagementRequest {
+
+  @Override
+  public Map<String, Object> toMap() {
+    return Map.of("user_id", userId);
+  }
+}

--- a/libs/idp-server-control-plane/src/test/java/org/idp/server/control_plane/management/token/handler/AdminTokenFactoryTest.java
+++ b/libs/idp-server-control-plane/src/test/java/org/idp/server/control_plane/management/token/handler/AdminTokenFactoryTest.java
@@ -1,0 +1,545 @@
+/*
+ * Copyright 2025 Hirokazu Kobayashi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.idp.server.control_plane.management.token.handler;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.Map;
+import org.idp.server.control_plane.management.token.io.TokenCreateRequest;
+import org.idp.server.core.openid.identity.User;
+import org.idp.server.core.openid.oauth.configuration.AuthorizationServerConfiguration;
+import org.idp.server.core.openid.oauth.configuration.client.ClientConfiguration;
+import org.idp.server.core.openid.oauth.type.extension.CreatedAt;
+import org.idp.server.core.openid.oauth.type.extension.ExpiresAt;
+import org.idp.server.core.openid.token.RefreshToken;
+import org.idp.server.platform.json.JsonConverter;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class AdminTokenFactoryTest {
+
+  AdminTokenFactory factory = new AdminTokenFactory();
+  JsonConverter jsonConverter = JsonConverter.snakeCaseInstance();
+
+  @Nested
+  @DisplayName("resolveUseJwt")
+  class ResolveUseJwtTest {
+
+    @Test
+    @DisplayName("リクエストでjwt指定 → サーバー設定に関係なくtrue")
+    void requestJwt_returnsTrue() {
+      Map<String, Object> body = new HashMap<>();
+      body.put("client_id", "test");
+      body.put("scopes", "openid");
+      body.put("token_format", "jwt");
+      TokenCreateRequest request = new TokenCreateRequest(body);
+
+      AuthorizationServerConfiguration serverConfig = createServerConfig(true);
+
+      assertTrue(factory.resolveUseJwt(request, serverConfig));
+    }
+
+    @Test
+    @DisplayName("リクエストでopaque指定 → サーバー設定に関係なくfalse")
+    void requestOpaque_returnsFalse() {
+      Map<String, Object> body = new HashMap<>();
+      body.put("client_id", "test");
+      body.put("scopes", "openid");
+      body.put("token_format", "opaque");
+      TokenCreateRequest request = new TokenCreateRequest(body);
+
+      AuthorizationServerConfiguration serverConfig = createServerConfig(false);
+
+      assertFalse(factory.resolveUseJwt(request, serverConfig));
+    }
+
+    @Test
+    @DisplayName("token_format未指定 → サーバー設定がJWTならtrue")
+    void noFormat_serverJwt_returnsTrue() {
+      Map<String, Object> body = new HashMap<>();
+      body.put("client_id", "test");
+      body.put("scopes", "openid");
+      TokenCreateRequest request = new TokenCreateRequest(body);
+
+      AuthorizationServerConfiguration serverConfig = createServerConfig(false);
+
+      assertTrue(factory.resolveUseJwt(request, serverConfig));
+    }
+
+    @Test
+    @DisplayName("token_format未指定 → サーバー設定がIdentifier(opaque)ならfalse")
+    void noFormat_serverIdentifier_returnsFalse() {
+      Map<String, Object> body = new HashMap<>();
+      body.put("client_id", "test");
+      body.put("scopes", "openid");
+      TokenCreateRequest request = new TokenCreateRequest(body);
+
+      AuthorizationServerConfiguration serverConfig = createServerConfig(true);
+
+      assertFalse(factory.resolveUseJwt(request, serverConfig));
+    }
+  }
+
+  @Nested
+  @DisplayName("resolveAccessTokenDuration")
+  class ResolveAccessTokenDurationTest {
+
+    @Test
+    @DisplayName("リクエスト指定 → リクエスト値が最優先")
+    void requestDuration_takesPrecedence() {
+      Map<String, Object> body = new HashMap<>();
+      body.put("client_id", "test");
+      body.put("scopes", "openid");
+      body.put("access_token_duration", 600);
+      TokenCreateRequest request = new TokenCreateRequest(body);
+
+      ClientConfiguration clientConfig = createClientConfig(1800);
+      AuthorizationServerConfiguration serverConfig = createServerConfig(3600);
+
+      assertEquals(600, factory.resolveAccessTokenDuration(request, clientConfig, serverConfig));
+    }
+
+    @Test
+    @DisplayName("リクエスト未指定 → クライアント設定が次に優先")
+    void noRequestDuration_clientTakesPrecedence() {
+      Map<String, Object> body = new HashMap<>();
+      body.put("client_id", "test");
+      body.put("scopes", "openid");
+      TokenCreateRequest request = new TokenCreateRequest(body);
+
+      ClientConfiguration clientConfig = createClientConfig(1800);
+      AuthorizationServerConfiguration serverConfig = createServerConfig(3600);
+
+      assertEquals(1800, factory.resolveAccessTokenDuration(request, clientConfig, serverConfig));
+    }
+
+    @Test
+    @DisplayName("リクエスト・クライアント未指定 → サーバー設定にフォールバック")
+    void noRequestNoClient_serverFallback() {
+      Map<String, Object> body = new HashMap<>();
+      body.put("client_id", "test");
+      body.put("scopes", "openid");
+      TokenCreateRequest request = new TokenCreateRequest(body);
+
+      ClientConfiguration clientConfig = createClientConfig(0);
+      AuthorizationServerConfiguration serverConfig = createServerConfig(3600);
+
+      assertEquals(3600, factory.resolveAccessTokenDuration(request, clientConfig, serverConfig));
+    }
+  }
+
+  @Nested
+  @DisplayName("shouldCreateRefreshToken")
+  class ShouldCreateRefreshTokenTest {
+
+    @Test
+    @DisplayName("user_idあり・duration未指定 → true")
+    void withUserId_noExplicitDuration_returnsTrue() {
+      Map<String, Object> body = new HashMap<>();
+      body.put("client_id", "test");
+      body.put("scopes", "openid");
+      body.put("user_id", "user-123");
+      TokenCreateRequest request = new TokenCreateRequest(body);
+
+      assertTrue(factory.shouldCreateRefreshToken(request));
+    }
+
+    @Test
+    @DisplayName("user_idなし → false（client_credentials相当）")
+    void noUserId_returnsFalse() {
+      Map<String, Object> body = new HashMap<>();
+      body.put("client_id", "test");
+      body.put("scopes", "openid");
+      TokenCreateRequest request = new TokenCreateRequest(body);
+
+      assertFalse(factory.shouldCreateRefreshToken(request));
+    }
+
+    @Test
+    @DisplayName("user_idあり・duration=0 → false（明示的に無効化）")
+    void withUserId_durationZero_returnsFalse() {
+      Map<String, Object> body = new HashMap<>();
+      body.put("client_id", "test");
+      body.put("scopes", "openid");
+      body.put("user_id", "user-123");
+      body.put("refresh_token_duration", 0);
+      TokenCreateRequest request = new TokenCreateRequest(body);
+
+      assertFalse(factory.shouldCreateRefreshToken(request));
+    }
+
+    @Test
+    @DisplayName("user_idあり・duration指定あり → true")
+    void withUserId_withDuration_returnsTrue() {
+      Map<String, Object> body = new HashMap<>();
+      body.put("client_id", "test");
+      body.put("scopes", "openid");
+      body.put("user_id", "user-123");
+      body.put("refresh_token_duration", 86400);
+      TokenCreateRequest request = new TokenCreateRequest(body);
+
+      assertTrue(factory.shouldCreateRefreshToken(request));
+    }
+  }
+
+  @Nested
+  @DisplayName("buildJwtPayload")
+  class BuildJwtPayloadTest {
+
+    @Test
+    @DisplayName("custom_claimsがJWTペイロードに含まれる")
+    void customClaims_includedInPayload() {
+      Map<String, Object> body = new HashMap<>();
+      body.put("client_id", "my-client");
+      body.put("scopes", "openid profile");
+      body.put("custom_claims", Map.of("role", "admin", "department", "engineering"));
+      TokenCreateRequest request = new TokenCreateRequest(body);
+
+      AuthorizationServerConfiguration serverConfig = createServerConfig(3600);
+      LocalDateTime now = LocalDateTime.of(2026, 3, 19, 12, 0, 0);
+      CreatedAt createdAt = new CreatedAt(now);
+      ExpiresAt expiresAt = new ExpiresAt(now.plusSeconds(3600));
+
+      Map<String, Object> payload =
+          factory.buildJwtPayload(
+              request,
+              serverConfig,
+              "my-client",
+              "openid profile",
+              new User(),
+              createdAt,
+              expiresAt);
+
+      assertEquals("admin", payload.get("role"));
+      assertEquals("engineering", payload.get("department"));
+    }
+
+    @Test
+    @DisplayName("標準クレームがcustom_claimsで上書きできない")
+    void standardClaims_cannotBeOverwritten() {
+      Map<String, Object> body = new HashMap<>();
+      body.put("client_id", "my-client");
+      body.put("scopes", "openid");
+      body.put("custom_claims", Map.of("iss", "evil-issuer", "exp", 9999999999L));
+      TokenCreateRequest request = new TokenCreateRequest(body);
+
+      AuthorizationServerConfiguration serverConfig = createServerConfig(3600);
+      LocalDateTime now = LocalDateTime.of(2026, 3, 19, 12, 0, 0);
+      CreatedAt createdAt = new CreatedAt(now);
+      ExpiresAt expiresAt = new ExpiresAt(now.plusSeconds(3600));
+
+      Map<String, Object> payload =
+          factory.buildJwtPayload(
+              request, serverConfig, "my-client", "openid", new User(), createdAt, expiresAt);
+
+      // iss must be the server's issuer, not the custom claim
+      assertNotEquals("evil-issuer", payload.get("iss"));
+      // exp must match the calculated expiry, not the custom claim
+      assertNotEquals(9999999999L, payload.get("exp"));
+    }
+
+    @Test
+    @DisplayName("user_idあり → subクレームが含まれる")
+    void withUser_subClaimIncluded() {
+      Map<String, Object> body = new HashMap<>();
+      body.put("client_id", "my-client");
+      body.put("scopes", "openid");
+      TokenCreateRequest request = new TokenCreateRequest(body);
+
+      AuthorizationServerConfiguration serverConfig = createServerConfig(3600);
+      LocalDateTime now = LocalDateTime.of(2026, 3, 19, 12, 0, 0);
+      CreatedAt createdAt = new CreatedAt(now);
+      ExpiresAt expiresAt = new ExpiresAt(now.plusSeconds(3600));
+
+      User user = jsonConverter.read("{\"sub\": \"user-abc-123\"}", User.class);
+
+      Map<String, Object> payload =
+          factory.buildJwtPayload(
+              request, serverConfig, "my-client", "openid", user, createdAt, expiresAt);
+
+      assertEquals("user-abc-123", payload.get("sub"));
+    }
+
+    @Test
+    @DisplayName("user_idなし → subクレームが含まれない")
+    void noUser_noSubClaim() {
+      Map<String, Object> body = new HashMap<>();
+      body.put("client_id", "my-client");
+      body.put("scopes", "openid");
+      TokenCreateRequest request = new TokenCreateRequest(body);
+
+      AuthorizationServerConfiguration serverConfig = createServerConfig(3600);
+      LocalDateTime now = LocalDateTime.of(2026, 3, 19, 12, 0, 0);
+      CreatedAt createdAt = new CreatedAt(now);
+      ExpiresAt expiresAt = new ExpiresAt(now.plusSeconds(3600));
+
+      Map<String, Object> payload =
+          factory.buildJwtPayload(
+              request, serverConfig, "my-client", "openid", new User(), createdAt, expiresAt);
+
+      assertFalse(payload.containsKey("sub"));
+    }
+
+    @Test
+    @DisplayName("必須標準クレームが全て含まれる")
+    void requiredStandardClaims_allPresent() {
+      Map<String, Object> body = new HashMap<>();
+      body.put("client_id", "my-client");
+      body.put("scopes", "openid");
+      TokenCreateRequest request = new TokenCreateRequest(body);
+
+      AuthorizationServerConfiguration serverConfig = createServerConfig(3600);
+      LocalDateTime now = LocalDateTime.of(2026, 3, 19, 12, 0, 0);
+      CreatedAt createdAt = new CreatedAt(now);
+      ExpiresAt expiresAt = new ExpiresAt(now.plusSeconds(3600));
+
+      Map<String, Object> payload =
+          factory.buildJwtPayload(
+              request, serverConfig, "my-client", "openid", new User(), createdAt, expiresAt);
+
+      assertNotNull(payload.get("iss"));
+      assertEquals("my-client", payload.get("client_id"));
+      assertEquals("openid", payload.get("scope"));
+      assertNotNull(payload.get("jti"));
+      assertNotNull(payload.get("iat"));
+      assertNotNull(payload.get("exp"));
+    }
+
+    @Test
+    @DisplayName("custom_claimsなし → 標準クレームのみで正常生成")
+    void noCustomClaims_onlyStandardClaims() {
+      Map<String, Object> body = new HashMap<>();
+      body.put("client_id", "my-client");
+      body.put("scopes", "openid");
+      TokenCreateRequest request = new TokenCreateRequest(body);
+
+      AuthorizationServerConfiguration serverConfig = createServerConfig(3600);
+      LocalDateTime now = LocalDateTime.of(2026, 3, 19, 12, 0, 0);
+      CreatedAt createdAt = new CreatedAt(now);
+      ExpiresAt expiresAt = new ExpiresAt(now.plusSeconds(3600));
+
+      Map<String, Object> payload =
+          factory.buildJwtPayload(
+              request, serverConfig, "my-client", "openid", new User(), createdAt, expiresAt);
+
+      assertNotNull(payload.get("iss"));
+      assertNotNull(payload.get("jti"));
+      assertEquals(6, payload.size()); // iss, client_id, scope, jti, iat, exp
+    }
+
+    @Test
+    @DisplayName("custom_claimsが空Map → 標準クレームのみで正常生成")
+    void emptyCustomClaims_onlyStandardClaims() {
+      Map<String, Object> body = new HashMap<>();
+      body.put("client_id", "my-client");
+      body.put("scopes", "openid");
+      body.put("custom_claims", new HashMap<>());
+      TokenCreateRequest request = new TokenCreateRequest(body);
+
+      AuthorizationServerConfiguration serverConfig = createServerConfig(3600);
+      LocalDateTime now = LocalDateTime.of(2026, 3, 19, 12, 0, 0);
+      CreatedAt createdAt = new CreatedAt(now);
+      ExpiresAt expiresAt = new ExpiresAt(now.plusSeconds(3600));
+
+      Map<String, Object> payload =
+          factory.buildJwtPayload(
+              request, serverConfig, "my-client", "openid", new User(), createdAt, expiresAt);
+
+      assertEquals(6, payload.size());
+    }
+
+    @Test
+    @DisplayName("iat/expの値がcreatedAt/expiresAtのエポック秒と一致する")
+    void iatAndExp_matchEpochSeconds() {
+      Map<String, Object> body = new HashMap<>();
+      body.put("client_id", "my-client");
+      body.put("scopes", "openid");
+      TokenCreateRequest request = new TokenCreateRequest(body);
+
+      AuthorizationServerConfiguration serverConfig = createServerConfig(3600);
+      LocalDateTime now = LocalDateTime.of(2026, 3, 19, 12, 0, 0);
+      CreatedAt createdAt = new CreatedAt(now);
+      ExpiresAt expiresAt = new ExpiresAt(now.plusSeconds(3600));
+
+      Map<String, Object> payload =
+          factory.buildJwtPayload(
+              request, serverConfig, "my-client", "openid", new User(), createdAt, expiresAt);
+
+      assertEquals(createdAt.toEpochSecondWithUtc(), payload.get("iat"));
+      assertEquals(expiresAt.toEpochSecondWithUtc(), payload.get("exp"));
+    }
+
+    @Test
+    @DisplayName("scopeの値が渡したscopes文字列と一致する")
+    void scope_matchesInputString() {
+      Map<String, Object> body = new HashMap<>();
+      body.put("client_id", "my-client");
+      body.put("scopes", "openid profile email management");
+      TokenCreateRequest request = new TokenCreateRequest(body);
+
+      AuthorizationServerConfiguration serverConfig = createServerConfig(3600);
+      LocalDateTime now = LocalDateTime.of(2026, 3, 19, 12, 0, 0);
+      CreatedAt createdAt = new CreatedAt(now);
+      ExpiresAt expiresAt = new ExpiresAt(now.plusSeconds(3600));
+
+      Map<String, Object> payload =
+          factory.buildJwtPayload(
+              request,
+              serverConfig,
+              "my-client",
+              "openid profile email management",
+              new User(),
+              createdAt,
+              expiresAt);
+
+      assertEquals("openid profile email management", payload.get("scope"));
+    }
+
+    @Test
+    @DisplayName("jtiがUUID形式である")
+    void jti_isValidUuid() {
+      Map<String, Object> body = new HashMap<>();
+      body.put("client_id", "my-client");
+      body.put("scopes", "openid");
+      TokenCreateRequest request = new TokenCreateRequest(body);
+
+      AuthorizationServerConfiguration serverConfig = createServerConfig(3600);
+      LocalDateTime now = LocalDateTime.of(2026, 3, 19, 12, 0, 0);
+      CreatedAt createdAt = new CreatedAt(now);
+      ExpiresAt expiresAt = new ExpiresAt(now.plusSeconds(3600));
+
+      Map<String, Object> payload =
+          factory.buildJwtPayload(
+              request, serverConfig, "my-client", "openid", new User(), createdAt, expiresAt);
+
+      String jti = (String) payload.get("jti");
+      assertDoesNotThrow(() -> java.util.UUID.fromString(jti));
+    }
+
+    @Test
+    @DisplayName("custom_claimsでsubを上書きできない（user_idあり）")
+    void customClaimsSub_cannotOverwriteUserSub() {
+      Map<String, Object> body = new HashMap<>();
+      body.put("client_id", "my-client");
+      body.put("scopes", "openid");
+      body.put("custom_claims", Map.of("sub", "evil-user-id"));
+      TokenCreateRequest request = new TokenCreateRequest(body);
+
+      AuthorizationServerConfiguration serverConfig = createServerConfig(3600);
+      LocalDateTime now = LocalDateTime.of(2026, 3, 19, 12, 0, 0);
+      CreatedAt createdAt = new CreatedAt(now);
+      ExpiresAt expiresAt = new ExpiresAt(now.plusSeconds(3600));
+
+      User user = jsonConverter.read("{\"sub\": \"real-user-id\"}", User.class);
+
+      Map<String, Object> payload =
+          factory.buildJwtPayload(
+              request, serverConfig, "my-client", "openid", user, createdAt, expiresAt);
+
+      assertEquals("real-user-id", payload.get("sub"));
+      assertNotEquals("evil-user-id", payload.get("sub"));
+    }
+  }
+
+  @Nested
+  @DisplayName("createRefreshToken")
+  class CreateRefreshTokenTest {
+
+    @Test
+    @DisplayName("指定した有効期限でリフレッシュトークンが生成される")
+    void createsWithCorrectExpiry() {
+      LocalDateTime now = LocalDateTime.of(2026, 3, 19, 12, 0, 0);
+      RefreshToken token = factory.createRefreshToken(86400, now);
+
+      assertNotNull(token.refreshTokenEntity().value());
+      assertFalse(token.refreshTokenEntity().value().isEmpty());
+      assertEquals(now.plusSeconds(86400), token.expiresAt().value());
+    }
+  }
+
+  @Nested
+  @DisplayName("buildResponse")
+  class BuildResponseTest {
+
+    @Test
+    @DisplayName("refresh_tokenがnullの場合はレスポンスに含まれない")
+    void noRefreshToken_notInResponse() {
+      Map<String, Object> response =
+          factory.buildResponse("id-1", "at-value", "Bearer", 3600, null, "openid");
+
+      assertEquals("id-1", response.get("id"));
+      assertEquals("at-value", response.get("access_token"));
+      assertEquals("Bearer", response.get("token_type"));
+      assertEquals(3600L, response.get("expires_in"));
+      assertFalse(response.containsKey("refresh_token"));
+      assertEquals("openid", response.get("scopes"));
+    }
+
+    @Test
+    @DisplayName("refresh_tokenがある場合はレスポンスに含まれる")
+    void withRefreshToken_inResponse() {
+      Map<String, Object> response =
+          factory.buildResponse("id-1", "at-value", "Bearer", 3600, "rt-value", "openid");
+
+      assertEquals("rt-value", response.get("refresh_token"));
+    }
+  }
+
+  // Helper methods
+
+  private AuthorizationServerConfiguration createServerConfig(long accessTokenDuration) {
+    Map<String, Object> config = new HashMap<>();
+    config.put("token_endpoint", "https://example.com/token");
+    config.put("issuer", "https://example.com");
+    config.put(
+        "extension",
+        Map.of(
+            "access_token_type",
+            "JWT",
+            "access_token_duration",
+            accessTokenDuration,
+            "refresh_token_duration",
+            86400));
+    return jsonConverter.read(jsonConverter.write(config), AuthorizationServerConfiguration.class);
+  }
+
+  private AuthorizationServerConfiguration createServerConfig(boolean isIdentifier) {
+    Map<String, Object> config = new HashMap<>();
+    config.put("token_endpoint", "https://example.com/token");
+    config.put("issuer", "https://example.com");
+    config.put(
+        "extension",
+        Map.of(
+            "access_token_type", isIdentifier ? "opaque" : "JWT",
+            "access_token_duration", 3600,
+            "refresh_token_duration", 86400));
+    return jsonConverter.read(jsonConverter.write(config), AuthorizationServerConfiguration.class);
+  }
+
+  private ClientConfiguration createClientConfig(long accessTokenDuration) {
+    Map<String, Object> config = new HashMap<>();
+    config.put("client_id", "test-client");
+    config.put("client_name", "Test Client");
+    if (accessTokenDuration > 0) {
+      config.put("extension", Map.of("access_token_duration", accessTokenDuration));
+    }
+    return jsonConverter.read(jsonConverter.write(config), ClientConfiguration.class);
+  }
+}

--- a/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/token/management/command/MysqlExecutor.java
+++ b/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/token/management/command/MysqlExecutor.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2025 Hirokazu Kobayashi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.idp.server.core.adapters.datasource.token.management.command;
+
+import java.util.List;
+import org.idp.server.core.openid.token.OAuthTokenIdentifier;
+import org.idp.server.platform.datasource.SqlExecutor;
+import org.idp.server.platform.multi_tenancy.tenant.Tenant;
+
+public class MysqlExecutor implements OAuthTokenManagementCommandSqlExecutor {
+
+  @Override
+  public void deleteById(Tenant tenant, OAuthTokenIdentifier identifier) {
+    SqlExecutor sqlExecutor = new SqlExecutor();
+    String sqlTemplate =
+        """
+            DELETE FROM oauth_token
+            WHERE tenant_id = ?
+            AND id = ?;
+            """;
+    List<Object> params = List.of(tenant.identifierValue(), identifier.value());
+    sqlExecutor.execute(sqlTemplate, params);
+  }
+
+  @Override
+  public void deleteAllByUser(Tenant tenant, String userId) {
+    SqlExecutor sqlExecutor = new SqlExecutor();
+    String sqlTemplate =
+        """
+            DELETE FROM oauth_token
+            WHERE tenant_id = ?
+            AND user_id = ?;
+            """;
+    List<Object> params = List.of(tenant.identifierValue(), userId);
+    sqlExecutor.execute(sqlTemplate, params);
+  }
+}

--- a/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/token/management/command/OAuthTokenManagementCommandDataSource.java
+++ b/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/token/management/command/OAuthTokenManagementCommandDataSource.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2025 Hirokazu Kobayashi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.idp.server.core.adapters.datasource.token.management.command;
+
+import org.idp.server.core.openid.token.OAuthTokenIdentifier;
+import org.idp.server.core.openid.token.repository.OAuthTokenManagementCommandRepository;
+import org.idp.server.platform.multi_tenancy.tenant.Tenant;
+
+public class OAuthTokenManagementCommandDataSource
+    implements OAuthTokenManagementCommandRepository {
+
+  OAuthTokenManagementCommandSqlExecutor executor;
+
+  public OAuthTokenManagementCommandDataSource(OAuthTokenManagementCommandSqlExecutor executor) {
+    this.executor = executor;
+  }
+
+  @Override
+  public void delete(Tenant tenant, OAuthTokenIdentifier identifier) {
+    executor.deleteById(tenant, identifier);
+  }
+
+  @Override
+  public void deleteAllByUser(Tenant tenant, String userId) {
+    executor.deleteAllByUser(tenant, userId);
+  }
+}

--- a/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/token/management/command/OAuthTokenManagementCommandDataSourceProvider.java
+++ b/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/token/management/command/OAuthTokenManagementCommandDataSourceProvider.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2025 Hirokazu Kobayashi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.idp.server.core.adapters.datasource.token.management.command;
+
+import org.idp.server.core.openid.token.repository.OAuthTokenManagementCommandRepository;
+import org.idp.server.platform.datasource.ApplicationDatabaseTypeProvider;
+import org.idp.server.platform.dependency.ApplicationComponentDependencyContainer;
+import org.idp.server.platform.dependency.ApplicationComponentProvider;
+
+public class OAuthTokenManagementCommandDataSourceProvider
+    implements ApplicationComponentProvider<OAuthTokenManagementCommandRepository> {
+
+  @Override
+  public Class<OAuthTokenManagementCommandRepository> type() {
+    return OAuthTokenManagementCommandRepository.class;
+  }
+
+  @Override
+  public OAuthTokenManagementCommandRepository provide(
+      ApplicationComponentDependencyContainer container) {
+    ApplicationDatabaseTypeProvider databaseTypeProvider =
+        container.resolve(ApplicationDatabaseTypeProvider.class);
+    OAuthTokenManagementCommandSqlExecutors executors =
+        new OAuthTokenManagementCommandSqlExecutors();
+    OAuthTokenManagementCommandSqlExecutor executor = executors.get(databaseTypeProvider.provide());
+    return new OAuthTokenManagementCommandDataSource(executor);
+  }
+}

--- a/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/token/management/command/OAuthTokenManagementCommandSqlExecutor.java
+++ b/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/token/management/command/OAuthTokenManagementCommandSqlExecutor.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2025 Hirokazu Kobayashi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.idp.server.core.adapters.datasource.token.management.command;
+
+import org.idp.server.core.openid.token.OAuthTokenIdentifier;
+import org.idp.server.platform.multi_tenancy.tenant.Tenant;
+
+public interface OAuthTokenManagementCommandSqlExecutor {
+
+  void deleteById(Tenant tenant, OAuthTokenIdentifier identifier);
+
+  void deleteAllByUser(Tenant tenant, String userId);
+}

--- a/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/token/management/command/OAuthTokenManagementCommandSqlExecutors.java
+++ b/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/token/management/command/OAuthTokenManagementCommandSqlExecutors.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2025 Hirokazu Kobayashi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.idp.server.core.adapters.datasource.token.management.command;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.idp.server.platform.datasource.DatabaseType;
+import org.idp.server.platform.exception.UnSupportedException;
+
+public class OAuthTokenManagementCommandSqlExecutors {
+
+  Map<DatabaseType, OAuthTokenManagementCommandSqlExecutor> executors;
+
+  public OAuthTokenManagementCommandSqlExecutors() {
+    this.executors = new HashMap<>();
+    executors.put(DatabaseType.POSTGRESQL, new PostgresqlExecutor());
+    executors.put(DatabaseType.MYSQL, new MysqlExecutor());
+  }
+
+  public OAuthTokenManagementCommandSqlExecutor get(DatabaseType databaseType) {
+    OAuthTokenManagementCommandSqlExecutor executor = executors.get(databaseType);
+    if (executor == null) {
+      throw new UnSupportedException("Unknown dialect " + databaseType.name());
+    }
+    return executor;
+  }
+}

--- a/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/token/management/command/PostgresqlExecutor.java
+++ b/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/token/management/command/PostgresqlExecutor.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2025 Hirokazu Kobayashi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.idp.server.core.adapters.datasource.token.management.command;
+
+import java.util.List;
+import org.idp.server.core.openid.token.OAuthTokenIdentifier;
+import org.idp.server.platform.datasource.SqlExecutor;
+import org.idp.server.platform.multi_tenancy.tenant.Tenant;
+
+public class PostgresqlExecutor implements OAuthTokenManagementCommandSqlExecutor {
+
+  @Override
+  public void deleteById(Tenant tenant, OAuthTokenIdentifier identifier) {
+    SqlExecutor sqlExecutor = new SqlExecutor();
+    String sqlTemplate =
+        """
+            DELETE FROM oauth_token
+            WHERE tenant_id = ?::uuid
+            AND id = ?::uuid;
+            """;
+    List<Object> params = List.of(tenant.identifierValue(), identifier.value());
+    sqlExecutor.execute(sqlTemplate, params);
+  }
+
+  @Override
+  public void deleteAllByUser(Tenant tenant, String userId) {
+    SqlExecutor sqlExecutor = new SqlExecutor();
+    String sqlTemplate =
+        """
+            DELETE FROM oauth_token
+            WHERE tenant_id = ?::uuid
+            AND user_id = ?::uuid;
+            """;
+    List<Object> params = List.of(tenant.identifierValue(), userId);
+    sqlExecutor.execute(sqlTemplate, params);
+  }
+}

--- a/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/token/management/query/MysqlExecutor.java
+++ b/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/token/management/query/MysqlExecutor.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2025 Hirokazu Kobayashi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.idp.server.core.adapters.datasource.token.management.query;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import org.idp.server.core.openid.token.OAuthTokenIdentifier;
+import org.idp.server.core.openid.token.OAuthTokenQueries;
+import org.idp.server.platform.datasource.SqlExecutor;
+import org.idp.server.platform.multi_tenancy.tenant.Tenant;
+
+public class MysqlExecutor implements OAuthTokenManagementQuerySqlExecutor {
+
+  @Override
+  public Map<String, String> selectOneById(Tenant tenant, OAuthTokenIdentifier identifier) {
+    SqlExecutor sqlExecutor = new SqlExecutor();
+    String sqlTemplate =
+        selectSql
+            + """
+            FROM oauth_token
+            WHERE tenant_id = ?
+            AND id = ?;
+            """;
+    List<Object> params = List.of(tenant.identifierValue(), identifier.value());
+    return sqlExecutor.selectOne(sqlTemplate, params);
+  }
+
+  @Override
+  public List<Map<String, String>> selectList(Tenant tenant, OAuthTokenQueries queries) {
+    SqlExecutor sqlExecutor = new SqlExecutor();
+
+    StringBuilder sqlBuilder = new StringBuilder();
+    sqlBuilder.append(selectSql);
+    sqlBuilder.append(" FROM oauth_token");
+    sqlBuilder.append(" WHERE tenant_id = ?");
+
+    List<Object> params = new ArrayList<>();
+    params.add(tenant.identifierValue());
+
+    appendFilters(sqlBuilder, params, queries);
+
+    sqlBuilder.append(" ORDER BY access_token_created_at DESC");
+    sqlBuilder.append(" LIMIT ? OFFSET ?;");
+    params.add(queries.limit());
+    params.add(queries.offset());
+
+    return sqlExecutor.selectList(sqlBuilder.toString(), params);
+  }
+
+  @Override
+  public Map<String, String> selectCount(Tenant tenant, OAuthTokenQueries queries) {
+    SqlExecutor sqlExecutor = new SqlExecutor();
+
+    StringBuilder sqlBuilder = new StringBuilder();
+    sqlBuilder.append("SELECT COUNT(*) as count FROM oauth_token");
+    sqlBuilder.append(" WHERE tenant_id = ?");
+
+    List<Object> params = new ArrayList<>();
+    params.add(tenant.identifierValue());
+
+    appendFilters(sqlBuilder, params, queries);
+
+    return sqlExecutor.selectOne(sqlBuilder.toString(), params);
+  }
+
+  @Override
+  public Map<String, String> selectCountByUser(Tenant tenant, String userId) {
+    SqlExecutor sqlExecutor = new SqlExecutor();
+    String sql =
+        """
+            SELECT COUNT(*) as count FROM oauth_token
+            WHERE tenant_id = ?
+            AND user_id = ?;
+            """;
+    List<Object> params = List.of(tenant.identifierValue(), userId);
+    return sqlExecutor.selectOne(sql, params);
+  }
+
+  private void appendFilters(
+      StringBuilder sqlBuilder, List<Object> params, OAuthTokenQueries queries) {
+
+    if (!queries.includeExpired()) {
+      sqlBuilder.append(" AND access_token_expires_at > now()");
+    }
+
+    if (queries.hasUserId()) {
+      sqlBuilder.append(" AND user_id = ?");
+      params.add(queries.userId());
+    }
+
+    if (queries.hasClientId()) {
+      sqlBuilder.append(" AND client_id = ?");
+      params.add(queries.clientId());
+    }
+
+    if (queries.hasGrantType()) {
+      sqlBuilder.append(" AND grant_type = ?");
+      params.add(queries.grantType());
+    }
+
+    if (queries.hasFrom()) {
+      sqlBuilder.append(" AND access_token_created_at >= ?");
+      params.add(queries.from());
+    }
+
+    if (queries.hasTo()) {
+      sqlBuilder.append(" AND access_token_created_at <= ?");
+      params.add(queries.to());
+    }
+  }
+
+  String selectSql =
+      """
+          SELECT
+          id,
+          tenant_id,
+          token_issuer,
+          token_type,
+          user_id,
+          client_id,
+          grant_type,
+          scopes,
+          expires_in,
+          access_token_expires_at,
+          access_token_created_at,
+          refresh_token_expires_at,
+          refresh_token_created_at,
+          hashed_refresh_token,
+          client_certification_thumbprint
+          """;
+}

--- a/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/token/management/query/MysqlExecutor.java
+++ b/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/token/management/query/MysqlExecutor.java
@@ -66,16 +66,17 @@ public class MysqlExecutor implements OAuthTokenManagementQuerySqlExecutor {
   public Map<String, String> selectCount(Tenant tenant, OAuthTokenQueries queries) {
     SqlExecutor sqlExecutor = new SqlExecutor();
 
-    StringBuilder sqlBuilder = new StringBuilder();
-    sqlBuilder.append("SELECT COUNT(*) as count FROM oauth_token");
-    sqlBuilder.append(" WHERE tenant_id = ?");
+    StringBuilder sql = new StringBuilder();
+    sql.append("SELECT id FROM oauth_token");
+    sql.append(" WHERE tenant_id = ?");
 
     List<Object> params = new ArrayList<>();
     params.add(tenant.identifierValue());
 
-    appendFilters(sqlBuilder, params, queries);
+    appendFilters(sql, params, queries);
 
-    return sqlExecutor.selectOne(sqlBuilder.toString(), params);
+    String countSql = "SELECT COUNT(*) as count FROM (" + sql + " LIMIT 1000001) t";
+    return sqlExecutor.selectOne(countSql, params);
   }
 
   @Override

--- a/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/token/management/query/MysqlExecutor.java
+++ b/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/token/management/query/MysqlExecutor.java
@@ -125,7 +125,7 @@ public class MysqlExecutor implements OAuthTokenManagementQuerySqlExecutor {
     }
   }
 
-  String selectSql =
+  private static final String selectSql =
       """
           SELECT
           id,

--- a/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/token/management/query/OAuthTokenManagementQueryDataSource.java
+++ b/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/token/management/query/OAuthTokenManagementQueryDataSource.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2025 Hirokazu Kobayashi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.idp.server.core.adapters.datasource.token.management.query;
+
+import java.util.List;
+import java.util.Map;
+import org.idp.server.core.openid.token.OAuthTokenIdentifier;
+import org.idp.server.core.openid.token.OAuthTokenQueries;
+import org.idp.server.core.openid.token.repository.OAuthTokenManagementQueryRepository;
+import org.idp.server.platform.multi_tenancy.tenant.Tenant;
+
+public class OAuthTokenManagementQueryDataSource implements OAuthTokenManagementQueryRepository {
+
+  OAuthTokenManagementQuerySqlExecutor executor;
+
+  public OAuthTokenManagementQueryDataSource(OAuthTokenManagementQuerySqlExecutor executor) {
+    this.executor = executor;
+  }
+
+  @Override
+  public Map<String, String> get(Tenant tenant, OAuthTokenIdentifier identifier) {
+    return executor.selectOneById(tenant, identifier);
+  }
+
+  @Override
+  public List<Map<String, String>> findList(Tenant tenant, OAuthTokenQueries queries) {
+    return executor.selectList(tenant, queries);
+  }
+
+  @Override
+  public long findTotalCount(Tenant tenant, OAuthTokenQueries queries) {
+    Map<String, String> result = executor.selectCount(tenant, queries);
+    if (result == null || result.isEmpty()) {
+      return 0;
+    }
+    return Long.parseLong(result.get("count"));
+  }
+
+  @Override
+  public long countByUser(Tenant tenant, String userId) {
+    Map<String, String> result = executor.selectCountByUser(tenant, userId);
+    if (result == null || result.isEmpty()) {
+      return 0;
+    }
+    return Long.parseLong(result.get("count"));
+  }
+}

--- a/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/token/management/query/OAuthTokenManagementQueryDataSourceProvider.java
+++ b/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/token/management/query/OAuthTokenManagementQueryDataSourceProvider.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2025 Hirokazu Kobayashi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.idp.server.core.adapters.datasource.token.management.query;
+
+import org.idp.server.core.openid.token.repository.OAuthTokenManagementQueryRepository;
+import org.idp.server.platform.datasource.ApplicationDatabaseTypeProvider;
+import org.idp.server.platform.dependency.ApplicationComponentDependencyContainer;
+import org.idp.server.platform.dependency.ApplicationComponentProvider;
+
+public class OAuthTokenManagementQueryDataSourceProvider
+    implements ApplicationComponentProvider<OAuthTokenManagementQueryRepository> {
+
+  @Override
+  public Class<OAuthTokenManagementQueryRepository> type() {
+    return OAuthTokenManagementQueryRepository.class;
+  }
+
+  @Override
+  public OAuthTokenManagementQueryRepository provide(
+      ApplicationComponentDependencyContainer container) {
+    ApplicationDatabaseTypeProvider databaseTypeProvider =
+        container.resolve(ApplicationDatabaseTypeProvider.class);
+    OAuthTokenManagementQuerySqlExecutors executors = new OAuthTokenManagementQuerySqlExecutors();
+    OAuthTokenManagementQuerySqlExecutor executor = executors.get(databaseTypeProvider.provide());
+    return new OAuthTokenManagementQueryDataSource(executor);
+  }
+}

--- a/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/token/management/query/OAuthTokenManagementQuerySqlExecutor.java
+++ b/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/token/management/query/OAuthTokenManagementQuerySqlExecutor.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2025 Hirokazu Kobayashi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.idp.server.core.adapters.datasource.token.management.query;
+
+import java.util.List;
+import java.util.Map;
+import org.idp.server.core.openid.token.OAuthTokenIdentifier;
+import org.idp.server.core.openid.token.OAuthTokenQueries;
+import org.idp.server.platform.multi_tenancy.tenant.Tenant;
+
+public interface OAuthTokenManagementQuerySqlExecutor {
+
+  Map<String, String> selectOneById(Tenant tenant, OAuthTokenIdentifier identifier);
+
+  List<Map<String, String>> selectList(Tenant tenant, OAuthTokenQueries queries);
+
+  Map<String, String> selectCount(Tenant tenant, OAuthTokenQueries queries);
+
+  Map<String, String> selectCountByUser(Tenant tenant, String userId);
+}

--- a/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/token/management/query/OAuthTokenManagementQuerySqlExecutors.java
+++ b/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/token/management/query/OAuthTokenManagementQuerySqlExecutors.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2025 Hirokazu Kobayashi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.idp.server.core.adapters.datasource.token.management.query;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.idp.server.platform.datasource.DatabaseType;
+import org.idp.server.platform.exception.UnSupportedException;
+
+public class OAuthTokenManagementQuerySqlExecutors {
+
+  Map<DatabaseType, OAuthTokenManagementQuerySqlExecutor> executors;
+
+  public OAuthTokenManagementQuerySqlExecutors() {
+    this.executors = new HashMap<>();
+    executors.put(DatabaseType.POSTGRESQL, new PostgresqlExecutor());
+    executors.put(DatabaseType.MYSQL, new MysqlExecutor());
+  }
+
+  public OAuthTokenManagementQuerySqlExecutor get(DatabaseType databaseType) {
+    OAuthTokenManagementQuerySqlExecutor executor = executors.get(databaseType);
+    if (executor == null) {
+      throw new UnSupportedException("Unknown dialect " + databaseType.name());
+    }
+    return executor;
+  }
+}

--- a/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/token/management/query/PostgresqlExecutor.java
+++ b/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/token/management/query/PostgresqlExecutor.java
@@ -66,16 +66,17 @@ public class PostgresqlExecutor implements OAuthTokenManagementQuerySqlExecutor 
   public Map<String, String> selectCount(Tenant tenant, OAuthTokenQueries queries) {
     SqlExecutor sqlExecutor = new SqlExecutor();
 
-    StringBuilder sqlBuilder = new StringBuilder();
-    sqlBuilder.append("SELECT COUNT(*) as count FROM oauth_token");
-    sqlBuilder.append(" WHERE tenant_id = ?::uuid");
+    StringBuilder sql = new StringBuilder();
+    sql.append("SELECT id FROM oauth_token");
+    sql.append(" WHERE tenant_id = ?::uuid");
 
     List<Object> params = new ArrayList<>();
     params.add(tenant.identifierValue());
 
-    appendFilters(sqlBuilder, params, queries);
+    appendFilters(sql, params, queries);
 
-    return sqlExecutor.selectOne(sqlBuilder.toString(), params);
+    String countSql = "SELECT COUNT(*) as count FROM (" + sql + " LIMIT 1000001) t";
+    return sqlExecutor.selectOne(countSql, params);
   }
 
   @Override

--- a/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/token/management/query/PostgresqlExecutor.java
+++ b/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/token/management/query/PostgresqlExecutor.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2025 Hirokazu Kobayashi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.idp.server.core.adapters.datasource.token.management.query;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import org.idp.server.core.openid.token.OAuthTokenIdentifier;
+import org.idp.server.core.openid.token.OAuthTokenQueries;
+import org.idp.server.platform.datasource.SqlExecutor;
+import org.idp.server.platform.multi_tenancy.tenant.Tenant;
+
+public class PostgresqlExecutor implements OAuthTokenManagementQuerySqlExecutor {
+
+  @Override
+  public Map<String, String> selectOneById(Tenant tenant, OAuthTokenIdentifier identifier) {
+    SqlExecutor sqlExecutor = new SqlExecutor();
+    String sqlTemplate =
+        selectSql
+            + """
+            FROM oauth_token
+            WHERE tenant_id = ?::uuid
+            AND id = ?::uuid;
+            """;
+    List<Object> params = List.of(tenant.identifierValue(), identifier.value());
+    return sqlExecutor.selectOne(sqlTemplate, params);
+  }
+
+  @Override
+  public List<Map<String, String>> selectList(Tenant tenant, OAuthTokenQueries queries) {
+    SqlExecutor sqlExecutor = new SqlExecutor();
+
+    StringBuilder sqlBuilder = new StringBuilder();
+    sqlBuilder.append(selectSql);
+    sqlBuilder.append(" FROM oauth_token");
+    sqlBuilder.append(" WHERE tenant_id = ?::uuid");
+
+    List<Object> params = new ArrayList<>();
+    params.add(tenant.identifierValue());
+
+    appendFilters(sqlBuilder, params, queries);
+
+    sqlBuilder.append(" ORDER BY access_token_created_at DESC");
+    sqlBuilder.append(" LIMIT ? OFFSET ?;");
+    params.add(queries.limit());
+    params.add(queries.offset());
+
+    return sqlExecutor.selectList(sqlBuilder.toString(), params);
+  }
+
+  @Override
+  public Map<String, String> selectCount(Tenant tenant, OAuthTokenQueries queries) {
+    SqlExecutor sqlExecutor = new SqlExecutor();
+
+    StringBuilder sqlBuilder = new StringBuilder();
+    sqlBuilder.append("SELECT COUNT(*) FROM oauth_token");
+    sqlBuilder.append(" WHERE tenant_id = ?::uuid");
+
+    List<Object> params = new ArrayList<>();
+    params.add(tenant.identifierValue());
+
+    appendFilters(sqlBuilder, params, queries);
+
+    return sqlExecutor.selectOne(sqlBuilder.toString(), params);
+  }
+
+  @Override
+  public Map<String, String> selectCountByUser(Tenant tenant, String userId) {
+    SqlExecutor sqlExecutor = new SqlExecutor();
+    String sql =
+        """
+            SELECT COUNT(*) FROM oauth_token
+            WHERE tenant_id = ?::uuid
+            AND user_id = ?::uuid;
+            """;
+    List<Object> params = List.of(tenant.identifierValue(), userId);
+    return sqlExecutor.selectOne(sql, params);
+  }
+
+  private void appendFilters(
+      StringBuilder sqlBuilder, List<Object> params, OAuthTokenQueries queries) {
+
+    if (!queries.includeExpired()) {
+      sqlBuilder.append(" AND access_token_expires_at > now()");
+    }
+
+    if (queries.hasUserId()) {
+      sqlBuilder.append(" AND user_id = ?::uuid");
+      params.add(queries.userId());
+    }
+
+    if (queries.hasClientId()) {
+      sqlBuilder.append(" AND client_id = ?");
+      params.add(queries.clientId());
+    }
+
+    if (queries.hasGrantType()) {
+      sqlBuilder.append(" AND grant_type = ?");
+      params.add(queries.grantType());
+    }
+
+    if (queries.hasFrom()) {
+      sqlBuilder.append(" AND access_token_created_at >= ?");
+      params.add(queries.from());
+    }
+
+    if (queries.hasTo()) {
+      sqlBuilder.append(" AND access_token_created_at <= ?");
+      params.add(queries.to());
+    }
+  }
+
+  String selectSql =
+      """
+          SELECT
+          id,
+          tenant_id,
+          token_issuer,
+          token_type,
+          user_id,
+          client_id,
+          grant_type,
+          scopes,
+          expires_in,
+          access_token_expires_at,
+          access_token_created_at,
+          refresh_token_expires_at,
+          refresh_token_created_at,
+          hashed_refresh_token,
+          client_certification_thumbprint
+          """;
+}

--- a/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/token/management/query/PostgresqlExecutor.java
+++ b/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/token/management/query/PostgresqlExecutor.java
@@ -67,7 +67,7 @@ public class PostgresqlExecutor implements OAuthTokenManagementQuerySqlExecutor 
     SqlExecutor sqlExecutor = new SqlExecutor();
 
     StringBuilder sqlBuilder = new StringBuilder();
-    sqlBuilder.append("SELECT COUNT(*) FROM oauth_token");
+    sqlBuilder.append("SELECT COUNT(*) as count FROM oauth_token");
     sqlBuilder.append(" WHERE tenant_id = ?::uuid");
 
     List<Object> params = new ArrayList<>();
@@ -83,7 +83,7 @@ public class PostgresqlExecutor implements OAuthTokenManagementQuerySqlExecutor 
     SqlExecutor sqlExecutor = new SqlExecutor();
     String sql =
         """
-            SELECT COUNT(*) FROM oauth_token
+            SELECT COUNT(*) as count FROM oauth_token
             WHERE tenant_id = ?::uuid
             AND user_id = ?::uuid;
             """;

--- a/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/token/management/query/PostgresqlExecutor.java
+++ b/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/token/management/query/PostgresqlExecutor.java
@@ -125,7 +125,7 @@ public class PostgresqlExecutor implements OAuthTokenManagementQuerySqlExecutor 
     }
   }
 
-  String selectSql =
+  private static final String selectSql =
       """
           SELECT
           id,

--- a/libs/idp-server-core-adapter/src/main/resources/META-INF/services/org.idp.server.platform.dependency.ApplicationComponentProvider
+++ b/libs/idp-server-core-adapter/src/main/resources/META-INF/services/org.idp.server.platform.dependency.ApplicationComponentProvider
@@ -29,6 +29,8 @@ org.idp.server.core.adapters.datasource.multi_tenancy.tenant.command.TenantComma
 org.idp.server.core.adapters.datasource.token.command.OAuthTokenDataSourceProvider
 org.idp.server.core.adapters.datasource.token.query.OAuthTokenQueryDataSourceProvider
 org.idp.server.core.adapters.datasource.token.operation.command.OAuthTokenCommandDataSourceProvider
+org.idp.server.core.adapters.datasource.token.management.query.OAuthTokenManagementQueryDataSourceProvider
+org.idp.server.core.adapters.datasource.token.management.command.OAuthTokenManagementCommandDataSourceProvider
 org.idp.server.core.adapters.datasource.authentication.transaction.command.AuthenticationTransactionCommandDataSourceProvider
 org.idp.server.core.adapters.datasource.authentication.transaction.query.AuthenticationTransactionQueryDataSourceProvider
 org.idp.server.core.adapters.datasource.authentication.transaction.operation.AuthenticationTransactionOperationCommandDataSourceProvider

--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/token/OAuthTokenQueries.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/token/OAuthTokenQueries.java
@@ -23,20 +23,29 @@ import org.idp.server.platform.date.LocalDateTimeParser;
 
 public class OAuthTokenQueries {
 
-  Map<String, String> values;
+  private static final int MAX_LIMIT = 1000;
+
+  private final Map<String, String> values;
 
   public OAuthTokenQueries(Map<String, String> values) {
     this.values = values;
   }
 
   public int limit() {
-    String limit = values.getOrDefault("limit", "20");
-    return Integer.parseInt(limit);
+    try {
+      int parsed = Integer.parseInt(values.getOrDefault("limit", "20"));
+      return Math.min(Math.max(parsed, 1), MAX_LIMIT);
+    } catch (NumberFormatException e) {
+      return 20;
+    }
   }
 
   public int offset() {
-    String offset = values.getOrDefault("offset", "0");
-    return Integer.parseInt(offset);
+    try {
+      return Math.max(Integer.parseInt(values.getOrDefault("offset", "0")), 0);
+    } catch (NumberFormatException e) {
+      return 0;
+    }
   }
 
   public boolean hasUserId() {

--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/token/OAuthTokenQueries.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/token/OAuthTokenQueries.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2025 Hirokazu Kobayashi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.idp.server.core.openid.token;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+import java.util.Objects;
+import org.idp.server.platform.date.LocalDateTimeParser;
+
+public class OAuthTokenQueries {
+
+  Map<String, String> values;
+
+  public OAuthTokenQueries(Map<String, String> values) {
+    this.values = values;
+  }
+
+  public int limit() {
+    String limit = values.getOrDefault("limit", "20");
+    return Integer.parseInt(limit);
+  }
+
+  public int offset() {
+    String offset = values.getOrDefault("offset", "0");
+    return Integer.parseInt(offset);
+  }
+
+  public boolean hasUserId() {
+    return values.containsKey("user_id")
+        && Objects.nonNull(values.get("user_id"))
+        && !values.get("user_id").isEmpty();
+  }
+
+  public String userId() {
+    return values.get("user_id");
+  }
+
+  public boolean hasClientId() {
+    return values.containsKey("client_id")
+        && Objects.nonNull(values.get("client_id"))
+        && !values.get("client_id").isEmpty();
+  }
+
+  public String clientId() {
+    return values.get("client_id");
+  }
+
+  public boolean hasGrantType() {
+    return values.containsKey("grant_type")
+        && Objects.nonNull(values.get("grant_type"))
+        && !values.get("grant_type").isEmpty();
+  }
+
+  public String grantType() {
+    return values.get("grant_type");
+  }
+
+  public boolean hasFrom() {
+    return values.containsKey("from")
+        && Objects.nonNull(values.get("from"))
+        && !values.get("from").isEmpty();
+  }
+
+  public LocalDateTime from() {
+    return LocalDateTimeParser.parse(values.get("from"));
+  }
+
+  public boolean hasTo() {
+    return values.containsKey("to")
+        && Objects.nonNull(values.get("to"))
+        && !values.get("to").isEmpty();
+  }
+
+  public LocalDateTime to() {
+    return LocalDateTimeParser.parse(values.get("to"));
+  }
+
+  public boolean includeExpired() {
+    String expired = values.getOrDefault("expired", "false");
+    return Boolean.parseBoolean(expired);
+  }
+}

--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/token/repository/OAuthTokenManagementCommandRepository.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/token/repository/OAuthTokenManagementCommandRepository.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2025 Hirokazu Kobayashi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.idp.server.core.openid.token.repository;
+
+import org.idp.server.core.openid.token.OAuthTokenIdentifier;
+import org.idp.server.platform.multi_tenancy.tenant.Tenant;
+
+public interface OAuthTokenManagementCommandRepository {
+
+  void delete(Tenant tenant, OAuthTokenIdentifier identifier);
+
+  void deleteAllByUser(Tenant tenant, String userId);
+}

--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/token/repository/OAuthTokenManagementQueryRepository.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/token/repository/OAuthTokenManagementQueryRepository.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2025 Hirokazu Kobayashi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.idp.server.core.openid.token.repository;
+
+import java.util.List;
+import java.util.Map;
+import org.idp.server.core.openid.token.OAuthTokenIdentifier;
+import org.idp.server.core.openid.token.OAuthTokenQueries;
+import org.idp.server.platform.multi_tenancy.tenant.Tenant;
+
+public interface OAuthTokenManagementQueryRepository {
+
+  Map<String, String> get(Tenant tenant, OAuthTokenIdentifier identifier);
+
+  List<Map<String, String>> findList(Tenant tenant, OAuthTokenQueries queries);
+
+  long findTotalCount(Tenant tenant, OAuthTokenQueries queries);
+
+  long countByUser(Tenant tenant, String userId);
+}

--- a/libs/idp-server-database/mysql/V0_9_33__oauth_token_management_indexes.mysql.sql
+++ b/libs/idp-server-database/mysql/V0_9_33__oauth_token_management_indexes.mysql.sql
@@ -1,0 +1,15 @@
+-- Indexes for Token Management API
+-- Supports filtering by user_id, client_id, and expired token filtering
+-- with access_token_expires_at for the default "active only" filter
+
+CREATE INDEX idx_oauth_token_tenant_user
+    ON oauth_token (tenant_id, user_id);
+
+CREATE INDEX idx_oauth_token_tenant_client
+    ON oauth_token (tenant_id, client_id);
+
+-- Composite index for the most common query pattern:
+-- WHERE tenant_id = ? AND access_token_expires_at > now()
+-- ORDER BY access_token_created_at DESC
+CREATE INDEX idx_oauth_token_tenant_expires_created
+    ON oauth_token (tenant_id, access_token_expires_at, access_token_created_at);

--- a/libs/idp-server-database/mysql/V0_9_33__oauth_token_management_indexes.mysql.sql
+++ b/libs/idp-server-database/mysql/V0_9_33__oauth_token_management_indexes.mysql.sql
@@ -12,4 +12,4 @@ CREATE INDEX idx_oauth_token_tenant_client
 -- WHERE tenant_id = ? AND access_token_expires_at > now()
 -- ORDER BY access_token_created_at DESC
 CREATE INDEX idx_oauth_token_tenant_expires_created
-    ON oauth_token (tenant_id, access_token_expires_at, access_token_created_at);
+    ON oauth_token (tenant_id, access_token_expires_at, access_token_created_at DESC);

--- a/libs/idp-server-database/postgresql/V0_9_33__oauth_token_management_indexes.sql
+++ b/libs/idp-server-database/postgresql/V0_9_33__oauth_token_management_indexes.sql
@@ -1,0 +1,15 @@
+-- Indexes for Token Management API
+-- Supports filtering by user_id, client_id, and expired token filtering
+-- with access_token_expires_at for the default "active only" filter
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_oauth_token_tenant_user
+    ON oauth_token (tenant_id, user_id);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_oauth_token_tenant_client
+    ON oauth_token (tenant_id, client_id);
+
+-- Composite index for the most common query pattern:
+-- WHERE tenant_id = ? AND access_token_expires_at > now()
+-- ORDER BY access_token_created_at DESC
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_oauth_token_tenant_expires_created
+    ON oauth_token (tenant_id, access_token_expires_at, access_token_created_at DESC);

--- a/libs/idp-server-springboot-adapter/src/main/java/org/idp/server/adapters/springboot/control_plane/restapi/management/TokenManagementV1Api.java
+++ b/libs/idp-server-springboot-adapter/src/main/java/org/idp/server/adapters/springboot/control_plane/restapi/management/TokenManagementV1Api.java
@@ -43,6 +43,30 @@ public class TokenManagementV1Api implements ParameterTransformable {
     this.tokenManagementApi = idpServerApplication.tokenManagementApi();
   }
 
+  @PostMapping("/tokens")
+  public ResponseEntity<?> create(
+      @AuthenticationPrincipal OperatorPrincipal operatorPrincipal,
+      @PathVariable("tenant-id") TenantIdentifier tenantIdentifier,
+      @RequestBody Map<String, Object> body,
+      @RequestParam(value = "dry_run", required = false, defaultValue = "false") boolean dryRun,
+      HttpServletRequest httpServletRequest) {
+
+    RequestAttributes requestAttributes = transform(httpServletRequest);
+
+    TokenManagementResponse response =
+        tokenManagementApi.create(
+            operatorPrincipal.authenticationContext(),
+            tenantIdentifier,
+            body,
+            requestAttributes,
+            dryRun);
+
+    HttpHeaders httpHeaders = new HttpHeaders();
+    httpHeaders.add("content-type", "application/json");
+    return new ResponseEntity<>(
+        response.contents(), httpHeaders, HttpStatus.valueOf(response.statusCode()));
+  }
+
   @GetMapping("/tokens")
   public ResponseEntity<?> getList(
       @AuthenticationPrincipal OperatorPrincipal operatorPrincipal,

--- a/libs/idp-server-springboot-adapter/src/main/java/org/idp/server/adapters/springboot/control_plane/restapi/management/TokenManagementV1Api.java
+++ b/libs/idp-server-springboot-adapter/src/main/java/org/idp/server/adapters/springboot/control_plane/restapi/management/TokenManagementV1Api.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2025 Hirokazu Kobayashi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.idp.server.adapters.springboot.control_plane.restapi.management;
+
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.Map;
+import org.idp.server.adapters.springboot.application.restapi.ParameterTransformable;
+import org.idp.server.adapters.springboot.control_plane.model.OperatorPrincipal;
+import org.idp.server.control_plane.management.token.TokenManagementApi;
+import org.idp.server.control_plane.management.token.io.TokenManagementResponse;
+import org.idp.server.core.openid.token.OAuthTokenIdentifier;
+import org.idp.server.core.openid.token.OAuthTokenQueries;
+import org.idp.server.platform.multi_tenancy.tenant.TenantIdentifier;
+import org.idp.server.platform.type.RequestAttributes;
+import org.idp.server.usecases.IdpServerApplication;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/v1/management/tenants/{tenant-id}")
+public class TokenManagementV1Api implements ParameterTransformable {
+
+  TokenManagementApi tokenManagementApi;
+
+  public TokenManagementV1Api(IdpServerApplication idpServerApplication) {
+    this.tokenManagementApi = idpServerApplication.tokenManagementApi();
+  }
+
+  @GetMapping("/tokens")
+  public ResponseEntity<?> getList(
+      @AuthenticationPrincipal OperatorPrincipal operatorPrincipal,
+      @PathVariable("tenant-id") TenantIdentifier tenantIdentifier,
+      @RequestParam Map<String, String> queryParams,
+      HttpServletRequest httpServletRequest) {
+
+    RequestAttributes requestAttributes = transform(httpServletRequest);
+
+    TokenManagementResponse response =
+        tokenManagementApi.findList(
+            operatorPrincipal.authenticationContext(),
+            tenantIdentifier,
+            new OAuthTokenQueries(queryParams),
+            requestAttributes);
+
+    HttpHeaders httpHeaders = new HttpHeaders();
+    httpHeaders.add("content-type", "application/json");
+    return new ResponseEntity<>(
+        response.contents(), httpHeaders, HttpStatus.valueOf(response.statusCode()));
+  }
+
+  @GetMapping("/tokens/{id}")
+  public ResponseEntity<?> get(
+      @AuthenticationPrincipal OperatorPrincipal operatorPrincipal,
+      @PathVariable("tenant-id") TenantIdentifier tenantIdentifier,
+      @PathVariable("id") OAuthTokenIdentifier identifier,
+      HttpServletRequest httpServletRequest) {
+
+    RequestAttributes requestAttributes = transform(httpServletRequest);
+
+    TokenManagementResponse response =
+        tokenManagementApi.get(
+            operatorPrincipal.authenticationContext(),
+            tenantIdentifier,
+            identifier,
+            requestAttributes);
+
+    HttpHeaders httpHeaders = new HttpHeaders();
+    httpHeaders.add("content-type", "application/json");
+    return new ResponseEntity<>(
+        response.contents(), httpHeaders, HttpStatus.valueOf(response.statusCode()));
+  }
+
+  @DeleteMapping("/tokens/{id}")
+  public ResponseEntity<?> delete(
+      @AuthenticationPrincipal OperatorPrincipal operatorPrincipal,
+      @PathVariable("tenant-id") TenantIdentifier tenantIdentifier,
+      @PathVariable("id") OAuthTokenIdentifier identifier,
+      @RequestParam(value = "dry_run", required = false, defaultValue = "false") boolean dryRun,
+      HttpServletRequest httpServletRequest) {
+
+    RequestAttributes requestAttributes = transform(httpServletRequest);
+
+    TokenManagementResponse response =
+        tokenManagementApi.delete(
+            operatorPrincipal.authenticationContext(),
+            tenantIdentifier,
+            identifier,
+            requestAttributes,
+            dryRun);
+
+    HttpHeaders httpHeaders = new HttpHeaders();
+    httpHeaders.add("content-type", "application/json");
+    return new ResponseEntity<>(
+        response.contents(), httpHeaders, HttpStatus.valueOf(response.statusCode()));
+  }
+
+  @DeleteMapping("/users/{user-id}/tokens")
+  public ResponseEntity<?> deleteUserTokens(
+      @AuthenticationPrincipal OperatorPrincipal operatorPrincipal,
+      @PathVariable("tenant-id") TenantIdentifier tenantIdentifier,
+      @PathVariable("user-id") String userId,
+      @RequestParam(value = "dry_run", required = false, defaultValue = "false") boolean dryRun,
+      HttpServletRequest httpServletRequest) {
+
+    RequestAttributes requestAttributes = transform(httpServletRequest);
+
+    TokenManagementResponse response =
+        tokenManagementApi.deleteUserTokens(
+            operatorPrincipal.authenticationContext(),
+            tenantIdentifier,
+            userId,
+            requestAttributes,
+            dryRun);
+
+    HttpHeaders httpHeaders = new HttpHeaders();
+    httpHeaders.add("content-type", "application/json");
+    return new ResponseEntity<>(
+        response.contents(), httpHeaders, HttpStatus.valueOf(response.statusCode()));
+  }
+}

--- a/libs/idp-server-springboot-adapter/src/main/java/org/idp/server/adapters/springboot/control_plane/restapi/organization/OrganizationTokenManagementV1Api.java
+++ b/libs/idp-server-springboot-adapter/src/main/java/org/idp/server/adapters/springboot/control_plane/restapi/organization/OrganizationTokenManagementV1Api.java
@@ -43,6 +43,31 @@ public class OrganizationTokenManagementV1Api implements ParameterTransformable 
     this.orgTokenManagementApi = idpServerApplication.orgTokenManagementApi();
   }
 
+  @PostMapping("/tokens")
+  public ResponseEntity<?> create(
+      @AuthenticationPrincipal OrganizationOperatorPrincipal organizationOperatorPrincipal,
+      @PathVariable String organizationId,
+      @PathVariable String tenantId,
+      @RequestBody Map<String, Object> body,
+      @RequestParam(value = "dry_run", required = false, defaultValue = "false") boolean dryRun,
+      HttpServletRequest httpServletRequest) {
+
+    RequestAttributes requestAttributes = transform(httpServletRequest);
+
+    TokenManagementResponse response =
+        orgTokenManagementApi.create(
+            organizationOperatorPrincipal.authenticationContext(),
+            new TenantIdentifier(tenantId),
+            body,
+            requestAttributes,
+            dryRun);
+
+    HttpHeaders httpHeaders = new HttpHeaders();
+    httpHeaders.add("content-type", "application/json");
+    return new ResponseEntity<>(
+        response.contents(), httpHeaders, HttpStatus.valueOf(response.statusCode()));
+  }
+
   @GetMapping("/tokens")
   public ResponseEntity<?> getList(
       @AuthenticationPrincipal OrganizationOperatorPrincipal organizationOperatorPrincipal,

--- a/libs/idp-server-springboot-adapter/src/main/java/org/idp/server/adapters/springboot/control_plane/restapi/organization/OrganizationTokenManagementV1Api.java
+++ b/libs/idp-server-springboot-adapter/src/main/java/org/idp/server/adapters/springboot/control_plane/restapi/organization/OrganizationTokenManagementV1Api.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2025 Hirokazu Kobayashi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.idp.server.adapters.springboot.control_plane.restapi.organization;
+
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.Map;
+import org.idp.server.adapters.springboot.application.restapi.ParameterTransformable;
+import org.idp.server.adapters.springboot.control_plane.model.OrganizationOperatorPrincipal;
+import org.idp.server.control_plane.management.token.OrgTokenManagementApi;
+import org.idp.server.control_plane.management.token.io.TokenManagementResponse;
+import org.idp.server.core.openid.token.OAuthTokenIdentifier;
+import org.idp.server.core.openid.token.OAuthTokenQueries;
+import org.idp.server.platform.multi_tenancy.tenant.TenantIdentifier;
+import org.idp.server.platform.type.RequestAttributes;
+import org.idp.server.usecases.IdpServerApplication;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/v1/management/organizations/{organizationId}/tenants/{tenantId}")
+public class OrganizationTokenManagementV1Api implements ParameterTransformable {
+
+  OrgTokenManagementApi orgTokenManagementApi;
+
+  public OrganizationTokenManagementV1Api(IdpServerApplication idpServerApplication) {
+    this.orgTokenManagementApi = idpServerApplication.orgTokenManagementApi();
+  }
+
+  @GetMapping("/tokens")
+  public ResponseEntity<?> getList(
+      @AuthenticationPrincipal OrganizationOperatorPrincipal organizationOperatorPrincipal,
+      @PathVariable String organizationId,
+      @PathVariable String tenantId,
+      @RequestParam Map<String, String> queryParams,
+      HttpServletRequest httpServletRequest) {
+
+    RequestAttributes requestAttributes = transform(httpServletRequest);
+
+    TokenManagementResponse response =
+        orgTokenManagementApi.findList(
+            organizationOperatorPrincipal.authenticationContext(),
+            new TenantIdentifier(tenantId),
+            new OAuthTokenQueries(queryParams),
+            requestAttributes);
+
+    HttpHeaders httpHeaders = new HttpHeaders();
+    httpHeaders.add("content-type", "application/json");
+    return new ResponseEntity<>(
+        response.contents(), httpHeaders, HttpStatus.valueOf(response.statusCode()));
+  }
+
+  @GetMapping("/tokens/{tokenId}")
+  public ResponseEntity<?> get(
+      @AuthenticationPrincipal OrganizationOperatorPrincipal organizationOperatorPrincipal,
+      @PathVariable String organizationId,
+      @PathVariable String tenantId,
+      @PathVariable String tokenId,
+      HttpServletRequest httpServletRequest) {
+
+    RequestAttributes requestAttributes = transform(httpServletRequest);
+
+    TokenManagementResponse response =
+        orgTokenManagementApi.get(
+            organizationOperatorPrincipal.authenticationContext(),
+            new TenantIdentifier(tenantId),
+            new OAuthTokenIdentifier(tokenId),
+            requestAttributes);
+
+    HttpHeaders httpHeaders = new HttpHeaders();
+    httpHeaders.add("content-type", "application/json");
+    return new ResponseEntity<>(
+        response.contents(), httpHeaders, HttpStatus.valueOf(response.statusCode()));
+  }
+
+  @DeleteMapping("/tokens/{tokenId}")
+  public ResponseEntity<?> delete(
+      @AuthenticationPrincipal OrganizationOperatorPrincipal organizationOperatorPrincipal,
+      @PathVariable String organizationId,
+      @PathVariable String tenantId,
+      @PathVariable String tokenId,
+      @RequestParam(value = "dry_run", required = false, defaultValue = "false") boolean dryRun,
+      HttpServletRequest httpServletRequest) {
+
+    RequestAttributes requestAttributes = transform(httpServletRequest);
+
+    TokenManagementResponse response =
+        orgTokenManagementApi.delete(
+            organizationOperatorPrincipal.authenticationContext(),
+            new TenantIdentifier(tenantId),
+            new OAuthTokenIdentifier(tokenId),
+            requestAttributes,
+            dryRun);
+
+    HttpHeaders httpHeaders = new HttpHeaders();
+    httpHeaders.add("content-type", "application/json");
+    return new ResponseEntity<>(
+        response.contents(), httpHeaders, HttpStatus.valueOf(response.statusCode()));
+  }
+
+  @DeleteMapping("/users/{userId}/tokens")
+  public ResponseEntity<?> deleteUserTokens(
+      @AuthenticationPrincipal OrganizationOperatorPrincipal organizationOperatorPrincipal,
+      @PathVariable String organizationId,
+      @PathVariable String tenantId,
+      @PathVariable String userId,
+      @RequestParam(value = "dry_run", required = false, defaultValue = "false") boolean dryRun,
+      HttpServletRequest httpServletRequest) {
+
+    RequestAttributes requestAttributes = transform(httpServletRequest);
+
+    TokenManagementResponse response =
+        orgTokenManagementApi.deleteUserTokens(
+            organizationOperatorPrincipal.authenticationContext(),
+            new TenantIdentifier(tenantId),
+            userId,
+            requestAttributes,
+            dryRun);
+
+    HttpHeaders httpHeaders = new HttpHeaders();
+    httpHeaders.add("content-type", "application/json");
+    return new ResponseEntity<>(
+        response.contents(), httpHeaders, HttpStatus.valueOf(response.statusCode()));
+  }
+}

--- a/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/IdpServerApplication.java
+++ b/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/IdpServerApplication.java
@@ -78,6 +78,8 @@ import org.idp.server.control_plane.management.tenant.invitation.TenantInvitatio
 import org.idp.server.control_plane.management.tenant.invitation.operation.TenantInvitationCommandRepository;
 import org.idp.server.control_plane.management.tenant.invitation.operation.TenantInvitationMetaDataApi;
 import org.idp.server.control_plane.management.tenant.invitation.operation.TenantInvitationQueryRepository;
+import org.idp.server.control_plane.management.token.OrgTokenManagementApi;
+import org.idp.server.control_plane.management.token.TokenManagementApi;
 import org.idp.server.core.extension.ciba.CibaFlowApi;
 import org.idp.server.core.extension.ciba.CibaFlowEventPublisher;
 import org.idp.server.core.extension.ciba.CibaProtocol;
@@ -143,6 +145,8 @@ import org.idp.server.core.openid.token.*;
 import org.idp.server.core.openid.token.JwtBearerUserFinder;
 import org.idp.server.core.openid.token.JwtBearerUserFindingDelegate;
 import org.idp.server.core.openid.token.repository.OAuthTokenCommandRepository;
+import org.idp.server.core.openid.token.repository.OAuthTokenManagementCommandRepository;
+import org.idp.server.core.openid.token.repository.OAuthTokenManagementQueryRepository;
 import org.idp.server.core.openid.token.repository.OAuthTokenOperationCommandRepository;
 import org.idp.server.core.openid.token.repository.OAuthTokenQueryRepository;
 import org.idp.server.core.openid.userinfo.UserinfoApi;
@@ -247,6 +251,7 @@ public class IdpServerApplication {
   IdentityVerificationConfigManagementApi identityVerificationConfigManagementApi;
   IdentityVerificationApplicationManagementApi identityVerificationApplicationManagementApi;
   IdentityVerificationResultManagementApi identityVerificationResultManagementApi;
+  TokenManagementApi tokenManagementApi;
   SecurityEventHookConfigurationManagementApi securityEventHookConfigurationManagementApi;
   SecurityEventManagementApi securityEventManagementApi;
   SecurityEventHookManagementApi securityEventHookManagementApi;
@@ -270,6 +275,7 @@ public class IdpServerApplication {
   OrgIdentityVerificationConfigManagementApi orgIdentityVerificationConfigManagementApi;
   OrgIdentityVerificationApplicationManagementApi orgIdentityVerificationApplicationManagementApi;
   OrgIdentityVerificationResultManagementApi orgIdentityVerificationResultManagementApi;
+  OrgTokenManagementApi orgTokenManagementApi;
   OrgFederationConfigManagementApi orgFederationConfigManagementApi;
   OrgSecurityEventHookConfigManagementApi orgSecurityEventHookConfigManagementApi;
   OrgAuthenticationInteractionManagementApi orgAuthenticationInteractionManagementApi;
@@ -454,6 +460,10 @@ public class IdpServerApplication {
         applicationComponentContainer.resolve(AuthorizationGrantedRepository.class);
     OAuthTokenCommandRepository oAuthTokenCommandRepository =
         applicationComponentContainer.resolve(OAuthTokenCommandRepository.class);
+    OAuthTokenManagementQueryRepository oAuthTokenManagementQueryRepository =
+        applicationComponentContainer.resolve(OAuthTokenManagementQueryRepository.class);
+    OAuthTokenManagementCommandRepository oAuthTokenManagementCommandRepository =
+        applicationComponentContainer.resolve(OAuthTokenManagementCommandRepository.class);
 
     // System configuration resolver for SSRF protection and trusted proxy settings
     SystemConfigurationRepository systemConfigurationRepository =
@@ -1024,6 +1034,16 @@ public class IdpServerApplication {
             IdentityVerificationResultManagementApi.class,
             databaseTypeProvider);
 
+    this.tokenManagementApi =
+        ManagementTypeEntryServiceProxy.createProxy(
+            new TokenManagementEntryService(
+                oAuthTokenManagementQueryRepository,
+                oAuthTokenManagementCommandRepository,
+                tenantQueryRepository,
+                auditLogPublisher),
+            TokenManagementApi.class,
+            databaseTypeProvider);
+
     this.securityEventManagementApi =
         ManagementTypeEntryServiceProxy.createProxy(
             new SecurityEventManagementEntryService(
@@ -1296,6 +1316,17 @@ public class IdpServerApplication {
             OrgIdentityVerificationResultManagementApi.class,
             databaseTypeProvider);
 
+    this.orgTokenManagementApi =
+        ManagementTypeEntryServiceProxy.createProxy(
+            new OrgTokenManagementEntryService(
+                tenantQueryRepository,
+                organizationRepository,
+                oAuthTokenManagementQueryRepository,
+                oAuthTokenManagementCommandRepository,
+                auditLogPublisher),
+            OrgTokenManagementApi.class,
+            databaseTypeProvider);
+
     this.orgAuditLogManagementApi =
         ManagementTypeEntryServiceProxy.createProxy(
             new OrgAuditLogManagementEntryService(
@@ -1459,6 +1490,10 @@ public class IdpServerApplication {
     return identityVerificationResultManagementApi;
   }
 
+  public TokenManagementApi tokenManagementApi() {
+    return tokenManagementApi;
+  }
+
   public UserAuthenticationApi operatorAuthenticationApi() {
     return userAuthenticationApi;
   }
@@ -1586,6 +1621,10 @@ public class IdpServerApplication {
 
   public OrgIdentityVerificationResultManagementApi orgIdentityVerificationResultManagementApi() {
     return orgIdentityVerificationResultManagementApi;
+  }
+
+  public OrgTokenManagementApi orgTokenManagementApi() {
+    return orgTokenManagementApi;
   }
 
   public OrgAuditLogManagementApi orgAuditLogManagementApi() {

--- a/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/IdpServerApplication.java
+++ b/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/IdpServerApplication.java
@@ -1039,6 +1039,10 @@ public class IdpServerApplication {
             new TokenManagementEntryService(
                 oAuthTokenManagementQueryRepository,
                 oAuthTokenManagementCommandRepository,
+                oAuthTokenCommandRepository,
+                authorizationServerConfigurationQueryRepository,
+                clientConfigurationQueryRepository,
+                userQueryRepository,
                 tenantQueryRepository,
                 auditLogPublisher),
             TokenManagementApi.class,
@@ -1323,6 +1327,10 @@ public class IdpServerApplication {
                 organizationRepository,
                 oAuthTokenManagementQueryRepository,
                 oAuthTokenManagementCommandRepository,
+                oAuthTokenCommandRepository,
+                authorizationServerConfigurationQueryRepository,
+                clientConfigurationQueryRepository,
+                userQueryRepository,
                 auditLogPublisher),
             OrgTokenManagementApi.class,
             databaseTypeProvider);

--- a/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/control_plane/organization_manager/OrgTokenManagementEntryService.java
+++ b/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/control_plane/organization_manager/OrgTokenManagementEntryService.java
@@ -24,8 +24,12 @@ import org.idp.server.control_plane.base.OrganizationAuthenticationContext;
 import org.idp.server.control_plane.management.token.OrgTokenManagementApi;
 import org.idp.server.control_plane.management.token.handler.*;
 import org.idp.server.control_plane.management.token.io.*;
+import org.idp.server.core.openid.identity.repository.UserQueryRepository;
+import org.idp.server.core.openid.oauth.configuration.AuthorizationServerConfigurationQueryRepository;
+import org.idp.server.core.openid.oauth.configuration.client.ClientConfigurationQueryRepository;
 import org.idp.server.core.openid.token.OAuthTokenIdentifier;
 import org.idp.server.core.openid.token.OAuthTokenQueries;
+import org.idp.server.core.openid.token.repository.OAuthTokenCommandRepository;
 import org.idp.server.core.openid.token.repository.OAuthTokenManagementCommandRepository;
 import org.idp.server.core.openid.token.repository.OAuthTokenManagementQueryRepository;
 import org.idp.server.platform.audit.AuditLog;
@@ -47,9 +51,20 @@ public class OrgTokenManagementEntryService implements OrgTokenManagementApi {
       OrganizationRepository organizationRepository,
       OAuthTokenManagementQueryRepository queryRepository,
       OAuthTokenManagementCommandRepository commandRepository,
+      OAuthTokenCommandRepository oAuthTokenCommandRepository,
+      AuthorizationServerConfigurationQueryRepository serverConfigRepository,
+      ClientConfigurationQueryRepository clientConfigRepository,
+      UserQueryRepository userQueryRepository,
       AuditLogPublisher auditLogPublisher) {
 
     Map<String, TokenManagementService<?>> services = new HashMap<>();
+    services.put(
+        "create",
+        new TokenCreationService(
+            serverConfigRepository,
+            clientConfigRepository,
+            userQueryRepository,
+            oAuthTokenCommandRepository));
     services.put("findList", new TokenFindListService(queryRepository));
     services.put("get", new TokenFindService(queryRepository));
     services.put("delete", new TokenDeletionService(queryRepository, commandRepository));
@@ -64,6 +79,30 @@ public class OrgTokenManagementEntryService implements OrgTokenManagementApi {
             organizationRepository,
             new OrganizationAccessVerifier());
     this.auditLogPublisher = auditLogPublisher;
+  }
+
+  @Override
+  public TokenManagementResponse create(
+      OrganizationAuthenticationContext authenticationContext,
+      TenantIdentifier tenantIdentifier,
+      Map<String, Object> body,
+      RequestAttributes requestAttributes,
+      boolean dryRun) {
+
+    TokenCreateRequest createRequest = new TokenCreateRequest(body);
+    TokenManagementResult result =
+        handler.handle(
+            "create",
+            authenticationContext,
+            tenantIdentifier,
+            createRequest,
+            requestAttributes,
+            dryRun);
+
+    AuditLog auditLog = AuditLogCreator.create(result.context());
+    auditLogPublisher.publish(auditLog);
+
+    return result.toResponse(dryRun);
   }
 
   @Override

--- a/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/control_plane/organization_manager/OrgTokenManagementEntryService.java
+++ b/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/control_plane/organization_manager/OrgTokenManagementEntryService.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright 2025 Hirokazu Kobayashi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.idp.server.usecases.control_plane.organization_manager;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.idp.server.control_plane.base.AuditLogCreator;
+import org.idp.server.control_plane.base.OrganizationAccessVerifier;
+import org.idp.server.control_plane.base.OrganizationAuthenticationContext;
+import org.idp.server.control_plane.management.token.OrgTokenManagementApi;
+import org.idp.server.control_plane.management.token.handler.*;
+import org.idp.server.control_plane.management.token.io.*;
+import org.idp.server.core.openid.token.OAuthTokenIdentifier;
+import org.idp.server.core.openid.token.OAuthTokenQueries;
+import org.idp.server.core.openid.token.repository.OAuthTokenManagementCommandRepository;
+import org.idp.server.core.openid.token.repository.OAuthTokenManagementQueryRepository;
+import org.idp.server.platform.audit.AuditLog;
+import org.idp.server.platform.audit.AuditLogPublisher;
+import org.idp.server.platform.datasource.Transaction;
+import org.idp.server.platform.multi_tenancy.organization.OrganizationRepository;
+import org.idp.server.platform.multi_tenancy.tenant.TenantIdentifier;
+import org.idp.server.platform.multi_tenancy.tenant.TenantQueryRepository;
+import org.idp.server.platform.type.RequestAttributes;
+
+@Transaction
+public class OrgTokenManagementEntryService implements OrgTokenManagementApi {
+
+  private final OrgTokenManagementHandler handler;
+  private final AuditLogPublisher auditLogPublisher;
+
+  public OrgTokenManagementEntryService(
+      TenantQueryRepository tenantQueryRepository,
+      OrganizationRepository organizationRepository,
+      OAuthTokenManagementQueryRepository queryRepository,
+      OAuthTokenManagementCommandRepository commandRepository,
+      AuditLogPublisher auditLogPublisher) {
+
+    Map<String, TokenManagementService<?>> services = new HashMap<>();
+    services.put("findList", new TokenFindListService(queryRepository));
+    services.put("get", new TokenFindService(queryRepository));
+    services.put("delete", new TokenDeletionService(queryRepository, commandRepository));
+    services.put(
+        "deleteUserTokens", new TokenUserDeletionService(queryRepository, commandRepository));
+
+    this.handler =
+        new OrgTokenManagementHandler(
+            services,
+            this,
+            tenantQueryRepository,
+            organizationRepository,
+            new OrganizationAccessVerifier());
+    this.auditLogPublisher = auditLogPublisher;
+  }
+
+  @Override
+  @Transaction(readOnly = true)
+  public TokenManagementResponse findList(
+      OrganizationAuthenticationContext authenticationContext,
+      TenantIdentifier tenantIdentifier,
+      OAuthTokenQueries queries,
+      RequestAttributes requestAttributes) {
+
+    TokenFindListRequest findListRequest = new TokenFindListRequest(queries);
+    TokenManagementResult result =
+        handler.handle(
+            "findList",
+            authenticationContext,
+            tenantIdentifier,
+            findListRequest,
+            requestAttributes,
+            false);
+
+    AuditLog auditLog = AuditLogCreator.create(result.context());
+    auditLogPublisher.publish(auditLog);
+
+    return result.toResponse(false);
+  }
+
+  @Override
+  @Transaction(readOnly = true)
+  public TokenManagementResponse get(
+      OrganizationAuthenticationContext authenticationContext,
+      TenantIdentifier tenantIdentifier,
+      OAuthTokenIdentifier identifier,
+      RequestAttributes requestAttributes) {
+
+    TokenFindRequest findRequest = new TokenFindRequest(identifier);
+    TokenManagementResult result =
+        handler.handle(
+            "get", authenticationContext, tenantIdentifier, findRequest, requestAttributes, false);
+
+    AuditLog auditLog = AuditLogCreator.create(result.context());
+    auditLogPublisher.publish(auditLog);
+
+    return result.toResponse(false);
+  }
+
+  @Override
+  public TokenManagementResponse delete(
+      OrganizationAuthenticationContext authenticationContext,
+      TenantIdentifier tenantIdentifier,
+      OAuthTokenIdentifier identifier,
+      RequestAttributes requestAttributes,
+      boolean dryRun) {
+
+    TokenDeleteRequest deleteRequest = new TokenDeleteRequest(identifier);
+    TokenManagementResult result =
+        handler.handle(
+            "delete",
+            authenticationContext,
+            tenantIdentifier,
+            deleteRequest,
+            requestAttributes,
+            dryRun);
+
+    AuditLog auditLog = AuditLogCreator.create(result.context());
+    auditLogPublisher.publish(auditLog);
+
+    return result.toResponse(dryRun);
+  }
+
+  @Override
+  public TokenManagementResponse deleteUserTokens(
+      OrganizationAuthenticationContext authenticationContext,
+      TenantIdentifier tenantIdentifier,
+      String userId,
+      RequestAttributes requestAttributes,
+      boolean dryRun) {
+
+    TokenUserDeleteRequest deleteRequest = new TokenUserDeleteRequest(userId);
+    TokenManagementResult result =
+        handler.handle(
+            "deleteUserTokens",
+            authenticationContext,
+            tenantIdentifier,
+            deleteRequest,
+            requestAttributes,
+            dryRun);
+
+    AuditLog auditLog = AuditLogCreator.create(result.context());
+    auditLogPublisher.publish(auditLog);
+
+    return result.toResponse(dryRun);
+  }
+}

--- a/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/control_plane/system_manager/TokenManagementEntryService.java
+++ b/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/control_plane/system_manager/TokenManagementEntryService.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2025 Hirokazu Kobayashi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.idp.server.usecases.control_plane.system_manager;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.idp.server.control_plane.base.AdminAuthenticationContext;
+import org.idp.server.control_plane.base.AuditLogCreator;
+import org.idp.server.control_plane.management.token.TokenManagementApi;
+import org.idp.server.control_plane.management.token.handler.*;
+import org.idp.server.control_plane.management.token.io.*;
+import org.idp.server.core.openid.token.OAuthTokenIdentifier;
+import org.idp.server.core.openid.token.OAuthTokenQueries;
+import org.idp.server.core.openid.token.repository.OAuthTokenManagementCommandRepository;
+import org.idp.server.core.openid.token.repository.OAuthTokenManagementQueryRepository;
+import org.idp.server.platform.audit.AuditLog;
+import org.idp.server.platform.audit.AuditLogPublisher;
+import org.idp.server.platform.datasource.Transaction;
+import org.idp.server.platform.multi_tenancy.tenant.TenantIdentifier;
+import org.idp.server.platform.multi_tenancy.tenant.TenantQueryRepository;
+import org.idp.server.platform.type.RequestAttributes;
+
+@Transaction
+public class TokenManagementEntryService implements TokenManagementApi {
+
+  private final TokenManagementHandler handler;
+  private final AuditLogPublisher auditLogPublisher;
+
+  public TokenManagementEntryService(
+      OAuthTokenManagementQueryRepository queryRepository,
+      OAuthTokenManagementCommandRepository commandRepository,
+      TenantQueryRepository tenantQueryRepository,
+      AuditLogPublisher auditLogPublisher) {
+
+    Map<String, TokenManagementService<?>> services = new HashMap<>();
+    services.put("findList", new TokenFindListService(queryRepository));
+    services.put("get", new TokenFindService(queryRepository));
+    services.put("delete", new TokenDeletionService(queryRepository, commandRepository));
+    services.put(
+        "deleteUserTokens", new TokenUserDeletionService(queryRepository, commandRepository));
+
+    this.handler = new TokenManagementHandler(services, this, tenantQueryRepository);
+    this.auditLogPublisher = auditLogPublisher;
+  }
+
+  @Override
+  @Transaction(readOnly = true)
+  public TokenManagementResponse findList(
+      AdminAuthenticationContext authenticationContext,
+      TenantIdentifier tenantIdentifier,
+      OAuthTokenQueries queries,
+      RequestAttributes requestAttributes) {
+
+    TokenFindListRequest findListRequest = new TokenFindListRequest(queries);
+    TokenManagementResult result =
+        handler.handle(
+            "findList",
+            authenticationContext,
+            tenantIdentifier,
+            findListRequest,
+            requestAttributes,
+            false);
+
+    AuditLog auditLog = AuditLogCreator.create(result.context());
+    auditLogPublisher.publish(auditLog);
+
+    return result.toResponse(false);
+  }
+
+  @Override
+  @Transaction(readOnly = true)
+  public TokenManagementResponse get(
+      AdminAuthenticationContext authenticationContext,
+      TenantIdentifier tenantIdentifier,
+      OAuthTokenIdentifier identifier,
+      RequestAttributes requestAttributes) {
+
+    TokenFindRequest findRequest = new TokenFindRequest(identifier);
+    TokenManagementResult result =
+        handler.handle(
+            "get", authenticationContext, tenantIdentifier, findRequest, requestAttributes, false);
+
+    AuditLog auditLog = AuditLogCreator.create(result.context());
+    auditLogPublisher.publish(auditLog);
+
+    return result.toResponse(false);
+  }
+
+  @Override
+  public TokenManagementResponse delete(
+      AdminAuthenticationContext authenticationContext,
+      TenantIdentifier tenantIdentifier,
+      OAuthTokenIdentifier identifier,
+      RequestAttributes requestAttributes,
+      boolean dryRun) {
+
+    TokenDeleteRequest deleteRequest = new TokenDeleteRequest(identifier);
+    TokenManagementResult result =
+        handler.handle(
+            "delete",
+            authenticationContext,
+            tenantIdentifier,
+            deleteRequest,
+            requestAttributes,
+            dryRun);
+
+    AuditLog auditLog = AuditLogCreator.create(result.context());
+    auditLogPublisher.publish(auditLog);
+
+    return result.toResponse(dryRun);
+  }
+
+  @Override
+  public TokenManagementResponse deleteUserTokens(
+      AdminAuthenticationContext authenticationContext,
+      TenantIdentifier tenantIdentifier,
+      String userId,
+      RequestAttributes requestAttributes,
+      boolean dryRun) {
+
+    TokenUserDeleteRequest deleteRequest = new TokenUserDeleteRequest(userId);
+    TokenManagementResult result =
+        handler.handle(
+            "deleteUserTokens",
+            authenticationContext,
+            tenantIdentifier,
+            deleteRequest,
+            requestAttributes,
+            dryRun);
+
+    AuditLog auditLog = AuditLogCreator.create(result.context());
+    auditLogPublisher.publish(auditLog);
+
+    return result.toResponse(dryRun);
+  }
+}

--- a/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/control_plane/system_manager/TokenManagementEntryService.java
+++ b/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/control_plane/system_manager/TokenManagementEntryService.java
@@ -23,8 +23,12 @@ import org.idp.server.control_plane.base.AuditLogCreator;
 import org.idp.server.control_plane.management.token.TokenManagementApi;
 import org.idp.server.control_plane.management.token.handler.*;
 import org.idp.server.control_plane.management.token.io.*;
+import org.idp.server.core.openid.identity.repository.UserQueryRepository;
+import org.idp.server.core.openid.oauth.configuration.AuthorizationServerConfigurationQueryRepository;
+import org.idp.server.core.openid.oauth.configuration.client.ClientConfigurationQueryRepository;
 import org.idp.server.core.openid.token.OAuthTokenIdentifier;
 import org.idp.server.core.openid.token.OAuthTokenQueries;
+import org.idp.server.core.openid.token.repository.OAuthTokenCommandRepository;
 import org.idp.server.core.openid.token.repository.OAuthTokenManagementCommandRepository;
 import org.idp.server.core.openid.token.repository.OAuthTokenManagementQueryRepository;
 import org.idp.server.platform.audit.AuditLog;
@@ -43,10 +47,21 @@ public class TokenManagementEntryService implements TokenManagementApi {
   public TokenManagementEntryService(
       OAuthTokenManagementQueryRepository queryRepository,
       OAuthTokenManagementCommandRepository commandRepository,
+      OAuthTokenCommandRepository oAuthTokenCommandRepository,
+      AuthorizationServerConfigurationQueryRepository serverConfigRepository,
+      ClientConfigurationQueryRepository clientConfigRepository,
+      UserQueryRepository userQueryRepository,
       TenantQueryRepository tenantQueryRepository,
       AuditLogPublisher auditLogPublisher) {
 
     Map<String, TokenManagementService<?>> services = new HashMap<>();
+    services.put(
+        "create",
+        new TokenCreationService(
+            serverConfigRepository,
+            clientConfigRepository,
+            userQueryRepository,
+            oAuthTokenCommandRepository));
     services.put("findList", new TokenFindListService(queryRepository));
     services.put("get", new TokenFindService(queryRepository));
     services.put("delete", new TokenDeletionService(queryRepository, commandRepository));
@@ -55,6 +70,30 @@ public class TokenManagementEntryService implements TokenManagementApi {
 
     this.handler = new TokenManagementHandler(services, this, tenantQueryRepository);
     this.auditLogPublisher = auditLogPublisher;
+  }
+
+  @Override
+  public TokenManagementResponse create(
+      AdminAuthenticationContext authenticationContext,
+      TenantIdentifier tenantIdentifier,
+      Map<String, Object> body,
+      RequestAttributes requestAttributes,
+      boolean dryRun) {
+
+    TokenCreateRequest createRequest = new TokenCreateRequest(body);
+    TokenManagementResult result =
+        handler.handle(
+            "create",
+            authenticationContext,
+            tenantIdentifier,
+            createRequest,
+            requestAttributes,
+            dryRun);
+
+    AuditLog auditLog = AuditLogCreator.create(result.context());
+    auditLogPublisher.publish(auditLog);
+
+    return result.toResponse(dryRun);
   }
 
   @Override


### PR DESCRIPTION
## Summary

- OAuthトークンの管理API（Token Management API）をシステムレベル・組織レベルで追加
- トークン値を含めずメタデータのみ返すセキュアな設計
- dry_run対応（個別削除・ユーザー全トークン一括削除）
- E2Eテスト（基本テスト + シナリオテスト）、OpenAPI仕様書追加

## 変更内容

### 管理API（GET list / GET detail / DELETE / DELETE user tokens）

| エンドポイント | 概要 |
|---|---|
| `GET /v1/management/tenants/{id}/tokens` | トークン一覧取得（user_id/client_id/grant_type/from/to/expiredフィルタ） |
| `GET /v1/management/tenants/{id}/tokens/{id}` | トークン詳細取得 |
| `DELETE /v1/management/tenants/{id}/tokens/{id}` | トークン個別失効（dry_run対応） |
| `DELETE /v1/management/tenants/{id}/users/{id}/tokens` | ユーザー全トークン失効（dry_run対応） |
| 上記の組織レベル版（`/organizations/{orgId}/tenants/{tenantId}/...`） | 同上 |

### セキュリティ設計
- アクセストークン値・リフレッシュトークン値はレスポンスに**含めない**
- `has_refresh_token` フラグで有無のみ表示
- 暗号化データを扱わない軽量SELECTで管理用query層を分離

### E2Eテスト
- **基本テスト**: ページネーション、フィルタ（grant_type/client_id/時間範囲）、404、dry_run（system/org）
- **シナリオテスト**: Onboarding → ログイン → トークン一覧 → 詳細取得 → dry_run削除 → 実削除 → introspectionで無効確認 → refresh token無効確認 → ユーザー全トークン削除

### ドキュメント
- `swagger-cp-token-ja.yaml` 追加
- Docusaurusビルド設定・APIリファレンスリンク追加

## Test plan
- [x] E2Eシナリオテスト（standard-06-token-management）パス
- [x] `./gradlew compileJava` ビルド成功
- [x] Docker起動確認済み

Closes #1406

🤖 Generated with [Claude Code](https://claude.com/claude-code)