### PR TITLE
fix: CodeQL を Java のみに変更

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   analyze:
-    name: Analyze (${{ matrix.language }})
+    name: Analyze Java
     runs-on: ubuntu-latest
     permissions:
       security-events: write
@@ -20,17 +20,11 @@ jobs:
       actions: read
       contents: read
 
-    strategy:
-      fail-fast: false
-      matrix:
-        language: ["java-kotlin", "javascript-typescript"]
-
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
       - name: Set up JDK 21
-        if: matrix.language == 'java-kotlin'
         uses: actions/setup-java@v4
         with:
           java-version: "21"
@@ -39,7 +33,7 @@ jobs:
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v3
         with:
-          languages: ${{ matrix.language }}
+          languages: java-kotlin
           # セキュリティクエリ（デフォルト） + 品質クエリ
           queries: security-extended
 
@@ -49,4 +43,4 @@ jobs:
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v3
         with:
-          category: "/language:${{ matrix.language }}"
+          category: "/language:java-kotlin"


### PR DESCRIPTION
## Summary

CodeQL の対象言語から JavaScript/TypeScript を除外し、Java のみに変更。

## 理由

- JavaScript/TypeScript のコードは E2E テストコードのみ
- テストコードのセキュリティスキャンはノイズになる（Node.js 20 deprecated 警告等）
- プロダクションコード（Java）のスキャンに集中する

## 変更内容

- matrix strategy を削除し、Java 単一ジョブに簡素化
- JDK 21 セットアップの条件分岐 (`if: matrix.language == 'java-kotlin'`) を削除

## Test plan

- [ ] PR で CodeQL が Java のみ実行されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)