### PR TITLE
fix: OPSession/ClientSessionにJsonReadableを追加し未知フィールドを許容

### DIFF
--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/session/ClientSession.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/session/ClientSession.java
@@ -21,9 +21,10 @@ import java.time.Instant;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import org.idp.server.platform.json.JsonReadable;
 import org.idp.server.platform.multi_tenancy.tenant.TenantIdentifier;
 
-public class ClientSession implements Serializable {
+public class ClientSession implements Serializable, JsonReadable {
 
   private ClientSessionIdentifier sid;
   private OPSessionIdentifier opSessionId;

--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/session/OPSession.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/session/OPSession.java
@@ -27,9 +27,10 @@ import org.idp.server.core.openid.authentication.Authentication;
 import org.idp.server.core.openid.authentication.AuthenticationInteractionResults;
 import org.idp.server.core.openid.identity.User;
 import org.idp.server.core.openid.identity.UserIdentifier;
+import org.idp.server.platform.json.JsonReadable;
 import org.idp.server.platform.multi_tenancy.tenant.TenantIdentifier;
 
-public class OPSession implements Serializable {
+public class OPSession implements Serializable, JsonReadable {
 
   private OPSessionIdentifier id;
   private TenantIdentifier tenantId;

--- a/libs/idp-server-core/src/test/java/org/idp/server/core/openid/session/OPSessionSerializationTest.java
+++ b/libs/idp-server-core/src/test/java/org/idp/server/core/openid/session/OPSessionSerializationTest.java
@@ -162,6 +162,51 @@ class OPSessionSerializationTest {
     }
   }
 
+  @Nested
+  class UnknownFieldHandling {
+
+    @Test
+    void ignoresUnknownFieldsInOPSession() {
+      // FAIL_ON_UNKNOWN_PROPERTIES=false により、未知フィールドを無視してデシリアライズできる
+      // → Jackson 3 で新フィールドが追加されても、ロールバック後の Jackson 2 で読める
+      OPSession original = createTestSession();
+      String json = jsonConverter.write(original);
+
+      // 未知フィールドを注入（Jackson 3 で追加される可能性のあるフィールドを想定）
+      String jsonWithUnknownFields =
+          json.substring(0, json.length() - 1)
+              + ",\"new_feature_flag\":true"
+              + ",\"migration_metadata\":{\"version\":3}"
+              + "}";
+
+      OPSession restored =
+          assertDoesNotThrow(
+              () -> jsonConverter.read(jsonWithUnknownFields, OPSession.class),
+              "OPSession should ignore unknown fields for rollback safety");
+
+      assertEquals(original.id().value(), restored.id().value());
+      assertEquals(original.tenantId().value(), restored.tenantId().value());
+      assertEquals(original.status(), restored.status());
+    }
+
+    @Test
+    void ignoresUnknownFieldsInClientSession() {
+      String json =
+          "{\"sid\":{\"value\":\"cs_test\"},"
+              + "\"op_session_id\":{\"value\":\"ops_test\"},"
+              + "\"status\":\"ACTIVE\","
+              + "\"unknown_new_field\":\"value\"}";
+
+      ClientSession restored =
+          assertDoesNotThrow(
+              () -> jsonConverter.read(json, ClientSession.class),
+              "ClientSession should ignore unknown fields for rollback safety");
+
+      assertEquals("cs_test", restored.sid().value());
+      assertEquals(SessionStatus.ACTIVE, restored.status());
+    }
+  }
+
   private OPSession createTestSession() {
     return createSessionWithInteractionResults(Map.of());
   }

--- a/libs/idp-server-platform/src/test/java/org/idp/server/platform/json/JacksonSerializationFormatTest.java
+++ b/libs/idp-server-platform/src/test/java/org/idp/server/platform/json/JacksonSerializationFormatTest.java
@@ -226,19 +226,37 @@ class JacksonSerializationFormatTest {
     }
 
     @Test
-    void rejectsUnknownFields() {
-      // Jackson 2 のデフォルト: FAIL_ON_UNKNOWN_PROPERTIES=true
-      // 未知フィールドが含まれると例外が発生する
-      // → Jackson 3 で新フィールドが追加された場合、Jackson 2 でのロールバック時に問題になる可能性
+    void rejectsUnknownFieldsByDefault() {
+      // JsonConverter のデフォルト: FAIL_ON_UNKNOWN_PROPERTIES=true
+      // JsonReadable を実装しないクラスは未知フィールドでエラーになる
+      // → 設定 JSON や API リクエストの typo を検出できる
       String json =
           "{\"id\":\"ops_test\",\"status\":\"ACTIVE\","
-              + "\"unknown_field\":\"should_be_ignored\","
+              + "\"unknown_field\":\"should_be_rejected\","
               + "\"another_new_field\":123}";
 
       assertThrows(
           JsonRuntimeException.class,
           () -> snakeCaseConverter.read(json, SessionLikeObject.class),
-          "Unknown fields should cause deserialization failure with default Jackson 2 settings");
+          "Classes without JsonReadable should reject unknown fields");
+    }
+
+    @Test
+    void ignoresUnknownFieldsWithJsonReadable() {
+      // JsonReadable を実装したクラスは未知フィールドを無視する
+      // → Jackson 3 移行時のロールバック安全性を確保
+      String json =
+          "{\"id\":\"ops_test\",\"status\":\"ACTIVE\","
+              + "\"unknown_field\":\"should_be_ignored\","
+              + "\"another_new_field\":123}";
+
+      JsonReadableSessionLikeObject result =
+          assertDoesNotThrow(
+              () -> snakeCaseConverter.read(json, JsonReadableSessionLikeObject.class),
+              "Classes with JsonReadable should ignore unknown fields");
+
+      assertEquals("ops_test", result.id);
+      assertEquals(Status.ACTIVE, result.status);
     }
   }
 
@@ -279,5 +297,12 @@ class JacksonSerializationFormatTest {
     Map<String, String> metadata;
 
     SessionLikeObject() {}
+  }
+
+  static class JsonReadableSessionLikeObject implements JsonReadable {
+    String id;
+    Status status;
+
+    JsonReadableSessionLikeObject() {}
   }
 }


### PR DESCRIPTION
## Summary
- Jackson 2→3 移行（PR #1424）のロールバック安全性を確保
- OPSession / ClientSession に `JsonReadable` を追加し、未知フィールドを無視するように変更
- `JsonConverter` のグローバル設定は変更せず、影響範囲をセッション系に限定

## 背景
Jackson 2 のデフォルト `FAIL_ON_UNKNOWN_PROPERTIES=true` では、JSON に未知フィールドが含まれるとデシリアライズが失敗する。Jackson 3 でシリアライズされたセッションデータを Jackson 2 で読み込む際に例外が発生し、**ロールバック時に全セッションが読めなくなるリスク**がある。

## 変更内容
- `OPSession`: `implements JsonReadable` 追加
- `ClientSession`: `implements JsonReadable` 追加
- テスト: 未知フィールドの無視/拒否を両パターンで検証

## 影響範囲
- セッション系クラス: 未知フィールドを無視（ロールバック安全）
- 設定 JSON / API リクエスト: 未知フィールドでエラー（typo 検出を維持）

## Test plan
- [x] `./gradlew build` — BUILD SUCCESSFUL
- [x] OPSession / ClientSession が未知フィールドを無視できることを検証
- [x] JsonReadable なしのクラスが未知フィールドで例外になることを検証

🤖 Generated with [Claude Code](https://claude.com/claude-code)