### PR TITLE
fix: webauthn4j を 0.31.5 にバンプして FIDO MDS BLOB v242 パースエラーを解消

### DIFF
--- a/libs/idp-server-springboot-adapter/build.gradle
+++ b/libs/idp-server-springboot-adapter/build.gradle
@@ -39,7 +39,7 @@ dependencies {
 	implementation 'org.springframework.session:spring-session-core'
 
 	//webauthn
-	implementation 'com.webauthn4j:webauthn4j-core:0.28.5.RELEASE'
+	implementation 'com.webauthn4j:webauthn4j-core:0.31.5.RELEASE'
 
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 

--- a/libs/idp-server-webauthn4j-adapter/build.gradle
+++ b/libs/idp-server-webauthn4j-adapter/build.gradle
@@ -15,8 +15,8 @@ dependencies {
 	implementation project(':libs:idp-server-platform')
 	implementation project(':libs:idp-server-core')
 	implementation project(':libs:idp-server-authentication-interactors')
-	implementation 'com.webauthn4j:webauthn4j-core:0.30.0.RELEASE'
-	implementation 'com.webauthn4j:webauthn4j-metadata:0.30.0.RELEASE'
+	implementation 'com.webauthn4j:webauthn4j-core:0.31.5.RELEASE'
+	implementation 'com.webauthn4j:webauthn4j-metadata:0.31.5.RELEASE'
 
 	testImplementation platform('org.junit:junit-bom:5.10.0')
 	testImplementation 'org.junit.jupiter:junit-jupiter'


### PR DESCRIPTION
## Summary

- FIDO Alliance の MDS BLOB v242 で追加された `AttachmentHint` 列挙値を webauthn4j 0.30.0 が解釈できず、FIDO2 登録時に毎回 `InvalidFormatException` の ERROR ログが出力されていた
- webauthn4j 0.30.3 / 0.31.3 以降で MDS BLOB v242 サポートが追加されたため、最新の 0.31.5 へバンプ
- 2 モジュール間で webauthn4j のバージョンが不一致だった点も同時に統一

## 変更

| ファイル | Before | After |
|---------|--------|-------|
| `libs/idp-server-webauthn4j-adapter/build.gradle` | `webauthn4j-core: 0.30.0` / `webauthn4j-metadata: 0.30.0` | `0.31.5` / `0.31.5` |
| `libs/idp-server-springboot-adapter/build.gradle` | `webauthn4j-core: 0.28.5` | `0.31.5` |

## 動作確認

Docker Compose 再起動後、FIDO2 登録試行で以下を確認：

```
INFO  Fetching MDS BLOB from FIDO Alliance...
INFO  MDS fetched and cached with 323 entries, nextUpdate: 2026-06-01
INFO  webauthn4j registration succeeded. credential id: ...
```

- ERROR ログが消失（従来は毎リクエストでスタックトレース出力）
- 323 エントリのキャッシュ生成成功
- credential metadata に `is_compromised: false` が付与される

## 互換性メモ

- webauthn4j 0.31.x シリーズは Jackson 3 + JDK 17 ベースラインで、idp-server の Spring Boot 4 + Jackson 3 + JDK 21 構成と互換
- `MdsCacheEntry.java` に deprecated API warning が 1 件あるが致命的でなく、本 PR では対応せず

## 関連 Issue

Fixes #1533

## Test plan
- [x] `./gradlew build` — BUILD SUCCESSFUL（全 183 タスク）
- [x] Docker Compose 再起動 → FIDO2 登録実機確認 → MDS フェッチ成功 / ERROR ログ消失を確認
- [x] CI で全テスト通過を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)