### PR TITLE
chore: webauthn4j 0.31 で deprecated になった getJsonConverter() を getJsonMapper() へ移行

### DIFF
--- a/libs/idp-server-webauthn4j-adapter/src/main/java/org/idp/server/authenticators/webauthn4j/mds/MdsCacheEntry.java
+++ b/libs/idp-server-webauthn4j-adapter/src/main/java/org/idp/server/authenticators/webauthn4j/mds/MdsCacheEntry.java
@@ -136,9 +136,7 @@ public class MdsCacheEntry implements JsonReadable {
     }
     try {
       MetadataStatement statement =
-          objectConverter
-              .getJsonMapper()
-              .readValue(metadataStatementJson, MetadataStatement.class);
+          objectConverter.getJsonMapper().readValue(metadataStatementJson, MetadataStatement.class);
       return Optional.ofNullable(statement);
     } catch (Exception e) {
       return Optional.empty();

--- a/libs/idp-server-webauthn4j-adapter/src/main/java/org/idp/server/authenticators/webauthn4j/mds/MdsCacheEntry.java
+++ b/libs/idp-server-webauthn4j-adapter/src/main/java/org/idp/server/authenticators/webauthn4j/mds/MdsCacheEntry.java
@@ -73,7 +73,7 @@ public class MdsCacheEntry implements JsonReadable {
       description = statement.getDescription();
       icon = statement.getIcon();
       try {
-        metadataStatementJson = objectConverter.getJsonConverter().writeValueAsString(statement);
+        metadataStatementJson = objectConverter.getJsonMapper().writeValueAsString(statement);
       } catch (Exception e) {
         // Ignore serialization errors
       }
@@ -137,7 +137,7 @@ public class MdsCacheEntry implements JsonReadable {
     try {
       MetadataStatement statement =
           objectConverter
-              .getJsonConverter()
+              .getJsonMapper()
               .readValue(metadataStatementJson, MetadataStatement.class);
       return Optional.ofNullable(statement);
     } catch (Exception e) {


### PR DESCRIPTION
## Summary

- webauthn4j 0.31.x で `ObjectConverter#getJsonConverter()` / `getCborConverter()` が `@Deprecated` となり、Jackson 3 標準の `JsonMapper` / `CborMapper` を返す `getJsonMapper()` / `getCborMapper()` が推奨に
- `MdsCacheEntry.java` で `getJsonConverter()` を使用していた 2 箇所を `getJsonMapper()` へ置換
- PR #1534（webauthn4j 0.30.0 → 0.31.5 バンプ）のレビューで指摘されていた deprecated API 警告を解消

## 背景

webauthn4j の `JsonConverter` は `ObjectMapper` の薄いラッパーで、checked 例外（`JsonProcessingException`）を unchecked にラップするだけのクラスだった。Jackson 3 で `JsonMapper` が標準提供されたため、ラッパーが不要となり deprecate された。

## 変更

`libs/idp-server-webauthn4j-adapter/src/main/java/org/idp/server/authenticators/webauthn4j/mds/MdsCacheEntry.java`

- L76: `objectConverter.getJsonConverter().writeValueAsString(statement)` → `objectConverter.getJsonMapper().writeValueAsString(statement)`
- L139: `objectConverter.getJsonConverter().readValue(...)` → `objectConverter.getJsonMapper().readValue(...)`

## 互換性メモ

- 例外型は `JsonProcessingException`（checked） → `JacksonException`（unchecked）に変わるが、既存コードは `catch (Exception e)` でまとめ受けしているため挙動・型互換に影響なし
- メソッドシグネチャは同一（`writeValueAsString(Object)`, `readValue(String, Class<T>)`）

## Test plan
- [x] `./gradlew clean build` — BUILD SUCCESSFUL（全 206 タスク実行）
- [x] コンパイル時の `Note: ... uses or overrides a deprecated API` 警告が消失
- [x] CI で全テスト通過を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)