### PR TITLE
docs: オンボーディングAPIをDocusaurusに追加

### DIFF
--- a/documentation/docs/content_07_reference/api-reference.md
+++ b/documentation/docs/content_07_reference/api-reference.md
@@ -14,6 +14,7 @@
 
 ### コントロールプレーン用のAPI仕様
 
+- [オンボーディングAPI](cp-onboarding-api-ja)
 - [テナント管理API](cp-tenant-api-ja)
 - [Grant管理API](api-grant-management-ja)
 - [クライアント管理API](cp-client-api-ja)

--- a/documentation/docusaurus.config.js
+++ b/documentation/docusaurus.config.js
@@ -145,6 +145,10 @@ const config = {
             spec: 'openapi/swagger-authentication-interaction-ja.yaml',
             route: '/docs/content_07_reference/api-authentication-interaction-ja/',
           },
+          {
+            spec: 'openapi/swagger-cp-onboarding-ja.yaml',
+            route: '/docs/content_07_reference/cp-onboarding-api-ja/',
+          },
         ],
         // Theme Options for modifying how redoc renders them
         theme: {

--- a/documentation/openapi/swagger-cp-onboarding-ja.yaml
+++ b/documentation/openapi/swagger-cp-onboarding-ja.yaml
@@ -238,7 +238,7 @@ components:
         enabled:
           type: boolean
           default: true
-          description: テナントの有効/無効フラグ（デフォルト: true）
+          description: "テナントの有効/無効フラグ（デフォルト: true）"
     AuthorizationServerRegistration:
       type: object
       description: |


### PR DESCRIPTION
## Summary
- redocusaurusに `swagger-cp-onboarding-ja.yaml` を登録し、Redocで表示可能に
- `api-reference.md` にオンボーディングAPIのリンクを追加
- `swagger-cp-onboarding-ja.yaml` のYAMLパースエラーを修正（descriptionのクォート）

## Test plan
- [ ] `cd documentation && npm run build` が成功すること
- [ ] `/docs/content_07_reference/cp-onboarding-api-ja/` でRedoc表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)