### PR TITLE
perf: JWT Bearer Grant 性能テストを追加 (RFC 7523 + DPoP 前段ベースライン)

### DIFF
--- a/performance-test/scripts/generate_users.py
+++ b/performance-test/scripts/generate_users.py
@@ -26,6 +26,9 @@ import uuid
 import os
 import json
 import argparse
+import base64
+import secrets
+import time
 from pathlib import Path
 
 
@@ -37,6 +40,20 @@ OUTPUT_DIR = "./performance-test/data"
 PROVIDER_ID = "idp-server"
 EMAIL_DOMAIN = "example.com"
 TEST_USERS_LIMIT = 500  # Number of test users per tenant for k6
+
+# Device secret defaults (matches DeviceSecretIssuer.java)
+DEVICE_SECRET_ALGORITHM = "HS256"
+DEVICE_SECRET_BYTES = 32  # HS256 minimum per OIDC Core Section 16.19
+
+
+def generate_device_secret() -> str:
+    """Generate a Base64URL-encoded random secret (no padding), matching backend RandomStringGenerator."""
+    return base64.urlsafe_b64encode(secrets.token_bytes(DEVICE_SECRET_BYTES)).rstrip(b"=").decode("ascii")
+
+
+def csv_escape_json(value: str) -> str:
+    """Escape a JSON string for CSV (FORMAT csv) field embedding."""
+    return '"' + value.replace('"', '""') + '"'
 
 
 def load_tenants(tenants_file: str) -> list:
@@ -61,8 +78,13 @@ def create_single_tenant_config(tenant_id: str, client_id: str, client_secret: s
     }]
 
 
-def generate_users(tenants: list, users_per_tenant: int, first_tenant_users: int, output_prefix: str):
-    """Generate user and device data for all tenants."""
+def generate_users(tenants: list, users_per_tenant: int, first_tenant_users: int, output_prefix: str, issue_device_secret: bool = True):
+    """Generate user and device data for all tenants.
+
+    When issue_device_secret=True, each device gets a jwt_bearer_symmetric credential
+    (matching DeviceSecretIssuer.java output) and the test users JSON includes the
+    device_secret for k6 JWT Bearer Grant scenarios.
+    """
 
     os.makedirs(OUTPUT_DIR, exist_ok=True)
 
@@ -129,23 +151,48 @@ def generate_users(tenants: list, users_per_tenant: int, first_tenant_users: int
                 )
                 f_users.write(user_line)
 
-                # idp_user_authentication_devices table data
+                # idp_user_authentication_devices table data (with optional jwt_bearer_symmetric credential)
+                if issue_device_secret:
+                    device_secret = generate_device_secret()
+                    credential_type = "jwt_bearer_symmetric"
+                    credential_id = str(uuid.uuid4())
+                    credential_payload_json = json.dumps(
+                        {"algorithm": DEVICE_SECRET_ALGORITHM, "secret_value": device_secret},
+                        ensure_ascii=False,
+                    )
+                    credential_metadata_json = json.dumps(
+                        {"issued_at": int(time.time() * 1000)}, ensure_ascii=False
+                    )
+                    credential_payload_escaped = csv_escape_json(credential_payload_json)
+                    credential_metadata_escaped = csv_escape_json(credential_metadata_json)
+                else:
+                    device_secret = None
+                    credential_type = ""
+                    credential_id = ""
+                    credential_payload_escaped = "{}"
+                    credential_metadata_escaped = "{}"
+
                 device_line = (
                     f"{device_id}\t{tenant_id}\t{user_sub}\tiOS 18.5\tiPhone15\tiOS\t\t"
-                    f"Test App\t1\t[]\ttest token\tfcm\n"
+                    f"Test App\t1\t[]\ttest token\tfcm\t"
+                    f"{credential_type}\t{credential_id}\t{credential_payload_escaped}\t{credential_metadata_escaped}\n"
                 )
                 f_devices.write(device_line)
 
                 # Collect test users for k6 (first N per tenant)
                 if i <= TEST_USERS_LIMIT:
-                    test_users_per_tenant[tenant_id].append({
+                    test_user = {
                         "device_id": device_id,
                         "user_id": user_sub,
                         "email": email,
                         "phone": phone,
                         "external_user_id": user_id,
-                        "provider_id": PROVIDER_ID
-                    })
+                        "provider_id": PROVIDER_ID,
+                    }
+                    if device_secret:
+                        test_user["device_secret"] = device_secret
+                        test_user["device_secret_algorithm"] = DEVICE_SECRET_ALGORITHM
+                    test_users_per_tenant[tenant_id].append(test_user)
 
                 user_count += 1
                 if user_count % 100000 == 0:
@@ -242,6 +289,12 @@ Examples:
         default=None,
         help='Output file prefix (auto-generated if not specified)'
     )
+    parser.add_argument(
+        '--no-device-secret',
+        action='store_true',
+        default=False,
+        help='Disable jwt_bearer_symmetric credential generation (default: enabled)'
+    )
 
     args = parser.parse_args()
 
@@ -274,7 +327,13 @@ Examples:
         exit(1)
 
     # Generate users
-    total = generate_users(tenants, args.users, args.first_tenant_users, args.output_prefix)
+    total = generate_users(
+        tenants,
+        args.users,
+        args.first_tenant_users,
+        args.output_prefix,
+        issue_device_secret=not args.no_device_secret,
+    )
 
     print("\n" + "=" * 60)
     print(f"Generation complete!")

--- a/performance-test/scripts/import_users.sh
+++ b/performance-test/scripts/import_users.sh
@@ -111,7 +111,8 @@ echo -e "${YELLOW}Importing devices...${NC}"
 docker exec -i postgres-primary psql -U idpserver -d idpserver -c "\COPY idp_user_authentication_devices (
   id, tenant_id, user_id, os, model, platform, locale,
   app_name, priority, available_methods,
-  notification_token, notification_channel
+  notification_token, notification_channel,
+  credential_type, credential_id, credential_payload, credential_metadata
 ) FROM STDIN WITH (FORMAT csv, HEADER false, DELIMITER E'\t')" < "$DEVICES_FILE"
 
 echo -e "${GREEN}Devices imported successfully!${NC}"

--- a/performance-test/stress/scenario-13-token-jwt-bearer-device.js
+++ b/performance-test/stress/scenario-13-token-jwt-bearer-device.js
@@ -1,0 +1,86 @@
+import http from 'k6/http';
+import { check } from 'k6';
+import crypto from 'k6/crypto';
+import encoding from 'k6/encoding';
+
+// 環境変数でカスタマイズ可能なパラメータ
+const VU_COUNT = parseInt(__ENV.VU_COUNT || '120');
+const DURATION = __ENV.DURATION || '30s';
+
+export let options = {
+  vus: VU_COUNT,
+  duration: DURATION,
+  thresholds: {
+    http_req_duration: ['p(95)<500'],
+    http_req_failed: ['rate<0.01'],
+  },
+};
+
+// テナント・ユーザー設定読み込み（generate_users.py で生成）
+const tenantData = JSON.parse(open('../data/performance-test-multi-tenant-users.json'));
+const tenantIndex = parseInt(__ENV.TENANT_INDEX || '0');
+const config = tenantData[tenantIndex];
+
+// device_secret を持つユーザーだけに絞る
+const usableUsers = config.users.filter((u) => u.device_secret);
+if (usableUsers.length === 0) {
+  throw new Error(
+    `No users with device_secret in tenant ${config.tenantId}. ` +
+      'Regenerate test data with generate_users.py (default issues device secrets).'
+  );
+}
+
+function b64url(input) {
+  return encoding.b64encode(input, 'rawurl');
+}
+
+function createJwtHS256(payload, secret) {
+  const header = { alg: 'HS256', typ: 'JWT' };
+  const headerB64 = b64url(JSON.stringify(header));
+  const payloadB64 = b64url(JSON.stringify(payload));
+  const signingInput = `${headerB64}.${payloadB64}`;
+  const signature = crypto.hmac('sha256', secret, signingInput, 'binary');
+  const signatureB64 = b64url(signature);
+  return `${signingInput}.${signatureB64}`;
+}
+
+export default function () {
+  const baseUrl = __ENV.BASE_URL || 'https://api.local.test';
+  const tenantId = config.tenantId;
+  const clientId = config.clientId;
+  const clientSecret = config.clientSecret;
+
+  // VU・iteration ごとに違うユーザーを循環
+  const user = usableUsers[(__VU + __ITER) % usableUsers.length];
+
+  const issuer = `${baseUrl}/${tenantId}`;
+  const tokenEndpoint = `${issuer}/v1/tokens`;
+
+  const now = Math.floor(Date.now() / 1000);
+  const assertion = createJwtHS256(
+    {
+      iss: `device:${user.device_id}`,
+      sub: user.device_id, // default subject_claim_mapping = device_id
+      aud: issuer,
+      jti: `${__VU}-${__ITER}-${now}`,
+      iat: now,
+      exp: now + 300,
+    },
+    user.device_secret
+  );
+
+  const payload =
+    `grant_type=${encodeURIComponent('urn:ietf:params:oauth:grant-type:jwt-bearer')}` +
+    `&assertion=${encodeURIComponent(assertion)}` +
+    `&scope=${encodeURIComponent('openid profile email')}` +
+    `&client_id=${clientId}` +
+    `&client_secret=${clientSecret}`;
+
+  const tokenRes = http.post(tokenEndpoint, payload, {
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+  });
+
+  check(tokenRes, {
+    'status is 200': (r) => r.status === 200,
+  });
+}


