### PR TITLE
fix: FIDO2/FIDO-UAFデバイス登録のmax_devicesチェックをchallenge段階で実施

### DIFF
--- a/.claude/skills/spec-authentication/skill.md
+++ b/.claude/skills/spec-authentication/skill.md
@@ -159,6 +159,13 @@ cd e2e && npm test -- scenario/application/scenario-03-mfa-registration.test.js
 - Pre-authentication: ユーザーが認証済みか確認
 - ACR Policy: 現在のACRが要求レベルを満たすか確認
 
+### MFA登録で「Authentication policy configuration not found」
+- MFAエンドポイント（`/v1/me/mfa/{type}`）は **`flow` 別の認証ポリシー**が必要
+- `flow: "oauth"` のポリシーだけでは不足
+- FIDO2の場合: `flow: "fido2-registration"` のポリシーを作成
+- FIDO-UAFの場合: `flow: "fido-uaf-registration"` のポリシーを作成
+- StandardAuthFlow一覧: `oauth`, `ciba`, `fido2-registration`, `fido-uaf-registration`, `fido2-deregistration`, `fido-uaf-deregistration`, `mfa-sms-registration`, `mfa-email-registration`
+
 ### 認証トランザクションが期限切れ
 - `AuthenticationTransaction` の有効期限（デフォルト: 5分）を確認
 - Redis等のセッションストレージが正常か確認

--- a/.claude/skills/spec-fido2/skill.md
+++ b/.claude/skills/spec-fido2/skill.md
@@ -158,6 +158,38 @@ FIDO2をブラウザUIで動かす際の必須確認事項:
 
 クライアントは `error: "device_limit_exceeded"` を検知して、「デバイス管理画面で不要なデバイスを削除してください」等の案内を表示できる。
 
+### MFAエンドポイント経由のデバイス登録
+
+`/v1/me/mfa/fido2-registration` エンドポイントでFIDO2デバイスを登録する場合、**`flow: "fido2-registration"` の認証ポリシーが別途必要**。
+
+```json
+{
+  "flow": "fido2-registration",
+  "enabled": true,
+  "policies": [{
+    "available_methods": ["fido2"],
+    "success_conditions": {
+      "any_of": [
+        [{ "path": "$.fido2-registration.success_count", "type": "integer", "operation": "gte", "value": 1 }]
+      ]
+    }
+  }]
+}
+```
+
+`flow: "oauth"` のポリシーだけでは MFA エンドポイントから `Authentication policy configuration not found` エラーが返る。
+
+**StandardAuthFlow一覧**:
+
+| flow | 用途 |
+|------|------|
+| `oauth` | 認可コードフロー |
+| `ciba` | CIBAフロー |
+| `fido2-registration` | FIDO2 MFA登録 |
+| `fido-uaf-registration` | FIDO-UAF MFA登録 |
+| `fido2-deregistration` | FIDO2 登録解除 |
+| `fido-uaf-deregistration` | FIDO-UAF 登録解除 |
+
 ### rp_id と allowed_origins の関係
 
 ```

--- a/.claude/skills/spec-fido2/skill.md
+++ b/.claude/skills/spec-fido2/skill.md
@@ -136,6 +136,28 @@ FIDO2をブラウザUIで動かす際の必須確認事項:
 | 7 | `step_definitions` でemail→fido2の順序定義 | 認証ポリシー | 未設定だとFIDO2ブラウザUIでユーザー識別ができない |
 | 8 | `device_registration_conditions` にMFA条件 | 認証ポリシー | 未設定だとMFAなしでデバイス登録可能（脆弱性） |
 
+### max_devices チェック
+
+`authentication_device_rule.max_devices` の上限チェックは **registration-challenge 段階**と **registration 段階**の両方で実施される。
+
+- **challenge段階**: `navigator.credentials.create()` の前にチェック。上限到達時はチャレンジを返さず、ブラウザ/認証器に孤立した鍵が生成されることを防止。
+- **registration段階**: 二重防御として維持。TOCTOU（Time-of-check to time-of-use）対策で、DBから最新のデバイス数を再取得して検証。
+
+`action: "reset"` の場合はチェックをスキップ（既存デバイスを置換するため）。
+
+**エラーレスポンス（`device_limit_exceeded`）**:
+
+```json
+{
+  "error": "device_limit_exceeded",
+  "error_description": "Maximum number of devices reached 1, user has already 1 devices.",
+  "max_devices": 1,
+  "current_devices": 1
+}
+```
+
+クライアントは `error: "device_limit_exceeded"` を検知して、「デバイス管理画面で不要なデバイスを削除してください」等の案内を表示できる。
+
 ### rp_id と allowed_origins の関係
 
 ```

--- a/documentation/docs/content_05_how-to/phase-3-advanced/fido2/01-registration.md
+++ b/documentation/docs/content_05_how-to/phase-3-advanced/fido2/01-registration.md
@@ -515,6 +515,48 @@ FIDO2登録の成功・失敗はセキュリティイベントとして記録さ
 
 ## 関連ドキュメント
 
+## デバイス上限エラー（device_limit_exceeded）
+
+テナントの `authentication_device_rule.max_devices` で設定された上限に達している場合、**registration-challenge 段階**でエラーが返されます。これにより `navigator.credentials.create()` が呼ばれず、ブラウザ/認証器に孤立した鍵が生成されることを防ぎます。
+
+### エラーレスポンス
+
+```json
+{
+  "error": "device_limit_exceeded",
+  "error_description": "Maximum number of devices reached 1, user has already 1 devices.",
+  "max_devices": 1,
+  "current_devices": 1
+}
+```
+
+### クライアント側のハンドリング
+
+```javascript
+const challengeRes = await fetch(`/authorizations/${authId}/fido2-registration-challenge`, {
+  method: 'POST',
+  body: JSON.stringify({ ... })
+});
+
+if (!challengeRes.ok) {
+  const error = await challengeRes.json();
+  if (error.error === 'device_limit_exceeded') {
+    // デバイス管理画面への誘導
+    showMessage(`デバイス上限（${error.max_devices}台）に達しています。不要なデバイスを削除してください。`);
+    return;
+  }
+  showError(error.error_description);
+  return;
+}
+
+// challenge成功時のみ鍵生成
+const credential = await navigator.credentials.create({ publicKey: challenge });
+```
+
+> **二重チェック**: registration 段階（`fido2-registration`）でもデバイス数を再検証します（TOCTOU対策）。
+
+## 関連ドキュメント
+
 - [パスキー認証](./02-authentication.md) - 登録後の認証フロー
 - [パスキー管理](./03-management.md) - 一覧・削除API
 - [アテステーション検証](./04-attestation-verification.md) - 認証器の信頼性検証

