### PR TITLE
fix: CodeQL から CSRF ルールを除外

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,12 @@
+# CodeQL カスタム設定
+# https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/customizing-your-advanced-setup-for-code-scanning
+#
+# idp-server は REST API + Bearer トークン認証のため、CSRF 保護は不要。
+# SecurityConfig で csrf().disable() を意図的に設定しており、
+# state-changing エンドポイント追加のたびに誤検知が増えるのを防ぐ。
+
+query-filters:
+  - exclude:
+      id: java/csrf-unprotected-request-type
+  - exclude:
+      id: java/spring-disabled-csrf-protection

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -34,7 +34,7 @@ jobs:
         uses: github/codeql-action/init@v3
         with:
           languages: java-kotlin
-          # セキュリティクエリ（デフォルト） + 品質クエリ
+          config-file: .github/codeql/codeql-config.yml
           queries: security-extended
 
       - name: Autobuild


### PR DESCRIPTION
## Summary

CodeQL の CSRF 関連ルール2つを除外。エンドポイント追加のたびに誤検知が増えるのを防ぐ。

## 理由

idp-server は REST API + Bearer トークン認証であり、CSRF 保護は不要。

- `SecurityConfig` で `csrf().disable()` + `SessionCreationPolicy.STATELESS` を意図的に設定
- CSRF はブラウザの Cookie 自動送信を悪用する攻撃。Bearer トークン（Authorization ヘッダー）はブラウザが自動送信しないため対象外
- OWASP: "If your application uses Bearer tokens for authentication, CSRF protection is not needed"

現状55件のCSRFアラートが誤検知として蓄積しており、更新系APIを追加するたびに増え続ける。

## 除外ルール

| ルール | 説明 |
|--------|------|
| `java/csrf-unprotected-request-type` | POST/PUT/DELETE/PATCHエンドポイントにCSRF保護がない |
| `java/spring-disabled-csrf-protection` | Spring SecurityでCSRFが無効化されている |

## 変更内容

- `.github/codeql/codeql-config.yml`: 新規作成。除外ルール定義
- `.github/workflows/codeql.yml`: `config-file` で設定ファイルを参照

## Test plan

- [ ] マージ後にCodeQLが実行され、CSRFアラートが新規検出されないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)