### PR DESCRIPTION
## Summary

- CIBA フローの代替候補となる **JWT Bearer Grant (RFC 7523)** の token endpoint 発行性能を測るストレステストを追加
- CIBA は 5 API call で平均 526〜670ms 要するが、JWT Bearer Grant は 1 API call で完結
- 1.9M ユーザー規模で **TPS 669 / p95 437ms** をベースライン測定
- DeviceSecretIssuer.java と完全互換のテストデータ生成ロジックを追加

## 背景

[Issue #1525 (FAPI 2.0 + DPoP)](https://github.com/hirokazu-kobayashi-koba-hiro/idp-server/issues/1525) の流れで、`feat/dpop-rfc9449` ブランチで DPoP 実装が進行中。本 PR では DPoP / Nonce による sender-constrained 強化の**前段ベースライン**として、純粋な JWT Bearer Grant 単体の性能を測定する。

次フェーズで「JWT Bearer + DPoP + Nonce piggyback」の最終形ストレステストを追加予定。

## 変更内容

### 1. `performance-test/stress/scenario-13-token-jwt-bearer-device.js`（新規）
k6 ストレステストシナリオ。
- 各 VU/iteration ごとに別ユーザーを循環使用（cache hit を分散させ、より本番に近い負荷を再現）
- `k6/crypto` の HMAC-SHA256 で `device_secret` 署名 JWT を生成
- `grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer` で POST `/v1/tokens`
- `subject_claim_mapping` のデフォルト (`device_id`) に合わせて `sub=device_id`

### 2. `performance-test/scripts/generate_users.py`
`DeviceSecretIssuer.java` のロジックを完全再現：
- `SecureRandom` 32 バイト → Base64URL（パディングなし）
- `credential_type='jwt_bearer_symmetric'`、`credential_id=UUIDv4`
- `credential_payload={algorithm: 'HS256', secret_value: ...}`
- `credential_metadata={issued_at: <epoch_ms>}`
- test_users JSON に `device_secret` / `device_secret_algorithm` を追加
- `--no-device-secret` フラグで従来挙動も維持

### 3. `performance-test/scripts/import_users.sh`
`COPY` 文に `credential_type`, `credential_id`, `credential_payload`, `credential_metadata` の 4 列を追加。

## 動作確認

- 1.9M ユーザー (1M + 9×100K) の TSV 生成・PostgreSQL 投入: 成功
- k6 スモーク (1 VU / 5s): 100% success、p95=11ms
- k6 本ストレス (120 VU / 30s): **TPS 669、p95 437ms、failure 0%**
- 結果ファイル: `performance-test/result/stress/2026-05-13/scenario-13-*.json`

## 性能比較（同条件、warmed up）

| シナリオ | API数 | tokens/s | 平均(ms) | p95(ms) |
|---------|-------|---------|---------|---------|
| **JWT Bearer (新)** | **1** | **669** | **179** | **438** |
| CIBA device | 5 | 178 | 670 | 1157 |
| CIBA sub | 5 | 211 | 566 | 972 |
| CIBA email | 5 | 203 | 587 | 1153 |
| CIBA phone | 5 | 205 | 581 | 1103 |
| CIBA ex-sub | 5 | 226 | 526 | 908 |

JWT Bearer Grant は CIBA フローの **3〜4 倍高速**。

## セキュリティ補足（今後の Issue 候補）

本 PR は性能ベースライン取得が目的であり、JWT Bearer Grant 単体ではリプレイ耐性が `exp` のみ（短期間ウィンドウ内のリプレイは可能）という制約あり。

今後の sender-constrained 強化候補：
- DPoP (RFC 9449) との組合せ — Issue #1525 / `feat/dpop-rfc9449` ブランチで進行中
- DPoP Nonce (RFC 9449 §8) の piggyback による 0 RT challenge-response
- `iat` freshness validation の追加

これらの機能完成後、組合せシナリオの性能テストを別 PR で追加予定。

## Test plan
- [x] `python3 generate_users.py --tenants-file ... --users 100000 --first-tenant-users 1000000` で 1.9M ユーザー生成
- [x] `import_users.sh multi_tenant_1m+9x100k -y` で PostgreSQL 投入
- [x] k6 スモーク (1 VU / 5s) で 200 応答確認
- [x] k6 本ストレス (120 VU / 30s) で閾値クリア確認
- [ ] CI で全テスト通過確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)