--- a/e2e/src/tests/usecase/financial-grade/financial-grade-02-authentication-device-rule.test.js
+++ b/e2e/src/tests/usecase/financial-grade/financial-grade-02-authentication-device-rule.test.js
@@ -872,7 +872,7 @@ describe("Financial Grade: Device Limit Enforcement (Issue #728)", () => {
     // Verify that registration is rejected
     console.log("Response:", JSON.stringify(mfaResponse.data, null, 2));
     expect(mfaResponse.status).toBe(400);
-    expect(mfaResponse.data.error).toBe("invalid_request");
+    expect(mfaResponse.data.error).toBe("device_limit_exceeded");
     expect(mfaResponse.data.error_description).toContain("Maximum number of devices reached");
     expect(mfaResponse.data.error_description).toContain("2");
 
@@ -1967,7 +1967,7 @@ describe("Financial Grade: TOCTOU Device Limit Prevention (Security Fix)", () =>
 
     // Verify that registration is rejected at COMPLETION time (not challenge time)
     expect(registrationResult2.status).toBe(400);
-    expect(registrationResult2.data.error).toBe("invalid_request");
+    expect(registrationResult2.data.error).toBe("device_limit_exceeded");
     expect(registrationResult2.data.error_description).toContain("Maximum number of devices reached");
     expect(registrationResult2.data.error_description).toContain("1");
 

--- a/e2e/src/tests/usecase/mfa/mfa-07-max-devices-challenge.test.js
+++ b/e2e/src/tests/usecase/mfa/mfa-07-max-devices-challenge.test.js
@@ -273,6 +273,252 @@ describe("Use Case: FIDO2 max_devices check at registration-challenge", () => {
     console.log("   No orphaned key created in browser/authenticator");
   });
 
+  it("should allow fido2-registration-challenge with action:reset even when max_devices is reached", async () => {
+    const timestamp = Date.now();
+    const organizationId = uuidv4();
+    const tenantId = uuidv4();
+    const clientId = uuidv4();
+    const clientSecret = `client-secret-${timestamp}`;
+    const redirectUri = "https://www.certification.openid.net/test/a/idp_oidc_basic/callback";
+    const userEmail = `fido2-reset-${timestamp}@example.com`;
+    const userPassword = `FidoReset${timestamp}!`;
+    const jwksContent = await generateECP256JWKS();
+
+    console.log("\n=== Setup: Create tenant with max_devices=1 (reset test) ===");
+
+    const onboardingResponse = await onboarding({
+      headers: { Authorization: `Bearer ${systemAccessToken}` },
+      body: {
+        organization: {
+          id: organizationId,
+          name: `FIDO2 Reset Test ${timestamp}`,
+          description: "Test reset action bypasses max_devices check",
+        },
+        tenant: {
+          id: tenantId,
+          name: `FIDO2 Reset Tenant ${timestamp}`,
+          domain: backendUrl,
+          authorization_provider: "idp-server",
+          tenant_type: "ORGANIZER",
+          identity_policy_config: {
+            identity_unique_key_type: "EMAIL",
+            authentication_device_rule: {
+              max_devices: 1,
+              required_identity_verification: false,
+              authentication_type: "none",
+            },
+          },
+        },
+        authorization_server: {
+          issuer: `${backendUrl}/${tenantId}`,
+          authorization_endpoint: `${backendUrl}/${tenantId}/v1/authorizations`,
+          token_endpoint: `${backendUrl}/${tenantId}/v1/tokens`,
+          token_endpoint_auth_methods_supported: ["client_secret_post"],
+          userinfo_endpoint: `${backendUrl}/${tenantId}/v1/userinfo`,
+          jwks_uri: `${backendUrl}/${tenantId}/v1/jwks`,
+          jwks: jwksContent,
+          grant_types_supported: ["authorization_code", "refresh_token", "password"],
+          token_signed_key_id: "signing_key_1",
+          id_token_signed_key_id: "signing_key_1",
+          scopes_supported: ["openid", "profile", "email", "management", "account"],
+          response_types_supported: ["code"],
+          response_modes_supported: ["query"],
+          subject_types_supported: ["public"],
+          id_token_signing_alg_values_supported: ["ES256"],
+          extension: { access_token_type: "JWT" },
+        },
+        user: {
+          sub: uuidv4(),
+          provider_id: "idp-server",
+          email: userEmail,
+          email_verified: true,
+          raw_password: userPassword,
+          authentication_devices: [
+            { id: uuidv4(), app_name: "Existing Device" },
+          ],
+        },
+        client: {
+          client_id: clientId,
+          client_secret: clientSecret,
+          redirect_uris: [redirectUri],
+          response_types: ["code"],
+          grant_types: ["authorization_code", "refresh_token", "password"],
+          scope: "openid profile email management account",
+          client_name: "FIDO2 Reset Client",
+          token_endpoint_auth_method: "client_secret_post",
+          application_type: "web",
+        },
+      },
+    });
+    expect(onboardingResponse.status).toBe(201);
+    console.log("Tenant created with max_devices=1, user has 1 device");
+
+    // Get access token with account scope for MFA endpoint
+    const tokenResponse = await requestToken({
+      endpoint: `${backendUrl}/${tenantId}/v1/tokens`,
+      grantType: "password",
+      username: userEmail,
+      password: userPassword,
+      scope: "openid profile email account",
+      clientId,
+      clientSecret,
+    });
+    expect(tokenResponse.status).toBe(200);
+    const accessToken = tokenResponse.data.access_token;
+
+    // Create auth configs
+    const mgmtTokenResp = await requestToken({
+      endpoint: `${backendUrl}/${tenantId}/v1/tokens`,
+      grantType: "password",
+      username: userEmail,
+      password: userPassword,
+      scope: "management",
+      clientId,
+      clientSecret,
+    });
+    const mgmtToken = mgmtTokenResp.data.access_token;
+
+    const fido2Details = {
+      rp_id: "local.test",
+      allowed_origins: [backendUrl],
+      rp_name: "Test Service",
+      require_resident_key: true,
+      attestation_preference: "none",
+      user_presence_required: true,
+      authenticator_attachment: "platform",
+      user_verification_required: true,
+    };
+
+    await postWithJson({
+      url: `${backendUrl}/v1/management/organizations/${organizationId}/tenants/${tenantId}/authentication-configurations`,
+      headers: { Authorization: `Bearer ${mgmtToken}` },
+      body: {
+        id: uuidv4(), type: "fido2", attributes: {}, metadata: {},
+        interactions: {
+          "fido2-registration-challenge": {
+            execution: { function: "webauthn4j_registration_challenge", details: fido2Details },
+            response: { body_mapping_rules: [{ from: "$.execution_webauthn4j", to: "*" }] },
+          },
+          "fido2-registration": {
+            execution: { function: "webauthn4j_registration", details: fido2Details },
+            response: { body_mapping_rules: [{ from: "$.execution_webauthn4j", to: "*" }] },
+          },
+        },
+      },
+    });
+
+    // Create auth policy for oauth flow
+    await postWithJson({
+      url: `${backendUrl}/v1/management/organizations/${organizationId}/tenants/${tenantId}/authentication-policies`,
+      headers: { Authorization: `Bearer ${mgmtToken}` },
+      body: {
+        id: uuidv4(),
+        flow: "oauth",
+        enabled: true,
+        policies: [{
+          priority: 100,
+          description: "default",
+          conditions: { scopes: ["openid"] },
+          available_methods: ["password", "fido2"],
+          success_conditions: {
+            any_of: [
+              [{ path: "$.password-authentication.success_count", type: "integer", operation: "gte", value: 1 }],
+            ],
+          },
+        }],
+      },
+    });
+
+    // Create auth policy for fido2-registration flow (MFA endpoint)
+    await postWithJson({
+      url: `${backendUrl}/v1/management/organizations/${organizationId}/tenants/${tenantId}/authentication-policies`,
+      headers: { Authorization: `Bearer ${mgmtToken}` },
+      body: {
+        id: uuidv4(),
+        flow: "fido2-registration",
+        enabled: true,
+        policies: [{
+          priority: 100,
+          description: "fido2 mfa registration",
+          conditions: { scopes: ["openid"] },
+          available_methods: ["fido2"],
+          success_conditions: {
+            any_of: [
+              [{ path: "$.fido2-registration.success_count", type: "integer", operation: "gte", value: 1 }],
+            ],
+          },
+        }],
+      },
+    });
+
+    // Create password auth config
+    await postWithJson({
+      url: `${backendUrl}/v1/management/organizations/${organizationId}/tenants/${tenantId}/authentication-configurations`,
+      headers: { Authorization: `Bearer ${mgmtToken}` },
+      body: {
+        id: uuidv4(), type: "password", attributes: {}, metadata: { type: "password" },
+        interactions: {
+          "password-authentication": {
+            request: {
+              schema: {
+                type: "object",
+                properties: { username: { type: "string" }, password: { type: "string" } },
+                required: ["username", "password"],
+              },
+            },
+            execution: { function: "password_verification" },
+            response: { body_mapping_rules: [{ from: "$.user_id", to: "user_id" }, { from: "$.error", to: "error" }] },
+          },
+        },
+      },
+    });
+
+    console.log("\n=== Step 1: MFA registration with action:reset ===");
+
+    const mfaResponse = await postWithJson({
+      url: `${backendUrl}/${tenantId}/v1/me/mfa/fido2-registration`,
+      body: {
+        app_name: "Reset Device",
+        platform: "Android",
+        os: "Android16",
+        model: "Test Device",
+        locale: "ja",
+        notification_channel: "fcm",
+        notification_token: "test-token",
+        priority: 1,
+        action: "reset",
+      },
+      headers: { Authorization: `Bearer ${accessToken}` },
+    });
+    console.log("MFA registration status:", mfaResponse.status);
+    console.log("MFA registration:", JSON.stringify(mfaResponse.data, null, 2));
+    expect(mfaResponse.status).toBe(200);
+    const transactionId = mfaResponse.data.id;
+
+    console.log("\n=== Step 2: fido2-registration-challenge (should succeed despite max_devices) ===");
+
+    const challengeResponse = await postWithJson({
+      url: `${backendUrl}/${tenantId}/v1/authentications/${transactionId}/fido2-registration-challenge`,
+      body: {
+        username: userEmail,
+        displayName: "Reset User",
+        authenticatorSelection: {
+          authenticatorAttachment: "platform",
+          requireResidentKey: true,
+          userVerification: "required",
+        },
+        attestation: "none",
+      },
+    });
+
+    console.log("Challenge response status:", challengeResponse.status);
+    console.log("Challenge response:", JSON.stringify(challengeResponse.data, null, 2));
+
+    // With action:reset, challenge should succeed even though max_devices is reached
+    expect(challengeResponse.status).toBe(200);
+    console.log("✅ Challenge succeeded with action:reset (max_devices check skipped)");
+  });
+
   it("should reject fido-uaf-registration-challenge when max_devices is reached", async () => {
     const timestamp = Date.now();
     const organizationId = uuidv4();
@@ -475,5 +721,211 @@ describe("Use Case: FIDO2 max_devices check at registration-challenge", () => {
     expect(challengeResponse.data.current_devices).toBeDefined();
 
     console.log("✅ FIDO-UAF challenge correctly rejected at max_devices limit");
+  });
+
+  it("should allow fido-uaf-registration-challenge with action:reset even when max_devices is reached", async () => {
+    const timestamp = Date.now();
+    const organizationId = uuidv4();
+    const tenantId = uuidv4();
+    const clientId = uuidv4();
+    const clientSecret = `client-secret-${timestamp}`;
+    const redirectUri = "https://www.certification.openid.net/test/a/idp_oidc_basic/callback";
+    const userEmail = `uaf-reset-${timestamp}@example.com`;
+    const userPassword = `UafReset${timestamp}!`;
+    const jwksContent = await generateECP256JWKS();
+
+    console.log("\n=== Setup: Create tenant with max_devices=1 (FIDO-UAF reset) ===");
+
+    const onboardingResponse = await onboarding({
+      headers: { Authorization: `Bearer ${systemAccessToken}` },
+      body: {
+        organization: {
+          id: organizationId,
+          name: `FIDO-UAF Reset Test ${timestamp}`,
+          description: "Test reset action bypasses max_devices for FIDO-UAF",
+        },
+        tenant: {
+          id: tenantId,
+          name: `FIDO-UAF Reset Tenant ${timestamp}`,
+          domain: backendUrl,
+          authorization_provider: "idp-server",
+          tenant_type: "ORGANIZER",
+          identity_policy_config: {
+            identity_unique_key_type: "EMAIL",
+            authentication_device_rule: {
+              max_devices: 1,
+              required_identity_verification: false,
+              authentication_type: "none",
+            },
+          },
+        },
+        authorization_server: {
+          issuer: `${backendUrl}/${tenantId}`,
+          authorization_endpoint: `${backendUrl}/${tenantId}/v1/authorizations`,
+          token_endpoint: `${backendUrl}/${tenantId}/v1/tokens`,
+          token_endpoint_auth_methods_supported: ["client_secret_post"],
+          userinfo_endpoint: `${backendUrl}/${tenantId}/v1/userinfo`,
+          jwks_uri: `${backendUrl}/${tenantId}/v1/jwks`,
+          jwks: jwksContent,
+          grant_types_supported: ["authorization_code", "refresh_token", "password"],
+          token_signed_key_id: "signing_key_1",
+          id_token_signed_key_id: "signing_key_1",
+          scopes_supported: ["openid", "profile", "email", "management", "account"],
+          response_types_supported: ["code"],
+          response_modes_supported: ["query"],
+          subject_types_supported: ["public"],
+          id_token_signing_alg_values_supported: ["ES256"],
+          extension: { access_token_type: "JWT" },
+        },
+        user: {
+          sub: uuidv4(),
+          provider_id: "idp-server",
+          email: userEmail,
+          email_verified: true,
+          raw_password: userPassword,
+          authentication_devices: [
+            { id: uuidv4(), app_name: "Existing UAF Device" },
+          ],
+        },
+        client: {
+          client_id: clientId,
+          client_secret: clientSecret,
+          redirect_uris: [redirectUri],
+          response_types: ["code"],
+          grant_types: ["authorization_code", "refresh_token", "password"],
+          scope: "openid profile email management account",
+          client_name: "FIDO-UAF Reset Client",
+          token_endpoint_auth_method: "client_secret_post",
+          application_type: "web",
+        },
+      },
+    });
+    expect(onboardingResponse.status).toBe(201);
+
+    const tokenResponse = await requestToken({
+      endpoint: `${backendUrl}/${tenantId}/v1/tokens`,
+      grantType: "password",
+      username: userEmail,
+      password: userPassword,
+      scope: "openid profile email account",
+      clientId,
+      clientSecret,
+    });
+    expect(tokenResponse.status).toBe(200);
+    const accessToken = tokenResponse.data.access_token;
+
+    const mgmtTokenResp = await requestToken({
+      endpoint: `${backendUrl}/${tenantId}/v1/tokens`,
+      grantType: "password",
+      username: userEmail,
+      password: userPassword,
+      scope: "management",
+      clientId,
+      clientSecret,
+    });
+    const mgmtToken = mgmtTokenResp.data.access_token;
+
+    // Create FIDO-UAF auth config (external type using mockoon)
+    const mockApiBaseUrl = process.env.MOCK_API_BASE_URL || "http://host.docker.internal:4000";
+    const oauthConfig = {
+      type: "password",
+      token_endpoint: `${mockApiBaseUrl}/token`,
+      client_id: "your-client-id",
+      username: "username",
+      password: "password",
+      scope: "application",
+      cache_enabled: true,
+      cache_ttl_seconds: 1800,
+      cache_buffer_seconds: 10,
+    };
+    await postWithJson({
+      url: `${backendUrl}/v1/management/organizations/${organizationId}/tenants/${tenantId}/authentication-configurations`,
+      headers: { Authorization: `Bearer ${mgmtToken}` },
+      body: {
+        id: uuidv4(), type: "fido-uaf", attributes: { type: "external" }, metadata: {},
+        interactions: {
+          "fido-uaf-registration-challenge": {
+            execution: {
+              function: "http_request",
+              http_request: {
+                url: `${mockApiBaseUrl}/fido-uaf/registration-challenge`,
+                method: "POST",
+                auth_type: "oauth2",
+                oauth_authorization: oauthConfig,
+                header_mapping_rules: [{ static_value: "application/json", to: "Content-Type" }],
+                body_mapping_rules: [{ from: "$.request_body", to: "*" }],
+              },
+            },
+            response: { body_mapping_rules: [{ from: "$.execution_http_request.response_body", to: "*" }] },
+          },
+          "fido-uaf-registration": {
+            execution: {
+              function: "http_request",
+              http_request: {
+                url: `${mockApiBaseUrl}/fido-uaf/registration`,
+                method: "POST",
+                auth_type: "oauth2",
+                oauth_authorization: oauthConfig,
+                header_mapping_rules: [{ static_value: "application/json", to: "Content-Type" }],
+                body_mapping_rules: [{ from: "$.request_body", to: "*" }],
+              },
+            },
+            response: { body_mapping_rules: [{ from: "$.execution_http_request.response_body", to: "*" }] },
+          },
+        },
+      },
+    });
+
+    // Create auth policies
+    await postWithJson({
+      url: `${backendUrl}/v1/management/organizations/${organizationId}/tenants/${tenantId}/authentication-policies`,
+      headers: { Authorization: `Bearer ${mgmtToken}` },
+      body: {
+        id: uuidv4(), flow: "fido-uaf-registration", enabled: true,
+        policies: [{
+          priority: 100, description: "fido-uaf mfa registration",
+          conditions: { scopes: ["openid"] },
+          available_methods: ["fido-uaf"],
+          success_conditions: { any_of: [
+            [{ path: "$.fido-uaf-registration.success_count", type: "integer", operation: "gte", value: 1 }],
+          ]},
+        }],
+      },
+    });
+
+    console.log("\n=== Step 1: MFA registration with action:reset ===");
+
+    const mfaResponse = await postWithJson({
+      url: `${backendUrl}/${tenantId}/v1/me/mfa/fido-uaf-registration`,
+      body: {
+        app_name: "Reset UAF Device",
+        platform: "Android",
+        os: "Android16",
+        model: "Test Device",
+        locale: "ja",
+        notification_channel: "fcm",
+        notification_token: "test-token",
+        priority: 1,
+        action: "reset",
+      },
+      headers: { Authorization: `Bearer ${accessToken}` },
+    });
+    console.log("MFA registration status:", mfaResponse.status);
+    expect(mfaResponse.status).toBe(200);
+    const transactionId = mfaResponse.data.id;
+
+    console.log("\n=== Step 2: fido-uaf-registration-challenge (should succeed despite max_devices) ===");
+
+    const challengeResponse = await postWithJson({
+      url: `${backendUrl}/${tenantId}/v1/authentications/${transactionId}/fido-uaf-registration-challenge`,
+      body: {},
+    });
+
+    console.log("Challenge response status:", challengeResponse.status);
+    console.log("Challenge response:", JSON.stringify(challengeResponse.data, null, 2));
+
+    // With action:reset, challenge should succeed even though max_devices is reached
+    expect(challengeResponse.status).toBe(200);
+    console.log("✅ FIDO-UAF challenge succeeded with action:reset (max_devices check skipped)");
   });
 });

--- a/e2e/src/tests/usecase/mfa/mfa-07-max-devices-challenge.test.js
+++ b/e2e/src/tests/usecase/mfa/mfa-07-max-devices-challenge.test.js
@@ -1,0 +1,475 @@
+import { describe, expect, it, beforeAll } from "@jest/globals";
+import { onboarding } from "../../../api/managementClient";
+import { postWithJson } from "../../../lib/http";
+import { requestToken } from "../../../api/oauthClient";
+import { generateECP256JWKS } from "../../../lib/jose";
+import { adminServerConfig, backendUrl } from "../../testConfig";
+import { v4 as uuidv4 } from "uuid";
+import { faker } from "@faker-js/faker";
+import {
+  convertNextAction,
+  convertToAuthorizationResponse,
+} from "../../../lib/util";
+import { generateRandomUser, generateValidCredentialFromChallenge } from "../../../lib/fido/fido2";
+
+/**
+ * FIDO2 max_devices check at challenge stage
+ *
+ * Issue #1372: Verify that max_devices limit is checked at the
+ * fido2-registration-challenge stage (before browser key generation),
+ * not only at the fido2-registration stage (after key generation).
+ *
+ * This prevents orphaned keys in the browser/authenticator when the
+ * server rejects the registration at completion time.
+ */
+describe("Use Case: FIDO2 max_devices check at registration-challenge", () => {
+  let systemAccessToken;
+
+  beforeAll(async () => {
+    const tokenResponse = await requestToken({
+      endpoint: adminServerConfig.tokenEndpoint,
+      grantType: "password",
+      username: adminServerConfig.oauth.username,
+      password: adminServerConfig.oauth.password,
+      scope: adminServerConfig.adminClient.scope,
+      clientId: adminServerConfig.adminClient.clientId,
+      clientSecret: adminServerConfig.adminClient.clientSecret,
+    });
+    expect(tokenResponse.status).toBe(200);
+    systemAccessToken = tokenResponse.data.access_token;
+  });
+
+  it("should reject fido2-registration-challenge when max_devices is reached", async () => {
+    const timestamp = Date.now();
+    const organizationId = uuidv4();
+    const tenantId = uuidv4();
+    const clientId = uuidv4();
+    const clientSecret = `client-secret-${timestamp}`;
+    const redirectUri = "https://www.certification.openid.net/test/a/idp_oidc_basic/callback";
+    const userEmail = `fido2-limit-${timestamp}@example.com`;
+    const userPassword = `FidoLimit${timestamp}!`;
+    const jwksContent = await generateECP256JWKS();
+
+    console.log("\n=== Setup: Create tenant with max_devices=1 ===");
+
+    const onboardingResponse = await onboarding({
+      headers: { Authorization: `Bearer ${systemAccessToken}` },
+      body: {
+        organization: {
+          id: organizationId,
+          name: `FIDO2 MaxDevices Test ${timestamp}`,
+          description: "Test max_devices check at challenge stage",
+        },
+        tenant: {
+          id: tenantId,
+          name: `FIDO2 MaxDevices Tenant ${timestamp}`,
+          domain: backendUrl,
+          authorization_provider: "idp-server",
+          tenant_type: "ORGANIZER",
+          identity_policy_config: {
+            identity_unique_key_type: "EMAIL",
+            authentication_device_rule: {
+              max_devices: 1,
+              required_identity_verification: false,
+              authentication_type: "none",
+            },
+          },
+        },
+        authorization_server: {
+          issuer: `${backendUrl}/${tenantId}`,
+          authorization_endpoint: `${backendUrl}/${tenantId}/v1/authorizations`,
+          token_endpoint: `${backendUrl}/${tenantId}/v1/tokens`,
+          token_endpoint_auth_methods_supported: ["client_secret_post"],
+          userinfo_endpoint: `${backendUrl}/${tenantId}/v1/userinfo`,
+          jwks_uri: `${backendUrl}/${tenantId}/v1/jwks`,
+          jwks: jwksContent,
+          grant_types_supported: ["authorization_code", "refresh_token", "password"],
+          token_signed_key_id: "signing_key_1",
+          id_token_signed_key_id: "signing_key_1",
+          scopes_supported: ["openid", "profile", "email", "management"],
+          response_types_supported: ["code"],
+          response_modes_supported: ["query"],
+          subject_types_supported: ["public"],
+          id_token_signing_alg_values_supported: ["ES256"],
+          extension: { access_token_type: "JWT" },
+        },
+        user: {
+          sub: uuidv4(),
+          provider_id: "idp-server",
+          email: userEmail,
+          email_verified: true,
+          raw_password: userPassword,
+          authentication_devices: [
+            {
+              id: uuidv4(),
+              app_name: "Existing Device",
+            },
+          ],
+        },
+        client: {
+          client_id: clientId,
+          client_secret: clientSecret,
+          redirect_uris: [redirectUri],
+          response_types: ["code"],
+          grant_types: ["authorization_code", "refresh_token", "password"],
+          scope: "openid profile email management",
+          client_name: "FIDO2 MaxDevices Client",
+          token_endpoint_auth_method: "client_secret_post",
+          application_type: "web",
+        },
+      },
+    });
+    expect(onboardingResponse.status).toBe(201);
+    console.log("Tenant created with max_devices=1, user has 1 device");
+
+    // Get admin token and setup auth configs
+    const adminToken = await requestToken({
+      endpoint: `${backendUrl}/${tenantId}/v1/tokens`,
+      grantType: "password",
+      username: userEmail,
+      password: userPassword,
+      scope: "management",
+      clientId,
+      clientSecret,
+    });
+    expect(adminToken.status).toBe(200);
+    const mgmtToken = adminToken.data.access_token;
+
+    // Create password auth config
+    await postWithJson({
+      url: `${backendUrl}/v1/management/organizations/${organizationId}/tenants/${tenantId}/authentication-configurations`,
+      headers: { Authorization: `Bearer ${mgmtToken}` },
+      body: {
+        id: uuidv4(),
+        type: "password",
+        attributes: {},
+        metadata: { type: "password" },
+        interactions: {
+          "password-authentication": {
+            request: {
+              schema: {
+                type: "object",
+                properties: { username: { type: "string" }, password: { type: "string" } },
+                required: ["username", "password"],
+              },
+            },
+            pre_hook: {},
+            execution: { function: "password_verification" },
+            post_hook: {},
+            response: {
+              body_mapping_rules: [
+                { from: "$.user_id", to: "user_id" },
+                { from: "$.error", to: "error" },
+              ],
+            },
+          },
+        },
+      },
+    });
+
+    // Create FIDO2 auth config
+    await postWithJson({
+      url: `${backendUrl}/v1/management/organizations/${organizationId}/tenants/${tenantId}/authentication-configurations`,
+      headers: { Authorization: `Bearer ${mgmtToken}` },
+      body: {
+        id: uuidv4(),
+        type: "fido2",
+        attributes: {},
+        metadata: { type: "fido2" },
+        interactions: {
+          "fido2-registration-challenge": {
+            execution: { function: "webauthn_registration_challenge" },
+            response: {
+              body_mapping_rules: [{ from: "$.result", to: "*" }],
+            },
+          },
+          "fido2-registration": {
+            execution: { function: "webauthn_registration" },
+            response: {
+              body_mapping_rules: [
+                { from: "$.result.device_id", to: "device_id" },
+                { from: "$.result.credential_id", to: "credential_id" },
+              ],
+            },
+          },
+        },
+      },
+    });
+
+    // Create auth policy
+    await postWithJson({
+      url: `${backendUrl}/v1/management/organizations/${organizationId}/tenants/${tenantId}/authentication-policies`,
+      headers: { Authorization: `Bearer ${mgmtToken}` },
+      body: {
+        id: uuidv4(),
+        priority: 100,
+        description: "default",
+        conditions: { scopes: ["openid"] },
+        available_methods: ["password", "fido2"],
+        success_conditions: {
+          any_of: [
+            [{ path: "$.password-authentication.success_count", type: "integer", operation: "gte", value: 1 }],
+            [{ path: "$.fido2-registration.success_count", type: "integer", operation: "gte", value: 1 }],
+          ],
+        },
+      },
+    });
+
+    console.log("\n=== Step 1: Login with password ===");
+
+    const cookieJar = {};
+    const authResponse = await postWithJson({
+      url: `${backendUrl}/${tenantId}/v1/authorizations?response_type=code&client_id=${clientId}&redirect_uri=${encodeURIComponent(redirectUri)}&scope=openid+profile+email&state=test-${timestamp}&prompt=login`,
+      body: {},
+    });
+
+    // Use direct flow: get auth, password auth, then try fido2-registration-challenge
+    const { get: httpGet } = await import("../../../lib/http/index.js");
+    const authResp = await httpGet({
+      url: `${backendUrl}/${tenantId}/v1/authorizations?response_type=code&client_id=${clientId}&redirect_uri=${encodeURIComponent(redirectUri)}&scope=openid+profile+email&state=test-${timestamp}&prompt=login`,
+    });
+
+    const { params } = convertNextAction(authResp.headers.location);
+    const authId = params.get("id");
+    console.log("Authorization ID:", authId);
+
+    // Password authentication
+    const pwAuthResponse = await postWithJson({
+      url: `${backendUrl}/${tenantId}/v1/authorizations/${authId}/password-authentication`,
+      body: { username: userEmail, password: userPassword },
+    });
+    expect(pwAuthResponse.status).toBe(200);
+    console.log("Password authentication: OK");
+
+    console.log("\n=== Step 2: Try fido2-registration-challenge (should fail - max_devices reached) ===");
+
+    const discoverableUser = generateRandomUser();
+    const challengeResponse = await postWithJson({
+      url: `${backendUrl}/${tenantId}/v1/authorizations/${authId}/fido2-registration-challenge`,
+      body: {
+        username: discoverableUser.username,
+        displayName: discoverableUser.displayName,
+        authenticatorSelection: {
+          authenticatorAttachment: "platform",
+          requireResidentKey: true,
+          userVerification: "required",
+        },
+        attestation: "none",
+      },
+    });
+
+    console.log("Challenge response status:", challengeResponse.status);
+    console.log("Challenge response:", JSON.stringify(challengeResponse.data, null, 2));
+
+    // Before fix: challenge succeeds, registration fails later (orphaned key)
+    // After fix: challenge fails with max_devices error
+    expect(challengeResponse.status).toBe(400);
+    expect(challengeResponse.data.error).toBe("invalid_request");
+    expect(challengeResponse.data.error_description).toContain("Maximum number of devices reached");
+
+    console.log("✅ Challenge correctly rejected at max_devices limit");
+    console.log("   No orphaned key created in browser/authenticator");
+  });
+
+  it("should reject fido-uaf-registration-challenge when max_devices is reached", async () => {
+    const timestamp = Date.now();
+    const organizationId = uuidv4();
+    const tenantId = uuidv4();
+    const clientId = uuidv4();
+    const clientSecret = `client-secret-${timestamp}`;
+    const redirectUri = "https://www.certification.openid.net/test/a/idp_oidc_basic/callback";
+    const userEmail = `uaf-limit-${timestamp}@example.com`;
+    const userPassword = `UafLimit${timestamp}!`;
+    const jwksContent = await generateECP256JWKS();
+
+    console.log("\n=== Setup: Create tenant with max_devices=1 (FIDO-UAF) ===");
+
+    const onboardingResponse = await onboarding({
+      headers: { Authorization: `Bearer ${systemAccessToken}` },
+      body: {
+        organization: {
+          id: organizationId,
+          name: `FIDO-UAF MaxDevices Test ${timestamp}`,
+          description: "Test max_devices check at FIDO-UAF challenge stage",
+        },
+        tenant: {
+          id: tenantId,
+          name: `FIDO-UAF MaxDevices Tenant ${timestamp}`,
+          domain: backendUrl,
+          authorization_provider: "idp-server",
+          tenant_type: "ORGANIZER",
+          identity_policy_config: {
+            identity_unique_key_type: "EMAIL",
+            authentication_device_rule: {
+              max_devices: 1,
+              required_identity_verification: false,
+              authentication_type: "none",
+            },
+          },
+        },
+        authorization_server: {
+          issuer: `${backendUrl}/${tenantId}`,
+          authorization_endpoint: `${backendUrl}/${tenantId}/v1/authorizations`,
+          token_endpoint: `${backendUrl}/${tenantId}/v1/tokens`,
+          token_endpoint_auth_methods_supported: ["client_secret_post"],
+          userinfo_endpoint: `${backendUrl}/${tenantId}/v1/userinfo`,
+          jwks_uri: `${backendUrl}/${tenantId}/v1/jwks`,
+          jwks: jwksContent,
+          grant_types_supported: ["authorization_code", "refresh_token", "password"],
+          token_signed_key_id: "signing_key_1",
+          id_token_signed_key_id: "signing_key_1",
+          scopes_supported: ["openid", "profile", "email", "management"],
+          response_types_supported: ["code"],
+          response_modes_supported: ["query"],
+          subject_types_supported: ["public"],
+          id_token_signing_alg_values_supported: ["ES256"],
+          extension: { access_token_type: "JWT" },
+        },
+        user: {
+          sub: uuidv4(),
+          provider_id: "idp-server",
+          email: userEmail,
+          email_verified: true,
+          raw_password: userPassword,
+          authentication_devices: [
+            {
+              id: uuidv4(),
+              app_name: "Existing UAF Device",
+            },
+          ],
+        },
+        client: {
+          client_id: clientId,
+          client_secret: clientSecret,
+          redirect_uris: [redirectUri],
+          response_types: ["code"],
+          grant_types: ["authorization_code", "refresh_token", "password"],
+          scope: "openid profile email management",
+          client_name: "FIDO-UAF MaxDevices Client",
+          token_endpoint_auth_method: "client_secret_post",
+          application_type: "web",
+        },
+      },
+    });
+    expect(onboardingResponse.status).toBe(201);
+    console.log("Tenant created with max_devices=1, user has 1 device");
+
+    const adminToken = await requestToken({
+      endpoint: `${backendUrl}/${tenantId}/v1/tokens`,
+      grantType: "password",
+      username: userEmail,
+      password: userPassword,
+      scope: "management",
+      clientId,
+      clientSecret,
+    });
+    expect(adminToken.status).toBe(200);
+    const mgmtToken = adminToken.data.access_token;
+
+    // Create password auth config
+    await postWithJson({
+      url: `${backendUrl}/v1/management/organizations/${organizationId}/tenants/${tenantId}/authentication-configurations`,
+      headers: { Authorization: `Bearer ${mgmtToken}` },
+      body: {
+        id: uuidv4(),
+        type: "password",
+        attributes: {},
+        metadata: { type: "password" },
+        interactions: {
+          "password-authentication": {
+            request: {
+              schema: {
+                type: "object",
+                properties: { username: { type: "string" }, password: { type: "string" } },
+                required: ["username", "password"],
+              },
+            },
+            execution: { function: "password_verification" },
+            response: {
+              body_mapping_rules: [
+                { from: "$.user_id", to: "user_id" },
+                { from: "$.error", to: "error" },
+              ],
+            },
+          },
+        },
+      },
+    });
+
+    // Create FIDO-UAF auth config
+    await postWithJson({
+      url: `${backendUrl}/v1/management/organizations/${organizationId}/tenants/${tenantId}/authentication-configurations`,
+      headers: { Authorization: `Bearer ${mgmtToken}` },
+      body: {
+        id: uuidv4(),
+        type: "fido-uaf",
+        attributes: {},
+        metadata: { type: "fido-uaf" },
+        interactions: {
+          "fido-uaf-registration-challenge": {
+            execution: { function: "fido_uaf_registration_challenge" },
+            response: {
+              body_mapping_rules: [{ from: "$.result", to: "*" }],
+            },
+          },
+          "fido-uaf-registration": {
+            execution: { function: "fido_uaf_registration" },
+            response: {
+              body_mapping_rules: [{ from: "$.result.device_id", to: "device_id" }],
+            },
+          },
+        },
+      },
+    });
+
+    // Create auth policy
+    await postWithJson({
+      url: `${backendUrl}/v1/management/organizations/${organizationId}/tenants/${tenantId}/authentication-policies`,
+      headers: { Authorization: `Bearer ${mgmtToken}` },
+      body: {
+        id: uuidv4(),
+        priority: 100,
+        description: "default",
+        conditions: { scopes: ["openid"] },
+        available_methods: ["password", "fido-uaf"],
+        success_conditions: {
+          any_of: [
+            [{ path: "$.password-authentication.success_count", type: "integer", operation: "gte", value: 1 }],
+          ],
+        },
+      },
+    });
+
+    console.log("\n=== Step 1: Login with password ===");
+
+    const { get: httpGet } = await import("../../../lib/http/index.js");
+    const authResp = await httpGet({
+      url: `${backendUrl}/${tenantId}/v1/authorizations?response_type=code&client_id=${clientId}&redirect_uri=${encodeURIComponent(redirectUri)}&scope=openid+profile+email&state=uaf-${timestamp}&prompt=login`,
+    });
+    const { params } = convertNextAction(authResp.headers.location);
+    const authId = params.get("id");
+
+    const pwAuthResponse = await postWithJson({
+      url: `${backendUrl}/${tenantId}/v1/authorizations/${authId}/password-authentication`,
+      body: { username: userEmail, password: userPassword },
+    });
+    expect(pwAuthResponse.status).toBe(200);
+    console.log("Password authentication: OK");
+
+    console.log("\n=== Step 2: Try fido-uaf-registration-challenge (should fail) ===");
+
+    const challengeResponse = await postWithJson({
+      url: `${backendUrl}/${tenantId}/v1/authorizations/${authId}/fido-uaf-registration-challenge`,
+      body: {},
+    });
+
+    console.log("Challenge response status:", challengeResponse.status);
+    console.log("Challenge response:", JSON.stringify(challengeResponse.data, null, 2));
+
+    expect(challengeResponse.status).toBe(400);
+    expect(challengeResponse.data.error).toBe("invalid_request");
+    expect(challengeResponse.data.error_description).toContain("Maximum number of devices reached");
+
+    console.log("✅ FIDO-UAF challenge correctly rejected at max_devices limit");
+  });
+});

--- a/e2e/src/tests/usecase/mfa/mfa-07-max-devices-challenge.test.js
+++ b/e2e/src/tests/usecase/mfa/mfa-07-max-devices-challenge.test.js
@@ -264,8 +264,10 @@ describe("Use Case: FIDO2 max_devices check at registration-challenge", () => {
     // Before fix: challenge succeeds, registration fails later (orphaned key)
     // After fix: challenge fails with max_devices error
     expect(challengeResponse.status).toBe(400);
-    expect(challengeResponse.data.error).toBe("invalid_request");
+    expect(challengeResponse.data.error).toBe("device_limit_exceeded");
     expect(challengeResponse.data.error_description).toContain("Maximum number of devices reached");
+    expect(challengeResponse.data.max_devices).toBeDefined();
+    expect(challengeResponse.data.current_devices).toBeDefined();
 
     console.log("✅ Challenge correctly rejected at max_devices limit");
     console.log("   No orphaned key created in browser/authenticator");
@@ -467,8 +469,10 @@ describe("Use Case: FIDO2 max_devices check at registration-challenge", () => {
     console.log("Challenge response:", JSON.stringify(challengeResponse.data, null, 2));
 
     expect(challengeResponse.status).toBe(400);
-    expect(challengeResponse.data.error).toBe("invalid_request");
+    expect(challengeResponse.data.error).toBe("device_limit_exceeded");
     expect(challengeResponse.data.error_description).toContain("Maximum number of devices reached");
+    expect(challengeResponse.data.max_devices).toBeDefined();
+    expect(challengeResponse.data.current_devices).toBeDefined();
 
     console.log("✅ FIDO-UAF challenge correctly rejected at max_devices limit");
   });

--- a/libs/idp-server-authentication-interactors/src/main/java/org/idp/server/authentication/interactors/fido2/Fido2RegistrationChallengeInteractor.java
+++ b/libs/idp-server-authentication-interactors/src/main/java/org/idp/server/authentication/interactors/fido2/Fido2RegistrationChallengeInteractor.java
@@ -121,6 +121,36 @@ public class Fido2RegistrationChallengeInteractor implements AuthenticationInter
           DefaultSecurityEventType.fido2_registration_challenge_failure);
     }
 
+    // Verify max_devices limit before generating challenge (skip for reset action)
+    User authenticatedUser = transaction.user();
+    boolean isResetAction = "reset".equals(request.toMap().get("action"));
+    int authenticationDeviceCount = authenticatedUser.authenticationDeviceCount();
+    int maxDevices = tenant.maxDevicesForAuthentication();
+
+    if (!isResetAction && authenticationDeviceCount >= maxDevices) {
+      log.warn(
+          "FIDO2 registration challenge rejected: device limit reached. user={}, current={}, max={}",
+          authenticatedUser.sub(),
+          authenticationDeviceCount,
+          maxDevices);
+
+      Map<String, Object> errorResponse = new HashMap<>();
+      errorResponse.put("error", "invalid_request");
+      errorResponse.put(
+          "error_description",
+          String.format(
+              "Maximum number of devices reached %d, user has already %d devices.",
+              maxDevices, authenticationDeviceCount));
+
+      return AuthenticationInteractionRequestResult.clientError(
+          errorResponse,
+          type,
+          operationType(),
+          method(),
+          authenticatedUser,
+          DefaultSecurityEventType.fido2_registration_challenge_failure);
+    }
+
     // Resolve username from request
     Map<String, Object> requestMap = resolveUsernameFromRequest(tenant, transaction, request);
     if (requestMap == null) {

--- a/libs/idp-server-authentication-interactors/src/main/java/org/idp/server/authentication/interactors/fido2/Fido2RegistrationChallengeInteractor.java
+++ b/libs/idp-server-authentication-interactors/src/main/java/org/idp/server/authentication/interactors/fido2/Fido2RegistrationChallengeInteractor.java
@@ -27,6 +27,7 @@ import org.idp.server.core.openid.authentication.interaction.execution.Authentic
 import org.idp.server.core.openid.authentication.interaction.execution.AuthenticationExecutionResult;
 import org.idp.server.core.openid.authentication.interaction.execution.AuthenticationExecutor;
 import org.idp.server.core.openid.authentication.interaction.execution.AuthenticationExecutors;
+import org.idp.server.core.openid.authentication.mfa.DeviceLimitExceededResponse;
 import org.idp.server.core.openid.authentication.policy.AuthenticationPolicy;
 import org.idp.server.core.openid.authentication.policy.AuthenticationResultConditionConfig;
 import org.idp.server.core.openid.authentication.repository.AuthenticationConfigurationQueryRepository;
@@ -123,7 +124,7 @@ public class Fido2RegistrationChallengeInteractor implements AuthenticationInter
 
     // Verify max_devices limit before generating challenge (skip for reset action)
     User authenticatedUser = transaction.user();
-    boolean isResetAction = "reset".equals(request.toMap().get("action"));
+    boolean isResetAction = isResetAction(request);
     int authenticationDeviceCount = authenticatedUser.authenticationDeviceCount();
     int maxDevices = tenant.maxDevicesForAuthentication();
 
@@ -134,18 +135,8 @@ public class Fido2RegistrationChallengeInteractor implements AuthenticationInter
           authenticationDeviceCount,
           maxDevices);
 
-      Map<String, Object> errorResponse = new HashMap<>();
-      errorResponse.put("error", "device_limit_exceeded");
-      errorResponse.put(
-          "error_description",
-          String.format(
-              "Maximum number of devices reached %d, user has already %d devices.",
-              maxDevices, authenticationDeviceCount));
-      errorResponse.put("max_devices", maxDevices);
-      errorResponse.put("current_devices", authenticationDeviceCount);
-
       return AuthenticationInteractionRequestResult.clientError(
-          errorResponse,
+          DeviceLimitExceededResponse.create(maxDevices, authenticationDeviceCount),
           type,
           operationType(),
           method(),
@@ -367,5 +358,9 @@ public class Fido2RegistrationChallengeInteractor implements AuthenticationInter
         // Fallback to preferredUsername
         return user.preferredUsername();
     }
+  }
+
+  private boolean isResetAction(AuthenticationInteractionRequest request) {
+    return "reset".equals(request.toMap().get("action"));
   }
 }

--- a/libs/idp-server-authentication-interactors/src/main/java/org/idp/server/authentication/interactors/fido2/Fido2RegistrationChallengeInteractor.java
+++ b/libs/idp-server-authentication-interactors/src/main/java/org/idp/server/authentication/interactors/fido2/Fido2RegistrationChallengeInteractor.java
@@ -124,7 +124,7 @@ public class Fido2RegistrationChallengeInteractor implements AuthenticationInter
 
     // Verify max_devices limit before generating challenge (skip for reset action)
     User authenticatedUser = transaction.user();
-    boolean isResetAction = isResetAction(request);
+    boolean isResetAction = isResetAction(transaction);
     int authenticationDeviceCount = authenticatedUser.authenticationDeviceCount();
     int maxDevices = tenant.maxDevicesForAuthentication();
 
@@ -360,7 +360,7 @@ public class Fido2RegistrationChallengeInteractor implements AuthenticationInter
     }
   }
 
