### PR TITLE
e2e-fix: B-27 unreachable URL テストの環境依存性を解消 (RFC 6761 .invalid TLD 使用)

### DIFF
--- a/e2e/src/tests/usecase/advance/advance-12-external-auth-config-effects.test.js
+++ b/e2e/src/tests/usecase/advance/advance-12-external-auth-config-effects.test.js
@@ -189,8 +189,12 @@ describe("Advance Use Case: External Password Auth Config Effects", () => {
   it("B-27: unreachable external auth URL causes authentication error", async () => {
     console.log("\n=== Unreachable External Auth URL ===");
 
+    // RFC 6761 §6.4: ".invalid" は予約 TLD で必ず DNS 解決失敗する。
+    // host.docker.internal:9999 を使うと OIDF Conformance Suite (port 9999 に JDWP listen)
+    // が稼働している環境で TCP connect が成功してしまい、502 (Bad Gateway) が返って
+    // テストが落ちる。UnknownHostException を確実に発生させて 503 を担保する。
     const env = await createExternalAuthEnv({
-      authUrl: "http://host.docker.internal:9999/auth/not-exist",
+      authUrl: "http://nonexistent-auth.invalid:9999/auth/not-exist",
       providerId: "unreachable",
     });
     try {


### PR DESCRIPTION
## Summary

E2E テスト B-27 (unreachable external auth URL → 503 期待) が、ローカルマシンで OIDF Conformance Suite を同時稼働させている環境で 502 になり失敗する不具合を修正。

## 原因

\`conformance-suite-server-1\` コンテナが port 9999 に JDWP (Java Debug Wire Protocol) debugger として listen しているため、本テストが使う \`http://host.docker.internal:9999/auth/not-exist\` は **TCP connect が成功してしまう**。

### 実際に発生していた挙動

| レイヤ | 期待 (test 設計) | 実態 (port 9999 = JDWP) |
|-------|----------------|----------------------|
| TCP connect | 失敗 (Connection refused) | **成功** (JDWP が listen) |
| HTTP リクエスト | (TCP 失敗で送信前に終わる) | 送信される |
| HTTP レスポンス | (発生しない) | **空レスポンス** (JDWP が "これ debugger ハンドシェイクじゃない" で close) |
| idp-server の解釈 | "unreachable" → 503 | "malformed/empty response" → **502 Bad Gateway** |

### 確認

\`docker logs conformance-suite-server-1\` に証拠あり:
\`\`\`
Debugger failed to attach: handshake failed - received >POST /auth/not< - expected >JDWP-Handshake<
\`\`\`

3/22 以降 503 で pass していたが、最近 502 で失敗するようになっていたのは、conformance-suite を上げっぱなしにしている開発者環境で発生する。

## 修正内容

\`authUrl\` を \`host.docker.internal:9999\` → \`nonexistent-auth.invalid:9999\` に変更。

**RFC 6761 §6.4** の予約 TLD \`.invalid\` を使うことで、DNS 解決失敗 (UnknownHostException) を確実に発生させ、ローカル環境の port 占有状況に依存しない真の "unreachable" を実現。

## 検証

- conformance-suite-server-1 稼働中 + 修正適用 → \`status=503\` で pass ✅
- 同 testfile の全 2 件 pass、regression なし ✅

## Test plan

- [x] B-27 単体テストで status=503 が返ることを確認
- [x] testfile 全体で regression なし
- [ ] CI で安定動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)