### PR TITLE
chore: org.json transitive 依存を除外 

### DIFF
--- a/libs/idp-server-core-adapter/build.gradle
+++ b/libs/idp-server-core-adapter/build.gradle
@@ -25,7 +25,10 @@ dependencies {
 	runtimeOnly 'com.mysql:mysql-connector-j:9.2.0'
 	implementation 'com.zaxxer:HikariCP:6.3.0'
 	//cache
-	implementation("redis.clients:jedis:5.1.0")
+	implementation("redis.clients:jedis:5.1.0") {
+		// org.json はライセンス審査の観点で transitive 取り込みを避ける (Public Domain 表記の不確実性)
+		exclude group: 'org.json', module: 'json'
+	}
 
 	testImplementation platform('org.junit:junit-bom:5.10.0')
 	testImplementation 'org.junit.jupiter:junit-jupiter'

--- a/libs/idp-server-platform/build.gradle
+++ b/libs/idp-server-platform/build.gradle
@@ -14,7 +14,10 @@ repositories {
 dependencies {
 	//json (Jackson 3: java.time support is built-in, no separate jsr310 module needed)
 	implementation 'tools.jackson.core:jackson-databind:3.1.2'
-	implementation 'com.jayway.jsonpath:json-path:2.9.0'
+	implementation('com.jayway.jsonpath:json-path:2.9.0') {
+		// org.json はライセンス審査の観点で transitive 取り込みを避ける (Public Domain 表記の不確実性)
+		exclude group: 'org.json', module: 'json'
+	}
 	//jose
 	implementation 'com.nimbusds:nimbus-jose-jwt:9.40'
 	// BouncyCastle for PEM key parsing


### PR DESCRIPTION
## Summary

idp-server (Apache 2.0 配布) において transitive で取り込まれていた `org.json:json` を build.gradle の exclude で除外する。Public Domain 表記の不確実性 (OSI 非公式 + 独・仏など Public Domain 概念が法的に認められない法域あり) による OSS 監査リスクを低減する目的。

idp-server 本体コードでは `org.json` を直接 import していないため、transitive 取り込みを抑止しても機能影響なし (テスト全件パスにて確認)。

## 背景

### org.json のライセンス変遷

| バージョン | ライセンス |
|----------|----------|
| 〜v20220924 (PR #688 以前) | "JSON License" (`"The Software shall be used for Good, not Evil"` 句あり / ASF Category X / Debian non-free) |
| v20220924 以降 | **Public Domain** |
| 我々が混入していた v20250517 | Public Domain |

ASF は v20220924 以降を Category X から外している (公式見解) ため**実害は限定的**だが、Public Domain は OSI 公式ライセンスではなく一部法域で扱いが不確実なため、transitive 取り込みを避けることで監査時の説明コストも削減する。

### idp-server での使用状況

- 直接 import: **0 件** (`grep -rl "^import org\.json\." libs app` 結果ゼロ)
- transitive 取り込み元:
  - `com.jayway.jsonpath:json-path:2.10.0` (Spring Boot Dependency Management 経由で 2.9.0 → 2.10.0 にアップグレード)
  - `redis.clients:jedis:7.0.0` (同上、5.1.0 → 7.0.0)

## 変更内容

| ファイル | 変更 |
|---------|------|
| `libs/idp-server-platform/build.gradle` | `com.jayway.jsonpath:json-path:2.9.0` に `exclude group: 'org.json', module: 'json'` を追加 |
| `libs/idp-server-core-adapter/build.gradle` | `redis.clients:jedis:5.1.0` に同 exclude を追加 |

## 動作確認

### dependency 解決
```
$ ./gradlew :app:dependencyInsight --dependency org.json:json
No dependencies matching given input were found in configuration ':app:runtimeClasspath'
```
→ runtime classpath から org.json が完全に消えていることを確認。

### 単体テスト
```
$ ./gradlew clean test
BUILD SUCCESSFUL in 1m 33s
115 actionable tasks: 115 executed
```

`idp-server-platform` の集計:
- **tests=1032, failures=0, errors=0**
- Mapper / JsonPath 系も全パス:
  - `ConditionSpecTest` (87件)
  - `MappingRuleConditionalTest` (13件)
  - `MappingRuleObjectMapperTest` (5件)
  - `MappingRuleObjectMapperConditionalTest` (11件)
  - Function 系各種 (Case 44, Filter, If, Join, Map, Replace, RegexReplace 37, MimeEncodedWord 50 等)

### E2E テスト
- ローカル環境で正常動作を確認

## 互換性メモ

- `jedis` および `json-path` の主要機能は Jackson でカバーされており、`org.json` 不在でも動作することは上記テスト結果で実証済み
- 将来 `org.json` の機能 (例: `JSONObject`) を直接利用したいケースが発生したら、その時に exclude を外す or 代替実装を検討

## 関連

- 関連 Discussion / Issue は特になし (検査中に判明した chore 系の改善)

## Test plan
- [x] `./gradlew clean test` BUILD SUCCESSFUL
- [x] `./gradlew :app:dependencyInsight --dependency org.json:json` で「No dependencies」を確認
- [x] E2E テストで実機動作を確認 (ローカル)
- [ ] CI で全テスト通過確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)