-  private boolean isResetAction(AuthenticationInteractionRequest request) {
-    return "reset".equals(request.toMap().get("action"));
+  private boolean isResetAction(AuthenticationTransaction transaction) {
+    return "reset".equals(transaction.attributes().getValueOrEmpty("action"));
   }
 }

--- a/libs/idp-server-authentication-interactors/src/main/java/org/idp/server/authentication/interactors/fido2/Fido2RegistrationChallengeInteractor.java
+++ b/libs/idp-server-authentication-interactors/src/main/java/org/idp/server/authentication/interactors/fido2/Fido2RegistrationChallengeInteractor.java
@@ -135,12 +135,14 @@ public class Fido2RegistrationChallengeInteractor implements AuthenticationInter
           maxDevices);
 
       Map<String, Object> errorResponse = new HashMap<>();
-      errorResponse.put("error", "invalid_request");
+      errorResponse.put("error", "device_limit_exceeded");
       errorResponse.put(
           "error_description",
           String.format(
               "Maximum number of devices reached %d, user has already %d devices.",
               maxDevices, authenticationDeviceCount));
+      errorResponse.put("max_devices", maxDevices);
+      errorResponse.put("current_devices", authenticationDeviceCount);
 
       return AuthenticationInteractionRequestResult.clientError(
           errorResponse,

--- a/libs/idp-server-authentication-interactors/src/main/java/org/idp/server/authentication/interactors/fido2/Fido2RegistrationInteractor.java
+++ b/libs/idp-server-authentication-interactors/src/main/java/org/idp/server/authentication/interactors/fido2/Fido2RegistrationInteractor.java
@@ -29,6 +29,7 @@ import org.idp.server.core.openid.authentication.interaction.execution.Authentic
 import org.idp.server.core.openid.authentication.interaction.execution.AuthenticationExecutionResult;
 import org.idp.server.core.openid.authentication.interaction.execution.AuthenticationExecutor;
 import org.idp.server.core.openid.authentication.interaction.execution.AuthenticationExecutors;
+import org.idp.server.core.openid.authentication.mfa.DeviceLimitExceededResponse;
 import org.idp.server.core.openid.authentication.policy.AuthenticationPolicy;
 import org.idp.server.core.openid.authentication.policy.AuthenticationResultConditionConfig;
 import org.idp.server.core.openid.authentication.repository.AuthenticationConfigurationQueryRepository;
@@ -204,18 +205,8 @@ public class Fido2RegistrationInteractor implements AuthenticationInteractor {
             authenticationDeviceCount,
             maxDevices);
 
-        Map<String, Object> errorResponse = new HashMap<>();
-        errorResponse.put("error", "device_limit_exceeded");
-        errorResponse.put(
-            "error_description",
-            String.format(
-                "Maximum number of devices reached %d, user has already %d devices.",
-                maxDevices, authenticationDeviceCount));
-        errorResponse.put("max_devices", maxDevices);
-        errorResponse.put("current_devices", authenticationDeviceCount);
-
         return AuthenticationInteractionRequestResult.clientError(
-            errorResponse,
+            DeviceLimitExceededResponse.create(maxDevices, authenticationDeviceCount),
             type,
             operationType(),
             method(),

--- a/libs/idp-server-authentication-interactors/src/main/java/org/idp/server/authentication/interactors/fido2/Fido2RegistrationInteractor.java
+++ b/libs/idp-server-authentication-interactors/src/main/java/org/idp/server/authentication/interactors/fido2/Fido2RegistrationInteractor.java
@@ -205,12 +205,14 @@ public class Fido2RegistrationInteractor implements AuthenticationInteractor {
             maxDevices);
 
         Map<String, Object> errorResponse = new HashMap<>();
-        errorResponse.put("error", "invalid_request");
+        errorResponse.put("error", "device_limit_exceeded");
         errorResponse.put(
             "error_description",
             String.format(
                 "Maximum number of devices reached %d, user has already %d devices.",
                 maxDevices, authenticationDeviceCount));
+        errorResponse.put("max_devices", maxDevices);
+        errorResponse.put("current_devices", authenticationDeviceCount);
 
         return AuthenticationInteractionRequestResult.clientError(
             errorResponse,

--- a/libs/idp-server-authentication-interactors/src/main/java/org/idp/server/authentication/interactors/fido2/Fido2RegistrationInteractor.java
+++ b/libs/idp-server-authentication-interactors/src/main/java/org/idp/server/authentication/interactors/fido2/Fido2RegistrationInteractor.java
@@ -183,14 +183,14 @@ public class Fido2RegistrationInteractor implements AuthenticationInteractor {
     }
 
     // Handle reset action: remove existing FIDO2 devices before adding new one
-    if (isRestAction(transaction)) {
+    if (isResetAction(transaction)) {
       baseUser = baseUser.removeAllAuthenticationDevicesOfType("fido2");
     }
 
     // Verify device count limit (skip for reset action as it replaces devices)
     // IMPORTANT: Fetch latest user state from DB to prevent TOCTOU race condition
     // (transaction.user() may have stale device count if another registration completed)
-    if (!isRestAction(transaction)) {
+    if (!isResetAction(transaction)) {
       User latestUser =
           userQueryRepository.findById(
               tenant, new org.idp.server.core.openid.identity.UserIdentifier(baseUser.sub()));
@@ -216,7 +216,7 @@ public class Fido2RegistrationInteractor implements AuthenticationInteractor {
     }
 
     DefaultSecurityEventType eventType =
-        isRestAction(transaction)
+        isResetAction(transaction)
             ? DefaultSecurityEventType.fido2_reset_success
             : DefaultSecurityEventType.fido2_registration_success;
 
@@ -355,7 +355,7 @@ public class Fido2RegistrationInteractor implements AuthenticationInteractor {
     return "";
   }
 
-  private boolean isRestAction(AuthenticationTransaction transaction) {
+  private boolean isResetAction(AuthenticationTransaction transaction) {
     return "reset".equals(transaction.attributes().getValueOrEmpty("action"));
   }
 

--- a/libs/idp-server-authentication-interactors/src/main/java/org/idp/server/authentication/interactors/fidouaf/FidoUafRegistrationChallengeInteractor.java
+++ b/libs/idp-server-authentication-interactors/src/main/java/org/idp/server/authentication/interactors/fidouaf/FidoUafRegistrationChallengeInteractor.java
@@ -125,12 +125,14 @@ public class FidoUafRegistrationChallengeInteractor implements AuthenticationInt
           maxDevices);
 
       Map<String, Object> errorResponse = new HashMap<>();
-      errorResponse.put("error", "invalid_request");
+      errorResponse.put("error", "device_limit_exceeded");
       errorResponse.put(
           "error_description",
           String.format(
               "Maximum number of devices reached %d, user has already %d devices.",
               maxDevices, authenticationDeviceCount));
+      errorResponse.put("max_devices", maxDevices);
+      errorResponse.put("current_devices", authenticationDeviceCount);
 
       return AuthenticationInteractionRequestResult.clientError(
           errorResponse,

--- a/libs/idp-server-authentication-interactors/src/main/java/org/idp/server/authentication/interactors/fidouaf/FidoUafRegistrationChallengeInteractor.java
+++ b/libs/idp-server-authentication-interactors/src/main/java/org/idp/server/authentication/interactors/fidouaf/FidoUafRegistrationChallengeInteractor.java
@@ -28,6 +28,7 @@ import org.idp.server.core.openid.authentication.interaction.execution.Authentic
 import org.idp.server.core.openid.authentication.interaction.execution.AuthenticationExecutionResult;
 import org.idp.server.core.openid.authentication.interaction.execution.AuthenticationExecutor;
 import org.idp.server.core.openid.authentication.interaction.execution.AuthenticationExecutors;
+import org.idp.server.core.openid.authentication.mfa.DeviceLimitExceededResponse;
 import org.idp.server.core.openid.authentication.policy.AuthenticationPolicy;
 import org.idp.server.core.openid.authentication.policy.AuthenticationResultConditionConfig;
 import org.idp.server.core.openid.authentication.repository.AuthenticationConfigurationQueryRepository;
@@ -113,7 +114,7 @@ public class FidoUafRegistrationChallengeInteractor implements AuthenticationInt
 
     // Verify max_devices limit before generating challenge (skip for reset action)
     User authenticatedUser = transaction.user();
-    boolean isResetAction = "reset".equals(request.toMap().get("action"));
+    boolean isResetAction = isResetAction(request);
     int authenticationDeviceCount = authenticatedUser.authenticationDeviceCount();
     int maxDevices = tenant.maxDevicesForAuthentication();
 
@@ -124,18 +125,8 @@ public class FidoUafRegistrationChallengeInteractor implements AuthenticationInt
           authenticationDeviceCount,
           maxDevices);
 
-      Map<String, Object> errorResponse = new HashMap<>();
-      errorResponse.put("error", "device_limit_exceeded");
-      errorResponse.put(
-          "error_description",
-          String.format(
-              "Maximum number of devices reached %d, user has already %d devices.",
-              maxDevices, authenticationDeviceCount));
-      errorResponse.put("max_devices", maxDevices);
-      errorResponse.put("current_devices", authenticationDeviceCount);
-
       return AuthenticationInteractionRequestResult.clientError(
-          errorResponse,
+          DeviceLimitExceededResponse.create(maxDevices, authenticationDeviceCount),
           type,
           operationType(),
           method(),
@@ -274,5 +265,9 @@ public class FidoUafRegistrationChallengeInteractor implements AuthenticationInt
     }
 
     return satisfied;
+  }
+
+  private boolean isResetAction(AuthenticationInteractionRequest request) {
+    return "reset".equals(request.toMap().get("action"));
   }
 }

--- a/libs/idp-server-authentication-interactors/src/main/java/org/idp/server/authentication/interactors/fidouaf/FidoUafRegistrationChallengeInteractor.java
+++ b/libs/idp-server-authentication-interactors/src/main/java/org/idp/server/authentication/interactors/fidouaf/FidoUafRegistrationChallengeInteractor.java
@@ -114,7 +114,7 @@ public class FidoUafRegistrationChallengeInteractor implements AuthenticationInt
 
     // Verify max_devices limit before generating challenge (skip for reset action)
     User authenticatedUser = transaction.user();
-    boolean isResetAction = isResetAction(request);
+    boolean isResetAction = isResetAction(transaction);
     int authenticationDeviceCount = authenticatedUser.authenticationDeviceCount();
     int maxDevices = tenant.maxDevicesForAuthentication();
 
@@ -267,7 +267,7 @@ public class FidoUafRegistrationChallengeInteractor implements AuthenticationInt
     return satisfied;
   }
 
-  private boolean isResetAction(AuthenticationInteractionRequest request) {
-    return "reset".equals(request.toMap().get("action"));
+  private boolean isResetAction(AuthenticationTransaction transaction) {
+    return "reset".equals(transaction.attributes().getValueOrEmpty("action"));
   }
 }

--- a/libs/idp-server-authentication-interactors/src/main/java/org/idp/server/authentication/interactors/fidouaf/FidoUafRegistrationChallengeInteractor.java
+++ b/libs/idp-server-authentication-interactors/src/main/java/org/idp/server/authentication/interactors/fidouaf/FidoUafRegistrationChallengeInteractor.java
@@ -32,6 +32,7 @@ import org.idp.server.core.openid.authentication.policy.AuthenticationPolicy;
 import org.idp.server.core.openid.authentication.policy.AuthenticationResultConditionConfig;
 import org.idp.server.core.openid.authentication.repository.AuthenticationConfigurationQueryRepository;
 import org.idp.server.core.openid.authentication.repository.AuthenticationInteractionCommandRepository;
+import org.idp.server.core.openid.identity.User;
 import org.idp.server.core.openid.identity.device.AuthenticationDeviceIdentifier;
 import org.idp.server.core.openid.identity.repository.UserQueryRepository;
 import org.idp.server.platform.json.JsonNodeWrapper;
@@ -107,6 +108,36 @@ public class FidoUafRegistrationChallengeInteractor implements AuthenticationInt
           type,
           operationType(),
           method(),
+          DefaultSecurityEventType.fido_uaf_registration_challenge_failure);
+    }
+
+    // Verify max_devices limit before generating challenge (skip for reset action)
+    User authenticatedUser = transaction.user();
+    boolean isResetAction = "reset".equals(request.toMap().get("action"));
+    int authenticationDeviceCount = authenticatedUser.authenticationDeviceCount();
+    int maxDevices = tenant.maxDevicesForAuthentication();
+
+    if (!isResetAction && authenticationDeviceCount >= maxDevices) {
+      log.warn(
+          "FIDO-UAF registration challenge rejected: device limit reached. user={}, current={}, max={}",
+          authenticatedUser.sub(),
+          authenticationDeviceCount,
+          maxDevices);
+
+      Map<String, Object> errorResponse = new HashMap<>();
+      errorResponse.put("error", "invalid_request");
+      errorResponse.put(
+          "error_description",
+          String.format(
+              "Maximum number of devices reached %d, user has already %d devices.",
+              maxDevices, authenticationDeviceCount));
+
+      return AuthenticationInteractionRequestResult.clientError(
+          errorResponse,
+          type,
+          operationType(),
+          method(),
+          authenticatedUser,
           DefaultSecurityEventType.fido_uaf_registration_challenge_failure);
     }
 

--- a/libs/idp-server-authentication-interactors/src/main/java/org/idp/server/authentication/interactors/fidouaf/FidoUafRegistrationChallengeInteractor.java
+++ b/libs/idp-server-authentication-interactors/src/main/java/org/idp/server/authentication/interactors/fidouaf/FidoUafRegistrationChallengeInteractor.java
@@ -112,28 +112,6 @@ public class FidoUafRegistrationChallengeInteractor implements AuthenticationInt
           DefaultSecurityEventType.fido_uaf_registration_challenge_failure);
     }
 
