### PR TITLE
feat: Spring Boot 4.0.6 + Jackson 3.1.2 移行

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,17 @@
 # -------- Step 1: Build Stage --------
-FROM gradle:8.14-jdk21-alpine AS builder
-
-WORKDIR /workspace
-
-# cache
-COPY settings.gradle build.gradle /workspace/
-COPY gradle /workspace/gradle
-
-# copy module
-COPY libs /workspace/libs
-COPY app /workspace/app
-
-RUN gradle clean build -x test --no-daemon
+#FROM gradle:8.14-jdk21-alpine AS builder
+#
+#WORKDIR /workspace
+#
+## cache
+#COPY settings.gradle build.gradle /workspace/
+#COPY gradle /workspace/gradle
+#
+## copy module
+#COPY libs /workspace/libs
+#COPY app /workspace/app
+#
+#RUN gradle clean build -x test --no-daemon
 
 # -------- Step 2: Runtime Stage --------
 FROM eclipse-temurin:21-jre-alpine AS runtime
@@ -19,7 +19,7 @@ FROM eclipse-temurin:21-jre-alpine AS runtime
 WORKDIR /app
 
 # app/build/libs/app-x.x.x.jar
-COPY --from=builder /workspace/app/build/libs/idp-server-*.jar /app/idp-server.jar
+COPY ./app/build/libs/idp-server-*.jar /app/idp-server.jar
 COPY entrypoint.sh /app/entrypoint.sh
 COPY plugins /app/plugins
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,17 @@
 # -------- Step 1: Build Stage --------
-#FROM gradle:8.14-jdk21-alpine AS builder
-#
-#WORKDIR /workspace
-#
-## cache
-#COPY settings.gradle build.gradle /workspace/
-#COPY gradle /workspace/gradle
-#
-## copy module
-#COPY libs /workspace/libs
-#COPY app /workspace/app
-#
-#RUN gradle clean build -x test --no-daemon
+FROM gradle:8.14-jdk21-alpine AS builder
+
+WORKDIR /workspace
+
+# cache
+COPY settings.gradle build.gradle /workspace/
+COPY gradle /workspace/gradle
+
+# copy module
+COPY libs /workspace/libs
+COPY app /workspace/app
+
+RUN gradle clean build -x test --no-daemon
 
 # -------- Step 2: Runtime Stage --------
 FROM eclipse-temurin:21-jre-alpine AS runtime
@@ -19,7 +19,7 @@ FROM eclipse-temurin:21-jre-alpine AS runtime
 WORKDIR /app
 
 # app/build/libs/app-x.x.x.jar
-COPY ./app/build/libs/idp-server-*.jar /app/idp-server.jar
+COPY --from=builder /workspace/app/build/libs/idp-server-*.jar /app/idp-server.jar
 COPY entrypoint.sh /app/entrypoint.sh
 COPY plugins /app/plugins
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,7 +1,7 @@
 plugins {
 	id 'java'
-	id 'org.springframework.boot' version '3.5.6'
-	id 'io.spring.dependency-management' version '1.1.4'
+	id 'org.springframework.boot' version '4.0.4'
+	id 'io.spring.dependency-management' version '1.1.7'
 	id "com.diffplug.spotless" version "6.24.0"
 }
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,6 +1,6 @@
 plugins {
 	id 'java'
-	id 'org.springframework.boot' version '4.0.4'
+	id 'org.springframework.boot' version '4.0.6'
 	id 'io.spring.dependency-management' version '1.1.7'
 	id "com.diffplug.spotless" version "6.24.0"
 }

--- a/app/src/main/java/org/idp/server/IdPApplication.java
+++ b/app/src/main/java/org/idp/server/IdPApplication.java
@@ -18,9 +18,8 @@ package org.idp.server;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.autoconfigure.session.SessionAutoConfiguration;
 
