### PR TITLE
config-feat: Organizerテナント向けFIDO2/メール認証セットアップとControl Plane動作確認ヘルパー追加

### DIFF
--- a/config/templates/use-cases/financial-grade/financial-tenant-template.json
+++ b/config/templates/use-cases/financial-grade/financial-tenant-template.json
@@ -41,7 +41,8 @@
       "include_user_pii": false,
       "include_trace_context": true,
       "tracing_enabled": true,
-      "persistence_enabled": true
+      "persistence_enabled": true,
+      "statistics_enabled": true
     },
     "identity_policy_config": {
       "identity_unique_key_type": "EMAIL",

--- a/config/templates/use-cases/financial-grade/helpers.sh
+++ b/config/templates/use-cases/financial-grade/helpers.sh
@@ -1,0 +1,316 @@
+#!/bin/bash
+#
+# Financial-Grade (FAPI Advanced + CIBA) - Experiment Helpers
+#
+# 管理ダッシュボードやコントロールプレーンAPIの動作確認で使う共通関数と変数を定義する。
+#
+# 使い方:
+#   source helpers.sh
+#   source helpers.sh --org financial-grade
+#
+# 関数一覧:
+#
+#   === トークン ===
+#   get_admin_token              管理者トークン取得（Organizerテナント）
+#
+#   === コントロールプレーン（組織レベルAPI）===
+#   list_tenants                 テナント一覧取得
+#   get_tenant                   テナント詳細取得
+#   list_users                   ユーザー一覧取得
+#   list_clients                 クライアント一覧取得
+#   list_security_events         セキュリティイベント一覧取得
+#   get_tenant_statistics        テナント統計情報取得
+#   list_auth_configs            認証設定一覧取得
+#   list_auth_policies           認証ポリシー一覧取得
+#
+#   === テナント・認可サーバー更新 ===
+#   update_tenant                テナント設定更新（jqフィルタ）
+#   update_auth_server           認可サーバー設定更新（jqフィルタ）
+#
+#   === ユーティリティ ===
+#   decode_jwt_payload           JWTペイロードデコード
+#   get_discovery                Discoveryエンドポイント確認
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
+ENV_FILE="${PROJECT_ROOT}/.env"
+
+# Parse arguments
+ORGANIZATION_NAME="financial-grade"
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --org) ORGANIZATION_NAME="$2"; shift 2 ;;
+    *) echo "Unknown option: $1"; return 1 2>/dev/null || exit 1 ;;
+  esac
+done
+
+# --- Load .env ---
+if [ ! -f "${ENV_FILE}" ]; then
+  echo "Error: .env file not found at ${ENV_FILE}"
+  return 1 2>/dev/null || exit 1
+fi
+
+set -a
+source "${ENV_FILE}"
+set +a
+
+: "${AUTHORIZATION_SERVER_URL:?AUTHORIZATION_SERVER_URL is required in .env}"
+
+# --- Load generated config ---
+CONFIG_DIR="${PROJECT_ROOT}/config/generated/${ORGANIZATION_NAME}"
+
+if [ ! -d "${CONFIG_DIR}" ]; then
+  echo "Error: Generated config not found at ${CONFIG_DIR}"
+  echo "Run setup.sh first."
+  return 1 2>/dev/null || exit 1
+fi
+
+ORG_ID=$(jq -r '.organization.id' "${CONFIG_DIR}/onboarding.json")
+ORGANIZER_TENANT_ID=$(jq -r '.tenant.id' "${CONFIG_DIR}/onboarding.json")
+ADMIN_EMAIL=$(jq -r '.user.email' "${CONFIG_DIR}/onboarding.json")
+ADMIN_PASSWORD=$(jq -r '.user.raw_password' "${CONFIG_DIR}/onboarding.json")
+ORG_CLIENT_ID=$(jq -r '.client.client_id' "${CONFIG_DIR}/onboarding.json")
+ORG_CLIENT_SECRET=$(jq -r '.client.client_secret' "${CONFIG_DIR}/onboarding.json")
+PUBLIC_TENANT_ID=$(jq -r '.tenant.id' "${CONFIG_DIR}/financial-tenant.json")
+TLS_CLIENT_ID=$(jq -r '.client_id' "${CONFIG_DIR}/tls-client-auth-client.json")
+PKJ_CLIENT_ID=$(jq -r '.client_id' "${CONFIG_DIR}/private-key-jwt-client.json")
+
+ORGANIZER_BASE="${AUTHORIZATION_SERVER_URL}/${ORGANIZER_TENANT_ID}"
+TENANT_BASE="${AUTHORIZATION_SERVER_URL}/${PUBLIC_TENANT_ID}"
+ORG_BASE_URL="${AUTHORIZATION_SERVER_URL}/v1/management/organizations/${ORG_ID}/tenants"
+
+# 生成済み設定をベースとして読み込む（PUT APIはフル置換のため）
+TENANT_JSON_INITIAL=$(jq '.tenant' "${CONFIG_DIR}/financial-tenant.json")
+TENANT_JSON="${TENANT_JSON_INITIAL}"
+AUTH_SERVER_JSON_INITIAL=$(jq '.authorization_server' "${CONFIG_DIR}/financial-tenant.json")
+AUTH_SERVER_JSON="${AUTH_SERVER_JSON_INITIAL}"
+
+echo "=========================================="
+echo "Financial-Grade Helpers Loaded"
+echo "=========================================="
+echo "  Server:            ${AUTHORIZATION_SERVER_URL}"
+echo "  Organization:      ${ORGANIZATION_NAME} (${ORG_ID})"
+echo "  Organizer Tenant:  ${ORGANIZER_TENANT_ID}"
+echo "  Financial Tenant:  ${PUBLIC_TENANT_ID}"
+echo "  Admin Email:       ${ADMIN_EMAIL}"
+echo "  TLS Client:        ${TLS_CLIENT_ID}"
+echo "  PKJ Client:        ${PKJ_CLIENT_ID}"
+echo ""
+
+# ============================================================
+# 管理トークン取得
+# ============================================================
+
+get_admin_token() {
+  local response
+  response=$(curl -s -X POST \
+    "${ORGANIZER_BASE}/v1/tokens" \
+    -H "Content-Type: application/x-www-form-urlencoded" \
+    --data-urlencode "grant_type=password" \
+    --data-urlencode "username=${ADMIN_EMAIL}" \
+    --data-urlencode "password=${ADMIN_PASSWORD}" \
+    --data-urlencode "client_id=${ORG_CLIENT_ID}" \
+    --data-urlencode "client_secret=${ORG_CLIENT_SECRET}" \
+    --data-urlencode "scope=openid profile email management")
+
+  ORG_ACCESS_TOKEN=$(echo "${response}" | jq -r '.access_token')
+
+  if [ -z "${ORG_ACCESS_TOKEN}" ] || [ "${ORG_ACCESS_TOKEN}" = "null" ]; then
+    echo "Error: Failed to get admin token"
+    echo "${response}" | jq '.' 2>/dev/null || echo "${response}"
+    return 1
+  fi
+
+  echo "Admin token: ${ORG_ACCESS_TOKEN:0:20}..."
+}
+
+# ============================================================
+# コントロールプレーン（組織レベルAPI）
+# ============================================================
+
+# テナント一覧
+list_tenants() {
+  curl -s "${ORG_BASE_URL}" \
+    -H "Authorization: Bearer ${ORG_ACCESS_TOKEN}" | jq '.'
+}
+
+# テナント詳細（デフォルト: Financial Tenant）
+# 使用例:
+#   get_tenant                           # Financial Tenant
+#   get_tenant "${ORGANIZER_TENANT_ID}"  # Organizer Tenant
+get_tenant() {
+  local tenant_id="${1:-${PUBLIC_TENANT_ID}}"
+  curl -s "${ORG_BASE_URL}/${tenant_id}" \
+    -H "Authorization: Bearer ${ORG_ACCESS_TOKEN}" | jq '.'
+}
+
+# ユーザー一覧（デフォルト: Financial Tenant）
+# 使用例:
+#   list_users                           # Financial Tenant
+#   list_users "${ORGANIZER_TENANT_ID}"  # Organizer Tenant
+#   list_users "" "limit=5&offset=0"     # ページネーション
+list_users() {
+  local tenant_id="${1:-${PUBLIC_TENANT_ID}}"
+  local query="${2:-}"
+  local url="${ORG_BASE_URL}/${tenant_id}/users"
+  [ -n "${query}" ] && url="${url}?${query}"
+
+  curl -s "${url}" \
+    -H "Authorization: Bearer ${ORG_ACCESS_TOKEN}" | jq '.'
+}
+
+# クライアント一覧（デフォルト: Financial Tenant）
+list_clients() {
+  local tenant_id="${1:-${PUBLIC_TENANT_ID}}"
+  curl -s "${ORG_BASE_URL}/${tenant_id}/clients" \
+    -H "Authorization: Bearer ${ORG_ACCESS_TOKEN}" | jq '.'
+}
+
+# セキュリティイベント一覧（デフォルト: Financial Tenant）
+# 使用例:
+#   list_security_events                          # デフォルト
+#   list_security_events "${PUBLIC_TENANT_ID}" 20 # 件数指定
+list_security_events() {
+  local tenant_id="${1:-${PUBLIC_TENANT_ID}}"
+  local limit="${2:-10}"
+
+  curl -s "${ORG_BASE_URL}/${tenant_id}/security-events?limit=${limit}" \
+    -H "Authorization: Bearer ${ORG_ACCESS_TOKEN}" | jq '.'
+}
+
+# テナント統計情報取得（デフォルト: Financial Tenant、当月）
+# 使用例:
+#   get_tenant_statistics                                    # デフォルト（当月）
+#   get_tenant_statistics "" "2026-01" "2026-04"             # 期間指定（YYYY-MM）
+#   get_tenant_statistics "${ORGANIZER_TENANT_ID}"           # Organizerテナント
+get_tenant_statistics() {
+  local tenant_id="${1:-${PUBLIC_TENANT_ID}}"
+  local from="${2:-$(date +%Y-%m)}"
+  local to="${3:-$(date +%Y-%m)}"
+
+  curl -s "${ORG_BASE_URL}/${tenant_id}/statistics?from=${from}&to=${to}" \
+    -H "Authorization: Bearer ${ORG_ACCESS_TOKEN}" | jq '.'
+}
+
+# 認証設定一覧（デフォルト: Financial Tenant）
+list_auth_configs() {
+  local tenant_id="${1:-${PUBLIC_TENANT_ID}}"
+
+  curl -s "${ORG_BASE_URL}/${tenant_id}/authentication-configurations" \
+    -H "Authorization: Bearer ${ORG_ACCESS_TOKEN}" | jq '.'
+}
+
+# 認証ポリシー一覧（デフォルト: Financial Tenant）
+list_auth_policies() {
+  local tenant_id="${1:-${PUBLIC_TENANT_ID}}"
+
+  curl -s "${ORG_BASE_URL}/${tenant_id}/authentication-policies" \
+    -H "Authorization: Bearer ${ORG_ACCESS_TOKEN}" | jq '.'
+}
+
+# ============================================================
+# テナント・認可サーバー更新ヘルパー
+#
+# 重要: PUT API はフル置換。$TENANT_JSON をベースに jq で変更して使う。
+#
+# 使用例:
+#   update_tenant '.session_config.timeout_seconds = 15'
+#   update_auth_server '.extension.access_token_duration = 60'
+# ============================================================
+
+update_tenant() {
+  local jq_filter="$1"
+  local updated response http_code
+  updated=$(echo "${TENANT_JSON}" | jq "${jq_filter}")
+
+  response=$(curl -s -w "\n%{http_code}" -X PUT "${ORG_BASE_URL}/${PUBLIC_TENANT_ID}" \
+    -H "Authorization: Bearer ${ORG_ACCESS_TOKEN}" \
+    -H "Content-Type: application/json" \
+    -d "${updated}")
+
+  http_code=$(echo "${response}" | tail -1)
+  local body
+  body=$(echo "${response}" | sed '$d')
+
+  if [ "${http_code}" != "200" ]; then
+    echo "Error: update_tenant failed (HTTP ${http_code})" >&2
+    echo "${body}" >&2
+    return 1
+  fi
+
+  TENANT_JSON="${updated}"
+  echo "${body}"
+}
+
+update_auth_server() {
+  local jq_filter="$1"
+  local updated response http_code
+  updated=$(echo "${AUTH_SERVER_JSON}" | jq "${jq_filter}")
+
+  response=$(curl -s -w "\n%{http_code}" -X PUT \
+    "${ORG_BASE_URL}/${PUBLIC_TENANT_ID}/authorization-server" \
+    -H "Authorization: Bearer ${ORG_ACCESS_TOKEN}" \
+    -H "Content-Type: application/json" \
+    -d "${updated}")
+
+  http_code=$(echo "${response}" | tail -1)
+  local body
+  body=$(echo "${response}" | sed '$d')
+
+  if [ "${http_code}" != "200" ]; then
+    echo "Error: update_auth_server failed (HTTP ${http_code})" >&2
+    echo "${body}" >&2
+    return 1
+  fi
+
+  AUTH_SERVER_JSON="${updated}"
+  echo "${body}"
+}
+
+# ============================================================
+# ユーティリティ
+# ============================================================
+
+# JWT ペイロードのデコード
+decode_jwt_payload() {
+  local token="$1"
+  local payload
+  payload=$(echo "${token}" | cut -d. -f2 | tr '_-' '/+')
+  local mod=$((${#payload} % 4))
+  if [ $mod -eq 2 ]; then payload="${payload}=="; elif [ $mod -eq 3 ]; then payload="${payload}="; fi
+  echo "${payload}" | base64 -d 2>/dev/null
+}
+
+# Discovery エンドポイント確認
+get_discovery() {
+  local tenant_id="${1:-${PUBLIC_TENANT_ID}}"
+  curl -s "${AUTHORIZATION_SERVER_URL}/${tenant_id}/.well-known/openid-configuration" | jq '.'
+}
+
+# ============================================================
+# クイックスタート
+#
+# 以下を順番に実行すると、管理機能を試せます:
+#
+#   source helpers.sh
+#   get_admin_token
+#
+#   # コントロールプレーン確認
+#   list_tenants
+#   get_tenant
+#   list_users
+#   list_clients
+#   list_security_events
+#   get_tenant_statistics
+#   list_auth_configs
+#   list_auth_policies
+#
+#   # Organizerテナントの情報
+#   get_tenant "${ORGANIZER_TENANT_ID}"
+#   list_users "${ORGANIZER_TENANT_ID}"
+#
+#   # Discovery
+#   get_discovery
+#   get_discovery "${ORGANIZER_TENANT_ID}"
+#
+# ============================================================

--- a/config/templates/use-cases/financial-grade/onboarding-template.json
+++ b/config/templates/use-cases/financial-grade/onboarding-template.json
@@ -10,6 +10,11 @@
     "type": "ORGANIZER",
     "domain": "${BASE_URL}",
     "authorization_provider": "idp-server",
+    "ui_config": {
+      "base_url": "${UI_BASE_URL}",
+      "signin_page": "/signin/fido2/",
+      "signup_page": "/signup/"
+    },
     "session_config": {
       "cookie_name": "${COOKIE_NAME}_ADMIN",
       "cookie_same_site": "Lax",
@@ -21,7 +26,8 @@
     "cors_config": {
       "allow_origins": [
         "${BASE_URL}",
-        "${MTLS_BASE_URL}"
+        "${MTLS_BASE_URL}",
+        "${UI_BASE_URL}"
       ],
       "allow_headers": "Authorization, Content-Type, Accept, x-device-id, X-SSL-Client-Cert",
       "allow_methods": "GET, POST, PUT, PATCH, DELETE, OPTIONS",
@@ -35,6 +41,7 @@
       "include_client_id": true,
       "include_ip_address": true,
       "persistence_enabled": true,
+      "statistics_enabled": true,
       "include_event_detail": true
     },
     "identity_policy_config": {
@@ -71,7 +78,10 @@
       "openid",
       "profile",
       "email",
-      "management"
+      "management",
+      "claims:roles",
+      "claims:permissions",
+      "claims:assigned_tenants"
     ],
     "response_types_supported": [
       "code"
@@ -102,15 +112,16 @@
       "address",
       "birthdate"
     ],
-    "token_introspection_endpoint": "${BASE_URL}/${ORGANIZER_TENANT_ID}/v1/tokens/introspection",
-    "token_revocation_endpoint": "${BASE_URL}/${ORGANIZER_TENANT_ID}/v1/tokens/revocation",
+    "introspection_endpoint": "${BASE_URL}/${ORGANIZER_TENANT_ID}/v1/tokens/introspection",
+    "revocation_endpoint": "${BASE_URL}/${ORGANIZER_TENANT_ID}/v1/tokens/revocation",
     "extension": {
       "access_token_type": "JWT",
       "token_signed_key_id": "${TOKEN_SIGNING_KEY_ID}",
       "id_token_signed_key_id": "${ID_TOKEN_SIGNING_KEY_ID}",
       "access_token_duration": 3600,
       "id_token_duration": 3600,
-      "refresh_token_duration": 86400
+      "refresh_token_duration": 86400,
+      "custom_claims_scope_mapping": true
     }
   },
   "user": {
@@ -136,7 +147,7 @@
       "refresh_token",
       "password"
     ],
-    "scope": "openid profile email management",
+    "scope": "openid profile email management claims:roles claims:permissions claims:assigned_tenants",
     "client_name": "${ORGANIZATION_NAME} Admin Client",
     "token_endpoint_auth_method": "client_secret_post",
     "application_type": "web"

--- a/config/templates/use-cases/financial-grade/setup.sh
+++ b/config/templates/use-cases/financial-grade/setup.sh
@@ -185,7 +185,8 @@ ONBOARDING_JSON=$(substitute_template "${SCRIPT_DIR}/onboarding-template.json" \
   "ADMIN_EMAIL" "${NEW_ADMIN_EMAIL}" \
   "ADMIN_PASSWORD" "${NEW_ADMIN_PASSWORD}" \
   "ADMIN_CLIENT_ID" "${NEW_ADMIN_CLIENT_ID}" \
-  "ADMIN_CLIENT_SECRET" "${NEW_ADMIN_CLIENT_SECRET}")
+  "ADMIN_CLIENT_SECRET" "${NEW_ADMIN_CLIENT_SECRET}" \
+  "UI_BASE_URL" "${UI_BASE_URL}")
 
 echo "${ONBOARDING_JSON}" | jq '.' > "${OUTPUT_DIR}/onboarding.json"
 echo "  Saved: ${OUTPUT_DIR}/onboarding.json"
@@ -236,6 +237,144 @@ echo ""
 
 # From here, use organization-level APIs with ORG_ACCESS_TOKEN
 ORG_BASE_URL="${AUTHORIZATION_SERVER_URL}/v1/management/organizations/${ORGANIZATION_ID}/tenants"
+
+# --- Step 3a: Create authentication configuration (email) for Organizer ---
+echo "Step 3a: Creating authentication configuration (email) for Organizer..."
+
+ORG_AUTH_CONFIG_EMAIL_ID=$(uuidgen | tr '[:upper:]' '[:lower:]')
+
+ORG_AUTH_CONFIG_EMAIL_JSON=$(jq --arg id "${ORG_AUTH_CONFIG_EMAIL_ID}" '. + {id: $id}' \
+  "${SCRIPT_DIR}/authentication-config-email.json")
+
+ORG_AUTH_CONFIG_EMAIL_RESPONSE=$(curl -s -w "\n%{http_code}" -X POST \
+  "${ORG_BASE_URL}/${ORGANIZER_TENANT_ID}/authentication-configurations" \
+  -H "Authorization: Bearer ${ORG_ACCESS_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d "${ORG_AUTH_CONFIG_EMAIL_JSON}")
+
+HTTP_CODE=$(echo "${ORG_AUTH_CONFIG_EMAIL_RESPONSE}" | tail -n1)
+RESPONSE_BODY=$(echo "${ORG_AUTH_CONFIG_EMAIL_RESPONSE}" | sed '$d')
+
+if [ "${HTTP_CODE}" = "200" ] || [ "${HTTP_CODE}" = "201" ]; then
+  echo "  Organizer email auth config created: ${ORG_AUTH_CONFIG_EMAIL_ID}"
+else
+  echo "  Failed (HTTP ${HTTP_CODE})"
+  echo "  ${RESPONSE_BODY}" | jq '.' 2>/dev/null || echo "  ${RESPONSE_BODY}"
+  exit 1
+fi
+echo ""
+
+# --- Step 3b: Create authentication configuration (FIDO2) for Organizer ---
+echo "Step 3b: Creating authentication configuration (FIDO2) for Organizer..."
+
+ORG_AUTH_CONFIG_FIDO2_ID=$(uuidgen | tr '[:upper:]' '[:lower:]')
+
+ORG_AUTH_CONFIG_FIDO2_JSON=$(substitute_template "${SCRIPT_DIR}/authentication-config-fido2.json" \
+  "FIDO2_RP_ID" "${FIDO2_RP_ID}" \
+  "UI_BASE_URL" "${UI_BASE_URL}" \
+  "ORGANIZATION_NAME" "${ORGANIZATION_NAME}")
+
+ORG_AUTH_CONFIG_FIDO2_JSON=$(echo "${ORG_AUTH_CONFIG_FIDO2_JSON}" | jq --arg id "${ORG_AUTH_CONFIG_FIDO2_ID}" '. + {id: $id}')
+
+ORG_AUTH_CONFIG_FIDO2_RESPONSE=$(curl -s -w "\n%{http_code}" -X POST \
+  "${ORG_BASE_URL}/${ORGANIZER_TENANT_ID}/authentication-configurations" \
+  -H "Authorization: Bearer ${ORG_ACCESS_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d "${ORG_AUTH_CONFIG_FIDO2_JSON}")
+
+HTTP_CODE=$(echo "${ORG_AUTH_CONFIG_FIDO2_RESPONSE}" | tail -n1)
+RESPONSE_BODY=$(echo "${ORG_AUTH_CONFIG_FIDO2_RESPONSE}" | sed '$d')
+
+if [ "${HTTP_CODE}" = "200" ] || [ "${HTTP_CODE}" = "201" ]; then
+  echo "  Organizer FIDO2 auth config created: ${ORG_AUTH_CONFIG_FIDO2_ID}"
+else
+  echo "  Failed (HTTP ${HTTP_CODE})"
+  echo "  ${RESPONSE_BODY}" | jq '.' 2>/dev/null || echo "  ${RESPONSE_BODY}"
+  exit 1
+fi
+echo ""
+
+# --- Step 3c: Create authentication policy for Organizer ---
+echo "Step 3c: Creating authentication policy for Organizer..."
+
+ORG_AUTH_POLICY_ID=$(uuidgen | tr '[:upper:]' '[:lower:]')
+
+ORG_AUTH_POLICY_RESPONSE=$(curl -s -w "\n%{http_code}" -X POST \
+  "${ORG_BASE_URL}/${ORGANIZER_TENANT_ID}/authentication-policies" \
+  -H "Authorization: Bearer ${ORG_ACCESS_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d "$(cat <<POLICY_EOF
+{
+  "id": "${ORG_AUTH_POLICY_ID}",
+  "flow": "oauth",
+  "enabled": true,
+  "policies": [
+    {
+      "description": "organizer_admin_policy",
+      "priority": 1,
+      "conditions": {
+        "scopes": ["openid"]
+      },
+      "available_methods": ["password", "fido2", "email"],
+      "step_definitions": [
+        {
+          "method": "email",
+          "order": 1,
+          "requires_user": false,
+          "allow_registration": false,
+          "user_identity_source": "email"
+        },
+        {
+          "method": "fido2",
+          "order": 2,
+          "requires_user": true,
+          "allow_registration": true,
+          "user_identity_source": "sub"
+        }
+      ],
+      "device_registration_conditions": {
+        "any_of": [
+          [{"path": "$.email-authentication.success_count", "type": "integer", "operation": "gte", "value": 1}]
+        ]
+      },
+      "success_conditions": {
+        "any_of": [
+          [{"path": "$.fido2-authentication.success_count", "type": "integer", "operation": "gte", "value": 1}],
+          [{"path": "$.password-authentication.success_count", "type": "integer", "operation": "gte", "value": 1}],
+          [{"path": "$.email-authentication.success_count", "type": "integer", "operation": "gte", "value": 1}]
+        ]
+      },
+      "failure_conditions": {
+        "any_of": [
+          [{"path": "$.fido2-authentication.failure_count", "type": "integer", "operation": "gte", "value": 5}],
+          [{"path": "$.password-authentication.failure_count", "type": "integer", "operation": "gte", "value": 5}],
+          [{"path": "$.email-authentication.failure_count", "type": "integer", "operation": "gte", "value": 5}]
+        ]
+      },
+      "lock_conditions": {
+        "any_of": [
+          [{"path": "$.fido2-authentication.failure_count", "type": "integer", "operation": "gte", "value": 5}],
+          [{"path": "$.password-authentication.failure_count", "type": "integer", "operation": "gte", "value": 5}],
+          [{"path": "$.email-authentication.failure_count", "type": "integer", "operation": "gte", "value": 5}]
+        ]
+      }
+    }
+  ]
+}
+POLICY_EOF
+)")
+
+HTTP_CODE=$(echo "${ORG_AUTH_POLICY_RESPONSE}" | tail -n1)
+RESPONSE_BODY=$(echo "${ORG_AUTH_POLICY_RESPONSE}" | sed '$d')
+
+if [ "${HTTP_CODE}" = "200" ] || [ "${HTTP_CODE}" = "201" ]; then
+  echo "  Organizer auth policy created: ${ORG_AUTH_POLICY_ID}"
+else
+  echo "  Failed (HTTP ${HTTP_CODE})"
+  echo "  ${RESPONSE_BODY}" | jq '.' 2>/dev/null || echo "  ${RESPONSE_BODY}"
+  exit 1
+fi
+echo ""
 
 # --- Step 4: Create financial tenant ---
 echo "Step 4: Creating financial tenant (FAPI Advanced + CIBA)..."


### PR DESCRIPTION
## Summary

financial-grade ユースケースの Organizer テナントを管理ダッシュボード(UI)経由で操作できるよう、認証セットアップと動作確認ヘルパーを整備。

- **Organizer 認証セットアップ**: `setup.sh` に Step 3a/3b/3c を追加し、Organizer テナントにメール/FIDO2 認証設定と認証ポリシー (`organizer_admin_policy`: メール → FIDO2 の2段階、5回失敗でロック) を自動作成
- **onboarding-template**: 管理 UI 用の `ui_config` (signin: `/signin/fido2/`)、`UI_BASE_URL` の CORS 許可、`claims:roles` / `claims:permissions` / `claims:assigned_tenants` スコープと `custom_claims_scope_mapping: true` を追加。`token_introspection_endpoint` → `introspection_endpoint` 等のキー名修正も同梱
- **helpers.sh (新規)**: `source helpers.sh` で管理者トークン取得・テナント/ユーザー/クライアント/セキュリティイベント/統計/認証設定/ポリシーの一覧取得、`update_tenant` / `update_auth_server` (jq フィルタでフル置換 PUT) などの Control Plane API 動作確認用関数を提供
- **financial-tenant-template**: `security_event_log_config.statistics_enabled: true` を追加

## Test plan

- [ ] `config/templates/use-cases/financial-grade/setup.sh` を実行し、Organizer の認証設定/ポリシーが作成されることを確認
- [ ] 管理 UI から Organizer 管理者ユーザーで FIDO2/メール認証ログインができることを確認
- [ ] `source helpers.sh` → `get_admin_token` → `list_tenants` / `get_tenant_statistics` 等が動作することを確認
- [ ] ID Token / UserInfo に `roles` / `permissions` / `assigned_tenants` クレームが含まれることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)