### PR TITLE
docs-fix: introspection-extensionsのエラーレスポンスをHTTPステータス別に分離

### DIFF
--- a/documentation/openapi/swagger-rp-ja.yaml
+++ b/documentation/openapi/swagger-rp-ja.yaml
@@ -744,7 +744,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/TokenIntrospectionExtensionErrorResponse'
+                $ref: '#/components/schemas/TokenIntrospectionExtensionClientErrorResponse'
         '429':
           $ref: '#/components/responses/TooManyRequests'
         '500':
@@ -2490,8 +2490,8 @@ components:
     TokenIntrospectionExtensionErrorResponse:
       type: object
       description: |
-        RFC 7662 拡張イントロスペクションのエラーレスポンス。
-        トークンが無効・期限切れ・スコープ不足・クライアント認証失敗等の場合に返却されます。
+        RFC 7662 拡張イントロスペクションのトークン検証エラーレスポンス（HTTP 200）。
+        トークンが無効・期限切れ・スコープ不足等の場合に返却されます。
         HTTP ステータスは 200 ですが、`active: false` とエラー詳細で判別します。
       required:
         - active
@@ -2507,13 +2507,11 @@ components:
           enum:
             - invalid_token
             - insufficient_scope
-            - invalid_client
             - server_error
           description: |
             エラーの種類。
-            - `invalid_token`: トークンが存在しない、期限切れ、またはユーザーが無効
+            - `invalid_token`: トークンが存在しない、期限切れ、ユーザーが無効、証明書不一致
             - `insufficient_scope`: 要求されたスコープがトークンに含まれていない
-            - `invalid_client`: クライアント認証失敗、クライアント設定が見つからない
             - `server_error`: サーバー内部エラー
         error_description:
           type: string
@@ -2524,11 +2522,41 @@ components:
           description: |
             エラーに対応する論理的なHTTPステータスコード。
             リソースサーバーがクライアントに返すべきステータスの参考値として使用できます。
-            - `400`: 不正なリクエスト（invalid_client）
             - `401`: 認証エラー（invalid_token、ユーザー無効、証明書不一致）
             - `403`: 権限不足（insufficient_scope）
             - `500`: サーバーエラー
           example: 401
+    TokenIntrospectionExtensionClientErrorResponse:
+      type: object
+      description: |
+        RFC 7662 拡張イントロスペクションのクライアント認証エラーレスポンス（HTTP 400）。
+        クライアント認証失敗、未登録クライアント、認証情報なし等の場合に返却されます。
+      required:
+        - active
+        - error
+        - status_code
+      properties:
+        active:
+          type: boolean
+          description: 常に `false`。
+          example: false
+        error:
+          type: string
+          enum:
+            - invalid_request
+            - invalid_client
+          description: |
+            エラーの種類。
+            - `invalid_request`: 必須パラメータの欠落、不正な形式
+            - `invalid_client`: クライアントシークレット不一致、未登録クライアント、認証情報なし、サーバー設定未発見
+        error_description:
+          type: string
+          description: エラーの詳細説明。原因の特定に使用できます。
+          example: "Client authentication failed: method=client_secret_post, client_id=xxx, reason=client_secret does not match"
+        status_code:
+          type: integer
+          description: 常に `400`。
+          example: 400
 
 
     TokenRevocationRequest:


### PR DESCRIPTION
## Summary
- `TokenIntrospectionExtensionErrorResponse`（HTTP 200）から `invalid_client` を除外
- `TokenIntrospectionExtensionClientErrorResponse`（HTTP 400）を新規追加
- 実装の `TokenIntrospectionErrorHandler` に基づき、error enum をHTTPステータス別に正確に分離

## 根拠
実装を確認した結果、`invalid_client` は常に `BAD_REQUEST(400)` で返却され、HTTP 200 では返らない:
- `ClientUnAuthorizedException` → HTTP 400
- `ClientConfigurationNotFoundException` → HTTP 400
- `ServerConfigurationNotFoundException` → HTTP 400

一方、HTTP 200 + `active: false` で返るのは:
- `TokenInvalidException` → `invalid_token` (status_code: 401)
- `TokenUserInactiveException` → `invalid_token` (status_code: 401)
- `TokenCertificationBindingInvalidException` → `invalid_token` (status_code: 401)
- `TokenInsufficientScopeException` → `insufficient_scope` (status_code: 403)
- その他例外 → `server_error` (status_code: 500)

## Test plan
- [x] 既存E2Eテスト（`token_introspection_extensions.test.js`）で全パターン検証済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)