### PR TITLE
e2e-fix: E2Eテストから廃止されたtenant_typeを削除

### DIFF
--- a/e2e/src/tests/integration/authentication-interactors/integration-01-authentication-interactor-error-propagation.test.js
+++ b/e2e/src/tests/integration/authentication-interactors/integration-01-authentication-interactor-error-propagation.test.js
@@ -72,7 +72,6 @@ describe("Authentication Interactor: External Service Error Code Propagation", (
           name: `Error Propagation Tenant ${timestamp}`,
           domain: backendUrl,
           authorization_provider: "idp-server",
-          tenant_type: "ORGANIZER",
           identity_policy_config: {
             identity_unique_key_type: "EMAIL",
           },

--- a/e2e/src/tests/integration/ida/integration-06-identity-verification-security-event.test.js
+++ b/e2e/src/tests/integration/ida/integration-06-identity-verification-security-event.test.js
@@ -66,7 +66,6 @@ describe("Integration: Identity Verification Security Event Logging", () => {
         name: `IDA Security Event Tenant ${timestamp}`,
         domain: backendUrl,
         authorization_provider: "idp-server",
-        tenant_type: "ORGANIZER",
         security_event_log_config: {
           format: "structured_json",
           stage: "processed",

--- a/e2e/src/tests/integration/ida/integration-07-oauth-retry-on-401.test.js
+++ b/e2e/src/tests/integration/ida/integration-07-oauth-retry-on-401.test.js
@@ -77,7 +77,6 @@ describe("Integration: OAuth Token Retry on 401/403", () => {
         name: `OAuth Retry Tenant ${timestamp}`,
         domain: backendUrl,
         authorization_provider: "idp-server",
-        tenant_type: "ORGANIZER",
       },
       authorization_server: {
         issuer: `${backendUrl}/${tenantId}`,

--- a/e2e/src/tests/scenario/application/scenario-10-disabled-tenant.test.js
+++ b/e2e/src/tests/scenario/application/scenario-10-disabled-tenant.test.js
@@ -42,8 +42,7 @@ describe("Disabled Tenant Scenario", () => {
           "name": `Disable Test Tenant ${timestamp}`,
           "domain": "http://localhost:8080",
           "description": "Test tenant for disable scenario",
-          "authorization_provider": "idp-server",
-          "tenant_type": "BUSINESS"
+          "authorization_provider": "idp-server"
         },
         authorization_server: {
           "issuer": `http://localhost:8080/${tenantId}`,

--- a/e2e/src/tests/scenario/application/scenario-11-password-policy-full-flow.test.js
+++ b/e2e/src/tests/scenario/application/scenario-11-password-policy-full-flow.test.js
@@ -84,8 +84,7 @@ describe("Issue #741: Password Policy Full Flow", () => {
           name: "Password Policy Test Tenant",
           domain: "http://localhost:8080",
           description: "Test tenant for password policy validation",
-          authorization_provider: "idp-server",
-          tenant_type: "BUSINESS"
+          authorization_provider: "idp-server"
         },
         authorization_server: {
           issuer: `${backendUrl}/${tenantId}`,
@@ -312,8 +311,7 @@ describe("Issue #741: Password Policy Full Flow", () => {
           name: "External Auth Test Tenant",
           domain: "http://localhost:8080",
           description: "Test tenant for external password authentication",
-          authorization_provider: "idp-server",
-          tenant_type: "BUSINESS"
+          authorization_provider: "idp-server"
         },
         authorization_server: {
           issuer: `${backendUrl}/${tenantId}`,

--- a/e2e/src/tests/scenario/control_plane/organization/organization_authorization_server_management.test.js
+++ b/e2e/src/tests/scenario/control_plane/organization/organization_authorization_server_management.test.js
@@ -37,8 +37,7 @@ describe("organization authorization server management api", () => {
             "name": `Test Tenant ${timestamp}`,
             "domain": "http://localhost:8080",
             "description": "Test tenant for authorization server management",
-            "authorization_provider": "idp-server",
-            "tenant_type": "BUSINESS"
+            "authorization_provider": "idp-server"
           },
           authorization_server: {
             "issuer": `http://localhost:8080/${newTenantId}`,
@@ -266,8 +265,7 @@ describe("organization authorization server management api", () => {
             "name": `OpenAPI Test Tenant ${timestamp}`,
             "domain": "http://localhost:8080",
             "description": "Test tenant for OpenAPI specification verification",
-            "authorization_provider": "idp-server",
-            "tenant_type": "BUSINESS"
+            "authorization_provider": "idp-server"
           },
           authorization_server: {
             "issuer": `http://localhost:8080/${newTenantId}`,
@@ -541,8 +539,7 @@ describe("organization authorization server management api", () => {
             "name": `Roundtrip Test Tenant ${Date.now()}`,
             "domain": "http://localhost:8080",
             "description": "Test tenant for GET-UPDATE roundtrip verification",
-            "authorization_provider": "idp-server",
-            "tenant_type": "BUSINESS"
+            "authorization_provider": "idp-server"
           },
           authorization_server: {
             "issuer": `http://localhost:8080/${newTenantId}`,

--- a/e2e/src/tests/scenario/control_plane/organization/organization_permission_management.test.js
+++ b/e2e/src/tests/scenario/control_plane/organization/organization_permission_management.test.js
@@ -38,8 +38,7 @@ describe("organization permission management api", () => {
             "name": `Permission Test Tenant ${timestamp}`,
             "domain": "http://localhost:8080",
             "description": "Test tenant for permission management",
-            "authorization_provider": "idp-server",
-            "tenant_type": "BUSINESS"
+            "authorization_provider": "idp-server"
           },
           authorization_server: {
             "issuer": `http://localhost:8080/${newTenantId}`,
@@ -249,8 +248,7 @@ describe("organization permission management api", () => {
             "name": `Permission Roundtrip Test Tenant ${Date.now()}`,
             "domain": "http://localhost:8080",
             "description": "Test tenant for permission roundtrip test",
-            "authorization_provider": "idp-server",
-            "tenant_type": "BUSINESS"
+            "authorization_provider": "idp-server"
           },
           authorization_server: {
             "issuer": `http://localhost:8080/${newTenantId}`,

--- a/e2e/src/tests/scenario/control_plane/organization/organization_permission_management_structured.test.js
+++ b/e2e/src/tests/scenario/control_plane/organization/organization_permission_management_structured.test.js
@@ -65,8 +65,7 @@ describe("Organization Permission Management API - Structured Tests", () => {
           "name": `E2E Test Tenant ${Date.now()}`,
           "domain": "http://localhost:8080",
           "description": "Test tenant for E2E testing",
-          "authorization_provider": "idp-server",
-          "tenant_type": "BUSINESS"
+          "authorization_provider": "idp-server"
         },
         authorization_server: {
           "issuer": `http://localhost:8080/${testTenantId}`,

--- a/e2e/src/tests/scenario/control_plane/organization/organization_role_management.test.js
+++ b/e2e/src/tests/scenario/control_plane/organization/organization_role_management.test.js
@@ -38,8 +38,7 @@ describe("organization role management api", () => {
             "name": `Role Test Tenant ${timestamp}`,
             "domain": "http://localhost:8080",
             "description": "Test tenant for role management",
-            "authorization_provider": "idp-server",
-            "tenant_type": "BUSINESS"
+            "authorization_provider": "idp-server"
           },
           authorization_server: {
             "issuer": `http://localhost:8080/${newTenantId}`,
@@ -374,8 +373,7 @@ describe("organization role management api", () => {
             "name": `Role Roundtrip Test Tenant ${Date.now()}`,
             "domain": "http://localhost:8080",
             "description": "Test tenant for role roundtrip test",
-            "authorization_provider": "idp-server",
-            "tenant_type": "BUSINESS"
+            "authorization_provider": "idp-server"
           },
           authorization_server: {
             "issuer": `http://localhost:8080/${newTenantId}`,

--- a/e2e/src/tests/scenario/control_plane/organization/organization_role_management_structured.test.js
+++ b/e2e/src/tests/scenario/control_plane/organization/organization_role_management_structured.test.js
@@ -67,8 +67,7 @@ describe("Organization Role Management API - Structured Tests", () => {
           "name": `E2E Test Tenant ${Date.now()}`,
           "domain": "http://localhost:8080",
           "description": "Test tenant for E2E testing",
-          "authorization_provider": "idp-server",
-          "tenant_type": "BUSINESS"
+          "authorization_provider": "idp-server"
         },
         authorization_server: {
           "issuer": `http://localhost:8080/${testTenantId}`,

--- a/e2e/src/tests/scenario/control_plane/organization/organization_tenant_management.test.js
+++ b/e2e/src/tests/scenario/control_plane/organization/organization_tenant_management.test.js
@@ -37,8 +37,7 @@ describe("organization tenant management api", () => {
             "name": `Organization Tenant ${timestamp}`,
             "domain": "http://localhost:8080",
             "description": "Test tenant for organization management",
-            "authorization_provider": "idp-server",
-            "tenant_type": "BUSINESS"
+            "authorization_provider": "idp-server"
           },
           authorization_server: {
             "issuer": "http://localhost:8080/952f6906-3e95-4ed3-86b2-981f90f785f9",
@@ -354,8 +353,7 @@ describe("organization tenant management api", () => {
             "name": `Dry Run Tenant ${timestamp}`,
             "domain": "http://localhost:8080",
             "description": "Test tenant for dry run",
-            "authorization_provider": "idp-server",
-            "tenant_type": "BUSINESS"
+            "authorization_provider": "idp-server"
           },
           authorization_server: {
             "issuer": "http://localhost:8080/952f6906-3e95-4ed3-86b2-981f90f785f9",
@@ -454,8 +452,7 @@ describe("organization tenant management api", () => {
             "name": `Test Tenant ${timestamp}`,
             "domain": "http://localhost:8080",
             "description": "Original description",
-            "authorization_provider": "idp-server",
-            "tenant_type": "BUSINESS"
+            "authorization_provider": "idp-server"
           },
           authorization_server: {
             "issuer": "http://localhost:8080/952f6906-3e95-4ed3-86b2-981f90f785f9",
@@ -569,8 +566,7 @@ describe("organization tenant management api", () => {
             "name": `Test Tenant ${timestamp}`,
             "domain": "http://localhost:8080",
             "description": "Test tenant for dry run delete",
-            "authorization_provider": "idp-server",
-            "tenant_type": "BUSINESS"
+            "authorization_provider": "idp-server"
           },
           authorization_server: {
             "issuer": "http://localhost:8080/952f6906-3e95-4ed3-86b2-981f90f785f9",
@@ -679,8 +675,7 @@ describe("organization tenant management api", () => {
             "name": `Roundtrip Tenant ${timestamp}`,
             "domain": "http://localhost:8080",
             "description": "Test tenant for roundtrip test",
-            "authorization_provider": "idp-server",
-            "tenant_type": "BUSINESS"
+            "authorization_provider": "idp-server"
           },
           authorization_server: {
             "issuer": "http://localhost:8080/952f6906-3e95-4ed3-86b2-981f90f785f9",
@@ -883,7 +878,7 @@ describe("organization tenant management api", () => {
 
     const invalidRequestCases = [
       ["missing tenant name", {
-        tenant: { "id": uuidv4(), "tenant_type": "BUSINESS", "domain": "http://localhost:8080", "authorization_provider": "idp-server" },
+        tenant: { "id": uuidv4(), "domain": "http://localhost:8080", "authorization_provider": "idp-server" },
         authorization_server: { "issuer": "http://localhost:8080/952f6906-3e95-4ed3-86b2-981f90f785f9" }
       }],
       ["invalid tenant type", {
@@ -891,7 +886,7 @@ describe("organization tenant management api", () => {
         authorization_server: { "issuer": "http://localhost:8080/952f6906-3e95-4ed3-86b2-981f90f785f9" }
       }],
       ["empty tenant id", {
-        tenant: { "id": "", "name": "Test", "tenant_type": "BUSINESS", "domain": "http://localhost:8080", "authorization_provider": "idp-server" },
+        tenant: { "id": "", "name": "Test", "domain": "http://localhost:8080", "authorization_provider": "idp-server" },
         authorization_server: { "issuer": "http://localhost:8080/952f6906-3e95-4ed3-86b2-981f90f785f9" }
       }]
     ];

--- a/e2e/src/tests/scenario/control_plane/organization/organization_tenant_management_structured.test.js
+++ b/e2e/src/tests/scenario/control_plane/organization/organization_tenant_management_structured.test.js
@@ -19,7 +19,7 @@ describe("Organization Tenant Management API - Structured Tests", () => {
   let accessToken;
 
   // Helper function to create a test tenant
-  const createTestTenant = async (tenantName, tenantType = "BUSINESS", description = "Test tenant") => {
+  const createTestTenant = async (tenantName, description = "Test tenant") => {
     const response = await postWithJson({
       url: `${backendUrl}/v1/management/organizations/${orgId}/tenants`,
       headers: { Authorization: `Bearer ${accessToken}` },
@@ -29,8 +29,7 @@ describe("Organization Tenant Management API - Structured Tests", () => {
           "name": tenantName,
           "domain": "http://localhost:8080",
           "description": description,
-          "authorization_provider": "idp-server",
-          "tenant_type": tenantType
+          "authorization_provider": "idp-server"
         },
         authorization_server: {
           "issuer": "http://localhost:8080/952f6906-3e95-4ed3-86b2-981f90f785f9",
@@ -91,7 +90,6 @@ describe("Organization Tenant Management API - Structured Tests", () => {
           body: {
             tenant: {
               "id": uuidv4(),
-              "tenant_type": "BUSINESS",
               "domain": "http://localhost:8080",
               "authorization_provider": "idp-server"
             },
@@ -115,8 +113,7 @@ describe("Organization Tenant Management API - Structured Tests", () => {
               "id": uuidv4(),
               "name": tenantName,
               "domain": "http://localhost:8080",
-              "authorization_provider": "idp-server",
-              "tenant_type": "BUSINESS"
+              "authorization_provider": "idp-server"
             },
             authorization_server: {
               "issuer": "http://localhost:8080/952f6906-3e95-4ed3-86b2-981f90f785f9",
@@ -171,7 +168,6 @@ describe("Organization Tenant Management API - Structured Tests", () => {
             tenant: {
               "id": "",
               "name": "Test Tenant",
-              "tenant_type": "BUSINESS",
               "domain": "http://localhost:8080",
               "authorization_provider": "idp-server"
             },
@@ -193,7 +189,6 @@ describe("Organization Tenant Management API - Structured Tests", () => {
             tenant: {
               "id": uuidv4(),
               "name": "Test Tenant",
-              "tenant_type": "BUSINESS",
               "domain": "http://localhost:8080",
               "authorization_provider": "idp-server"
             }
@@ -271,8 +266,7 @@ describe("Organization Tenant Management API - Structured Tests", () => {
           url: `${backendUrl}/v1/management/organizations/${orgId}/tenants/${nonExistentId}`,
           headers: { Authorization: `Bearer ${accessToken}` },
           body: {
-            "name": "Updated Name",
-            "tenant_type": "BUSINESS"
+            "name": "Updated Name"
           }
         });
 
@@ -307,8 +301,7 @@ describe("Organization Tenant Management API - Structured Tests", () => {
               "name": tenantName,
               "domain": "http://localhost:8080",
               "description": "Another test tenant",
-              "authorization_provider": "idp-server",
-              "tenant_type": "BUSINESS"
+              "authorization_provider": "idp-server"
             },
             authorization_server: {
               "issuer": "http://localhost:8080/952f6906-3e95-4ed3-86b2-981f90f785f9",
@@ -371,7 +364,7 @@ describe("Organization Tenant Management API - Structured Tests", () => {
     describe("Complete CRUD Workflow", () => {
       it("should successfully create a tenant with all fields", async () => {
         const tenantName = `Integration Test Tenant ${generateRandomString(8)}`;
-        const tenant = await createTestTenant(tenantName, "BUSINESS", "Integration test tenant");
+        const tenant = await createTestTenant(tenantName, "Integration test tenant");
 
         expect(tenant).toHaveProperty("id");
         expect(tenant).toHaveProperty("name", tenantName);
@@ -471,8 +464,7 @@ describe("Organization Tenant Management API - Structured Tests", () => {
               "name": tenantName,
               "domain": "http://localhost:8080",
               "description": "Dry run test tenant",
-              "authorization_provider": "idp-server",
-              "tenant_type": "BUSINESS"
+              "authorization_provider": "idp-server"
             },
             authorization_server: {
               "issuer": "http://localhost:8080/952f6906-3e95-4ed3-86b2-981f90f785f9",
@@ -670,7 +662,6 @@ describe("Organization Tenant Management API - Structured Tests", () => {
             tenant: {
               "id": uuidv4(),
               "name": "Test Tenant",
-              "tenant_type": "BUSINESS",
               "domain": "http://localhost:8080",
               "authorization_provider": "idp-server"
             }

--- a/e2e/src/tests/scenario/control_plane/system/tenant_management.test.js
+++ b/e2e/src/tests/scenario/control_plane/system/tenant_management.test.js
@@ -48,8 +48,7 @@ describe("System-Level Tenant Management API", () => {
             "name": `System Tenant ${timestamp}`,
             "domain": "http://localhost:8080",
             "description": "Test tenant for system management",
-            "authorization_provider": "idp-server",
-            "tenant_type": "BUSINESS"
+            "authorization_provider": "idp-server"
           },
           authorization_server: {
             "issuer": `http://localhost:8080/${adminServerConfig.tenantId}`,

--- a/e2e/src/tests/security/invalid_user_status_authorization.test.js
+++ b/e2e/src/tests/security/invalid_user_status_authorization.test.js
@@ -67,8 +67,7 @@ describe("User Status verification. Can not authorize when user status is not ac
           name: "Password Policy Test Tenant",
           domain: "http://localhost:8080",
           description: "Test tenant for password policy validation",
-          authorization_provider: "idp-server",
-          tenant_type: "BUSINESS"
+          authorization_provider: "idp-server"
         },
         authorization_server: {
           issuer: `${backendUrl}/${tenantId}`,
@@ -299,8 +298,7 @@ describe("User Status verification. Can not authorize when user status is not ac
           name: "Userinfo Status Test Tenant",
           domain: "http://localhost:8080",
           description: "Test tenant for userinfo status validation",
-          authorization_provider: "idp-server",
-          tenant_type: "BUSINESS"
+          authorization_provider: "idp-server"
         },
         authorization_server: {
           issuer: `${backendUrl}/${tenantId}`,
@@ -498,8 +496,7 @@ describe("User Status verification. Can not authorize when user status is not ac
           name: "Refresh Token Status Test Tenant",
           domain: "http://localhost:8080",
           description: "Test tenant for refresh token status validation",
-          authorization_provider: "idp-server",
-          tenant_type: "BUSINESS"
+          authorization_provider: "idp-server"
         },
         authorization_server: {
           issuer: `${backendUrl}/${tenantId}`,
@@ -729,8 +726,7 @@ describe("User Status verification. Can not authorize when user status is not ac
           name: "Password Grant Status Test Tenant",
           domain: "http://localhost:8080",
           description: "Test tenant for password grant status validation",
-          authorization_provider: "idp-server",
-          tenant_type: "BUSINESS"
+          authorization_provider: "idp-server"
         },
         authorization_server: {
           issuer: `${backendUrl}/${tenantId}`,
@@ -947,8 +943,7 @@ describe("User Status verification. Can not authorize when user status is not ac
           name: "Token Introspection Status Test Tenant",
           domain: "http://localhost:8080",
           description: "Test tenant for token introspection status validation",
-          authorization_provider: "idp-server",
-          tenant_type: "BUSINESS"
+          authorization_provider: "idp-server"
         },
         authorization_server: {
           issuer: `${backendUrl}/${tenantId}`,
@@ -1172,8 +1167,7 @@ describe("User Status verification. Can not authorize when user status is not ac
           name: "Token Introspection Extension Status Test Tenant",
           domain: "http://localhost:8080",
           description: "Test tenant for token introspection extension status validation",
-          authorization_provider: "idp-server",
-          tenant_type: "BUSINESS"
+          authorization_provider: "idp-server"
         },
         authorization_server: {
           issuer: `${backendUrl}/${tenantId}`,
@@ -1400,8 +1394,7 @@ describe("User Status verification. Can not authorize when user status is not ac
           name: "User Deletion Test Tenant (Refresh Token)",
           domain: "http://localhost:8080",
           description: "Test tenant for user deletion after token issuance",
-          authorization_provider: "idp-server",
-          tenant_type: "BUSINESS"
+          authorization_provider: "idp-server"
         },
         authorization_server: {
           issuer: `${backendUrl}/${tenantId}`,
@@ -1606,8 +1599,7 @@ describe("User Status verification. Can not authorize when user status is not ac
           name: "User Deletion Test Tenant (Introspection)",
           domain: "http://localhost:8080",
           description: "Test tenant for user deletion after token issuance (introspection)",
-          authorization_provider: "idp-server",
-          tenant_type: "BUSINESS"
+          authorization_provider: "idp-server"
         },
         authorization_server: {
           issuer: `${backendUrl}/${tenantId}`,
@@ -1807,8 +1799,7 @@ describe("User Status verification. Can not authorize when user status is not ac
           name: "CIBA User Status Test Tenant",
           domain: "http://localhost:8080",
           description: "Test tenant for CIBA user status validation",
-          authorization_provider: "idp-server",
-          tenant_type: "BUSINESS"
+          authorization_provider: "idp-server"
         },
         authorization_server: {
           issuer: `${backendUrl}/${tenantId}`,

--- a/e2e/src/tests/usecase/advance/advance-01-federation-security-event-user-name.test.js
+++ b/e2e/src/tests/usecase/advance/advance-01-federation-security-event-user-name.test.js
@@ -213,7 +213,6 @@ describe("Advance Use Case: Federation Security Event User Name (Issue #1131)", 
         name: `Provider Tenant ${timestamp}`,
         domain: backendUrl,
         authorization_provider: "idp-server",
-        tenant_type: "BUSINESS",
         session_config: {
           cookie_name: `FED_PROVIDER_${organizationId.substring(0, 8)}`,
           use_secure_cookie: false,

--- a/e2e/src/tests/usecase/device-credential/device-credential-04-device-secret-issuance.test.js
+++ b/e2e/src/tests/usecase/device-credential/device-credential-04-device-secret-issuance.test.js
@@ -80,7 +80,6 @@ describe("Device Credential Use Case: Device Secret Issuance via FIDO-UAF Regist
         name: `Device Secret FIDO-UAF Tenant ${timestamp}`,
         domain: backendUrl,
         authorization_provider: "idp-server",
-        tenant_type: "ORGANIZER",
         security_event_log_config: {
           format: "structured_json",
           stage: "processed",
@@ -918,7 +917,6 @@ describe("Device Credential Use Case: Device Secret Issuance via FIDO-UAF Regist
         name: `Device Secret ${algorithm} Tenant ${timestamp}`,
         domain: backendUrl,
         authorization_provider: "idp-server",
-        tenant_type: "ORGANIZER",
         security_event_log_config: {
           format: "structured_json",
           stage: "processed",
@@ -1266,7 +1264,6 @@ describe("Device Credential Use Case: Device Secret Issuance via FIDO-UAF Regist
         name: `No Device Secret Tenant ${timestamp}`,
         domain: backendUrl,
         authorization_provider: "idp-server",
-        tenant_type: "ORGANIZER",
         security_event_log_config: {
           format: "structured_json",
           stage: "processed",

--- a/e2e/src/tests/usecase/mfa/mfa-01-password-reset-email-auth.test.js
+++ b/e2e/src/tests/usecase/mfa/mfa-01-password-reset-email-auth.test.js
@@ -71,7 +71,6 @@ describe("Use Case: Password Reset with Email Authentication", () => {
         name: `Password Reset Tenant ${timestamp}`,
         domain: backendUrl,
         authorization_provider: "idp-server",
-        tenant_type: "ORGANIZER",
       },
       authorization_server: {
         issuer: `${backendUrl}/${tenantId}`,
@@ -605,7 +604,6 @@ describe("Use Case: Password Reset with Email Authentication", () => {
         name: `Scope Test Tenant ${timestamp}`,
         domain: backendUrl,
         authorization_provider: "idp-server",
-        tenant_type: "BUSINESS",
       },
       authorization_server: {
         issuer: `${backendUrl}/${testTenantId}`,
@@ -749,7 +747,6 @@ describe("Use Case: Password Reset with Email Authentication", () => {
         name: `Policy Test Tenant ${timestamp}`,
         domain: backendUrl,
         authorization_provider: "idp-server",
-        tenant_type: "BUSINESS",
         identity_policy_config: {
           identity_unique_key_type: "EMAIL_OR_EXTERNAL_USER_ID",
           password_policy: {
@@ -1134,7 +1131,6 @@ describe("Use Case: Password Reset with Email Authentication", () => {
         name: `Auth Policy Tenant ${timestamp}`,
         domain: backendUrl,
         authorization_provider: "idp-server",
-        tenant_type: "ORGANIZER",
       },
       authorization_server: {
         issuer: `${backendUrl}/${testTenantId}`,
@@ -1377,7 +1373,6 @@ describe("Use Case: Password Reset with Email Authentication", () => {
         name: `Multi-Policy Tenant ${timestamp}`,
         domain: backendUrl,
         authorization_provider: "idp-server",
-        tenant_type: "ORGANIZER",
       },
       authorization_server: {
         issuer: `${backendUrl}/${testTenantId}`,
@@ -1675,7 +1670,6 @@ describe("Use Case: Password Reset with Email Authentication", () => {
         name: `Client Policy Tenant ${timestamp}`,
         domain: backendUrl,
         authorization_provider: "idp-server",
-        tenant_type: "ORGANIZER",
       },
       authorization_server: {
         issuer: `${backendUrl}/${testTenantId}`,
@@ -2058,7 +2052,6 @@ describe("Use Case: Password Reset with Email Authentication", () => {
         name: `OTP Replay Tenant ${timestamp}`,
         domain: backendUrl,
         authorization_provider: "idp-server",
-        tenant_type: "ORGANIZER",
       },
       authorization_server: {
         issuer: `${backendUrl}/${testTenantId}`,
@@ -2391,7 +2384,6 @@ describe("Use Case: Password Reset with Email Authentication", () => {
         name: `ACR Policy Tenant ${timestamp}`,
         domain: backendUrl,
         authorization_provider: "idp-server",
-        tenant_type: "ORGANIZER",
       },
       authorization_server: {
         issuer: `${backendUrl}/${testTenantId}`,
@@ -2749,7 +2741,6 @@ describe("Use Case: Password Reset with Email Authentication", () => {
           name: `Executor Test Tenant ${timestamp}`,
           domain: backendUrl,
           authorization_provider: "idp-server",
-          tenant_type: "ORGANIZER",
         },
         authorization_server: {
           issuer: `${backendUrl}/${testTenantId}`,

--- a/e2e/src/tests/usecase/mfa/mfa-02-security-event-logging.test.js
+++ b/e2e/src/tests/usecase/mfa/mfa-02-security-event-logging.test.js
@@ -61,7 +61,6 @@ describe("Use Case: MFA Security Event Logging", () => {
         name: `MFA Security Event Tenant ${timestamp}`,
         domain: backendUrl,
         authorization_provider: "idp-server",
-        tenant_type: "ORGANIZER",
         security_event_log_config: {
           format: "structured_json",
           stage: "processed",

--- a/e2e/src/tests/usecase/mfa/mfa-03-fido-uaf-device-registration-acr-policy.test.js
+++ b/e2e/src/tests/usecase/mfa/mfa-03-fido-uaf-device-registration-acr-policy.test.js
@@ -72,7 +72,6 @@ describe("Use Case: FIDO-UAF Device Registration with ACR Policy", () => {
         name: `FIDO-UAF ACR Tenant ${timestamp}`,
         domain: backendUrl,
         authorization_provider: "idp-server",
-        tenant_type: "ORGANIZER",
         security_event_log_config: {
           format: "structured_json",
           stage: "processed",
@@ -622,7 +621,6 @@ describe("Use Case: FIDO-UAF Device Registration with ACR Policy", () => {
         name: `FIDO-UAF MFA Tenant ${timestamp}`,
         domain: backendUrl,
         authorization_provider: "idp-server",
-        tenant_type: "ORGANIZER",
         security_event_log_config: {
           format: "structured_json",
           stage: "processed",
@@ -1091,7 +1089,6 @@ describe("Use Case: FIDO-UAF Device Registration with ACR Policy", () => {
         name: `FIDO-UAF No ACR Tenant ${timestamp}`,
         domain: backendUrl,
         authorization_provider: "idp-server",
-        tenant_type: "ORGANIZER",
         security_event_log_config: {
           format: "structured_json",
           stage: "processed",

--- a/e2e/src/tests/usecase/mfa/mfa-04-fido2-device-registration-acr-policy.test.js
+++ b/e2e/src/tests/usecase/mfa/mfa-04-fido2-device-registration-acr-policy.test.js
@@ -76,7 +76,6 @@ describe("Use Case: FIDO2 Device Registration with ACR Policy", () => {
         name: `FIDO2 ACR Tenant ${timestamp}`,
         domain: backendUrl,
         authorization_provider: "idp-server",
-        tenant_type: "ORGANIZER",
         security_event_log_config: {
           format: "structured_json",
           stage: "processed",
@@ -639,7 +638,6 @@ describe("Use Case: FIDO2 Device Registration with ACR Policy", () => {
         name: `FIDO2 MFA Tenant ${timestamp}`,
         domain: backendUrl,
         authorization_provider: "idp-server",
-        tenant_type: "ORGANIZER",
         security_event_log_config: {
           format: "structured_json",
           stage: "processed",
@@ -1127,7 +1125,6 @@ describe("Use Case: FIDO2 Device Registration with ACR Policy", () => {
         name: `FIDO2 Unauth Tenant ${timestamp}`,
         domain: backendUrl,
         authorization_provider: "idp-server",
-        tenant_type: "ORGANIZER",
         security_event_log_config: {
           format: "structured_json",
           stage: "processed",
@@ -1437,7 +1434,6 @@ describe("Use Case: FIDO2 Device Registration with ACR Policy", () => {
         name: `FIDO2 Full Flow Tenant ${timestamp}`,
         domain: backendUrl,
         authorization_provider: "idp-server",
-        tenant_type: "ORGANIZER",
         security_event_log_config: {
           format: "structured_json",
           stage: "processed",

--- a/e2e/src/tests/usecase/mfa/mfa-05-fido2-authentication-and-security.test.js
+++ b/e2e/src/tests/usecase/mfa/mfa-05-fido2-authentication-and-security.test.js
@@ -72,7 +72,6 @@ describe("FIDO2 Authentication and Security Tests", () => {
         name: `FIDO2 Error Tenant ${timestamp}`,
         domain: backendUrl,
         authorization_provider: "idp-server",
-        tenant_type: "ORGANIZER",
       },
       authorization_server: {
         issuer: `${backendUrl}/${tenantId}`,
@@ -433,7 +432,6 @@ describe("FIDO2 Authentication and Security Tests", () => {
         name: `CVE Test Tenant ${timestamp}`,
         domain: backendUrl,
         authorization_provider: "idp-server",
-        tenant_type: "ORGANIZER",
       },
       authorization_server: {
         issuer: `${backendUrl}/${tenantId}`,

--- a/e2e/src/tests/usecase/mfa/mfa-06-fido2-attestation-verification.test.js
+++ b/e2e/src/tests/usecase/mfa/mfa-06-fido2-attestation-verification.test.js
@@ -694,7 +694,6 @@ function createOnboardingRequest(organizationId, tenantId, timestamp, jwks, redi
       name: `Attestation Tenant ${timestamp}`,
       domain: backendUrl,
       authorization_provider: "idp-server",
-      tenant_type: "ORGANIZER",
     },
     authorization_server: {
       issuer: `${backendUrl}/${tenantId}`,


### PR DESCRIPTION
## Summary
- PR #1482 で `TenantType` enum を `ADMIN/ORGANIZER/PUBLIC` に刷新し、テナント作成API・オンボーディングAPIがサーバー側で `tenant_type` をハードコードするようになった
- E2Eテストのリクエストボディに残存していた旧 `tenant_type`（`BUSINESS`/`ORGANIZER`）フィールドを削除
- `INVALID_TYPE` のエラーハンドリングテストは正しく保持

## 変更内容
- `tenant_type: "BUSINESS"` を35箇所以上削除（scenario/control_plane, security, usecase/advance, usecase/mfa）
- `tenant_type: "ORGANIZER"` を25箇所削除（usecase/mfa, usecase/device-credential, integration）
- 22ファイル修正（+36 -99）

## Test plan
- [x] 既存E2Eテストがtenant_typeなしで通ること
- [x] `INVALID_TYPE` テストケースが引き続きエラーハンドリングを検証すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)