### PR TITLE
fix: CodeQL を Java ファイル変更時のみ実行

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -3,8 +3,12 @@ name: "CodeQL Security Analysis"
 on:
   push:
     branches: [main]
+    paths:
+      - '**/*.java'
   pull_request:
     branches: [main]
+    paths:
+      - '**/*.java'
   schedule:
     # 毎日 03:00 JST (18:00 UTC)
     - cron: "0 18 * * *"


### PR DESCRIPTION
## Summary

CodeQL Security Analysis に paths フィルタを追加。Java ファイルの変更がない PR/push では実行をスキップ。

## 変更

```yaml
on:
  push:
    branches: [main]
    paths: ['**/*.java']    # 追加
  pull_request:
    branches: [main]
    paths: ['**/*.java']    # 追加
  schedule: ...             # 変更なし（毎日実行）
  workflow_dispatch: ...    # 変更なし（手動実行）
```

## 理由

ドキュメント・設定ファイル・E2Eテストのみの PR で CodeQL（約6分）が毎回実行されていた。Java コードに変更がない場合はスキャン不要。

## Test plan

- [ ] Java ファイルを含まない PR で CodeQL がスキップされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)