-    // Verify max_devices limit before generating challenge (skip for reset action)
-    User authenticatedUser = transaction.user();
-    boolean isResetAction = isResetAction(transaction);
-    int authenticationDeviceCount = authenticatedUser.authenticationDeviceCount();
-    int maxDevices = tenant.maxDevicesForAuthentication();
-
-    if (!isResetAction && authenticationDeviceCount >= maxDevices) {
-      log.warn(
-          "FIDO-UAF registration challenge rejected: device limit reached. user={}, current={}, max={}",
-          authenticatedUser.sub(),
-          authenticationDeviceCount,
-          maxDevices);
-
-      return AuthenticationInteractionRequestResult.clientError(
-          DeviceLimitExceededResponse.create(maxDevices, authenticationDeviceCount),
-          type,
-          operationType(),
-          method(),
-          authenticatedUser,
-          DefaultSecurityEventType.fido_uaf_registration_challenge_failure);
-    }
-
     // Verify device registration ACR/MFA requirements
     if (!isDeviceRegistrationPolicyMet(tenant, transaction)) {
       log.warn(
@@ -154,6 +132,28 @@ public class FidoUafRegistrationChallengeInteractor implements AuthenticationInt
           operationType(),
           method(),
           transaction.user(),
+          DefaultSecurityEventType.fido_uaf_registration_challenge_failure);
+    }
+
+    // Verify max_devices limit before generating challenge (skip for reset action)
+    User authenticatedUser = transaction.user();
+    boolean isResetAction = isResetAction(transaction);
+    int authenticationDeviceCount = authenticatedUser.authenticationDeviceCount();
+    int maxDevices = tenant.maxDevicesForAuthentication();
+
+    if (!isResetAction && authenticationDeviceCount >= maxDevices) {
+      log.warn(
+          "FIDO-UAF registration challenge rejected: device limit reached. user={}, current={}, max={}",
+          authenticatedUser.sub(),
+          authenticationDeviceCount,
+          maxDevices);
+
+      return AuthenticationInteractionRequestResult.clientError(
+          DeviceLimitExceededResponse.create(maxDevices, authenticationDeviceCount),
+          type,
+          operationType(),
+          method(),
+          authenticatedUser,
           DefaultSecurityEventType.fido_uaf_registration_challenge_failure);
     }
 

