### PR TITLE
fix: IdentityVerification の全 context に user を追加

### DIFF
--- a/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/application/enduser/IdentityVerificationApplicationEntryService.java
+++ b/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/application/enduser/IdentityVerificationApplicationEntryService.java
@@ -168,6 +168,7 @@ public class IdentityVerificationApplicationEntryService
         new IdentityVerificationContextBuilder()
             .previousContext(applyingResult.applicationContext())
             .application(application)
+            .user(user)
             .build();
     Map<String, Object> response =
         IdentityVerificationDynamicResponseMapper.buildDynamicResponse(
@@ -334,6 +335,7 @@ public class IdentityVerificationApplicationEntryService
         new IdentityVerificationContextBuilder()
             .previousContext(applyingResult.applicationContext())
             .application(application)
+            .user(user)
             .build();
 
     Map<String, Object> response =

--- a/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/application/identity_verification_service/IdentityVerificationCallbackEntryService.java
+++ b/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/application/identity_verification_service/IdentityVerificationCallbackEntryService.java
@@ -184,18 +184,19 @@ public class IdentityVerificationCallbackEntryService implements IdentityVerific
       IdentityVerificationConfiguration verificationConfiguration,
       Tenant tenant,
       IdentityVerificationProcessConfiguration processConfiguration) {
+    User user = userQueryRepository.get(tenant, application.userIdentifier());
+
     IdentityVerificationContext context =
         new IdentityVerificationContextBuilder()
             .request(request)
             .requestAttributes(requestAttributes)
             .application(application)
+            .user(user)
             .build();
 
     IdentityVerificationApplication updatedApplication =
         application.updateCallbackWith(process, context, verificationConfiguration);
     applicationCommandRepository.update(tenant, updatedApplication);
-
-    User user = userQueryRepository.get(tenant, application.userIdentifier());
 
     if (updatedApplication.isApproved()) {
       IdentityVerificationResult identityVerificationResult =

--- a/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/application/identity_verification_service/IdentityVerificationEntryService.java
+++ b/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/application/identity_verification_service/IdentityVerificationEntryService.java
@@ -121,6 +121,7 @@ public class IdentityVerificationEntryService implements IdentityVerificationApi
         new IdentityVerificationContextBuilder()
             .request(request)
             .requestAttributes(requestAttributes)
+            .user(user)
             .build();
 
     IdentityVerificationResult identityVerificationResult =


### PR DESCRIPTION
## Summary

- IdentityVerification の context 構築で `.user(user)` が抜けていた全箇所を修正
- `$.user.*` を参照する mapping_rules が全経路で正しく動作するようになる

## 問題

callback 経路・direct registration 経路・レスポンス生成時の context に `user` が含まれておらず、`$.user.verified_claims.claims.*` 等が常に `null` に解決されていた。

ドキュメント（02-application.md）ではコンテキストデータとして `$.user` が利用可能と記載されているが、実装が追いついていなかった。

## 修正箇所

| ファイル | 箇所 | 用途 |
|---------|------|------|
| `IdentityVerificationCallbackEntryService` | context 構築 | callback の verified_claims_mapping_rules |
| `IdentityVerificationEntryService` | context 構築 | direct registration の verified_claims_mapping_rules |
| `IdentityVerificationApplicationEntryService` | apply レスポンス | body_mapping_rules |
| `IdentityVerificationApplicationEntryService` | process レスポンス | body_mapping_rules |

## 影響

PR #1511 で追加された merge/append/pluck の累積マッピング（`$.user.verified_claims.claims.*` を読んで既存データにマージ）が callback/direct 経由でも動作するようになる。

Closes #1516

## Test plan

- [x] ビルド通過
- [x] 既存 E2E テスト（integration-09, integration-10）が evaluate-result 経由で動作確認済み
- [ ] callback 経由の E2E テストは別途追加予定

🤖 Generated with [Claude Code](https://claude.com/claude-code)