### PR TITLE
fix: 身元確認申込みAPI仕様と実装の不一致を修正しE2Eテストを強化

### DIFF
--- a/documentation/openapi/swagger-resource-owner-ja.yaml
+++ b/documentation/openapi/swagger-resource-owner-ja.yaml
@@ -754,8 +754,12 @@ paths:
         - $ref: '#/components/parameters/VerificationType'
         - $ref: '#/components/parameters/ApplicationId'
       responses:
-        '204':
-          description: No Content
+        '200':
+          description: 削除成功
+          content:
+            application/json:
+              schema:
+                type: object
         '400':
           $ref: '#/components/responses/BadRequest'
         '401':
@@ -951,6 +955,14 @@ components:
               error:
                 type: string
                 example: "invalid_request"
+                description: |
+                  エラーコード。以下の値を取りうる:
+
+                  | error 値 | 説明 |
+                  |---------|------|
+                  | `invalid_request` | リクエストパラメータの不正、JSON Schema 検証エラー、プロセスシーケンスエラー |
+                  | `pre_hook_validation_failed` | Pre-hook バリデーション失敗（ユーザークレーム検証、重複申込み検知等） |
+                  | `execution_failed` | 外部サービス実行エラー（`error_details` に詳細が含まれる） |
               error_description:
                 type: string
                 example: "Request validation failed"
@@ -963,7 +975,7 @@ components:
               error_details:
                 type: object
                 description: |
-                  外部サービス実行時のエラー詳細情報（execution_failed の場合のみ）。オプショナル。
+                  外部サービス実行時のエラー詳細情報（`execution_failed` の場合のみ）。オプショナル。
                 required:
                   - execution_type
                   - status_category
@@ -1006,6 +1018,12 @@ components:
                 error_description: "Process sequence violation"
                 error_messages:
                   - "process 'complete-verification' is not available at current state"
+            pre_hook_validation_failed:
+              value:
+                error: "pre_hook_validation_failed"
+                error_description: "Pre-hook validation failed for identity verification request"
+                error_messages:
+                  - "User claim verification failed. unmatched: $.request_body.email_address, user:email"
             external_service_400:
               value:
                 error: "execution_failed"

--- a/e2e/src/tests/integration/ida/integration-05-identity-verification-error-handling.test.js
+++ b/e2e/src/tests/integration/ida/integration-05-identity-verification-error-handling.test.js
@@ -297,6 +297,53 @@ describe("Identity Verification Error Handling", () => {
 
   });
 