--- a/libs/idp-server-authentication-interactors/src/main/java/org/idp/server/authentication/interactors/fidouaf/FidoUafRegistrationInteractor.java
+++ b/libs/idp-server-authentication-interactors/src/main/java/org/idp/server/authentication/interactors/fidouaf/FidoUafRegistrationInteractor.java
@@ -29,6 +29,7 @@ import org.idp.server.core.openid.authentication.interaction.execution.Authentic
 import org.idp.server.core.openid.authentication.interaction.execution.AuthenticationExecutionResult;
 import org.idp.server.core.openid.authentication.interaction.execution.AuthenticationExecutor;
 import org.idp.server.core.openid.authentication.interaction.execution.AuthenticationExecutors;
+import org.idp.server.core.openid.authentication.mfa.DeviceLimitExceededResponse;
 import org.idp.server.core.openid.authentication.policy.AuthenticationPolicy;
 import org.idp.server.core.openid.authentication.policy.AuthenticationResultConditionConfig;
 import org.idp.server.core.openid.authentication.repository.AuthenticationConfigurationQueryRepository;
@@ -211,18 +212,8 @@ public class FidoUafRegistrationInteractor implements AuthenticationInteractor {
             authenticationDeviceCount,
             maxDevices);
 
-        Map<String, Object> errorResponse = new HashMap<>();
-        errorResponse.put("error", "device_limit_exceeded");
-        errorResponse.put(
-            "error_description",
-            String.format(
-                "Maximum number of devices reached %d, user has already %d devices.",
-                maxDevices, authenticationDeviceCount));
-        errorResponse.put("max_devices", maxDevices);
-        errorResponse.put("current_devices", authenticationDeviceCount);
-
         return AuthenticationInteractionRequestResult.clientError(
-            errorResponse,
+            DeviceLimitExceededResponse.create(maxDevices, authenticationDeviceCount),
             type,
             operationType(),
             method(),

--- a/libs/idp-server-authentication-interactors/src/main/java/org/idp/server/authentication/interactors/fidouaf/FidoUafRegistrationInteractor.java
+++ b/libs/idp-server-authentication-interactors/src/main/java/org/idp/server/authentication/interactors/fidouaf/FidoUafRegistrationInteractor.java
@@ -212,12 +212,14 @@ public class FidoUafRegistrationInteractor implements AuthenticationInteractor {
             maxDevices);
 
         Map<String, Object> errorResponse = new HashMap<>();
-        errorResponse.put("error", "invalid_request");
+        errorResponse.put("error", "device_limit_exceeded");
         errorResponse.put(
             "error_description",
             String.format(
                 "Maximum number of devices reached %d, user has already %d devices.",
                 maxDevices, authenticationDeviceCount));
+        errorResponse.put("max_devices", maxDevices);
+        errorResponse.put("current_devices", authenticationDeviceCount);
 
         return AuthenticationInteractionRequestResult.clientError(
             errorResponse,

--- a/libs/idp-server-authentication-interactors/src/main/java/org/idp/server/authentication/interactors/fidouaf/FidoUafRegistrationInteractor.java
+++ b/libs/idp-server-authentication-interactors/src/main/java/org/idp/server/authentication/interactors/fidouaf/FidoUafRegistrationInteractor.java
@@ -190,14 +190,14 @@ public class FidoUafRegistrationInteractor implements AuthenticationInteractor {
 
     User baseUser = transaction.user();
     // Handle reset action: remove existing FIDO-UAF devices before adding new one
-    if (isRestAction(transaction)) {
+    if (isResetAction(transaction)) {
       baseUser = baseUser.removeAllAuthenticationDevicesOfType("fido-uaf");
     }
 
     // Verify device count limit (skip for reset action as it replaces devices)
     // IMPORTANT: Fetch latest user state from DB to prevent TOCTOU race condition
     // (transaction.user() may have stale device count if another registration completed)
-    if (!isRestAction(transaction)) {
+    if (!isResetAction(transaction)) {
       User latestUser =
           userQueryRepository.findById(
               tenant, new org.idp.server.core.openid.identity.UserIdentifier(baseUser.sub()));
@@ -223,7 +223,7 @@ public class FidoUafRegistrationInteractor implements AuthenticationInteractor {
     }
 
     DefaultSecurityEventType eventType =
-        isRestAction(transaction)
+        isResetAction(transaction)
             ? DefaultSecurityEventType.fido_uaf_reset_success
             : DefaultSecurityEventType.fido_uaf_registration_success;
 
@@ -274,7 +274,7 @@ public class FidoUafRegistrationInteractor implements AuthenticationInteractor {
         eventType);
   }
 
-  private boolean isRestAction(AuthenticationTransaction transaction) {
+  private boolean isResetAction(AuthenticationTransaction transaction) {
     return "reset".equals(transaction.attributes().getValueOrEmpty("action"));
   }
 

--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/authentication/mfa/DeviceLimitExceededResponse.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/authentication/mfa/DeviceLimitExceededResponse.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2025 Hirokazu Kobayashi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.idp.server.core.openid.authentication.mfa;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Creates a standardized error response for device limit exceeded scenarios.
+ *
+ * <p>Used by FIDO2 and FIDO-UAF registration (both challenge and registration stages) to return a
+ * consistent error response when the user has reached the maximum number of allowed devices.
+ *
+ * <p>The error code {@code device_limit_exceeded} allows clients to identify this specific error
+ * and display appropriate UI guidance (e.g., "Please remove an existing device before registering a
+ * new one").
+ */
+public class DeviceLimitExceededResponse {
+
+  public static Map<String, Object> create(int maxDevices, int currentDevices) {
+    Map<String, Object> errorResponse = new HashMap<>();
+    errorResponse.put("error", "device_limit_exceeded");
+    errorResponse.put(
+        "error_description",
+        String.format(
+            "Maximum number of devices reached %d, user has already %d devices.",
+            maxDevices, currentDevices));
+    errorResponse.put("max_devices", maxDevices);
+    errorResponse.put("current_devices", currentDevices);
+    return errorResponse;
+  }
+}

--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/authentication/mfa/FidoUafRegistrationVerifier.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/authentication/mfa/FidoUafRegistrationVerifier.java
@@ -16,8 +16,6 @@
 
 package org.idp.server.core.openid.authentication.mfa;
 
-import java.util.HashMap;
-import java.util.Map;
 import org.idp.server.core.openid.identity.User;
 import org.idp.server.core.openid.identity.io.MfaRegistrationRequest;
 import org.idp.server.platform.multi_tenancy.tenant.Tenant;
@@ -37,17 +35,8 @@ public class FidoUafRegistrationVerifier implements MfaRequestVerifier {
     int maxDevices = tenant.maxDevicesForAuthentication();
 
     if (authenticationDeviceCount >= maxDevices) {
-      Map<String, Object> errors = new HashMap<>();
-      errors.put("error", "device_limit_exceeded");
-      errors.put(
-          "error_description",
-          String.format(
-              "Maximum number of devices reached %d, user has already %d devices.",
-              maxDevices, authenticationDeviceCount));
-      errors.put("max_devices", maxDevices);
-      errors.put("current_devices", authenticationDeviceCount);
-
-      return MfaVerificationResult.failure(errors);
+      return MfaVerificationResult.failure(
+          DeviceLimitExceededResponse.create(maxDevices, authenticationDeviceCount));
     }
 
     return MfaVerificationResult.success();

--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/authentication/mfa/FidoUafRegistrationVerifier.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/authentication/mfa/FidoUafRegistrationVerifier.java
@@ -38,12 +38,14 @@ public class FidoUafRegistrationVerifier implements MfaRequestVerifier {
 
     if (authenticationDeviceCount >= maxDevices) {
       Map<String, Object> errors = new HashMap<>();
-      errors.put("error", "invalid_request");
+      errors.put("error", "device_limit_exceeded");
       errors.put(
           "error_description",
           String.format(
               "Maximum number of devices reached %d, user has already %d devices.",
               maxDevices, authenticationDeviceCount));
+      errors.put("max_devices", maxDevices);
+      errors.put("current_devices", authenticationDeviceCount);
 
       return MfaVerificationResult.failure(errors);
     }


### PR DESCRIPTION
## Summary
- `fido2-registration-challenge` / `fido-uaf-registration-challenge` 段階で `max_devices` を検証し、上限到達時はチャレンジを返さないように修正
- `navigator.credentials.create()` が呼ばれる前にエラーを返すことで、サーバーに登録されない孤立した鍵の生成を防止
- エラーコードを `invalid_request` → `device_limit_exceeded` に変更し、`max_devices` / `current_devices` をレスポンスに追加

## エラーレスポンス

```json
{
  "error": "device_limit_exceeded",
  "error_description": "Maximum number of devices reached 1, user has already 1 devices.",
  "max_devices": 1,
  "current_devices": 1
}
```

クライアントは `error: "device_limit_exceeded"` を検知して「不要なデバイスを削除してください」等の案内を表示可能。

## 変更箇所（全5箇所統一）
- `Fido2RegistrationChallengeInteractor` — challenge段階チェック追加 + エラーコード変更
- `Fido2RegistrationInteractor` — エラーコード変更（二重チェック維持）
- `FidoUafRegistrationChallengeInteractor` — challenge段階チェック追加 + エラーコード変更
- `FidoUafRegistrationInteractor` — エラーコード変更（二重チェック維持）
- `FidoUafRegistrationVerifier` — エラーコード変更

## Test plan
- [x] `mfa-07` FIDO2 challenge段階でmax_devicesチェック（2テストパス）
- [x] `financial-grade-02` 既存テストのアサーション更新
- [x] ビルド成功

closes #1372

🤖 Generated with [Claude Code](https://claude.com/claude-code)