### PR TITLE
docs-fix: IDトークンヘッダーからtyp記載を削除

### DIFF
--- a/documentation/openapi/swagger-rp-ja.yaml
+++ b/documentation/openapi/swagger-rp-ja.yaml
@@ -2043,7 +2043,6 @@ components:
             |-----------|------|------|
             | `alg` | string | 署名アルゴリズム（例: `RS256`, `ES256`） |
             | `kid` | string | 署名に使用した鍵の Key ID（`jwks_uri` で公開鍵を取得可能） |
-            | `typ` | string | トークンタイプ（通常 `JWT`） |
 
             ---
 


### PR DESCRIPTION
## Summary
- `swagger-rp-ja.yaml` の ID トークン Header テーブルから `typ` フィールドの記載を削除
- 実装（`JsonWebSignatureFactory`）では `JWSHeader.Builder` で `alg` と `kid` のみ設定しており、`typ` は含まれない

## Test plan
- [x] 実装コード（`JsonWebSignatureFactory.java`）で `typ` が設定されていないことを確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)