+  describe("403 Forbidden - Insufficient Scope Tests", () => {
+
+    it("should return 403 when deleting application without identity_verification_application_delete scope", async () => {
+      console.log("\n🧪 Test: 403 - DELETE without identity_verification_application_delete scope");
+
+      // Create a token WITHOUT identity_verification_application_delete scope
+      const { user: noDeleteScopeUser, accessToken: noDeleteScopeToken } = await createFederatedUser({
+        serverConfig: serverConfig,
+        federationServerConfig: federationServerConfig,
+        client: clientSecretPostClient,
+        adminClient: clientSecretPostClient,
+        scope: "openid profile phone email identity_verification_application identity_verification_result " + clientSecretPostClient.identityVerificationScope
+      });
+
+      // First create an application with the limited-scope token
+      const applyUrl = `${backendUrl}/${tenantId}/v1/me/identity-verification/applications/${configurationType}/apply`;
+      const applyResponse = await postWithJson({
+        url: applyUrl,
+        body: { "name": "Delete Scope Test" },
+        headers: {
+          "Content-Type": "application/json",
+          "Authorization": `Bearer ${noDeleteScopeToken}`
+        }
+      });
+      expect(applyResponse.status).toBe(200);
+      const applicationId = applyResponse.data.id;
+
+      // Attempt to delete without the required scope
+      const deleteUrl = `${backendUrl}/${tenantId}/v1/me/identity-verification/applications/${configurationType}/${applicationId}`;
+      const deleteResponse = await deletion({
+        url: deleteUrl,
+        headers: {
+          "Content-Type": "application/json",
+          "Authorization": `Bearer ${noDeleteScopeToken}`
+        }
+      });
+
+      console.log(`Response status: ${deleteResponse.status}`);
+      console.log("Response data:", JSON.stringify(deleteResponse.data, null, 2));
+
+      expect(deleteResponse.status).toBe(403);
+
+      console.log("✅ Correctly returned 403 for DELETE without identity_verification_application_delete scope");
+    });
+
+  });
+
   describe("404 Not Found Tests", () => {
 
     it("should return 404 when accessing subsequent process with non-existent application ID", async () => {

--- a/e2e/src/tests/scenario/application/scenario-05-identity_verification-application.test.js
+++ b/e2e/src/tests/scenario/application/scenario-05-identity_verification-application.test.js
@@ -127,6 +127,21 @@ describe("identity-verification application", () => {
       expect(applicationsResponse.data.list[0].status).toEqual("applying");
       expect(applicationsResponse.data.list[0]).toHaveProperty("requested_at");
       expect(applicationsResponse.data.list[0].attributes.label).toEqual("証券口座開設");
+      expect(applicationsResponse.data.list[0]).toHaveProperty("processes");
+      const processes = applicationsResponse.data.list[0].processes;
+      console.log("processes:", JSON.stringify(processes, null, 2));
+      // apply, request-ekyc, complete-ekyc have been called
+      expect(processes).toHaveProperty("apply");
+      expect(processes.apply).toHaveProperty("call_count");
+      expect(processes.apply).toHaveProperty("success_count");
+      expect(processes.apply).toHaveProperty("failure_count");
+      expect(processes.apply.call_count).toBeGreaterThanOrEqual(1);
+      expect(processes.apply.success_count).toBeGreaterThanOrEqual(1);
+      // pagination fields
+      expect(applicationsResponse.data).toHaveProperty("total_count");
+      expect(applicationsResponse.data.total_count).toBeGreaterThanOrEqual(1);
+      expect(applicationsResponse.data).toHaveProperty("limit");
+      expect(applicationsResponse.data).toHaveProperty("offset");
 
       const registrationResponse = await post({
         url: processEndpoint.replace("{process}", "crm-registration"),
@@ -422,6 +437,7 @@ describe("identity-verification application", () => {
       expect(resultsResponse.status).toBe(200);
       expect(resultsResponse.data.list.length).toBe(1);
       expect(resultsResponse.data.list[0]).toHaveProperty("id");
+      expect(resultsResponse.data.list[0]).toHaveProperty("application_id");
       expect(resultsResponse.data.list[0].type).toEqual(type);
       expect(resultsResponse.data.list[0].tenant_id).toEqual(serverConfig.tenantId);
       expect(resultsResponse.data.list[0].user_id).toEqual(user.sub);
@@ -429,7 +445,13 @@ describe("identity-verification application", () => {
       expect(resultsResponse.data.list[0]).toHaveProperty("source_details");
       expect(resultsResponse.data.list[0].source_details.status).not.toBeNull();
       expect(resultsResponse.data.list[0]).toHaveProperty("verified_at");
+      expect(resultsResponse.data.list[0]).toHaveProperty("verified_claims");
       expect(resultsResponse.data.list[0].attributes.label).toEqual("証券口座開設");
+      // pagination fields
+      expect(resultsResponse.data).toHaveProperty("total_count");
+      expect(resultsResponse.data.total_count).toBeGreaterThanOrEqual(1);
+      expect(resultsResponse.data).toHaveProperty("limit");
+      expect(resultsResponse.data).toHaveProperty("offset");
 
       const deleteUrl = serverConfig.identityVerificationApplicationsDeletionEndpoint
         .replace("{type}", type)


### PR DESCRIPTION
## Summary
- 身元確認申込みAPIのOpenAPI specと実装の不一致を調査・修正
- 不足していたE2Eテストを追加

## OpenAPI spec修正

| 項目 | 修正前 | 修正後 | 根拠 |
|------|--------|--------|------|
| DELETE レスポンスコード | `204 No Content` | `200 OK` | 実装は `IdentityVerificationApplicationResponse.OK(Map.of())` を返す。Status enum に 204 が存在しない |
| BadRequest `error` 値 | `invalid_request` のみ例示 | `invalid_request`, `pre_hook_validation_failed`, `execution_failed` の一覧表追記 | `IdentityVerificationErrorDetails.ErrorCodes` の定数定義 |
| `pre_hook_validation_failed` example | なし | 追加 | E2Eテスト（scenario-05 email unmatched）で確認済み |

## E2Eテスト追加

| テスト | ファイル | 検証内容 |
|--------|---------|---------|
| DELETE スコープ不足 403 | integration-05 | `identity_verification_application_delete` スコープなしで DELETE → 403 |
| 一覧取得ページネーション | scenario-05 | `total_count`, `limit`, `offset` の存在と値 |
| processes フィールド | scenario-05 | `call_count`, `success_count`, `failure_count` の存在と値 |
| 結果一覧レスポンス | scenario-05 | `verified_claims`, `application_id`, ページネーションフィールド |

## 調査で確認した一致項目（修正不要）
- DELETE スコープ: SecurityConfig で `identity_verification_application_delete` を正しく要求
- `error_messages`: BadRequest schema に定義済み
- `evaluate-result`: 固定エンドポイントではなく process 名（後続処理APIでカバー）
- callback: internal API（別 spec 管轄）

## Test plan
- [x] integration-05: DELETE スコープ不足 403 テスト通過
- [x] scenario-05: investment-account-opening 全テスト通過（processes, pagination含む）

🤖 Generated with [Claude Code](https://claude.com/claude-code)