-@SpringBootApplication(exclude = SessionAutoConfiguration.class)
+@SpringBootApplication
 public class IdPApplication {
 
   public static void main(String[] args) {

--- a/documentation/docs/content_06_developer-guide/06-migration/01-spring-boot-4-migration.md
+++ b/documentation/docs/content_06_developer-guide/06-migration/01-spring-boot-4-migration.md
@@ -1,0 +1,245 @@
+# Spring Boot 4.0 移行ガイド
+
+## 概要
+
+Spring Boot 3.5.6 → 4.0.4 + Jackson 2 → 3 への移行で発生した問題と対応をまとめる。
+
+### バージョン変更
+
+| コンポーネント | Before | After |
+|-------------|--------|-------|
+| Spring Boot | 3.5.6 | 4.0.4 |
+| Spring Framework | 6.x | 7.x |
+| Spring Security | 6.x | 7.x |
+| Jackson | 2.14.2 | 3.1.0 |
+| Servlet API | 6.0 (Tomcat 10.x) | 6.1 (Tomcat 11) |
+| dependency-management plugin | 1.1.4 | 1.1.7 |
+
+---
+
+## 1. Jackson 2 → 3 移行
+
+> **公式ガイド**: [Migrating to Jackson 3](https://github.com/FasterXML/jackson/blob/main/jackson3/MIGRATING_TO_JACKSON_3.md) | [Jackson 3.0.0 Release Notes](https://cowtowncoder.medium.com/jackson-3-0-0-ga-released-1f669cda529a) | [Jackson 3 in Spring Boot 4](https://www.danvega.dev/blog/2025/11/10/jackson-3-spring-boot-4) | [Spring の Jackson 3 サポート](https://spring.io/blog/2025/10/07/introducing-jackson-3-support-in-spring/)
+
+### 1.1 パッケージ変更
+
+| Before | After | 備考 |
+|--------|-------|------|
+| `com.fasterxml.jackson.databind.ObjectMapper` | `tools.jackson.databind.json.JsonMapper` | immutable builder pattern |
+| `com.fasterxml.jackson.core.JsonProcessingException` | `tools.jackson.core.JacksonException` | unchecked exception |
+| `com.fasterxml.jackson.databind.JsonNode` | `tools.jackson.databind.JsonNode` | |
+| `com.fasterxml.jackson.databind.node.JsonNodeFactory` | `tools.jackson.databind.node.JsonNodeFactory` | |
+| `com.fasterxml.jackson.databind.PropertyNamingStrategies` | `tools.jackson.databind.PropertyNamingStrategies` | |
+| `com.fasterxml.jackson.annotation.*` | 変更なし | annotations は共有 |
+
+### 1.2 API 変更
+
+#### ObjectMapper → JsonMapper (Builder Pattern)
+
+```java
+// Before (Jackson 2)
+ObjectMapper objectMapper = new ObjectMapper();
+objectMapper.setVisibility(PropertyAccessor.ALL, Visibility.NONE);
+objectMapper.setVisibility(PropertyAccessor.FIELD, Visibility.ANY);
+objectMapper.setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE);
+objectMapper.registerModule(new JavaTimeModule());
+
+// After (Jackson 3)
+JsonMapper jsonMapper = JsonMapper.builder()
+    .changeDefaultVisibility(vc ->
+        vc.withVisibility(PropertyAccessor.ALL, Visibility.NONE)
+          .withVisibility(PropertyAccessor.FIELD, Visibility.ANY))
+    .propertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE)
+    // JavaTimeModule は不要（Jackson 3 に内蔵）
+    .build();
+```
+
+#### Coercion 設定
+
+```java
+// Before (Jackson 2)
+objectMapper
+    .coercionConfigFor(LogicalType.Collection)
+    .setCoercion(CoercionInputShape.String, CoercionAction.AsNull);
+
+// After (Jackson 3)
+JsonMapper.builder()
+    .withCoercionConfig(LogicalType.Collection, config -> {
+        config.setCoercion(CoercionInputShape.String, CoercionAction.AsNull);
+    })
+    .build();
+```
+
+#### JsonNode API 変更
+
+| Before (Jackson 2) | After (Jackson 3) |
+|---------------------|-------------------|
+| `jsonNode.fieldNames()` | `jsonNode.properties()` → `Set<Map.Entry<String, JsonNode>>` |
+| `jsonNode.elements()` | `jsonNode.iterator()` |
+
+#### jackson-datatype-jsr310
+
+Jackson 3 では `java.time` サポートが内蔵されたため、`jackson-datatype-jsr310` 依存は不要。
+
+### 1.3 private final フィールド問題（重要）
+
+**Jackson 3 では `private final` フィールドへのリフレクション書き込みができなくなった。**
+
+Jackson でデシリアライズされるクラス（Redis キャッシュ経由、JSON → Object 変換等）の `private final` フィールドを `private` に変更する必要がある。
+
+```java
+// Before - Jackson 3 でデシリアライズ失敗
+public class SecurityEventLogConfiguration {
+    private final boolean persistenceEnabled;  // ← final があるとデフォルト値のまま
+}
+
+// After - Jackson 3 でデシリアライズ成功
+public class SecurityEventLogConfiguration {
+    private boolean persistenceEnabled;  // ← final を外す
+}
+```
+
+**影響範囲**: フィールドの型として使われるネストされたオブジェクトも含めて、デシリアライズ対象のオブジェクトグラフ全体で `private final` を確認する必要がある。
+
+**対象クラスの例**:
+- テナント設定クラス（`SecurityEventLogConfiguration`, `SessionConfiguration`, `CorsConfiguration`, `UIConfiguration` 等）
+- セッション関連値オブジェクト（`OPSessionIdentifier`, `BrowserState` 等）
+- Redis キャッシュ経由でシリアライズ/デシリアライズされる全オブジェクト
+
+---
+
+## 2. Spring Boot 4.0 固有の変更
+
+> **公式ガイド**: [Spring Boot 4.0 Migration Guide](https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-4.0-Migration-Guide) | [Spring Boot 4.0 Release Notes](https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-4.0-Release-Notes) | [Spring Security 7 リファレンス](https://docs.spring.io/spring-security/reference/)
+
+### 2.1 SessionAutoConfiguration 削除
+
+Spring Boot 4.0 では `SessionAutoConfiguration` が削除された。
+
+```java
+// Before
+@SpringBootApplication(exclude = SessionAutoConfiguration.class)
+public class IdPApplication { }
+
+// After
+@SpringBootApplication
+public class IdPApplication { }
+```
+
+### 2.2 ContentCachingRequestWrapper
+
+`ContentCachingRequestWrapper` のコンストラクタに `maxContentLength` 引数が必須になった。
+
+```java
+// Before
+new ContentCachingRequestWrapper(request);
+
+// After
+new ContentCachingRequestWrapper(request, 50000);
+```
+
+### 2.3 httpBasic の無効化
+
+Spring Security 7 では `httpBasic` を明示的に無効化する必要がある場合がある。
+
+```java
+http.httpBasic(AbstractHttpConfigurer::disable);
+```
+
+---
+
+## 3. Tomcat 11 (Servlet 6.1) の変更
+
+> **公式ガイド**: [Tomcat 11 Migration Guide](https://tomcat.apache.org/migration-11.html) | [Servlet 6.1 Specification (Jakarta EE 11)](https://jakarta.ee/specifications/servlet/6.1/) | [RFC 7230 Section 3.2 - Header Fields](https://www.rfc-editor.org/rfc/rfc7230#section-3.2)
+
+### 3.1 ヘッダー名のケース保持
+
+**Tomcat 10.x** では `HttpServletRequest.getHeaderNames()` がヘッダー名を小文字で返していたが、**Tomcat 11** では原形のケースを保持するようになった。
+
+```
+Tomcat 10.x: "authorization"
+Tomcat 11:   "Authorization"
+```
+
+HTTP ヘッダー名は RFC 7230 で case-insensitive と定義されているため、ヘッダー名でMap検索する場合は case-insensitive で比較する必要がある。
+
+```java
+// Before - Tomcat 10.x では動いたが Tomcat 11 で失敗
+String authorization = headersMap.get("authorization");
+
+// After - case-insensitive 検索
+private String getHeaderValueCaseInsensitive(Map<String, String> headers, String name) {
+    for (Map.Entry<String, String> entry : headers.entrySet()) {
+        if (entry.getKey().equalsIgnoreCase(name)) {
+            return entry.getValue();
+        }
+    }
+    return "";
+}
+```
+
+**注意**: Spring MVC の `@RequestHeader` アノテーションは内部で case-insensitive 処理を行うため、この問題は発生しない。問題は `HttpServletRequest.getHeaderNames()` で取得したヘッダー名を自前で Map に格納し、後から文字列キーで検索するパターンで発生する。
+
+---
+
+## 4. 移行チェックリスト
+
+### build.gradle
+
+- [ ] Spring Boot バージョンを 4.0.x に更新
+- [ ] dependency-management プラグインを 1.1.7 に更新
+- [ ] Jackson 依存を `tools.jackson.core:jackson-databind` に変更
+- [ ] `jackson-datatype-jsr310` 依存を削除
+
+### Java コード
+
+- [ ] Jackson import 文を `tools.jackson.*` に変更（annotations は除く）
+- [ ] `ObjectMapper` → `JsonMapper` (Builder Pattern) に変更
+- [ ] `JsonProcessingException` → `JacksonException` に変更
+- [ ] `fieldNames()` → `properties()` に変更
+- [ ] `elements()` → `iterator()` に変更
+- [ ] Coercion 設定を Builder API に変更
+- [ ] `SessionAutoConfiguration` の exclude を削除
+- [ ] `ContentCachingRequestWrapper` に `maxContentLength` 引数を追加
+- [ ] Jackson でデシリアライズされるクラスの `private final` → `private` に変更
+- [ ] ヘッダー名の case-insensitive 検索を確認
+
+### テスト
+
+- [ ] ユニットテスト全通し
+- [ ] E2E テスト全通し
+- [ ] Redis キャッシュをフラッシュしてからテスト（古い形式のキャッシュデータが残ると問題）
+
+---
+
+## 5. 影響を受けないもの
+
+- `@RequestHeader` アノテーション経由のヘッダー取得（Spring MVC が case-insensitive 処理）
+- `com.fasterxml.jackson.annotation.*`（Jackson 2/3 共有）
+- MongoDB, Undertow, Hazelcast（未使用）
+- `@MockBean` / `@SpyBean`（未使用）
+
+---
+
+## 参考資料
+
+### Spring Boot / Spring Framework
+- [Spring Boot 4.0 Migration Guide](https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-4.0-Migration-Guide)
+- [Spring Boot 4.0 Release Notes](https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-4.0-Release-Notes)
+- [Spring Boot 4.0 Migration Guide for Production Teams](https://dev.to/aytronn/spring-boot-40-migration-guide-for-production-teams-what-actually-breaks-and-how-to-upgrade-safely-22me)
+- [Spring Boot 4 Migration Guide: Faster, Safer, at Scale (Moderne)](https://www.moderne.ai/blog/spring-boot-4x-migration-guide)
+- [Spring Security 7 リファレンス](https://docs.spring.io/spring-security/reference/)
+- [Spring Boot Dependency Versions](https://docs.spring.io/spring-boot/appendix/dependency-versions/index.html)
+
+### Jackson
+- [Jackson 3 Migration Guide](https://github.com/FasterXML/jackson/blob/main/jackson3/MIGRATING_TO_JACKSON_3.md)
+- [Jackson 3.0.0 (GA) Released](https://cowtowncoder.medium.com/jackson-3-0-0-ga-released-1f669cda529a)
+- [Jackson 3 in Spring Boot 4: JsonMapper, JSON Views, and What's Changed](https://www.danvega.dev/blog/2025/11/10/jackson-3-spring-boot-4)
+- [Introducing Jackson 3 support in Spring](https://spring.io/blog/2025/10/07/introducing-jackson-3-support-in-spring/)
+- [Upgrading to Jackson 3 with Spring Boot 4](https://dimitri.codes/jsonmapper/)
+- [OpenRewrite: Migrate Jackson 2.x to 3.x](https://docs.openrewrite.org/recipes/java/jackson/upgradejackson_2_3)
+
+### Tomcat / Servlet
+- [Tomcat 11 Migration Guide](https://tomcat.apache.org/migration-11.html)
+- [Jakarta EE 11 - Servlet 6.1 Specification](https://jakarta.ee/specifications/servlet/6.1/)
+- [RFC 7230 Section 3.2 - Header Fields (case-insensitive)](https://www.rfc-editor.org/rfc/rfc7230#section-3.2)

--- a/documentation/docs/content_06_developer-guide/06-migration/01-spring-boot-4-migration.md
+++ b/documentation/docs/content_06_developer-guide/06-migration/01-spring-boot-4-migration.md
@@ -2,16 +2,16 @@
 
 ## 概要
 
-Spring Boot 3.5.6 → 4.0.4 + Jackson 2 → 3 への移行で発生した問題と対応をまとめる。
+Spring Boot 3.5.6 → 4.0.6 + Jackson 2 → 3 への移行で発生した問題と対応をまとめる。
 
 ### バージョン変更
 
 | コンポーネント | Before | After |
 |-------------|--------|-------|
-| Spring Boot | 3.5.6 | 4.0.4 |
+| Spring Boot | 3.5.6 | 4.0.6 |
 | Spring Framework | 6.x | 7.x |
 | Spring Security | 6.x | 7.x |
-| Jackson | 2.14.2 | 3.1.0 |
+| Jackson | 2.14.2 | 3.1.2 |
 | Servlet API | 6.0 (Tomcat 10.x) | 6.1 (Tomcat 11) |
 | dependency-management plugin | 1.1.4 | 1.1.7 |
 
@@ -105,6 +105,24 @@ public class SecurityEventLogConfiguration {
 - テナント設定クラス（`SecurityEventLogConfiguration`, `SessionConfiguration`, `CorsConfiguration`, `UIConfiguration` 等）
 - セッション関連値オブジェクト（`OPSessionIdentifier`, `BrowserState` 等）
 - Redis キャッシュ経由でシリアライズ/デシリアライズされる全オブジェクト
+
+### 1.4 FAIL_ON_UNKNOWN_PROPERTIES のデフォルト変更（重要）
+
+**Jackson 3 ではデシリアライズ時の未知フィールドの扱いが Jackson 2 と逆になった。**
+
+| バージョン | デフォルト | 未知フィールド遭遇時 |
+|----------|----------|----------|
+| Jackson 2.x | `true` | `UnrecognizedPropertyException` を投げる |
+| Jackson 3.x | `false` | 黙って無視する |
+
+`JsonConverter` は明示的な設定をしていないため、Jackson 3 のデフォルト挙動（**未知フィールドを無視**）が適用される。
+
+**影響**:
+- 設定 JSON や API リクエストの typo は実行時エラーにならない
+- 旧→新、新→旧 の双方向ロールバックで未知フィールドを許容できる（前方互換性向上）
+- Jackson 3.1.0 にはこの設定が `@JsonIgnoreProperties` と相互作用するバグがあり、3.1.2 で修正された
+
+> Jackson 2 互換の厳格挙動を維持したい場合は、`JsonMapper.builder().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, true)` を明示する必要がある。
 
 ---
 

--- a/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/base/OrganizationAccessControlResult.java
+++ b/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/base/OrganizationAccessControlResult.java
@@ -28,8 +28,8 @@ public class OrganizationAccessControlResult {
     FORBIDDEN
   }
 
-  private final AccessControlStatus status;
-  private final String reason;
+  private AccessControlStatus status;
+  private String reason;
 
   private OrganizationAccessControlResult(AccessControlStatus status, String reason) {
     this.status = status;

--- a/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/base/definition/DefaultAdminPermission.java
+++ b/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/base/definition/DefaultAdminPermission.java
@@ -143,8 +143,8 @@ public enum DefaultAdminPermission {
   SYSTEM_READ("idp:system:read", "Admin Read system configuration"),
   SYSTEM_WRITE("idp:system:write", "Admin Write system configuration");
 
-  private final String value;
-  private final String description;
+  private String value;
+  private String description;
 
   DefaultAdminPermission(String value, String description) {
     this.value = value;

--- a/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/base/definition/DefaultAdminRole.java
+++ b/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/base/definition/DefaultAdminRole.java
@@ -28,9 +28,9 @@ public enum DefaultAdminRole {
       "Administrator with full control plane access via wildcard permission",
       DefaultAdminPermission.getWildcard());
 
-  private final String name;
-  private final String description;
-  private final Set<DefaultAdminPermission> permissions;
+  private String name;
+  private String description;
+  private Set<DefaultAdminPermission> permissions;
 
   DefaultAdminRole(String name, String description, Set<DefaultAdminPermission> permissions) {
     this.name = name;

--- a/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/audit/handler/AuditLogManagementResult.java
+++ b/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/audit/handler/AuditLogManagementResult.java
@@ -40,9 +40,9 @@ import org.idp.server.control_plane.management.exception.*;
  */
 public class AuditLogManagementResult {
 
-  private final AuditableContext context;
-  private final ManagementApiException exception;
-  private final AuditLogManagementResponse response;
+  private AuditableContext context;
+  private ManagementApiException exception;
+  private AuditLogManagementResponse response;
 
   private AuditLogManagementResult(
       AuditableContext context,

--- a/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/authentication/configuration/handler/AuthenticationConfigManagementResult.java
+++ b/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/authentication/configuration/handler/AuthenticationConfigManagementResult.java
@@ -40,9 +40,9 @@ import org.idp.server.control_plane.management.exception.*;
  */
 public class AuthenticationConfigManagementResult {
 
-  private final AuditableContext context;
-  private final ManagementApiException exception;
-  private final AuthenticationConfigManagementResponse response;
+  private AuditableContext context;
+  private ManagementApiException exception;
+  private AuthenticationConfigManagementResponse response;
 
   private AuthenticationConfigManagementResult(
       AuditableContext context,

--- a/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/authentication/interaction/handler/AuthenticationInteractionManagementResult.java
+++ b/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/authentication/interaction/handler/AuthenticationInteractionManagementResult.java
@@ -40,9 +40,9 @@ import org.idp.server.control_plane.management.exception.*;
  */
 public class AuthenticationInteractionManagementResult {
 
-  private final AuditableContext context;
-  private final ManagementApiException exception;
-  private final AuthenticationInteractionManagementResponse response;
+  private AuditableContext context;
+  private ManagementApiException exception;
+  private AuthenticationInteractionManagementResponse response;
 
   private AuthenticationInteractionManagementResult(
       AuditableContext context,

--- a/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/authentication/policy/handler/AuthenticationPolicyConfigManagementResult.java
+++ b/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/authentication/policy/handler/AuthenticationPolicyConfigManagementResult.java
@@ -40,9 +40,9 @@ import org.idp.server.control_plane.management.exception.*;
  */
 public class AuthenticationPolicyConfigManagementResult {
 
-  private final AuditableContext context;
-  private final ManagementApiException exception;
-  private final AuthenticationPolicyConfigManagementResponse response;
+  private AuditableContext context;
+  private ManagementApiException exception;
+  private AuthenticationPolicyConfigManagementResponse response;
 
   private AuthenticationPolicyConfigManagementResult(
       AuditableContext context,

--- a/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/authentication/transaction/handler/AuthenticationTransactionManagementResult.java
+++ b/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/authentication/transaction/handler/AuthenticationTransactionManagementResult.java
@@ -43,9 +43,9 @@ import org.idp.server.control_plane.management.exception.ResourceNotFoundExcepti
  */
 public class AuthenticationTransactionManagementResult {
 
-  private final AuditableContext context;
-  private final ManagementApiException exception;
-  private final AuthenticationTransactionManagementResponse response;
+  private AuditableContext context;
+  private ManagementApiException exception;
+  private AuthenticationTransactionManagementResponse response;
 
   private AuthenticationTransactionManagementResult(
       AuditableContext context,

--- a/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/exception/InvalidRequestException.java
+++ b/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/exception/InvalidRequestException.java
@@ -34,7 +34,7 @@ import java.util.Map;
  */
 public class InvalidRequestException extends ManagementApiException {
 
-  private final List<String> errorMessages;
+  private List<String> errorMessages;
 
   public InvalidRequestException(String message, List<String> errorMessages) {
     super(message);

--- a/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/exception/PermissionDeniedException.java
+++ b/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/exception/PermissionDeniedException.java
@@ -36,8 +36,8 @@ import org.idp.server.control_plane.base.definition.AdminPermissions;
  */
 public class PermissionDeniedException extends ManagementApiException {
 
-  private final AdminPermissions required;
-  private final Set<String> actual;
+  private AdminPermissions required;
+  private Set<String> actual;
 
   public PermissionDeniedException(AdminPermissions required, Set<String> actual) {
     super(

--- a/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/federation/io/FederationConfigManagementResult.java
+++ b/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/federation/io/FederationConfigManagementResult.java
@@ -41,9 +41,9 @@ import org.idp.server.control_plane.management.exception.ResourceNotFoundExcepti
  */
 public class FederationConfigManagementResult {
 
-  private final AuditableContext context;
-  private final ManagementApiException exception;
-  private final FederationConfigManagementResponse response;
+  private AuditableContext context;
+  private ManagementApiException exception;
+  private FederationConfigManagementResponse response;
 
   private FederationConfigManagementResult(
       AuditableContext context,

--- a/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/identity/user/handler/UserManagementResult.java
+++ b/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/identity/user/handler/UserManagementResult.java
@@ -57,9 +57,9 @@ import org.idp.server.control_plane.management.identity.user.io.UserManagementSt
  */
 public class UserManagementResult {
 
-  private final UserManagementResponse response;
-  private final AuditableContext context;
-  private final ManagementApiException exception;
+  private UserManagementResponse response;
+  private AuditableContext context;
+  private ManagementApiException exception;
 
   private UserManagementResult(
       UserManagementResponse response, AuditableContext context, ManagementApiException exception) {

--- a/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/identity/verification/handler/IdentityVerificationConfigManagementResult.java
+++ b/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/identity/verification/handler/IdentityVerificationConfigManagementResult.java
@@ -45,9 +45,9 @@ import org.idp.server.control_plane.management.identity.verification.io.Identity
  */
 public class IdentityVerificationConfigManagementResult {
 
-  private final AuditableContext context;
-  private final ManagementApiException exception;
-  private final IdentityVerificationConfigManagementResponse response;
+  private AuditableContext context;
+  private ManagementApiException exception;
+  private IdentityVerificationConfigManagementResponse response;
 
   private IdentityVerificationConfigManagementResult(
       AuditableContext context,

--- a/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/oidc/authorization/handler/AuthorizationServerManagementResult.java
+++ b/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/oidc/authorization/handler/AuthorizationServerManagementResult.java
@@ -43,9 +43,9 @@ import org.idp.server.control_plane.management.oidc.authorization.io.Authorizati
  */
 public class AuthorizationServerManagementResult {
 
-  private final AuditableContext context;
-  private final ManagementApiException exception;
-  private final AuthorizationServerManagementResponse response;
+  private AuditableContext context;
+  private ManagementApiException exception;
+  private AuthorizationServerManagementResponse response;
 
   private AuthorizationServerManagementResult(
       AuditableContext context,

--- a/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/oidc/client/io/ClientManagementResult.java
+++ b/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/oidc/client/io/ClientManagementResult.java
@@ -43,9 +43,9 @@ import org.idp.server.control_plane.management.oidc.client.handler.ClientManagem
  */
 public class ClientManagementResult {
 
-  private final AuditableContext context;
-  private final ManagementApiException exception;
-  private final ClientManagementResponse response;
+  private AuditableContext context;
+  private ManagementApiException exception;
+  private ClientManagementResponse response;
 
   private ClientManagementResult(
       AuditableContext context,

--- a/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/oidc/grant/io/GrantManagementStatus.java
+++ b/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/oidc/grant/io/GrantManagementStatus.java
@@ -23,7 +23,7 @@ public enum GrantManagementStatus {
   FORBIDDEN(403),
   NOT_FOUND(404);
 
-  private final int statusCode;
+  private int statusCode;
 
   GrantManagementStatus(int statusCode) {
     this.statusCode = statusCode;

--- a/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/onboarding/handler/OnboardingManagementResult.java
+++ b/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/onboarding/handler/OnboardingManagementResult.java
@@ -40,9 +40,9 @@ import org.idp.server.control_plane.management.onboarding.io.OnboardingStatus;
  */
 public class OnboardingManagementResult {
 
-  private final AuditableContext context;
-  private final ManagementApiException exception;
-  private final OnboardingResponse response;
+  private AuditableContext context;
+  private ManagementApiException exception;
+  private OnboardingResponse response;
 
   private OnboardingManagementResult(
       AuditableContext context, ManagementApiException exception, OnboardingResponse response) {

--- a/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/organization/handler/OrganizationManagementResult.java
+++ b/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/organization/handler/OrganizationManagementResult.java
@@ -38,9 +38,9 @@ import org.idp.server.control_plane.management.organization.io.OrganizationManag
  */
 public class OrganizationManagementResult {
 
-  private final AuditableContext context;
-  private final ManagementApiException exception;
-  private final OrganizationManagementResponse response;
+  private AuditableContext context;
+  private ManagementApiException exception;
+  private OrganizationManagementResponse response;
 
   private OrganizationManagementResult(
       AuditableContext context,

--- a/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/permission/io/PermissionManagementResult.java
+++ b/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/permission/io/PermissionManagementResult.java
@@ -43,9 +43,9 @@ import org.idp.server.control_plane.management.permission.handler.PermissionMana
  */
 public class PermissionManagementResult {
 
-  private final AuditableContext context;
-  private final ManagementApiException exception;
-  private final PermissionManagementResponse response;
+  private AuditableContext context;
+  private ManagementApiException exception;
+  private PermissionManagementResponse response;
 
   private PermissionManagementResult(
       AuditableContext context,

--- a/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/role/io/RoleManagementResult.java
+++ b/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/role/io/RoleManagementResult.java
@@ -43,9 +43,9 @@ import org.idp.server.control_plane.management.role.handler.RoleManagementServic
  */
 public class RoleManagementResult {
 
-  private final AuditableContext context;
-  private final ManagementApiException exception;
-  private final RoleManagementResponse response;
+  private AuditableContext context;
+  private ManagementApiException exception;
+  private RoleManagementResponse response;
 
   private RoleManagementResult(
       AuditableContext context, ManagementApiException exception, RoleManagementResponse response) {

--- a/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/security/event/handler/SecurityEventManagementResult.java
+++ b/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/security/event/handler/SecurityEventManagementResult.java
@@ -37,9 +37,9 @@ import org.idp.server.control_plane.management.security.event.io.SecurityEventMa
  */
 public class SecurityEventManagementResult {
 
-  private final AuditableContext context;
-  private final ManagementApiException exception;
-  private final SecurityEventManagementResponse response;
+  private AuditableContext context;
+  private ManagementApiException exception;
+  private SecurityEventManagementResponse response;
 
   private SecurityEventManagementResult(
       AuditableContext context,

--- a/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/security/hook/handler/SecurityEventHookConfigFindListRequest.java
+++ b/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/security/hook/handler/SecurityEventHookConfigFindListRequest.java
@@ -26,8 +26,8 @@ import java.util.Map;
 public class SecurityEventHookConfigFindListRequest
     implements SecurityEventHookConfigManagementRequest {
 
-  private final int limit;
-  private final int offset;
+  private int limit;
+  private int offset;
 
   public SecurityEventHookConfigFindListRequest(int limit, int offset) {
     this.limit = limit;

--- a/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/security/hook/handler/SecurityEventHookConfigManagementResult.java
+++ b/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/security/hook/handler/SecurityEventHookConfigManagementResult.java
@@ -48,9 +48,9 @@ import org.idp.server.control_plane.management.security.hook.io.SecurityEventHoo
  */
 public class SecurityEventHookConfigManagementResult {
 
-  private final ManagementApiException exception;
-  private final SecurityEventHookConfigManagementResponse response;
-  private final AuditableContext context;
+  private ManagementApiException exception;
+  private SecurityEventHookConfigManagementResponse response;
+  private AuditableContext context;
 
   private SecurityEventHookConfigManagementResult(
       ManagementApiException exception,

--- a/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/security/hook/handler/SecurityEventHookConfigUpdateRequest.java
+++ b/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/security/hook/handler/SecurityEventHookConfigUpdateRequest.java
@@ -28,8 +28,8 @@ import org.idp.server.platform.security.hook.configuration.SecurityEventHookConf
 public class SecurityEventHookConfigUpdateRequest
     implements SecurityEventHookConfigManagementRequest {
 
-  private final SecurityEventHookConfigurationIdentifier identifier;
-  private final SecurityEventHookRequest request;
+  private SecurityEventHookConfigurationIdentifier identifier;
+  private SecurityEventHookRequest request;
 
   public SecurityEventHookConfigUpdateRequest(
       SecurityEventHookConfigurationIdentifier identifier, SecurityEventHookRequest request) {

--- a/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/security/hook_result/handler/SecurityEventHookManagementResult.java
+++ b/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/security/hook_result/handler/SecurityEventHookManagementResult.java
@@ -47,9 +47,9 @@ import org.idp.server.control_plane.management.security.hook_result.io.SecurityE
  */
 public class SecurityEventHookManagementResult {
 
-  private final AuditableContext context;
-  private final ManagementApiException exception;
-  private final SecurityEventHookManagementResponse response;
+  private AuditableContext context;
+  private ManagementApiException exception;
+  private SecurityEventHookManagementResponse response;
 
   private SecurityEventHookManagementResult(
       AuditableContext context,

--- a/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/statistics/TenantStatisticsResponse.java
+++ b/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/statistics/TenantStatisticsResponse.java
@@ -25,8 +25,8 @@ import org.idp.server.platform.statistics.TenantStatisticsReport;
 
 public class TenantStatisticsResponse {
 
-  private final TenantStatisticsStatus status;
-  private final Map<String, Object> contents;
+  private TenantStatisticsStatus status;
+  private Map<String, Object> contents;
 
   public TenantStatisticsResponse(TenantStatisticsStatus status, Map<String, Object> contents) {
     this.status = status;

--- a/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/statistics/TenantStatisticsStatus.java
+++ b/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/statistics/TenantStatisticsStatus.java
@@ -23,7 +23,7 @@ public enum TenantStatisticsStatus {
   NOT_FOUND(404),
   SERVER_ERROR(500);
 
-  private final int statusCode;
+  private int statusCode;
 
   TenantStatisticsStatus(int statusCode) {
     this.statusCode = statusCode;

--- a/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/statistics/handler/TenantStatisticsManagementResult.java
+++ b/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/statistics/handler/TenantStatisticsManagementResult.java
@@ -28,9 +28,9 @@ import org.idp.server.control_plane.management.statistics.TenantStatisticsStatus
 
 public class TenantStatisticsManagementResult {
 
-  private final AuditableContext context;
-  private final TenantStatisticsResponse response;
-  private final ManagementApiException exception;
+  private AuditableContext context;
+  private TenantStatisticsResponse response;
+  private ManagementApiException exception;
 
   private TenantStatisticsManagementResult(
       AuditableContext context,

--- a/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/system/SystemConfigurationManagementContext.java
+++ b/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/system/SystemConfigurationManagementContext.java
@@ -34,14 +34,14 @@ import org.idp.server.platform.type.RequestAttributes;
  */
 public class SystemConfigurationManagementContext implements AuditableContext {
 
-  private final User operator;
-  private final OAuthToken oAuthToken;
-  private final RequestAttributes requestAttributes;
-  private final SystemConfiguration before;
-  private final SystemConfiguration after;
-  private final SystemConfigurationUpdateRequest request;
-  private final boolean dryRun;
-  private final ManagementApiException exception;
+  private User operator;
+  private OAuthToken oAuthToken;
+  private RequestAttributes requestAttributes;
+  private SystemConfiguration before;
+  private SystemConfiguration after;
+  private SystemConfigurationUpdateRequest request;
+  private boolean dryRun;
+  private ManagementApiException exception;
 
   public SystemConfigurationManagementContext(
       User operator,

--- a/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/system/handler/SystemConfigurationManagementResult.java
+++ b/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/system/handler/SystemConfigurationManagementResult.java
@@ -38,9 +38,9 @@ import org.idp.server.control_plane.management.system.io.SystemConfigurationMana
  */
 public class SystemConfigurationManagementResult {
 
-  private final AuditableContext context;
-  private final ManagementApiException exception;
-  private final SystemConfigurationManagementResponse response;
+  private AuditableContext context;
+  private ManagementApiException exception;
+  private SystemConfigurationManagementResponse response;
 
   private SystemConfigurationManagementResult(
       AuditableContext context,

--- a/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/system/io/SystemConfigurationManagementStatus.java
+++ b/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/system/io/SystemConfigurationManagementStatus.java
@@ -24,7 +24,7 @@ public enum SystemConfigurationManagementStatus {
   FORBIDDEN(403),
   ERROR(500);
 
-  private final int statusCode;
+  private int statusCode;
 
   SystemConfigurationManagementStatus(int statusCode) {
     this.statusCode = statusCode;

--- a/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/tenant/handler/TenantManagementResult.java
+++ b/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/tenant/handler/TenantManagementResult.java
@@ -38,9 +38,9 @@ import org.idp.server.control_plane.management.tenant.io.TenantManagementStatus;
  */
 public class TenantManagementResult {
 
-  private final AuditableContext context;
-  private final ManagementApiException exception;
-  private final TenantManagementResponse response;
+  private AuditableContext context;
+  private ManagementApiException exception;
+  private TenantManagementResponse response;
 
   private TenantManagementResult(
       AuditableContext context,

--- a/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/multi_tenancy/tenant/query/TenantQueryDataSource.java
+++ b/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/multi_tenancy/tenant/query/TenantQueryDataSource.java
@@ -22,10 +22,12 @@ import java.util.Objects;
 import java.util.Optional;
 import org.idp.server.platform.datasource.cache.CacheStore;
 import org.idp.server.platform.json.JsonConverter;
+import org.idp.server.platform.log.LoggerWrapper;
 import org.idp.server.platform.multi_tenancy.tenant.*;
 
 public class TenantQueryDataSource implements TenantQueryRepository {
 
+  private static final LoggerWrapper log = LoggerWrapper.getLogger(TenantQueryDataSource.class);
   TenantQuerySqlExecutor executor;
   JsonConverter jsonConverter;
   CacheStore cacheStore;
@@ -42,9 +44,12 @@ public class TenantQueryDataSource implements TenantQueryRepository {
     Optional<Tenant> optionalTenant = cacheStore.find(key, Tenant.class);
 
     if (optionalTenant.isPresent()) {
-      return optionalTenant.get();
+      Tenant cached = optionalTenant.get();
+      log.trace("tenant cache HIT: tenant={}", tenantIdentifier.value());
+      return cached;
     }
 
+    log.trace("tenant cache MISS: tenant={}", tenantIdentifier.value());
     Map<String, String> result = executor.selectOne(tenantIdentifier);
 
     if (Objects.isNull(result) || result.isEmpty()) {

--- a/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/session/OPSessionDataSource.java
+++ b/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/session/OPSessionDataSource.java
@@ -110,10 +110,12 @@ public class OPSessionDataSource implements OPSessionRepository {
               });
     } catch (Exception e) {
       log.error(
-          "Failed to find OP session (graceful degradation). id:{}, tenant:{}, error:{}",
+          "Failed to find OP session (graceful degradation). id:{}, tenant:{}, error:{}, exceptionClass:{}",
           id.value(),
           tenant.identifierValue(),
-          e.getMessage());
+          e.getMessage(),
+          e.getClass().getName(),
+          e);
       return Optional.empty();
     }
   }

--- a/libs/idp-server-core-extension-ida/src/main/java/org/idp/server/core/extension/identity/verification/application/pre_hook/additional_parameter/AdditionalParameterResolveResult.java
+++ b/libs/idp-server-core-extension-ida/src/main/java/org/idp/server/core/extension/identity/verification/application/pre_hook/additional_parameter/AdditionalParameterResolveResult.java
@@ -27,10 +27,10 @@ import org.idp.server.core.extension.identity.verification.io.IdentityVerificati
  */
 public class AdditionalParameterResolveResult {
 
-  private final boolean success;
-  private final Map<String, Object> data;
-  private final IdentityVerificationErrorDetails errorDetails;
-  private final boolean failFast;
+  private boolean success;
+  private Map<String, Object> data;
+  private IdentityVerificationErrorDetails errorDetails;
+  private boolean failFast;
 
   private AdditionalParameterResolveResult(
       boolean success,

--- a/libs/idp-server-core-extension-ida/src/main/java/org/idp/server/core/extension/identity/verification/io/IdentityVerificationErrorDetails.java
+++ b/libs/idp-server-core-extension-ida/src/main/java/org/idp/server/core/extension/identity/verification/io/IdentityVerificationErrorDetails.java
@@ -53,11 +53,11 @@ import java.util.Map;
  */
 public class IdentityVerificationErrorDetails {
 
-  private final String error;
-  private final String errorDescription;
-  private final Map<String, Object> errorDetails;
-  private final List<String> errorMessages;
-  private final int statusCode;
+  private String error;
+  private String errorDescription;
+  private Map<String, Object> errorDetails;
+  private List<String> errorMessages;
+  private int statusCode;
 
   private IdentityVerificationErrorDetails(Builder builder) {
     this.error = builder.error;
@@ -113,8 +113,8 @@ public class IdentityVerificationErrorDetails {
   public static class Builder {
     private String error;
     private String errorDescription;
-    private final Map<String, Object> errorDetails = new HashMap<>();
-    private final List<String> errorMessages = new java.util.ArrayList<>();
+    private Map<String, Object> errorDetails = new HashMap<>();
+    private List<String> errorMessages = new java.util.ArrayList<>();
     private int statusCode;
 
     private Builder() {}

--- a/libs/idp-server-core-extension-ida/src/main/java/org/idp/server/core/extension/identity/verification/io/ReservedIdentityVerificationProcess.java
+++ b/libs/idp-server-core-extension-ida/src/main/java/org/idp/server/core/extension/identity/verification/io/ReservedIdentityVerificationProcess.java
@@ -23,7 +23,7 @@ public enum ReservedIdentityVerificationProcess {
   CALLBACK_RESULT("callback-result"),
   EVALUATE_RESULT("evaluate-result");
 
-  private final String value;
+  private String value;
 
   ReservedIdentityVerificationProcess(String value) {
     this.value = value;

--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/authentication/AuthSessionId.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/authentication/AuthSessionId.java
@@ -34,7 +34,7 @@ public class AuthSessionId {
   private static final SecureRandom SECURE_RANDOM = new SecureRandom();
   private static final int TOKEN_LENGTH = 32; // 256 bits
 
-  private final String value;
+  private String value;
 
   public AuthSessionId() {
     this.value = "";

--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/authentication/StandardAuthenticationMethod.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/authentication/StandardAuthenticationMethod.java
@@ -23,7 +23,7 @@ public enum StandardAuthenticationMethod {
   FIDO_UAF("fido-uaf"),
   FIDO2("fido2");
 
-  private final String type;
+  private String type;
 
   StandardAuthenticationMethod(String type) {
     this.type = type;

--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/authentication/StandardAuthenticationMethodReference.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/authentication/StandardAuthenticationMethodReference.java
@@ -58,8 +58,8 @@ public enum StandardAuthenticationMethodReference {
   UNKNOWN("unknown", "Unknown authentication method [RFC4949]."),
   ;
 
-  private final String value;
-  private final String description;
+  private String value;
+  private String description;
 
   StandardAuthenticationMethodReference(String value, String description) {
     this.value = value;

--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/identity/authentication/PasswordChangeStatus.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/identity/authentication/PasswordChangeStatus.java
@@ -24,7 +24,7 @@ public enum PasswordChangeStatus {
   INVALID_REQUEST(400),
   FORBIDDEN(403);
 
-  private final int statusCode;
+  private int statusCode;
 
   PasswordChangeStatus(int statusCode) {
     this.statusCode = statusCode;

--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/identity/authentication/PasswordPolicyValidationResult.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/identity/authentication/PasswordPolicyValidationResult.java
@@ -19,8 +19,8 @@ package org.idp.server.core.openid.identity.authentication;
 /** Password policy validation result. */
 public class PasswordPolicyValidationResult {
 
-  private final boolean valid;
-  private final String errorMessage;
+  private boolean valid;
+  private String errorMessage;
 
   private PasswordPolicyValidationResult(boolean valid, String errorMessage) {
     this.valid = valid;

--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/identity/device/authentication/DeviceAuthenticationDeviceFinder.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/identity/device/authentication/DeviceAuthenticationDeviceFinder.java
@@ -32,7 +32,7 @@ import org.idp.server.platform.multi_tenancy.tenant.Tenant;
  */
 public class DeviceAuthenticationDeviceFinder implements DeviceAuthenticationDeviceFindingDelegate {
 
-  private final UserQueryRepository userQueryRepository;
+  private UserQueryRepository userQueryRepository;
 
   public DeviceAuthenticationDeviceFinder(UserQueryRepository userQueryRepository) {
     this.userQueryRepository = userQueryRepository;

--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/identity/device/credential/FidoCredentialData.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/identity/device/credential/FidoCredentialData.java
@@ -27,10 +27,10 @@ import java.util.Map;
  */
 public class FidoCredentialData {
 
-  private final String fidoServerId;
-  private final String credentialId;
-  private final String rpId;
-  private final String appId;
+  private String fidoServerId;
+  private String credentialId;
+  private String rpId;
+  private String appId;
 
   private FidoCredentialData(String fidoServerId, String credentialId, String rpId, String appId) {
     this.fidoServerId = fidoServerId;

--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/identity/device/credential/JwtBearerCredentialData.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/identity/device/credential/JwtBearerCredentialData.java
@@ -27,9 +27,9 @@ import org.idp.server.platform.json.JsonConverter;
  */
 public class JwtBearerCredentialData {
 
-  private final String algorithm;
-  private final String secretValue;
-  private final String jwks;
+  private String algorithm;
+  private String secretValue;
+  private String jwks;
 
   private JwtBearerCredentialData(String algorithm, String secretValue, String jwks) {
     this.algorithm = algorithm;

--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/identity/permission/ReservedNamespaceException.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/identity/permission/ReservedNamespaceException.java
@@ -24,8 +24,8 @@ package org.idp.server.core.openid.identity.permission;
  */
 public class ReservedNamespaceException extends RuntimeException {
 
-  private final String permissionName;
-  private final String namespace;
+  private String permissionName;
+  private String namespace;
 
   public ReservedNamespaceException(String permissionName, String namespace) {
     super(

--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/oauth/OAuthRequestContext.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/oauth/OAuthRequestContext.java
@@ -45,11 +45,13 @@ import org.idp.server.core.openid.oauth.view.OAuthViewUrlResolver;
 import org.idp.server.core.openid.session.OPSession;
 import org.idp.server.platform.date.SystemDateTime;
 import org.idp.server.platform.jose.JoseContext;
+import org.idp.server.platform.log.LoggerWrapper;
 import org.idp.server.platform.multi_tenancy.tenant.Tenant;
 import org.idp.server.platform.multi_tenancy.tenant.TenantIdentifier;
 
 /** OAuthRequestContext */
 public class OAuthRequestContext implements ResponseModeDecidable {
+  private static final LoggerWrapper log = LoggerWrapper.getLogger(OAuthRequestContext.class);
   Tenant tenant;
   OAuthRequestPattern pattern;
   OAuthRequestParameters parameters;
@@ -92,11 +94,19 @@ public class OAuthRequestContext implements ResponseModeDecidable {
       return false;
     }
 
+    log.debug(
+        "canAutomaticallyAuthorize: opSession={}, opSessionExists={}, opSessionIsNull={}",
+        opSession != null ? opSession.id() : "null",
+        opSession != null ? opSession.exists() : "N/A",
+        opSession == null);
+
     if (opSession == null || !opSession.exists()) {
       throw new OAuthRedirectableBadRequestException(
           "login_required", "invalid session, session is not registered", this);
     }
     if (!opSession.isActive()) {
+      log.info(
+          "DEBUG canAutomaticallyAuthorize: session not active, status={}", opSession.status());
       throw new OAuthRedirectableBadRequestException(
           "login_required", "invalid session, session is expired or terminated", this);
     }

--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/oauth/OAuthRequestContext.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/oauth/OAuthRequestContext.java
@@ -105,8 +105,7 @@ public class OAuthRequestContext implements ResponseModeDecidable {
           "login_required", "invalid session, session is not registered", this);
     }
     if (!opSession.isActive()) {
-      log.info(
-          "DEBUG canAutomaticallyAuthorize: session not active, status={}", opSession.status());
+      log.debug("canAutomaticallyAuthorize: session not active, status={}", opSession.status());
       throw new OAuthRedirectableBadRequestException(
           "login_required", "invalid session, session is expired or terminated", this);
     }

--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/oauth/clientauthenticator/exception/ClientUnAuthorizedException.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/oauth/clientauthenticator/exception/ClientUnAuthorizedException.java
@@ -19,9 +19,9 @@ package org.idp.server.core.openid.oauth.clientauthenticator.exception;
 import org.idp.server.core.openid.oauth.type.oauth.RequestedClientId;
 
 public class ClientUnAuthorizedException extends RuntimeException {
-  private final String method;
-  private final RequestedClientId clientId;
-  private final String reason;
+  private String method;
+  private RequestedClientId clientId;
+  private String reason;
 
   public ClientUnAuthorizedException(String message) {
     super(message);

--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/oauth/logout/IdTokenHintResult.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/oauth/logout/IdTokenHintResult.java
@@ -26,8 +26,8 @@ import org.idp.server.platform.jose.JsonWebTokenClaims;
  */
 public class IdTokenHintResult {
 
-  private final JsonWebTokenClaims claims;
-  private final ClientConfiguration clientConfiguration;
+  private JsonWebTokenClaims claims;
+  private ClientConfiguration clientConfiguration;
 
   public IdTokenHintResult(JsonWebTokenClaims claims, ClientConfiguration clientConfiguration) {
     this.claims = claims;

--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/session/BrowserState.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/session/BrowserState.java
@@ -25,7 +25,7 @@ public class BrowserState {
   private static final int RANDOM_BYTES_LENGTH = 32;
   private static final SecureRandom SECURE_RANDOM = new SecureRandom();
 
-  private final String value;
+  private String value;
 
   public BrowserState() {
     this.value = "";

--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/session/ClientSessionIdentifier.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/session/ClientSessionIdentifier.java
@@ -26,7 +26,7 @@ public class ClientSessionIdentifier {
   private static final int RANDOM_BYTES_LENGTH = 32;
   private static final SecureRandom SECURE_RANDOM = new SecureRandom();
 
-  private final String value;
+  private String value;
 
   public ClientSessionIdentifier() {
     this.value = "";

--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/session/ClientSessions.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/session/ClientSessions.java
@@ -24,7 +24,7 @@ import java.util.stream.Stream;
 
 public class ClientSessions implements Iterable<ClientSession> {
 
-  private final List<ClientSession> values;
+  private List<ClientSession> values;
 
   public ClientSessions() {
     this.values = new ArrayList<>();

--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/session/DifferentUserAuthenticatedException.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/session/DifferentUserAuthenticatedException.java
@@ -29,8 +29,8 @@ import org.idp.server.platform.exception.ForbiddenException;
  */
 public class DifferentUserAuthenticatedException extends ForbiddenException {
 
-  private final String existingUserSub;
-  private final String authenticatedUserSub;
+  private String existingUserSub;
+  private String authenticatedUserSub;
 
   public DifferentUserAuthenticatedException(String existingUserSub, String authenticatedUserSub) {
     super(

--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/session/IdentityCookieToken.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/session/IdentityCookieToken.java
@@ -28,12 +28,12 @@ import java.util.Map;
  */
 public class IdentityCookieToken {
 
-  private final String issuer;
-  private final String subject;
-  private final String opSessionId;
-  private final Instant authTime;
-  private final Instant issuedAt;
-  private final Instant expiration;
+  private String issuer;
+  private String subject;
+  private String opSessionId;
+  private Instant authTime;
+  private Instant issuedAt;
+  private Instant expiration;
 
   public IdentityCookieToken(
       String issuer,

--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/session/OPSessionIdentifier.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/session/OPSessionIdentifier.java
@@ -26,7 +26,7 @@ public class OPSessionIdentifier {
   private static final int RANDOM_BYTES_LENGTH = 32;
   private static final SecureRandom SECURE_RANDOM = new SecureRandom();
 
-  private final String value;
+  private String value;
 
   public OPSessionIdentifier() {
     this.value = "";

--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/session/OPSessions.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/session/OPSessions.java
@@ -25,7 +25,7 @@ import java.util.stream.Stream;
 
 public class OPSessions implements Iterable<OPSession> {
 
-  private final List<OPSession> values;
+  private List<OPSession> values;
 
   public OPSessions() {
     this.values = new ArrayList<>();

--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/session/SessionValidationResult.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/session/SessionValidationResult.java
@@ -26,10 +26,10 @@ import org.idp.server.platform.security.event.DefaultSecurityEventType;
  */
 public class SessionValidationResult {
 
-  private final boolean valid;
-  private final String errorCode;
-  private final String errorDescription;
-  private final DefaultSecurityEventType eventType;
+  private boolean valid;
+  private String errorCode;
+  private String errorDescription;
+  private DefaultSecurityEventType eventType;
 
   private SessionValidationResult(
       boolean valid,

--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/session/TerminationReason.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/session/TerminationReason.java
@@ -26,7 +26,7 @@ public enum TerminationReason {
   USER_SWITCH("user_switch"),
   UNKNOWN("unknown");
 
-  private final String value;
+  private String value;
 
   TerminationReason(String value) {
     this.value = value;

--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/token/JwtBearerUserFinder.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/token/JwtBearerUserFinder.java
@@ -33,7 +33,7 @@ import org.idp.server.platform.multi_tenancy.tenant.Tenant;
  */
 public class JwtBearerUserFinder implements JwtBearerUserFindingDelegate {
 
-  private final UserQueryRepository userQueryRepository;
+  private UserQueryRepository userQueryRepository;
 
   public JwtBearerUserFinder(UserQueryRepository userQueryRepository) {
     this.userQueryRepository = userQueryRepository;

--- a/libs/idp-server-notification-apns-adapter/src/main/java/org/idp/server/notification/push/apns/JwtTokenCache.java
+++ b/libs/idp-server-notification-apns-adapter/src/main/java/org/idp/server/notification/push/apns/JwtTokenCache.java
@@ -22,8 +22,8 @@ import org.idp.server.platform.date.SystemDateTime;
 
 public class JwtTokenCache {
 
-  private final String token;
-  private final LocalDateTime expiresAt;
+  private String token;
+  private LocalDateTime expiresAt;
 
   public JwtTokenCache(String token, LocalDateTime expiresAt) {
     this.token = token;

--- a/libs/idp-server-platform/build.gradle
+++ b/libs/idp-server-platform/build.gradle
@@ -12,9 +12,8 @@ repositories {
 }
 
 dependencies {
-	//json
-	implementation 'com.fasterxml.jackson.core:jackson-databind:2.14.2'
-	implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.15.2'
+	//json (Jackson 3: java.time support is built-in, no separate jsr310 module needed)
+	implementation 'tools.jackson.core:jackson-databind:3.1.0'
 	implementation 'com.jayway.jsonpath:json-path:2.9.0'
 	//jose
 	implementation 'com.nimbusds:nimbus-jose-jwt:9.40'

--- a/libs/idp-server-platform/build.gradle
+++ b/libs/idp-server-platform/build.gradle
@@ -13,7 +13,7 @@ repositories {
 
 dependencies {
 	//json (Jackson 3: java.time support is built-in, no separate jsr310 module needed)
-	implementation 'tools.jackson.core:jackson-databind:3.1.0'
+	implementation 'tools.jackson.core:jackson-databind:3.1.2'
 	implementation 'com.jayway.jsonpath:json-path:2.9.0'
 	//jose
 	implementation 'com.nimbusds:nimbus-jose-jwt:9.40'

--- a/libs/idp-server-platform/src/main/java/org/idp/server/platform/datasource/DatabaseTypeConfiguration.java
+++ b/libs/idp-server-platform/src/main/java/org/idp/server/platform/datasource/DatabaseTypeConfiguration.java
@@ -19,7 +19,7 @@ package org.idp.server.platform.datasource;
 /** Configuration class that holds the application-level database type. */
 public class DatabaseTypeConfiguration {
 
-  private final DatabaseType databaseType;
+  private DatabaseType databaseType;
 
   public DatabaseTypeConfiguration(String databaseTypeConfig) {
     this.databaseType = DatabaseType.of(databaseTypeConfig);

--- a/libs/idp-server-platform/src/main/java/org/idp/server/platform/datasource/session/SessionConfiguration.java
+++ b/libs/idp-server-platform/src/main/java/org/idp/server/platform/datasource/session/SessionConfiguration.java
@@ -24,14 +24,14 @@ package org.idp.server.platform.datasource.session;
  */
 public class SessionConfiguration {
 
-  private final String host;
-  private final int port;
-  private final int database;
-  private final int timeout;
-  private final String password;
-  private final int maxTotal;
-  private final int maxIdle;
-  private final int minIdle;
+  private String host;
+  private int port;
+  private int database;
+  private int timeout;
+  private String password;
+  private int maxTotal;
+  private int maxIdle;
+  private int minIdle;
 
   public SessionConfiguration(
       String host,

--- a/libs/idp-server-platform/src/main/java/org/idp/server/platform/exception/MaliciousInputException.java
+++ b/libs/idp-server-platform/src/main/java/org/idp/server/platform/exception/MaliciousInputException.java
@@ -38,8 +38,8 @@ package org.idp.server.platform.exception;
  */
 public class MaliciousInputException extends RuntimeException {
 
-  private final String attackType;
-  private final String inputValue;
+  private String attackType;
+  private String inputValue;
 
   public MaliciousInputException(String attackType, String inputValue) {
     super(String.format("%s detected: %s", attackType, inputValue));

--- a/libs/idp-server-platform/src/main/java/org/idp/server/platform/health/HealthCheckResult.java
+++ b/libs/idp-server-platform/src/main/java/org/idp/server/platform/health/HealthCheckResult.java
@@ -26,7 +26,7 @@ import java.util.Map;
  */
 public class HealthCheckResult {
 
-  private final HealthStatus status;
+  private HealthStatus status;
 
   private HealthCheckResult(HealthStatus status) {
     this.status = status;

--- a/libs/idp-server-platform/src/main/java/org/idp/server/platform/http/HttpRetryStrategy.java
+++ b/libs/idp-server-platform/src/main/java/org/idp/server/platform/http/HttpRetryStrategy.java
@@ -53,8 +53,8 @@ import org.idp.server.platform.log.LoggerWrapper;
  */
 public class HttpRetryStrategy {
 
-  private final IdempotencyKeyManager idempotencyKeyManager;
-  private final LoggerWrapper log;
+  private IdempotencyKeyManager idempotencyKeyManager;
+  private LoggerWrapper log;
 
   public HttpRetryStrategy() {
     this.idempotencyKeyManager = new IdempotencyKeyManager();

--- a/libs/idp-server-platform/src/main/java/org/idp/server/platform/http/IdempotencyKeyManager.java
+++ b/libs/idp-server-platform/src/main/java/org/idp/server/platform/http/IdempotencyKeyManager.java
@@ -57,7 +57,7 @@ import org.idp.server.platform.log.LoggerWrapper;
  */
 public class IdempotencyKeyManager {
 
-  private final LoggerWrapper log = LoggerWrapper.getLogger(IdempotencyKeyManager.class);
+  private LoggerWrapper log = LoggerWrapper.getLogger(IdempotencyKeyManager.class);
 
   /**
    * Generates a unique idempotency key for the given HTTP request.

--- a/libs/idp-server-platform/src/main/java/org/idp/server/platform/http/SsrfProtectedHttpClient.java
+++ b/libs/idp-server-platform/src/main/java/org/idp/server/platform/http/SsrfProtectedHttpClient.java
@@ -66,9 +66,9 @@ import org.idp.server.platform.system.config.SsrfProtectionConfig;
  */
 public class SsrfProtectedHttpClient {
 
-  private final HttpClient httpClient;
-  private final SystemConfigurationResolver systemConfigurationResolver;
-  private final LoggerWrapper log = LoggerWrapper.getLogger(SsrfProtectedHttpClient.class);
+  private HttpClient httpClient;
+  private SystemConfigurationResolver systemConfigurationResolver;
+  private LoggerWrapper log = LoggerWrapper.getLogger(SsrfProtectedHttpClient.class);
 
   public SsrfProtectedHttpClient(
       HttpClient httpClient, SystemConfigurationResolver systemConfigurationResolver) {

--- a/libs/idp-server-platform/src/main/java/org/idp/server/platform/jose/JwtCredential.java
+++ b/libs/idp-server-platform/src/main/java/org/idp/server/platform/jose/JwtCredential.java
@@ -38,9 +38,9 @@ package org.idp.server.platform.jose;
  */
 public class JwtCredential {
 
-  private final JwtCredentialType type;
-  private final String secret;
-  private final String jwks;
+  private JwtCredentialType type;
+  private String secret;
+  private String jwks;
 
   private JwtCredential(JwtCredentialType type, String secret, String jwks) {
     this.type = type;

--- a/libs/idp-server-platform/src/main/java/org/idp/server/platform/json/JsonConverter.java
+++ b/libs/idp-server-platform/src/main/java/org/idp/server/platform/json/JsonConverter.java
@@ -18,17 +18,13 @@ package org.idp.server.platform.json;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.PropertyAccessor;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.PropertyNamingStrategies;
-import com.fasterxml.jackson.databind.cfg.CoercionAction;
-import com.fasterxml.jackson.databind.cfg.CoercionInputShape;
-import com.fasterxml.jackson.databind.type.LogicalType;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
-import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.Map;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.PropertyNamingStrategies;
+import tools.jackson.databind.cfg.CoercionAction;
+import tools.jackson.databind.cfg.CoercionInputShape;
+import tools.jackson.databind.json.JsonMapper;
+import tools.jackson.databind.type.LogicalType;
 
 public class JsonConverter {
 
@@ -43,10 +39,10 @@ public class JsonConverter {
     return SNAKE_CASE;
   }
 
-  private final ObjectMapper objectMapper;
+  private JsonMapper jsonMapper;
 
-  private JsonConverter(ObjectMapper objectMapper) {
-    this.objectMapper = objectMapper;
+  private JsonConverter(JsonMapper jsonMapper) {
+    this.jsonMapper = jsonMapper;
   }
 
   /**
@@ -58,74 +54,73 @@ public class JsonConverter {
    * error.
    */
   private static JsonConverter create() {
-    JavaTimeModule javaTimeModule = new JavaTimeModule();
-    javaTimeModule.addDeserializer(
-        LocalDateTime.class,
-        new LocalDateTimeDeserializer(DateTimeFormatter.ofPattern("yyyy/MM/dd HH:mm:ss")));
-    ObjectMapper objectMapper = new ObjectMapper();
-    objectMapper.setVisibility(PropertyAccessor.ALL, JsonAutoDetect.Visibility.NONE);
-    objectMapper.setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY);
-    objectMapper.registerModule(javaTimeModule);
-    objectMapper
-        .coercionConfigFor(LogicalType.Collection)
-        .setCoercion(CoercionInputShape.String, CoercionAction.AsNull)
-        .setCoercion(CoercionInputShape.EmptyString, CoercionAction.AsNull);
-    return new JsonConverter(objectMapper);
+    JsonMapper jsonMapper =
+        JsonMapper.builder()
+            .changeDefaultVisibility(
+                vc ->
+                    vc.withVisibility(PropertyAccessor.ALL, JsonAutoDetect.Visibility.NONE)
+                        .withVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY))
+            .withCoercionConfig(
+                LogicalType.Collection,
+                config -> {
+                  config.setCoercion(CoercionInputShape.String, CoercionAction.AsNull);
+                  config.setCoercion(CoercionInputShape.EmptyString, CoercionAction.AsNull);
+                })
+            .build();
+    return new JsonConverter(jsonMapper);
   }
 
   /** Creates a snake_case JsonConverter instance. See {@link #create()} for coercion details. */
   private static JsonConverter createWithSnakeCaseStrategy() {
-    JavaTimeModule javaTimeModule = new JavaTimeModule();
-    javaTimeModule.addDeserializer(
-        LocalDateTime.class,
-        new LocalDateTimeDeserializer(DateTimeFormatter.ofPattern("yyyy/MM/dd HH:mm:ss")));
-    ObjectMapper objectMapper = new ObjectMapper();
-    objectMapper.setVisibility(PropertyAccessor.ALL, JsonAutoDetect.Visibility.NONE);
-    objectMapper.setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY);
-    objectMapper.setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE);
-    objectMapper.registerModule(javaTimeModule);
-    objectMapper
-        .coercionConfigFor(LogicalType.Collection)
-        .setCoercion(CoercionInputShape.String, CoercionAction.AsNull)
-        .setCoercion(CoercionInputShape.EmptyString, CoercionAction.AsNull);
-    return new JsonConverter(objectMapper);
+    JsonMapper jsonMapper =
+        JsonMapper.builder()
+            .changeDefaultVisibility(
+                vc ->
+                    vc.withVisibility(PropertyAccessor.ALL, JsonAutoDetect.Visibility.NONE)
+                        .withVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY))
+            .propertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE)
+            .withCoercionConfig(
+                LogicalType.Collection,
+                config -> {
+                  config.setCoercion(CoercionInputShape.String, CoercionAction.AsNull);
+                  config.setCoercion(CoercionInputShape.EmptyString, CoercionAction.AsNull);
+                })
+            .build();
+    return new JsonConverter(jsonMapper);
   }
 
   public <TYPE> TYPE read(Object jsonObject, Class<TYPE> type) {
-    return objectMapper.convertValue(jsonObject, type);
+    return jsonMapper.convertValue(jsonObject, type);
   }
 
   public <TYPE> TYPE read(String value, Class<TYPE> typeClass) {
     try {
-      return objectMapper.readValue(value, typeClass);
-    } catch (JsonProcessingException exception) {
+      return jsonMapper.readValue(value, typeClass);
+    } catch (JacksonException exception) {
       throw new JsonRuntimeException(exception);
     }
   }
 
   public JsonNodeWrapper readTree(String jsonString) {
     try {
-
-      return new JsonNodeWrapper(objectMapper.readTree(jsonString));
-    } catch (JsonProcessingException exception) {
+      return new JsonNodeWrapper(jsonMapper.readTree(jsonString));
+    } catch (JacksonException exception) {
       throw new JsonRuntimeException(exception);
     }
   }
 
   public JsonNodeWrapper readTree(Map<String, Object> jsonObject) {
-
-    return new JsonNodeWrapper(objectMapper.valueToTree(jsonObject));
+    return new JsonNodeWrapper(jsonMapper.valueToTree(jsonObject));
   }
 
   public JsonNodeWrapper readTree(Object jsonObject) {
-
-    return new JsonNodeWrapper(objectMapper.valueToTree(jsonObject));
+    return new JsonNodeWrapper(jsonMapper.valueToTree(jsonObject));
   }
 
   public String write(Object value) {
     try {
-      return objectMapper.writeValueAsString(value);
-    } catch (JsonProcessingException exception) {
+      return jsonMapper.writeValueAsString(value);
+    } catch (JacksonException exception) {
       throw new JsonRuntimeException(exception);
     }
   }

--- a/libs/idp-server-platform/src/main/java/org/idp/server/platform/json/JsonConverter.java
+++ b/libs/idp-server-platform/src/main/java/org/idp/server/platform/json/JsonConverter.java
@@ -39,7 +39,7 @@ public class JsonConverter {
     return SNAKE_CASE;
   }
 
-  private JsonMapper jsonMapper;
+  private final JsonMapper jsonMapper;
 
   private JsonConverter(JsonMapper jsonMapper) {
     this.jsonMapper = jsonMapper;

--- a/libs/idp-server-platform/src/main/java/org/idp/server/platform/json/JsonConverter.java
+++ b/libs/idp-server-platform/src/main/java/org/idp/server/platform/json/JsonConverter.java
@@ -18,12 +18,17 @@ package org.idp.server.platform.json;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.PropertyAccessor;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.Map;
 import tools.jackson.core.JacksonException;
 import tools.jackson.databind.PropertyNamingStrategies;
 import tools.jackson.databind.cfg.CoercionAction;
 import tools.jackson.databind.cfg.CoercionInputShape;
+import tools.jackson.databind.cfg.DateTimeFeature;
+import tools.jackson.databind.ext.javatime.deser.LocalDateTimeDeserializer;
 import tools.jackson.databind.json.JsonMapper;
+import tools.jackson.databind.module.SimpleModule;
 import tools.jackson.databind.type.LogicalType;
 
 public class JsonConverter {
@@ -54,8 +59,14 @@ public class JsonConverter {
    * error.
    */
   private static JsonConverter create() {
+    SimpleModule customDateTimeModule = new SimpleModule();
+    customDateTimeModule.addDeserializer(
+        LocalDateTime.class,
+        new LocalDateTimeDeserializer(DateTimeFormatter.ofPattern("yyyy/MM/dd HH:mm:ss")));
     JsonMapper jsonMapper =
         JsonMapper.builder()
+            .addModule(customDateTimeModule)
+            .enable(DateTimeFeature.WRITE_DATES_AS_TIMESTAMPS)
             .changeDefaultVisibility(
                 vc ->
                     vc.withVisibility(PropertyAccessor.ALL, JsonAutoDetect.Visibility.NONE)
@@ -72,8 +83,14 @@ public class JsonConverter {
 
   /** Creates a snake_case JsonConverter instance. See {@link #create()} for coercion details. */
   private static JsonConverter createWithSnakeCaseStrategy() {
+    SimpleModule customDateTimeModule = new SimpleModule();
+    customDateTimeModule.addDeserializer(
+        LocalDateTime.class,
+        new LocalDateTimeDeserializer(DateTimeFormatter.ofPattern("yyyy/MM/dd HH:mm:ss")));
     JsonMapper jsonMapper =
         JsonMapper.builder()
+            .addModule(customDateTimeModule)
+            .enable(DateTimeFeature.WRITE_DATES_AS_TIMESTAMPS)
             .changeDefaultVisibility(
                 vc ->
                     vc.withVisibility(PropertyAccessor.ALL, JsonAutoDetect.Visibility.NONE)

--- a/libs/idp-server-platform/src/main/java/org/idp/server/platform/json/JsonNodeWrapper.java
+++ b/libs/idp-server-platform/src/main/java/org/idp/server/platform/json/JsonNodeWrapper.java
@@ -16,9 +16,9 @@
 
 package org.idp.server.platform.json;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import java.util.*;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.node.JsonNodeFactory;
 
 /**
  * A lightweight wrapper for Jackson's {@link JsonNode} providing convenient and safe access
@@ -75,7 +75,9 @@ public class JsonNodeWrapper {
     if (jsonNode == null) {
       return Collections.emptyIterator();
     }
-    return jsonNode.fieldNames();
+    Set<String> names = new LinkedHashSet<>();
+    jsonNode.properties().forEach(entry -> names.add(entry.getKey()));
+    return names.iterator();
   }
 
   public List<String> fieldNamesAsList() {
@@ -87,7 +89,7 @@ public class JsonNodeWrapper {
   public List<String> toList() {
     List<String> list = new ArrayList<>();
     if (jsonNode.isArray()) {
-      Iterator<JsonNode> iterator = jsonNode.elements();
+      Iterator<JsonNode> iterator = jsonNode.iterator();
       while (iterator.hasNext()) {
         list.add(iterator.next().asText());
       }
@@ -107,7 +109,7 @@ public class JsonNodeWrapper {
    */
   public List<JsonNodeWrapper> getValueAsJsonNodeList(String fieldName) {
     List<JsonNodeWrapper> values = new ArrayList<>();
-    Iterator<JsonNode> iterator = jsonNode.get(fieldName).elements();
+    Iterator<JsonNode> iterator = jsonNode.get(fieldName).iterator();
     while (iterator.hasNext()) {
       values.add(new JsonNodeWrapper(iterator.next()));
     }
@@ -116,7 +118,7 @@ public class JsonNodeWrapper {
 
   public List<Map<String, Object>> toListAsMap() {
     List<Map<String, Object>> values = new ArrayList<>();
-    Iterator<JsonNode> iterator = jsonNode.elements();
+    Iterator<JsonNode> iterator = jsonNode.iterator();
     while (iterator.hasNext()) {
       values.add(new JsonNodeWrapper(iterator.next()).toMap());
     }
@@ -125,7 +127,7 @@ public class JsonNodeWrapper {
 
   public List<Map<String, Object>> getValueAsJsonNodeListAsMap(String fieldName) {
     List<Map<String, Object>> values = new ArrayList<>();
-    Iterator<JsonNode> iterator = jsonNode.get(fieldName).elements();
+    Iterator<JsonNode> iterator = jsonNode.get(fieldName).iterator();
     while (iterator.hasNext()) {
       values.add(new JsonNodeWrapper(iterator.next()).toMap());
     }
@@ -135,7 +137,7 @@ public class JsonNodeWrapper {
   public List<JsonNodeWrapper> elements() {
     List<JsonNodeWrapper> list = new ArrayList<>();
     if (jsonNode.isArray()) {
-      Iterator<JsonNode> iterator = jsonNode.elements();
+      Iterator<JsonNode> iterator = jsonNode.iterator();
       while (iterator.hasNext()) {
         list.add(new JsonNodeWrapper(iterator.next()));
       }
@@ -217,11 +219,11 @@ public class JsonNodeWrapper {
   public Map<String, Object> toMap() {
     Map<String, Object> results = new HashMap<>();
     jsonNode
-        .fieldNames()
-        .forEachRemaining(
-            fieldName -> {
-              JsonNodeWrapper valueWrapper = getValueAsJsonNode(fieldName);
-              JsonNode valueNode = (JsonNode) valueWrapper.node();
+        .properties()
+        .forEach(
+            entry -> {
+              String fieldName = entry.getKey();
+              JsonNode valueNode = entry.getValue();
               Object value = toPrimitive(valueNode);
               results.put(fieldName, value);
             });
@@ -304,16 +306,15 @@ public class JsonNodeWrapper {
   private Object toPrimitive(JsonNode node) {
     if (node.isObject()) {
       Map<String, Object> map = new HashMap<>();
-      node.fieldNames()
-          .forEachRemaining(
-              fieldName -> {
-                JsonNode childNode = node.get(fieldName);
-                map.put(fieldName, toPrimitive(childNode));
+      node.properties()
+          .forEach(
+              entry -> {
+                map.put(entry.getKey(), toPrimitive(entry.getValue()));
               });
       return map;
     } else if (node.isArray()) {
       List<Object> list = new ArrayList<>();
-      node.elements().forEachRemaining(element -> list.add(toPrimitive(element)));
+      node.iterator().forEachRemaining(element -> list.add(toPrimitive(element)));
       return list;
     } else if (node.isTextual()) {
       return node.asText();

--- a/libs/idp-server-platform/src/main/java/org/idp/server/platform/mapper/functions/FunctionRegistry.java
+++ b/libs/idp-server-platform/src/main/java/org/idp/server/platform/mapper/functions/FunctionRegistry.java
@@ -21,7 +21,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class FunctionRegistry {
-  private final Map<String, ValueFunction> map;
+  private Map<String, ValueFunction> map;
 
   public FunctionRegistry() {
     Map<String, ValueFunction> temp = new HashMap<>();

--- a/libs/idp-server-platform/src/main/java/org/idp/server/platform/mapper/functions/RandomStringFunction.java
+++ b/libs/idp-server-platform/src/main/java/org/idp/server/platform/mapper/functions/RandomStringFunction.java
@@ -23,7 +23,7 @@ public class RandomStringFunction implements ValueFunction {
 
   private static final String DEFAULT_ALPHABET =
       "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
-  private final SecureRandom random = new SecureRandom();
+  private SecureRandom random = new SecureRandom();
 
   @Override
   public Object apply(Object input, Map<String, Object> args) {

--- a/libs/idp-server-platform/src/main/java/org/idp/server/platform/mapper/functions/UuidShortFunction.java
+++ b/libs/idp-server-platform/src/main/java/org/idp/server/platform/mapper/functions/UuidShortFunction.java
@@ -70,7 +70,7 @@ public class UuidShortFunction implements ValueFunction {
   private static final int MIN_LENGTH = 4;
   private static final int MAX_LENGTH = 32;
 
-  private final SecureRandom random = new SecureRandom();
+  private SecureRandom random = new SecureRandom();
 
   /**
    * Generates a short UUID-like identifier.

--- a/libs/idp-server-platform/src/main/java/org/idp/server/platform/multi_tenancy/tenant/config/CorsConfiguration.java
+++ b/libs/idp-server-platform/src/main/java/org/idp/server/platform/multi_tenancy/tenant/config/CorsConfiguration.java
@@ -29,10 +29,10 @@ import java.util.Objects;
  */
 public class CorsConfiguration {
 
-  private final List<String> allowOrigins;
-  private final String allowHeaders;
-  private final String allowMethods;
-  private final boolean allowCredentials;
+  private List<String> allowOrigins;
+  private String allowHeaders;
+  private String allowMethods;
+  private boolean allowCredentials;
 
   public CorsConfiguration() {
     this.allowOrigins = List.of();

--- a/libs/idp-server-platform/src/main/java/org/idp/server/platform/multi_tenancy/tenant/config/SessionConfiguration.java
+++ b/libs/idp-server-platform/src/main/java/org/idp/server/platform/multi_tenancy/tenant/config/SessionConfiguration.java
@@ -28,14 +28,14 @@ import java.util.Objects;
  */
 public class SessionConfiguration {
 
-  private final String cookieName;
-  private final String cookieDomain;
-  private final String cookieSameSite;
-  private final boolean useSecureCookie;
-  private final boolean useHttpOnlyCookie;
-  private final String cookiePath;
-  private final int timeoutSeconds;
-  private final String switchPolicy;
+  private String cookieName;
+  private String cookieDomain;
+  private String cookieSameSite;
+  private boolean useSecureCookie;
+  private boolean useHttpOnlyCookie;
+  private String cookiePath;
+  private int timeoutSeconds;
+  private String switchPolicy;
 
   public SessionConfiguration() {
     this.cookieName = null;

--- a/libs/idp-server-platform/src/main/java/org/idp/server/platform/multi_tenancy/tenant/config/UIConfiguration.java
+++ b/libs/idp-server-platform/src/main/java/org/idp/server/platform/multi_tenancy/tenant/config/UIConfiguration.java
@@ -28,9 +28,9 @@ import java.util.Objects;
  */
 public class UIConfiguration {
 
-  private final String baseUrl;
-  private final String signupPage;
-  private final String signinPage;
+  private String baseUrl;
+  private String signupPage;
+  private String signinPage;
 
   public UIConfiguration() {
     this.baseUrl = null;

--- a/libs/idp-server-platform/src/main/java/org/idp/server/platform/security/event/SecurityEventUserAttributeConfiguration.java
+++ b/libs/idp-server-platform/src/main/java/org/idp/server/platform/security/event/SecurityEventUserAttributeConfiguration.java
@@ -22,29 +22,29 @@ import java.util.Objects;
 
 public class SecurityEventUserAttributeConfiguration {
 
-  private final boolean includeId;
-  private final boolean includeName;
-  private final boolean includeExternalUserId;
-  private final boolean includeEmail;
-  private final boolean includePhoneNumber;
-  private final boolean includeGivenName;
-  private final boolean includeFamilyName;
-  private final boolean includePreferredUsername;
-  private final boolean includeProfile;
-  private final boolean includePicture;
-  private final boolean includeWebsite;
-  private final boolean includeGender;
-  private final boolean includeBirthdate;
-  private final boolean includeZoneinfo;
-  private final boolean includeLocale;
-  private final boolean includeAddress;
-  private final boolean includeRoles;
-  private final boolean includePermissions;
-  private final boolean includeCurrentTenant;
-  private final boolean includeAssignedTenants;
-  private final boolean includeVerifiedClaims;
-  private final boolean includeStatus;
-  private final boolean includeAuthenticationDeviceIds;
+  private boolean includeId;
+  private boolean includeName;
+  private boolean includeExternalUserId;
+  private boolean includeEmail;
+  private boolean includePhoneNumber;
+  private boolean includeGivenName;
+  private boolean includeFamilyName;
+  private boolean includePreferredUsername;
+  private boolean includeProfile;
+  private boolean includePicture;
+  private boolean includeWebsite;
+  private boolean includeGender;
+  private boolean includeBirthdate;
+  private boolean includeZoneinfo;
+  private boolean includeLocale;
+  private boolean includeAddress;
+  private boolean includeRoles;
+  private boolean includePermissions;
+  private boolean includeCurrentTenant;
+  private boolean includeAssignedTenants;
+  private boolean includeVerifiedClaims;
+  private boolean includeStatus;
+  private boolean includeAuthenticationDeviceIds;
 
   public SecurityEventUserAttributeConfiguration() {
     this.includeId = true;

--- a/libs/idp-server-platform/src/main/java/org/idp/server/platform/security/hook/SecurityEventHookBatchRetryResult.java
+++ b/libs/idp-server-platform/src/main/java/org/idp/server/platform/security/hook/SecurityEventHookBatchRetryResult.java
@@ -22,11 +22,11 @@ import java.util.List;
 /** Result of a batch security event hook retry operation. */
 public class SecurityEventHookBatchRetryResult {
 
-  private final List<SecurityEventHookRetryResult> results;
-  private final int totalCount;
-  private final int successfulCount;
-  private final int failedCount;
-  private final int skippedCount;
+  private List<SecurityEventHookRetryResult> results;
+  private int totalCount;
+  private int successfulCount;
+  private int failedCount;
+  private int skippedCount;
 
   private SecurityEventHookBatchRetryResult(List<SecurityEventHookRetryResult> results) {
     this.results = List.copyOf(results);
@@ -72,7 +72,7 @@ public class SecurityEventHookBatchRetryResult {
   }
 
   public static class Builder {
-    private final List<SecurityEventHookRetryResult> results = new ArrayList<>();
+    private List<SecurityEventHookRetryResult> results = new ArrayList<>();
 
     public Builder addResult(SecurityEventHookRetryResult result) {
       results.add(result);

--- a/libs/idp-server-platform/src/main/java/org/idp/server/platform/security/hook/SecurityEventHookExecutionContext.java
+++ b/libs/idp-server-platform/src/main/java/org/idp/server/platform/security/hook/SecurityEventHookExecutionContext.java
@@ -29,8 +29,8 @@ import org.idp.server.platform.security.hook.configuration.SecurityEventHookConf
  */
 public class SecurityEventHookExecutionContext {
 
-  private final HookExecutionContext hookExecutionContext;
-  private final ExecutionResult executionResult;
+  private HookExecutionContext hookExecutionContext;
+  private ExecutionResult executionResult;
 
   public SecurityEventHookExecutionContext(
       HookExecutionContext hookExecutionContext, ExecutionResult executionResult) {
@@ -119,9 +119,9 @@ public class SecurityEventHookExecutionContext {
 
   /** Hook execution context containing metadata about the hook execution. */
   public static class HookExecutionContext {
-    private final String hookType;
-    private final String hookConfigurationId;
-    private final LocalDateTime executionTimestamp;
+    private String hookType;
+    private String hookConfigurationId;
+    private LocalDateTime executionTimestamp;
 
     public HookExecutionContext(
         String hookType, String hookConfigurationId, LocalDateTime executionTimestamp) {
@@ -153,10 +153,10 @@ public class SecurityEventHookExecutionContext {
 
   /** Execution result containing status and detailed information about the execution outcome. */
   public static class ExecutionResult {
-    private final SecurityEventHookStatus status;
-    private final Map<String, Object> executionDetails;
-    private final long executionDurationMs;
-    private final ErrorDetails errorDetails;
+    private SecurityEventHookStatus status;
+    private Map<String, Object> executionDetails;
+    private long executionDurationMs;
+    private ErrorDetails errorDetails;
 
     private ExecutionResult(
         SecurityEventHookStatus status,
@@ -217,8 +217,8 @@ public class SecurityEventHookExecutionContext {
 
   /** Error details for failed hook executions. */
   public static class ErrorDetails {
-    private final String errorType;
-    private final String errorMessage;
+    private String errorType;
+    private String errorMessage;
 
     public ErrorDetails(String errorType, String errorMessage) {
       this.errorType = errorType;

--- a/libs/idp-server-platform/src/main/java/org/idp/server/platform/security/hook/SecurityEventHookRetryResult.java
+++ b/libs/idp-server-platform/src/main/java/org/idp/server/platform/security/hook/SecurityEventHookRetryResult.java
@@ -21,12 +21,12 @@ import java.util.Map;
 /** Result of a security event hook retry operation. */
 public class SecurityEventHookRetryResult {
 
-  private final SecurityEventHookResultIdentifier originalResultIdentifier;
-  private final SecurityEventHookRetryStatus status;
-  private final SecurityEventHookResultIdentifier newResultIdentifier;
-  private final SecurityEventHookResult newResult;
-  private final String errorMessage;
-  private final Map<String, Object> retryDetails;
+  private SecurityEventHookResultIdentifier originalResultIdentifier;
+  private SecurityEventHookRetryStatus status;
+  private SecurityEventHookResultIdentifier newResultIdentifier;
+  private SecurityEventHookResult newResult;
+  private String errorMessage;
+  private Map<String, Object> retryDetails;
 
   private SecurityEventHookRetryResult(
       SecurityEventHookResultIdentifier originalResultIdentifier,

--- a/libs/idp-server-platform/src/main/java/org/idp/server/platform/security/log/SecurityEventLogConfiguration.java
+++ b/libs/idp-server-platform/src/main/java/org/idp/server/platform/security/log/SecurityEventLogConfiguration.java
@@ -27,26 +27,26 @@ import java.util.Set;
 
 public class SecurityEventLogConfiguration {
 
-  private final SecurityEventLogFormatter.Format format;
-  private final boolean debugEnabled;
-  private final String stage;
-  private final boolean includeUserId;
-  private final boolean includeUserName;
-  private final boolean includeUserExSub;
-  private final boolean includeClientId;
-  private final boolean includeIpAddress;
-  private final boolean includeUserAgent;
-  private final boolean includeEventDetail;
-  private final boolean includeUserDetail;
-  private final boolean includeUserPii;
-  private final List<String> allowedUserPiiKeys;
-  private final boolean includeTraceContext;
-  private final String serviceName;
-  private final List<String> customTags;
-  private final boolean tracingEnabled;
-  private final boolean persistenceEnabled;
-  private final boolean statisticsEnabled;
-  private final List<String> detailScrubKeys;
+  private SecurityEventLogFormatter.Format format;
+  private boolean debugEnabled;
+  private String stage;
+  private boolean includeUserId;
+  private boolean includeUserName;
+  private boolean includeUserExSub;
+  private boolean includeClientId;
+  private boolean includeIpAddress;
+  private boolean includeUserAgent;
+  private boolean includeEventDetail;
+  private boolean includeUserDetail;
+  private boolean includeUserPii;
+  private List<String> allowedUserPiiKeys;
+  private boolean includeTraceContext;
+  private String serviceName;
+  private List<String> customTags;
+  private boolean tracingEnabled;
+  private boolean persistenceEnabled;
+  private boolean statisticsEnabled;
+  private List<String> detailScrubKeys;
 
   private static final List<String> ESSENTIAL_SCRUB_KEYS =
       List.of(

--- a/libs/idp-server-platform/src/main/java/org/idp/server/platform/security/log/SecurityEventLogFormatter.java
+++ b/libs/idp-server-platform/src/main/java/org/idp/server/platform/security/log/SecurityEventLogFormatter.java
@@ -38,8 +38,8 @@ public interface SecurityEventLogFormatter {
     OBSERVABILITY("observability", "Enhanced format for observability platforms"),
     DISABLED("disabled", "Disable security event logging");
 
-    private final String value;
-    private final String description;
+    private String value;
+    private String description;
 
     Format(String value, String description) {
       this.value = value;

--- a/libs/idp-server-platform/src/main/java/org/idp/server/platform/security/ssrf/PrivateIpRange.java
+++ b/libs/idp-server-platform/src/main/java/org/idp/server/platform/security/ssrf/PrivateIpRange.java
@@ -82,12 +82,12 @@ public enum PrivateIpRange {
   // IPv4-mapped IPv6 addresses
   IPV4_MAPPED_IPV6("::ffff:0:0", 96, "IPv4-mapped IPv6");
 
-  private final String baseAddress;
-  private final int prefixLength;
-  private final String description;
-  private final BigInteger networkAddress;
-  private final BigInteger broadcastAddress;
-  private final boolean isIpv6;
+  private String baseAddress;
+  private int prefixLength;
+  private String description;
+  private BigInteger networkAddress;
+  private BigInteger broadcastAddress;
+  private boolean isIpv6;
 
   PrivateIpRange(String baseAddress, int prefixLength, String description) {
     this.baseAddress = baseAddress;

--- a/libs/idp-server-platform/src/main/java/org/idp/server/platform/security/ssrf/SsrfProtectionException.java
+++ b/libs/idp-server-platform/src/main/java/org/idp/server/platform/security/ssrf/SsrfProtectionException.java
@@ -29,9 +29,9 @@ package org.idp.server.platform.security.ssrf;
  */
 public class SsrfProtectionException extends RuntimeException {
 
-  private final String blockedHost;
-  private final String blockedIp;
-  private final PrivateIpRange matchedRange;
+  private String blockedHost;
+  private String blockedIp;
+  private PrivateIpRange matchedRange;
 
   public SsrfProtectionException(String message) {
     super(message);

--- a/libs/idp-server-platform/src/main/java/org/idp/server/platform/security/type/DeviceInfo.java
+++ b/libs/idp-server-platform/src/main/java/org/idp/server/platform/security/type/DeviceInfo.java
@@ -27,12 +27,12 @@ import java.util.regex.Pattern;
  */
 public class DeviceInfo {
 
-  private final String device;
-  private final String os;
-  private final String osVersion;
-  private final String browser;
-  private final String browserVersion;
-  private final boolean mobile;
+  private String device;
+  private String os;
+  private String osVersion;
+  private String browser;
+  private String browserVersion;
+  private boolean mobile;
 
   public DeviceInfo(
       String device,

--- a/libs/idp-server-platform/src/main/java/org/idp/server/platform/statistics/TenantStatistics.java
+++ b/libs/idp-server-platform/src/main/java/org/idp/server/platform/statistics/TenantStatistics.java
@@ -53,13 +53,13 @@ import org.idp.server.platform.multi_tenancy.tenant.TenantIdentifier;
  */
 public class TenantStatistics {
 
-  private final TenantStatisticsIdentifier id;
-  private final TenantIdentifier tenantId;
-  private final String statMonth;
-  private final Map<String, Object> monthlySummary;
-  private final Map<String, Map<String, Object>> dailyMetrics;
-  private final Instant createdAt;
-  private final Instant updatedAt;
+  private TenantStatisticsIdentifier id;
+  private TenantIdentifier tenantId;
+  private String statMonth;
+  private Map<String, Object> monthlySummary;
+  private Map<String, Map<String, Object>> dailyMetrics;
+  private Instant createdAt;
+  private Instant updatedAt;
 
   private TenantStatistics(Builder builder) {
     this.id = builder.id;

--- a/libs/idp-server-platform/src/main/java/org/idp/server/platform/statistics/TenantStatisticsReport.java
+++ b/libs/idp-server-platform/src/main/java/org/idp/server/platform/statistics/TenantStatisticsReport.java
@@ -47,10 +47,10 @@ import org.idp.server.platform.multi_tenancy.tenant.TenantIdentifier;
  */
 public class TenantStatisticsReport {
 
-  private final TenantIdentifier tenantId;
-  private final Period period;
-  private final Map<String, Object> summary;
-  private final List<MonthlyData> monthly;
+  private TenantIdentifier tenantId;
+  private Period period;
+  private Map<String, Object> summary;
+  private List<MonthlyData> monthly;
 
   private TenantStatisticsReport(Builder builder) {
     this.tenantId = Objects.requireNonNull(builder.tenantId, "tenantId must not be null");
@@ -89,9 +89,9 @@ public class TenantStatisticsReport {
 
   /** Period information */
   public static class Period {
-    private final String year;
-    private final String fromMonth;
-    private final String toMonth;
+    private String year;
+    private String fromMonth;
+    private String toMonth;
 
     public Period(String year, String fromMonth, String toMonth) {
       this.year = year;
@@ -122,10 +122,10 @@ public class TenantStatisticsReport {
 
   /** Monthly data with daily breakdown */
   public static class MonthlyData {
-    private final String month;
-    private final Map<String, Object> metrics;
-    private final int cumulativeYau;
-    private final List<DailyData> daily;
+    private String month;
+    private Map<String, Object> metrics;
+    private int cumulativeYau;
+    private List<DailyData> daily;
 
     private MonthlyData(MonthlyDataBuilder builder) {
       this.month = Objects.requireNonNull(builder.month, "month must not be null");
@@ -218,8 +218,8 @@ public class TenantStatisticsReport {
 
   /** Daily data */
   public static class DailyData {
-    private final String day;
-    private final Map<String, Object> metrics;
+    private String day;
+    private Map<String, Object> metrics;
 
     private DailyData(DailyDataBuilder builder) {
       this.day = Objects.requireNonNull(builder.day, "day must not be null");

--- a/libs/idp-server-platform/src/main/java/org/idp/server/platform/statistics/TenantStatisticsReportQuery.java
+++ b/libs/idp-server-platform/src/main/java/org/idp/server/platform/statistics/TenantStatisticsReportQuery.java
@@ -26,7 +26,7 @@ import java.util.Objects;
  */
 public class TenantStatisticsReportQuery {
 
-  private final String year;
+  private String year;
 
   public TenantStatisticsReportQuery(String year) {
     this.year = Objects.requireNonNull(year, "year must not be null");

--- a/libs/idp-server-platform/src/main/java/org/idp/server/platform/statistics/TenantYearlyStatistics.java
+++ b/libs/idp-server-platform/src/main/java/org/idp/server/platform/statistics/TenantYearlyStatistics.java
@@ -40,12 +40,12 @@ import org.idp.server.platform.multi_tenancy.tenant.TenantIdentifier;
  */
 public class TenantYearlyStatistics {
 
-  private final TenantYearlyStatisticsIdentifier id;
-  private final TenantIdentifier tenantId;
-  private final String statYear;
-  private final Map<String, Object> yearlySummary;
-  private final Instant createdAt;
-  private final Instant updatedAt;
+  private TenantYearlyStatisticsIdentifier id;
+  private TenantIdentifier tenantId;
+  private String statYear;
+  private Map<String, Object> yearlySummary;
+  private Instant createdAt;
+  private Instant updatedAt;
 
   private TenantYearlyStatistics(Builder builder) {
     this.id = builder.id;

--- a/libs/idp-server-platform/src/main/java/org/idp/server/platform/statistics/TenantYearlyStatisticsIdentifier.java
+++ b/libs/idp-server-platform/src/main/java/org/idp/server/platform/statistics/TenantYearlyStatisticsIdentifier.java
@@ -21,7 +21,7 @@ import java.util.Objects;
 /** Identifier for TenantYearlyStatistics */
 public class TenantYearlyStatisticsIdentifier {
 
-  private final String value;
+  private String value;
 
   public TenantYearlyStatisticsIdentifier(String value) {
     this.value = value;

--- a/libs/idp-server-platform/src/main/java/org/idp/server/platform/type/RequestAttributes.java
+++ b/libs/idp-server-platform/src/main/java/org/idp/server/platform/type/RequestAttributes.java
@@ -20,6 +20,7 @@ import java.util.Map;
 import org.idp.server.platform.http.BasicAuth;
 import org.idp.server.platform.http.BasicAuthConvertable;
 import org.idp.server.platform.json.JsonNodeWrapper;
+import org.idp.server.platform.log.LoggerWrapper;
 import org.idp.server.platform.security.type.Action;
 import org.idp.server.platform.security.type.IpAddress;
 import org.idp.server.platform.security.type.Resource;
@@ -27,6 +28,7 @@ import org.idp.server.platform.security.type.UserAgent;
 
 public class RequestAttributes implements BasicAuthConvertable {
 
+  private static final LoggerWrapper log = LoggerWrapper.getLogger(RequestAttributes.class);
   JsonNodeWrapper jsonNodeWrapper;
 
   public RequestAttributes() {}
@@ -91,8 +93,21 @@ public class RequestAttributes implements BasicAuthConvertable {
 
   public BasicAuth basicAuth() {
     JsonNodeWrapper headersNode = getJsonNode("headers");
-    String authorization = headersNode.getValueOrEmptyAsString("authorization");
+    String authorization = getHeaderValueCaseInsensitive(headersNode, "authorization");
     return convertBasicAuth(authorization);
+  }
+
+  private String getHeaderValueCaseInsensitive(JsonNodeWrapper headersNode, String headerName) {
+    String value = headersNode.getValueOrEmptyAsString(headerName);
+    if (!value.isEmpty()) {
+      return value;
+    }
+    for (String key : headersNode.fieldNamesAsList()) {
+      if (key.equalsIgnoreCase(headerName)) {
+        return headersNode.getValueOrEmptyAsString(key);
+      }
+    }
+    return "";
   }
 
   public boolean hasBasicAuth() {

--- a/libs/idp-server-platform/src/test/java/org/idp/server/platform/json/JacksonSerializationFormatTest.java
+++ b/libs/idp-server-platform/src/test/java/org/idp/server/platform/json/JacksonSerializationFormatTest.java
@@ -226,25 +226,29 @@ class JacksonSerializationFormatTest {
     }
 
     @Test
-    void rejectsUnknownFieldsByDefault() {
-      // JsonConverter のデフォルト: FAIL_ON_UNKNOWN_PROPERTIES=true
-      // JsonReadable を実装しないクラスは未知フィールドでエラーになる
-      // → 設定 JSON や API リクエストの typo を検出できる
+    void ignoresUnknownFieldsByDefault() {
+      // Jackson 3 のデフォルト: FAIL_ON_UNKNOWN_PROPERTIES=false
+      // → 未知フィールドは黙って無視される（Jackson 2 では例外を投げていた）
+      // → 旧→新、新→旧 双方向のロールバック安全性が標準で確保される
       String json =
           "{\"id\":\"ops_test\",\"status\":\"ACTIVE\","
-              + "\"unknown_field\":\"should_be_rejected\","
+              + "\"unknown_field\":\"should_be_ignored\","
               + "\"another_new_field\":123}";
 
-      assertThrows(
-          JsonRuntimeException.class,
-          () -> snakeCaseConverter.read(json, SessionLikeObject.class),
-          "Classes without JsonReadable should reject unknown fields");
+      SessionLikeObject result =
+          assertDoesNotThrow(
+              () -> snakeCaseConverter.read(json, SessionLikeObject.class),
+              "Jackson 3 ignores unknown fields by default");
+
+      assertEquals("ops_test", result.id);
+      assertEquals(Status.ACTIVE, result.status);
     }
 
     @Test
     void ignoresUnknownFieldsWithJsonReadable() {
-      // JsonReadable を実装したクラスは未知フィールドを無視する
-      // → Jackson 3 移行時のロールバック安全性を確保
+      // JsonReadable を実装したクラスも未知フィールドを無視する
+      // Jackson 3 ではデフォルトで無視されるため、デフォルト挙動と同じ結果になる
+      // （JsonReadable は意図の明示マーカーとして機能）
       String json =
           "{\"id\":\"ops_test\",\"status\":\"ACTIVE\","
               + "\"unknown_field\":\"should_be_ignored\","

--- a/libs/idp-server-platform/src/test/java/org/idp/server/platform/json/JsonConverterTest.java
+++ b/libs/idp-server-platform/src/test/java/org/idp/server/platform/json/JsonConverterTest.java
@@ -286,41 +286,43 @@ class JsonConverterTest {
     }
 
     @Test
-    void deserializesPrivateFinalFields() {
+    void cannotDeserializePrivateFinalFields() {
       // Jackson 2: private final フィールドへのリフレクション書き込みが可能
-      // Jackson 3: private final フィールドへの書き込みは不可（テスト失敗する想定）
-      // PR #1424 では final を外すことで対応
+      // Jackson 3: private final フィールドへの書き込みは不可
+      //   → 例外は投げず、デフォルト値（null/0）のまま残る
+      // PR #1424 で本番コードは final を外して対応済み
       JsonConverter converter = JsonConverter.defaultInstance();
       String json = "{\"code\":\"ABC\",\"amount\":100}";
 
       PrivateFinalFieldObject result = converter.read(json, PrivateFinalFieldObject.class);
 
-      assertEquals("ABC", result.getCode());
-      assertEquals(100, result.getAmount());
+      assertNull(result.getCode(), "private final String stays at default (null)");
+      assertEquals(0, result.getAmount(), "private final int stays at default (0)");
     }
 
     @Test
-    void roundTripsPrivateFinalFields() {
+    void roundTripLosesPrivateFinalFieldValues() {
+      // Jackson 3 では private final へ書き込めないため、シリアライズ→デシリアライズで値が失われる
       JsonConverter converter = JsonConverter.defaultInstance();
       PrivateFinalFieldObject original = new PrivateFinalFieldObject("XYZ", 999);
 
       String json = converter.write(original);
       PrivateFinalFieldObject restored = converter.read(json, PrivateFinalFieldObject.class);
 
-      assertEquals(original.getCode(), restored.getCode());
-      assertEquals(original.getAmount(), restored.getAmount());
+      assertNull(restored.getCode(), "round-trip loses private final String");
+      assertEquals(0, restored.getAmount(), "round-trip loses private final int");
     }
 
     @Test
-    void deserializesPrivateFinalBooleanField() {
-      // boolean/Boolean の final フィールドも Jackson 3 で問題になる
+    void cannotDeserializePrivateFinalBooleanField() {
+      // boolean/Boolean の final フィールドも同様（Jackson 3 では書き込み不可）
       JsonConverter converter = JsonConverter.defaultInstance();
       String json = "{\"enabled\":true,\"label\":\"test\"}";
 
       PrivateFinalBooleanObject result = converter.read(json, PrivateFinalBooleanObject.class);
 
-      assertTrue(result.isEnabled());
-      assertEquals("test", result.getLabel());
+      assertFalse(result.isEnabled(), "private final boolean stays at default (false)");
+      assertNull(result.getLabel(), "private final String stays at default (null)");
     }
   }
 

--- a/libs/idp-server-platform/src/test/java/org/idp/server/platform/json/schema/JsonSchemaValidatorTest.java
+++ b/libs/idp-server-platform/src/test/java/org/idp/server/platform/json/schema/JsonSchemaValidatorTest.java
@@ -19,13 +19,13 @@ package org.idp.server.platform.json.schema;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.idp.server.platform.json.JsonNodeWrapper;
 import org.junit.jupiter.api.Test;
+import tools.jackson.databind.json.JsonMapper;
 
 public class JsonSchemaValidatorTest {
 
-  ObjectMapper objectMapper = new ObjectMapper();
+  JsonMapper jsonMapper = JsonMapper.builder().build();
 
   @Test
   public void testValidationFailsWhenRequiredFieldIsMissing() throws Exception {
@@ -40,14 +40,14 @@ public class JsonSchemaValidatorTest {
       }
       """;
     JsonSchemaDefinition schemaDefinition =
-        new JsonSchemaDefinition(new JsonNodeWrapper(objectMapper.readTree(schemaJson)));
+        new JsonSchemaDefinition(new JsonNodeWrapper(jsonMapper.readTree(schemaJson)));
 
     String json = """
       {
         "name": "taro"
       }
       """;
-    JsonNodeWrapper input = new JsonNodeWrapper(objectMapper.readTree(json));
+    JsonNodeWrapper input = new JsonNodeWrapper(jsonMapper.readTree(json));
 
     JsonSchemaValidator validator = new JsonSchemaValidator(schemaDefinition);
     JsonSchemaValidationResult result = validator.validate(input);
@@ -69,14 +69,14 @@ public class JsonSchemaValidatorTest {
       }
       """;
     JsonSchemaDefinition schemaDefinition =
-        new JsonSchemaDefinition(new JsonNodeWrapper(objectMapper.readTree(schemaJson)));
+        new JsonSchemaDefinition(new JsonNodeWrapper(jsonMapper.readTree(schemaJson)));
 
     String json = """
       {
         "email": "user@example.com"
       }
       """;
-    JsonNodeWrapper input = new JsonNodeWrapper(objectMapper.readTree(json));
+    JsonNodeWrapper input = new JsonNodeWrapper(jsonMapper.readTree(json));
 
     JsonSchemaValidator validator = new JsonSchemaValidator(schemaDefinition);
     JsonSchemaValidationResult result = validator.validate(input);
@@ -107,8 +107,8 @@ public class JsonSchemaValidatorTest {
       """;
 
     JsonSchemaDefinition schemaDefinition =
-        new JsonSchemaDefinition(new JsonNodeWrapper(objectMapper.readTree(schemaJson)));
-    JsonNodeWrapper input = new JsonNodeWrapper(objectMapper.readTree(json));
+        new JsonSchemaDefinition(new JsonNodeWrapper(jsonMapper.readTree(schemaJson)));
+    JsonNodeWrapper input = new JsonNodeWrapper(jsonMapper.readTree(json));
     JsonSchemaValidator validator = new JsonSchemaValidator(schemaDefinition);
     JsonSchemaValidationResult result = validator.validate(input);
 
@@ -138,8 +138,8 @@ public class JsonSchemaValidatorTest {
       """;
 
     JsonSchemaDefinition schemaDefinition =
-        new JsonSchemaDefinition(new JsonNodeWrapper(objectMapper.readTree(schemaJson)));
-    JsonNodeWrapper input = new JsonNodeWrapper(objectMapper.readTree(json));
+        new JsonSchemaDefinition(new JsonNodeWrapper(jsonMapper.readTree(schemaJson)));
+    JsonNodeWrapper input = new JsonNodeWrapper(jsonMapper.readTree(json));
     JsonSchemaValidator validator = new JsonSchemaValidator(schemaDefinition);
     JsonSchemaValidationResult result = validator.validate(input);
 
@@ -168,8 +168,8 @@ public class JsonSchemaValidatorTest {
       """;
 
     JsonSchemaDefinition schemaDefinition =
-        new JsonSchemaDefinition(new JsonNodeWrapper(objectMapper.readTree(schemaJson)));
-    JsonNodeWrapper input = new JsonNodeWrapper(objectMapper.readTree(json));
+        new JsonSchemaDefinition(new JsonNodeWrapper(jsonMapper.readTree(schemaJson)));
+    JsonNodeWrapper input = new JsonNodeWrapper(jsonMapper.readTree(json));
     JsonSchemaValidator validator = new JsonSchemaValidator(schemaDefinition);
     JsonSchemaValidationResult result = validator.validate(input);
 
@@ -200,8 +200,8 @@ public class JsonSchemaValidatorTest {
       """;
 
     JsonSchemaDefinition schemaDefinition =
-        new JsonSchemaDefinition(new JsonNodeWrapper(objectMapper.readTree(schemaJson)));
-    JsonNodeWrapper input = new JsonNodeWrapper(objectMapper.readTree(json));
+        new JsonSchemaDefinition(new JsonNodeWrapper(jsonMapper.readTree(schemaJson)));
+    JsonNodeWrapper input = new JsonNodeWrapper(jsonMapper.readTree(json));
     JsonSchemaValidator validator = new JsonSchemaValidator(schemaDefinition);
     JsonSchemaValidationResult result = validator.validate(input);
 
@@ -231,8 +231,8 @@ public class JsonSchemaValidatorTest {
       """;
 
     JsonSchemaDefinition schemaDefinition =
-        new JsonSchemaDefinition(new JsonNodeWrapper(objectMapper.readTree(schemaJson)));
-    JsonNodeWrapper input = new JsonNodeWrapper(objectMapper.readTree(json));
+        new JsonSchemaDefinition(new JsonNodeWrapper(jsonMapper.readTree(schemaJson)));
+    JsonNodeWrapper input = new JsonNodeWrapper(jsonMapper.readTree(json));
     JsonSchemaValidator validator = new JsonSchemaValidator(schemaDefinition);
     JsonSchemaValidationResult result = validator.validate(input);
 
@@ -264,8 +264,8 @@ public class JsonSchemaValidatorTest {
       """;
 
     JsonSchemaDefinition schemaDefinition =
-        new JsonSchemaDefinition(new JsonNodeWrapper(objectMapper.readTree(schemaJson)));
-    JsonNodeWrapper input = new JsonNodeWrapper(objectMapper.readTree(json));
+        new JsonSchemaDefinition(new JsonNodeWrapper(jsonMapper.readTree(schemaJson)));
+    JsonNodeWrapper input = new JsonNodeWrapper(jsonMapper.readTree(json));
     JsonSchemaValidator validator = new JsonSchemaValidator(schemaDefinition);
     JsonSchemaValidationResult result = validator.validate(input);
 
@@ -333,7 +333,7 @@ public class JsonSchemaValidatorTest {
             .formatted(IP_ADDRESS_PATTERN);
 
     JsonSchemaDefinition schemaDefinition =
-        new JsonSchemaDefinition(new JsonNodeWrapper(objectMapper.readTree(schemaJson)));
+        new JsonSchemaDefinition(new JsonNodeWrapper(jsonMapper.readTree(schemaJson)));
     JsonSchemaValidator validator = new JsonSchemaValidator(schemaDefinition);
 
     // Valid IPv4 addresses
@@ -341,28 +341,28 @@ public class JsonSchemaValidatorTest {
       { "ip_address": "127.0.0.1" }
       """;
     JsonSchemaValidationResult result1 =
-        validator.validate(new JsonNodeWrapper(objectMapper.readTree(validIp1)));
+        validator.validate(new JsonNodeWrapper(jsonMapper.readTree(validIp1)));
     assertTrue(result1.isValid(), "127.0.0.1 should be valid");
 
     String validIp2 = """
       { "ip_address": "192.168.1.100" }
       """;
     JsonSchemaValidationResult result2 =
-        validator.validate(new JsonNodeWrapper(objectMapper.readTree(validIp2)));
+        validator.validate(new JsonNodeWrapper(jsonMapper.readTree(validIp2)));
     assertTrue(result2.isValid(), "192.168.1.100 should be valid");
 
     String validIp3 = """
       { "ip_address": "255.255.255.255" }
       """;
     JsonSchemaValidationResult result3 =
-        validator.validate(new JsonNodeWrapper(objectMapper.readTree(validIp3)));
+        validator.validate(new JsonNodeWrapper(jsonMapper.readTree(validIp3)));
     assertTrue(result3.isValid(), "255.255.255.255 should be valid");
 
     String validIp4 = """
       { "ip_address": "0.0.0.0" }
       """;
     JsonSchemaValidationResult result4 =
-        validator.validate(new JsonNodeWrapper(objectMapper.readTree(validIp4)));
+        validator.validate(new JsonNodeWrapper(jsonMapper.readTree(validIp4)));
     assertTrue(result4.isValid(), "0.0.0.0 should be valid");
   }
 
@@ -383,7 +383,7 @@ public class JsonSchemaValidatorTest {
             .formatted(IP_ADDRESS_PATTERN);
 
     JsonSchemaDefinition schemaDefinition =
-        new JsonSchemaDefinition(new JsonNodeWrapper(objectMapper.readTree(schemaJson)));
+        new JsonSchemaDefinition(new JsonNodeWrapper(jsonMapper.readTree(schemaJson)));
     JsonSchemaValidator validator = new JsonSchemaValidator(schemaDefinition);
 
     // Invalid: non-IP string
@@ -391,7 +391,7 @@ public class JsonSchemaValidatorTest {
       { "ip_address": "invalid-ip" }
       """;
     JsonSchemaValidationResult result1 =
-        validator.validate(new JsonNodeWrapper(objectMapper.readTree(invalidIp1)));
+        validator.validate(new JsonNodeWrapper(jsonMapper.readTree(invalidIp1)));
     assertFalse(result1.isValid(), "invalid-ip should be invalid");
 
     // Invalid: out of range (999 > 255)
@@ -399,7 +399,7 @@ public class JsonSchemaValidatorTest {
       { "ip_address": "999.999.999.999" }
       """;
     JsonSchemaValidationResult result2 =
-        validator.validate(new JsonNodeWrapper(objectMapper.readTree(invalidIp2)));
+        validator.validate(new JsonNodeWrapper(jsonMapper.readTree(invalidIp2)));
     assertFalse(result2.isValid(), "999.999.999.999 should be invalid (out of range)");
 
     // Invalid: 256 > 255
@@ -407,7 +407,7 @@ public class JsonSchemaValidatorTest {
       { "ip_address": "256.1.1.1" }
       """;
     JsonSchemaValidationResult result3 =
-        validator.validate(new JsonNodeWrapper(objectMapper.readTree(invalidIp3)));
+        validator.validate(new JsonNodeWrapper(jsonMapper.readTree(invalidIp3)));
     assertFalse(result3.isValid(), "256.1.1.1 should be invalid (256 > 255)");
 
     // Invalid: missing octet
@@ -415,7 +415,7 @@ public class JsonSchemaValidatorTest {
       { "ip_address": "192.168.1" }
       """;
     JsonSchemaValidationResult result4 =
-        validator.validate(new JsonNodeWrapper(objectMapper.readTree(invalidIp4)));
+        validator.validate(new JsonNodeWrapper(jsonMapper.readTree(invalidIp4)));
     assertFalse(result4.isValid(), "192.168.1 should be invalid (missing octet)");
 
     // Invalid: extra octet
@@ -423,7 +423,7 @@ public class JsonSchemaValidatorTest {
       { "ip_address": "192.168.1.1.1" }
       """;
     JsonSchemaValidationResult result5 =
-        validator.validate(new JsonNodeWrapper(objectMapper.readTree(invalidIp5)));
+        validator.validate(new JsonNodeWrapper(jsonMapper.readTree(invalidIp5)));
     assertFalse(result5.isValid(), "192.168.1.1.1 should be invalid (extra octet)");
   }
 
@@ -444,7 +444,7 @@ public class JsonSchemaValidatorTest {
             .formatted(IP_ADDRESS_PATTERN);
 
     JsonSchemaDefinition schemaDefinition =
-        new JsonSchemaDefinition(new JsonNodeWrapper(objectMapper.readTree(schemaJson)));
+        new JsonSchemaDefinition(new JsonNodeWrapper(jsonMapper.readTree(schemaJson)));
     JsonSchemaValidator validator = new JsonSchemaValidator(schemaDefinition);
 
     // Valid IPv6: full form
@@ -453,7 +453,7 @@ public class JsonSchemaValidatorTest {
       { "ip_address": "2001:0db8:85a3:0000:0000:8a2e:0370:7334" }
       """;
     JsonSchemaValidationResult result1 =
-        validator.validate(new JsonNodeWrapper(objectMapper.readTree(validIpv6_1)));
+        validator.validate(new JsonNodeWrapper(jsonMapper.readTree(validIpv6_1)));
     assertTrue(result1.isValid(), "Full IPv6 address should be valid");
 
     // Valid IPv6: unspecified address
@@ -461,7 +461,7 @@ public class JsonSchemaValidatorTest {
       { "ip_address": "::" }
       """;
     JsonSchemaValidationResult result2 =
-        validator.validate(new JsonNodeWrapper(objectMapper.readTree(validIpv6_2)));
+        validator.validate(new JsonNodeWrapper(jsonMapper.readTree(validIpv6_2)));
     assertTrue(result2.isValid(), ":: (IPv6 unspecified) should be valid");
 
     // Valid IPv6: localhost
@@ -469,7 +469,7 @@ public class JsonSchemaValidatorTest {
       { "ip_address": "::1" }
       """;
     JsonSchemaValidationResult result3 =
-        validator.validate(new JsonNodeWrapper(objectMapper.readTree(validIpv6_3)));
+        validator.validate(new JsonNodeWrapper(jsonMapper.readTree(validIpv6_3)));
     assertTrue(result3.isValid(), "::1 (IPv6 localhost) should be valid");
 
     // Valid IPv6: link-local with abbreviation
@@ -477,7 +477,7 @@ public class JsonSchemaValidatorTest {
       { "ip_address": "fe80::1" }
       """;
     JsonSchemaValidationResult result4 =
-        validator.validate(new JsonNodeWrapper(objectMapper.readTree(validIpv6_4)));
+        validator.validate(new JsonNodeWrapper(jsonMapper.readTree(validIpv6_4)));
     assertTrue(result4.isValid(), "fe80::1 (link-local) should be valid");
 
     // Valid IPv6: abbreviation in the middle
@@ -485,7 +485,7 @@ public class JsonSchemaValidatorTest {
       { "ip_address": "2001:db8::1" }
       """;
     JsonSchemaValidationResult result5 =
-        validator.validate(new JsonNodeWrapper(objectMapper.readTree(validIpv6_5)));
+        validator.validate(new JsonNodeWrapper(jsonMapper.readTree(validIpv6_5)));
     assertTrue(result5.isValid(), "2001:db8::1 should be valid");
 
     // Valid IPv6: trailing abbreviation
@@ -493,7 +493,7 @@ public class JsonSchemaValidatorTest {
       { "ip_address": "2001:db8::" }
       """;
     JsonSchemaValidationResult result6 =
-        validator.validate(new JsonNodeWrapper(objectMapper.readTree(validIpv6_6)));
+        validator.validate(new JsonNodeWrapper(jsonMapper.readTree(validIpv6_6)));
     assertTrue(result6.isValid(), "2001:db8:: should be valid");
 
     // Valid IPv6: multiple segments after abbreviation
@@ -501,7 +501,7 @@ public class JsonSchemaValidatorTest {
       { "ip_address": "2001:db8::8a2e:370:7334" }
       """;
     JsonSchemaValidationResult result7 =
-        validator.validate(new JsonNodeWrapper(objectMapper.readTree(validIpv6_7)));
+        validator.validate(new JsonNodeWrapper(jsonMapper.readTree(validIpv6_7)));
     assertTrue(result7.isValid(), "2001:db8::8a2e:370:7334 should be valid");
   }
 }

--- a/libs/idp-server-springboot-adapter/build.gradle
+++ b/libs/idp-server-springboot-adapter/build.gradle
@@ -1,7 +1,7 @@
 plugins {
 	id 'java'
-	id 'org.springframework.boot' version '3.5.6'
-	id 'io.spring.dependency-management' version '1.1.4'
+	id 'org.springframework.boot' version '4.0.4'
+	id 'io.spring.dependency-management' version '1.1.7'
 	id "com.diffplug.spotless" version "6.24.0"
 }
 

--- a/libs/idp-server-springboot-adapter/build.gradle
+++ b/libs/idp-server-springboot-adapter/build.gradle
@@ -1,6 +1,6 @@
 plugins {
 	id 'java'
-	id 'org.springframework.boot' version '4.0.4'
+	id 'org.springframework.boot' version '4.0.6'
 	id 'io.spring.dependency-management' version '1.1.7'
 	id "com.diffplug.spotless" version "6.24.0"
 }

--- a/libs/idp-server-springboot-adapter/src/main/java/org/idp/server/adapters/springboot/SecurityConfig.java
+++ b/libs/idp-server-springboot-adapter/src/main/java/org/idp/server/adapters/springboot/SecurityConfig.java
@@ -56,6 +56,7 @@ public class SecurityConfig {
             httpSecuritySessionManagementConfigurer.sessionCreationPolicy(
                 SessionCreationPolicy.STATELESS));
     http.csrf(AbstractHttpConfigurer::disable);
+    http.httpBasic(AbstractHttpConfigurer::disable);
 
     http.authorizeHttpRequests(
         (authorize) ->

--- a/libs/idp-server-springboot-adapter/src/main/java/org/idp/server/adapters/springboot/application/restapi/health/HealthV1Api.java
+++ b/libs/idp-server-springboot-adapter/src/main/java/org/idp/server/adapters/springboot/application/restapi/health/HealthV1Api.java
@@ -50,7 +50,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping
 public class HealthV1Api implements ParameterTransformable {
 
-  private final HealthCheckApi healthCheckApi;
+  private HealthCheckApi healthCheckApi;
 
   public HealthV1Api(IdpServerApplication idpServerApplication) {
     this.healthCheckApi = idpServerApplication.healthCheckApi();

--- a/libs/idp-server-springboot-adapter/src/main/java/org/idp/server/adapters/springboot/application/session/SessionCookieService.java
+++ b/libs/idp-server-springboot-adapter/src/main/java/org/idp/server/adapters/springboot/application/session/SessionCookieService.java
@@ -87,14 +87,21 @@ public class SessionCookieService implements SessionCookieDelegate {
     addCookieWithSameSiteAndDomain(sessionCookie, sameSite, cookieDomain);
 
     log.debug(
-        "Session cookies set: IDP_IDENTITY and IDP_SESSION, path={}, domain={}",
+        "Session cookies set: IDP_IDENTITY and IDP_SESSION, path={}, domain={}, secure={}, sameSite={}",
         cookiePath,
-        cookieDomain != null ? cookieDomain : "(host only)");
+        cookieDomain != null ? cookieDomain : "(host only)",
+        secureCookie,
+        sameSite);
   }
 
   @Override
   public Optional<String> getIdentityToken() {
-    return getCookieValue(IDENTITY_COOKIE_NAME);
+    Optional<String> value = getCookieValue(IDENTITY_COOKIE_NAME);
+    log.debug(
+        "getIdentityToken: present={}, cookieCount={}",
+        value.isPresent(),
+        httpServletRequest.getCookies() != null ? httpServletRequest.getCookies().length : 0);
+    return value;
   }
 
   @Override

--- a/libs/idp-server-springboot-adapter/src/main/java/org/idp/server/adapters/springboot/control_plane/model/OrganizationOperatorPrincipal.java
+++ b/libs/idp-server-springboot-adapter/src/main/java/org/idp/server/adapters/springboot/control_plane/model/OrganizationOperatorPrincipal.java
@@ -35,7 +35,7 @@ import org.springframework.security.authentication.AbstractAuthenticationToken;
  */
 public class OrganizationOperatorPrincipal extends AbstractAuthenticationToken {
 
-  private final OrganizationAuthenticationContext authenticationContext;
+  private OrganizationAuthenticationContext authenticationContext;
 
   /**
    * Constructs a new OrganizationOperatorPrincipal.

--- a/libs/idp-server-springboot-adapter/src/main/java/org/idp/server/adapters/springboot/logging/RequestResponseLoggingFilter.java
+++ b/libs/idp-server-springboot-adapter/src/main/java/org/idp/server/adapters/springboot/logging/RequestResponseLoggingFilter.java
@@ -91,7 +91,8 @@ public class RequestResponseLoggingFilter extends OncePerRequestFilter {
     }
 
     if (logger.isDebugEnabled()) {
-      ContentCachingRequestWrapper wrappedRequest = new ContentCachingRequestWrapper(request);
+      ContentCachingRequestWrapper wrappedRequest =
+          new ContentCachingRequestWrapper(request, 50000);
       ContentCachingResponseWrapper wrappedResponse = new ContentCachingResponseWrapper(response);
 
       try {

--- a/libs/idp-server-springboot-adapter/src/main/java/org/idp/server/adapters/springboot/logging/RequestResponseLoggingFilter.java
+++ b/libs/idp-server-springboot-adapter/src/main/java/org/idp/server/adapters/springboot/logging/RequestResponseLoggingFilter.java
@@ -66,6 +66,7 @@ import org.springframework.web.util.ContentCachingResponseWrapper;
 @Order(Ordered.HIGHEST_PRECEDENCE + 10)
 public class RequestResponseLoggingFilter extends OncePerRequestFilter {
 
+  private static final int MAX_CONTENT_CACHE_SIZE = 50000;
   private static final LoggerWrapper logger =
       LoggerWrapper.getLogger(RequestResponseLoggingFilter.class);
 
@@ -92,7 +93,7 @@ public class RequestResponseLoggingFilter extends OncePerRequestFilter {
 
     if (logger.isDebugEnabled()) {
       ContentCachingRequestWrapper wrappedRequest =
-          new ContentCachingRequestWrapper(request, 50000);
+          new ContentCachingRequestWrapper(request, MAX_CONTENT_CACHE_SIZE);
       ContentCachingResponseWrapper wrappedResponse = new ContentCachingResponseWrapper(response);
 
       try {


### PR DESCRIPTION
## Summary

- Spring Boot 3.5.6 → 4.0.6、Jackson 2.14.2 → 3.1.2 への移行
- Spring Boot 3.5 の EOL（2026年6月30日）に向けた対応
- ロールバック耐性を考慮したシリアライズ形式の維持

## 主な変更

### Spring Boot 4.0.6
- dependency-management 1.1.4 → 1.1.7
- `SessionAutoConfiguration` exclude 削除（Spring Boot 4.0で削除済み）
- `ContentCachingRequestWrapper` maxContentLength 引数追加
- `httpBasic` 明示的無効化

### Jackson 2 → 3 (3.1.2)
- `com.fasterxml.jackson.core:jackson-databind:2.14.2` → `tools.jackson.core:jackson-databind:3.1.2`
- `jackson-datatype-jsr310` 削除（Jackson 3に内蔵）
- `ObjectMapper` → `JsonMapper`（immutable builder pattern）
- `JsonNode` API変更: `fieldNames()` → `properties()`, `elements()` → `iterator()`
- `private final` → `private`（Jackson 3はfinalフィールドにリフレクション書き込み不可）
- **`FAIL_ON_UNKNOWN_PROPERTIES` のデフォルトが `true` → `false` に変更**（Jackson 3の仕様）
  - 未知フィールドは黙って無視される
  - ロールバック時のJSON前方互換性が標準で確保される
- **シリアライズ形式は Jackson 2 互換を維持**（ロールバック対応）
  - `DateTimeFeature.WRITE_DATES_AS_TIMESTAMPS` を有効化
  - LocalDateTime の `yyyy/MM/dd HH:mm:ss` 形式デシリアライザを `SimpleModule` で登録

### Tomcat 11 (Servlet 6.1)
- ヘッダー名のケース保持対応（Tomcat 10.xは小文字、11は原形保持）
- `RequestAttributes.basicAuth()` で case-insensitive 検索に変更

### ドキュメント
- 移行ガイド追加: `content_06_developer-guide/06-migration/01-spring-boot-4-migration.md`
- `FAIL_ON_UNKNOWN_PROPERTIES` のデフォルト変更に関するセクション追加
- 公式ガイドへのリンク付き

## 移行で発見した問題と対応

| # | 問題 | 原因 | 対応 |
|---|------|------|------|
| 1 | Jackson 3 API変更 | パッケージ・クラス名変更 | import/API書き直し |
| 2 | boolean/オブジェクトのデシリアライズ失敗 | Jackson 3がprivate finalフィールドに書き込み不可 | private final → private |
| 3 | セッション自動設定 | SessionAutoConfiguration削除 | exclude削除 |
| 4 | 身元確認BasicAuth失敗 | Tomcat 11がヘッダー名の原形ケースを保持 | case-insensitive検索 |
| 5 | RequestWrapper | コンストラクタ引数変更 | maxContentLength追加 |
| 6 | ロールバック時の日付デシリアライズ失敗 | Jackson 3がISO-8601文字列で出力 | WRITE_DATES_AS_TIMESTAMPS有効化 + カスタムデシリアライザ |
| 7 | Jackson 3.1.0 の `@JsonIgnoreProperties` バグ | 3.1.0 でデフォルト挙動が不安定 | 3.1.2 へバンプ＋テストを Jackson 3 仕様に整合 |

## Test plan
- [x] `./gradlew spotlessApply && ./gradlew build` — BUILD SUCCESSFUL
- [x] `./gradlew test` — ユニットテスト全通し（1032件 in idp-server-platform）
- [x] E2Eテスト全通し

🤖 Generated with [Claude Code](https://claude.com/claude-code)