### PR TITLE
feat: JaCoCo コードカバレッジ計測を導入

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,10 @@
 plugins {
 	id "com.diffplug.spotless" version "6.24.0"
+	id 'jacoco'
+}
+
+repositories {
+	mavenCentral()
 }
 
 task stage(dependsOn: ['clean',':app:bootJar']) {
@@ -11,6 +16,26 @@ task stage(dependsOn: ['clean',':app:bootJar']) {
 import java.nio.file.Files
 
 subprojects {
+	apply plugin: 'jacoco'
+
+	jacoco {
+		toolVersion = "0.8.12"
+	}
+
+	plugins.withId('java') {
+		jacocoTestReport {
+			dependsOn test
+			reports {
+				xml.required = true
+				html.required = true
+				csv.required = false
+			}
+		}
+
+		test {
+			finalizedBy jacocoTestReport
+		}
+	}
 
 	tasks.register('addApacheLicenseHeader') {
 		group = 'license'
@@ -83,5 +108,28 @@ tasks.register('checkLicenseHeader') {
 		} else {
 			println "✅ All .java files have Apache license headers."
 		}
+	}
+}
+
+tasks.register('jacocoAggregatedReport', JacocoReport) {
+	group = 'verification'
+	description = 'Generates aggregated JaCoCo coverage report for all subprojects'
+
+	def javaSubprojects = subprojects.findAll { it.plugins.hasPlugin('java') }
+	dependsOn javaSubprojects.collect { it.tasks.named('test') }
+
+	executionData.from(javaSubprojects.collect {
+		it.tasks.named('test').map { t -> t.jacoco.destinationFile }
+	})
+
+	sourceDirectories.from(javaSubprojects.collect { it.sourceSets.main.java.srcDirs })
+	classDirectories.from(javaSubprojects.collect { it.sourceSets.main.output })
+
+	reports {
+		xml.required = true
+		xml.outputLocation = layout.buildDirectory.file("reports/jacoco/aggregated/jacoco.xml")
+		html.required = true
+		html.outputLocation = layout.buildDirectory.dir("reports/jacoco/aggregated/html")
+		csv.required = false
 	}
 }


### PR DESCRIPTION
## Summary

- 全23サブプロジェクトにJaCoCo 0.8.12を適用し、コードカバレッジ計測を導入
- `./gradlew test` 実行時に自動でモジュール別レポート生成
- 全モジュール集約レポートタスク `jacocoAggregatedReport` を追加

## 使い方

```bash
./gradlew test                        # テスト＋モジュール別レポート
./gradlew test jacocoAggregatedReport # 全モジュール集約レポート
open build/reports/jacoco/aggregated/html/index.html
```

## 現状のカバレッジ（参考値）

| 指標 | カバレッジ |
|------|----------|
| LINE | 4,390 / 58,311 (7.5%) |
| BRANCH | 1,691 / 17,473 (9.7%) |
| METHOD | 991 / 14,116 (7.0%) |

- platform層（mapper, json, http, security）はユニットテストが充実（40-92%）
- usecases層・adapters層はE2E（Jest）でカバーしているためJavaユニットテストとしては0%

## Test plan

- [x] `./gradlew test` で全テストPASS＋カバレッジレポート生成確認
- [x] `./gradlew test jacocoAggregatedReport` で集約レポート生成確認
- [x] 既存のビルド・テストに影響なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)