### PR TITLE
fix: jest-circus 移行に伴う jest.setTimeout 互換性修正

### DIFF
--- a/e2e/src/tests/scenario/application/scenario-09-token-refresh.test.js
+++ b/e2e/src/tests/scenario/application/scenario-09-token-refresh.test.js
@@ -1,4 +1,4 @@
-import { jest, describe, expect, it } from "@jest/globals";
+import { describe, expect, it } from "@jest/globals";
 import { createFederatedUser } from "../../../user";
 import {
   backendUrl,
@@ -13,7 +13,6 @@ import { post } from "../../../lib/http";
 describe("token refresh strategy", () => {
 
   it("fixed & rotate strategy", async () => {
-    jest.setTimeout(180_000);
 
     const { user, accessToken, refreshToken: initialRefreshToken } = await createFederatedUser({
       serverConfig: serverConfig,
@@ -74,7 +73,7 @@ describe("token refresh strategy", () => {
     expect(refreshTokenResponse.status).toBe(400);
     expect(refreshTokenResponse.data.error).toEqual("invalid_grant");
     expect(refreshTokenResponse.data.error_description).toEqual("refresh token is expired");
-  });
+  }, 180_000);
 
 
 });


### PR DESCRIPTION
## Summary

- PR #1426 の jest-jasmine2 → jest-circus 移行に伴い、`jest.setTimeout()` の互換性問題を修正

## 問題

`scenario-09-token-refresh.test.js` で `it()` 内の `jest.setTimeout(180_000)` が jest-circus では無視され、デフォルトの30秒でタイムアウトしていた。

| runner | `it()` 内の `jest.setTimeout()` | `it()` 第3引数 |
|--------|-------------------------------|---------------|
| jasmine2 | 有効 | 有効 |
| circus | **無視される** | 有効 |

## 修正

```javascript
// Before (jasmine2 依存)
it("test", async () => {
  jest.setTimeout(180_000);
  // ...
});

// After (circus 互換)
it("test", async () => {
  // ...
}, 180_000);
```

## Test plan

- [x] `npm test -- --testPathPattern="scenario-09-token-refresh"` PASS (62秒で完了)
- [x] 他に `jest.setTimeout` を `it()` 内で呼んでいるテストがないことを確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)