### PR TITLE
refactor: 認証 interact フローを単一トランザクションに統合

### DIFF
--- a/libs/idp-server-core-extension-ciba/src/main/java/org/idp/server/core/extension/ciba/CibaFlowApi.java
+++ b/libs/idp-server-core-extension-ciba/src/main/java/org/idp/server/core/extension/ciba/CibaFlowApi.java
@@ -23,6 +23,7 @@ import org.idp.server.core.openid.authentication.AuthenticationInteractionReques
 import org.idp.server.core.openid.authentication.AuthenticationInteractionRequestResult;
 import org.idp.server.core.openid.authentication.AuthenticationInteractionType;
 import org.idp.server.core.openid.authentication.AuthenticationTransaction;
+import org.idp.server.platform.multi_tenancy.tenant.Tenant;
 import org.idp.server.platform.multi_tenancy.tenant.TenantIdentifier;
 import org.idp.server.platform.type.RequestAttributes;
 
@@ -38,6 +39,33 @@ public interface CibaFlowApi {
       TenantIdentifier tenantIdentifier,
       BackchannelAuthenticationRequestIdentifier backchannelAuthenticationRequestIdentifier,
       AuthenticationTransaction authenticationTransaction,
+      AuthenticationInteractionType type,
+      AuthenticationInteractionRequest request,
+      RequestAttributes requestAttributes);
+
+  /**
+   * Executes a CIBA interact operation with a pre-fetched {@link Tenant} and an already
+   * pessimistically locked {@link AuthenticationTransaction}.
+   *
+   * <p>This variant is intended to be called from within an existing {@code @Transaction}
+   * (typically the orchestrating {@code AuthenticationTransactionEntryService.interact()}), via the
+   * {@link org.idp.server.usecases.IdpServerApplication#rawCibaFlowApi() raw (non-proxied)}
+   * accessor to avoid opening a nested transaction.
+   *
+   * <p>By skipping the redundant {@code tenantQueryRepository.get()} and {@code
+   * authenticationTransactionQueryRepository.getForUpdate()} that the standard {@link
+   * #interact(TenantIdentifier, BackchannelAuthenticationRequestIdentifier,
+   * AuthenticationTransaction, AuthenticationInteractionType, AuthenticationInteractionRequest,
+   * RequestAttributes) interact} would do, this method reduces transactions, {@code set_config()}
+   * calls, and DB connection acquisitions per request.
+   *
+   * @param tenant pre-resolved tenant
+   * @param lockedTransaction authentication transaction already obtained with {@code
+   *     getForUpdate()} in the caller's transaction
+   */
+  AuthenticationInteractionRequestResult interactInternal(
+      Tenant tenant,
+      AuthenticationTransaction lockedTransaction,
       AuthenticationInteractionType type,
       AuthenticationInteractionRequest request,
       RequestAttributes requestAttributes);

--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/authentication/AuthenticationTransactionApi.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/authentication/AuthenticationTransactionApi.java
@@ -33,4 +33,21 @@ public interface AuthenticationTransactionApi {
       String authorizationHeader,
       AuthenticationTransactionQueries queries,
       RequestAttributes requestAttributes);
+
+  /**
+   * Consolidated entry point for authentication interaction across all flows (OAuth, CIBA, user
+   * operation). Performs the tenant lookup and pessimistic lock acquisition once, then dispatches
+   * to the appropriate flow-specific handler (via the raw, non-proxied API) so the entire
+   * interaction runs in a single transaction.
+   *
+   * <p>This avoids the duplicate transaction / duplicate {@code set_config} pattern that occurs
+   * when the controller pre-fetches the transaction and the downstream entry service re-acquires it
+   * with {@code getForUpdate()}.
+   */
+  AuthenticationInteractionRequestResult interact(
+      TenantIdentifier tenantIdentifier,
+      AuthenticationTransactionIdentifier authenticationTransactionIdentifier,
+      AuthenticationInteractionType type,
+      AuthenticationInteractionRequest request,
+      RequestAttributes requestAttributes);
 }

--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/identity/UserOperationApi.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/identity/UserOperationApi.java
@@ -19,6 +19,7 @@ package org.idp.server.core.openid.identity;
 import org.idp.server.core.openid.authentication.AuthenticationInteractionRequest;
 import org.idp.server.core.openid.authentication.AuthenticationInteractionRequestResult;
 import org.idp.server.core.openid.authentication.AuthenticationInteractionType;
+import org.idp.server.core.openid.authentication.AuthenticationTransaction;
 import org.idp.server.core.openid.authentication.AuthenticationTransactionIdentifier;
 import org.idp.server.core.openid.identity.authentication.PasswordChangeRequest;
 import org.idp.server.core.openid.identity.authentication.PasswordChangeResponse;
@@ -29,6 +30,7 @@ import org.idp.server.core.openid.identity.io.MfaRegistrationRequest;
 import org.idp.server.core.openid.identity.io.UserOperationResponse;
 import org.idp.server.core.openid.oauth.type.AuthFlow;
 import org.idp.server.core.openid.token.OAuthToken;
+import org.idp.server.platform.multi_tenancy.tenant.Tenant;
 import org.idp.server.platform.multi_tenancy.tenant.TenantIdentifier;
 import org.idp.server.platform.type.RequestAttributes;
 
@@ -45,6 +47,21 @@ public interface UserOperationApi {
   AuthenticationInteractionRequestResult interact(
       TenantIdentifier tenantIdentifier,
       AuthenticationTransactionIdentifier authenticationTransactionIdentifier,
+      AuthenticationInteractionType type,
+      AuthenticationInteractionRequest request,
+      RequestAttributes requestAttributes);
+
+  /**
+   * Variant of {@link #interact} that accepts an already-locked {@link AuthenticationTransaction}.
+   *
+   * <p>Intended for the consolidated dispatcher in {@code AuthenticationTransactionEntryService} to
+   * avoid redundant {@code tenantQueryRepository.get()} and {@code getForUpdate()} calls. Invoke
+   * via the {@link org.idp.server.usecases.IdpServerApplication#rawUserOperationApi() raw
+   * (non-proxied)} accessor so it joins the caller's transaction.
+   */
+  AuthenticationInteractionRequestResult interactInternal(
+      Tenant tenant,
+      AuthenticationTransaction lockedTransaction,
       AuthenticationInteractionType type,
       AuthenticationInteractionRequest request,
       RequestAttributes requestAttributes);

--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/oauth/OAuthFlowApi.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/oauth/OAuthFlowApi.java
@@ -20,6 +20,7 @@ import java.util.Map;
 import org.idp.server.core.openid.authentication.AuthenticationInteractionRequest;
 import org.idp.server.core.openid.authentication.AuthenticationInteractionRequestResult;
 import org.idp.server.core.openid.authentication.AuthenticationInteractionType;
+import org.idp.server.core.openid.authentication.AuthenticationTransaction;
 import org.idp.server.core.openid.federation.FederationInteractionResult;
 import org.idp.server.core.openid.federation.FederationType;
 import org.idp.server.core.openid.federation.io.FederationCallbackRequest;
@@ -27,6 +28,7 @@ import org.idp.server.core.openid.federation.io.FederationRequestResponse;
 import org.idp.server.core.openid.federation.sso.SsoProvider;
 import org.idp.server.core.openid.oauth.io.*;
 import org.idp.server.core.openid.oauth.request.AuthorizationRequestIdentifier;
+import org.idp.server.platform.multi_tenancy.tenant.Tenant;
 import org.idp.server.platform.multi_tenancy.tenant.TenantIdentifier;
 import org.idp.server.platform.type.RequestAttributes;
 
@@ -52,6 +54,21 @@ public interface OAuthFlowApi {
   AuthenticationInteractionRequestResult interact(
       TenantIdentifier tenantIdentifier,
       AuthorizationRequestIdentifier authorizationRequestIdentifier,
+      AuthenticationInteractionType type,
+      AuthenticationInteractionRequest request,
+      RequestAttributes requestAttributes);
+
+  /**
+   * Variant of {@link #interact} that accepts an already-locked {@link AuthenticationTransaction}.
+   *
+   * <p>Intended for the consolidated dispatcher in {@code AuthenticationTransactionEntryService} to
+   * avoid redundant {@code tenantQueryRepository.get()} and {@code getForUpdate()} calls. Invoke
+   * via the {@link org.idp.server.usecases.IdpServerApplication#rawOAuthFlowApi() raw
+   * (non-proxied)} accessor so it joins the caller's transaction.
+   */
+  AuthenticationInteractionRequestResult interactInternal(
+      Tenant tenant,
+      AuthenticationTransaction lockedTransaction,
       AuthenticationInteractionType type,
       AuthenticationInteractionRequest request,
       RequestAttributes requestAttributes);

--- a/libs/idp-server-springboot-adapter/src/main/java/org/idp/server/adapters/springboot/application/restapi/authentication/AuthenticationV1Api.java
+++ b/libs/idp-server-springboot-adapter/src/main/java/org/idp/server/adapters/springboot/application/restapi/authentication/AuthenticationV1Api.java
@@ -19,13 +19,8 @@ package org.idp.server.adapters.springboot.application.restapi.authentication;
 import jakarta.servlet.http.HttpServletRequest;
 import java.util.Map;
 import org.idp.server.adapters.springboot.application.restapi.ParameterTransformable;
-import org.idp.server.core.extension.ciba.CibaFlowApi;
-import org.idp.server.core.extension.ciba.request.BackchannelAuthenticationRequestIdentifier;
 import org.idp.server.core.openid.authentication.*;
 import org.idp.server.core.openid.authentication.AuthenticationTransactionApi;
-import org.idp.server.core.openid.identity.UserOperationApi;
-import org.idp.server.core.openid.oauth.OAuthFlowApi;
-import org.idp.server.core.openid.oauth.request.AuthorizationRequestIdentifier;
 import org.idp.server.platform.multi_tenancy.tenant.TenantIdentifier;
 import org.idp.server.platform.type.RequestAttributes;
 import org.idp.server.usecases.IdpServerApplication;
@@ -39,15 +34,9 @@ import org.springframework.web.bind.annotation.*;
 public class AuthenticationV1Api implements ParameterTransformable {
 
   AuthenticationTransactionApi authenticationTransactionApi;
-  OAuthFlowApi oAuthFlowApi;
-  CibaFlowApi cibaFlowApi;
-  UserOperationApi userOperationApi;
 
   public AuthenticationV1Api(IdpServerApplication idpServerApplication) {
     this.authenticationTransactionApi = idpServerApplication.authenticationApi();
-    this.oAuthFlowApi = idpServerApplication.oAuthFlowApi();
-    this.cibaFlowApi = idpServerApplication.cibaFlowApi();
-    this.userOperationApi = idpServerApplication.userOperationApi();
   }
 
   @PostMapping("/{id}/{interaction-type}")
@@ -61,54 +50,17 @@ public class AuthenticationV1Api implements ParameterTransformable {
     AuthenticationInteractionRequest request = new AuthenticationInteractionRequest(requestBody);
     RequestAttributes requestAttributes = transform(httpServletRequest);
 
-    AuthenticationTransaction authenticationTransaction =
-        authenticationTransactionApi.get(tenantIdentifier, authenticationTransactionIdentifier);
     AuthenticationInteractionRequestResult result =
-        interact(tenantIdentifier, authenticationTransaction, type, request, requestAttributes);
+        authenticationTransactionApi.interact(
+            tenantIdentifier,
+            authenticationTransactionIdentifier,
+            type,
+            request,
+            requestAttributes);
 
     HttpHeaders httpHeaders = new HttpHeaders();
     httpHeaders.add("Content-Type", "application/json");
     return new ResponseEntity<>(
         result.response(), httpHeaders, HttpStatus.valueOf(result.statusCode()));
-  }
-
-  private AuthenticationInteractionRequestResult interact(
-      TenantIdentifier tenantIdentifier,
-      AuthenticationTransaction authenticationTransaction,
-      AuthenticationInteractionType type,
-      AuthenticationInteractionRequest request,
-      RequestAttributes requestAttributes) {
-
-    switch (authenticationTransaction.flow().name()) {
-      case "oauth" -> {
-        return oAuthFlowApi.interact(
-            tenantIdentifier,
-            new AuthorizationRequestIdentifier(
-                authenticationTransaction.authorizationIdentifier().value()),
-            type,
-            request,
-            requestAttributes);
-      }
-
-      case "ciba" -> {
-        return cibaFlowApi.interact(
-            tenantIdentifier,
-            new BackchannelAuthenticationRequestIdentifier(
-                authenticationTransaction.authorizationIdentifier().value()),
-            authenticationTransaction,
-            type,
-            request,
-            requestAttributes);
-      }
-
-      default -> {
-        return userOperationApi.interact(
-            tenantIdentifier,
-            authenticationTransaction.identifier(),
-            type,
-            request,
-            requestAttributes);
-      }
-    }
   }
 }

--- a/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/IdpServerApplication.java
+++ b/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/IdpServerApplication.java
@@ -207,10 +207,12 @@ public class IdpServerApplication {
   IdpServerStarterApi idpServerStarterApi;
   IdpServerOperationApi idpServerOperationApi;
   OAuthFlowApi oAuthFlowApi;
+  OAuthFlowApi rawOAuthFlowApi;
   TokenApi tokenApi;
   OidcMetaDataApi oidcMetaDataApi;
   UserinfoApi userinfoApi;
   CibaFlowApi cibaFlowApi;
+  CibaFlowApi rawCibaFlowApi;
   AuthenticationMetaDataApi authenticationMetaDataApi;
   AuthenticationTransactionApi authenticationTransactionApi;
   IdentityVerificationApplicationApi identityVerificationApplicationApi;
@@ -224,6 +226,7 @@ public class IdpServerApplication {
   OrganizationTenantResolverApi organizationTenantResolverApi;
   TenantInvitationMetaDataApi tenantInvitationMetaDataApi;
   UserOperationApi userOperationApi;
+  UserOperationApi rawUserOperationApi;
   UserLifecycleEventApi userLifecycleEventApi;
   AuthenticationDeviceLogApi authenticationDeviceLogApi;
   OnboardingApi onboardingApi;
@@ -606,25 +609,26 @@ public class IdpServerApplication {
     AuditLogWriters auditLogWriters =
         AuditLogWriterPluginLoader.load(applicationComponentContainer);
 
+    OAuthFlowEntryService oAuthFlowEntryService =
+        new OAuthFlowEntryService(
+            new OAuthProtocols(protocolContainer.resolveAll(OAuthProtocol.class)),
+            sessionCookieDelegate,
+            authSessionCookieDelegate,
+            authenticationInteractors,
+            federationInteractors,
+            userQueryRepository,
+            userCommandRepository,
+            tenantQueryRepository,
+            authenticationTransactionCommandRepository,
+            authenticationTransactionQueryRepository,
+            authenticationPolicyConfigurationQueryRepository,
+            oAuthFLowEventPublisher,
+            userLifecycleEventPublisher,
+            oidcSessionHandler);
+    this.rawOAuthFlowApi = oAuthFlowEntryService;
     this.oAuthFlowApi =
         TenantAwareEntryServiceProxy.createProxy(
-            new OAuthFlowEntryService(
-                new OAuthProtocols(protocolContainer.resolveAll(OAuthProtocol.class)),
-                sessionCookieDelegate,
-                authSessionCookieDelegate,
-                authenticationInteractors,
-                federationInteractors,
-                userQueryRepository,
-                userCommandRepository,
-                tenantQueryRepository,
-                authenticationTransactionCommandRepository,
-                authenticationTransactionQueryRepository,
-                authenticationPolicyConfigurationQueryRepository,
-                oAuthFLowEventPublisher,
-                userLifecycleEventPublisher,
-                oidcSessionHandler),
-            OAuthFlowApi.class,
-            databaseTypeProvider);
+            oAuthFlowEntryService, OAuthFlowApi.class, databaseTypeProvider);
 
     this.tokenApi =
         TenantAwareEntryServiceProxy.createProxy(
@@ -654,21 +658,22 @@ public class IdpServerApplication {
             UserinfoApi.class,
             databaseTypeProvider);
 
+    CibaFlowEntryService cibaFlowEntryService =
+        new CibaFlowEntryService(
+            new CibaProtocols(protocolContainer.resolveAll(CibaProtocol.class)),
+            authenticationInteractors,
+            userQueryRepository,
+            tenantQueryRepository,
+            authenticationTransactionCommandRepository,
+            authenticationTransactionQueryRepository,
+            authenticationPolicyConfigurationQueryRepository,
+            cibaFlowEventPublisher,
+            userLifecycleEventPublisher,
+            passwordVerificationDelegation);
+    this.rawCibaFlowApi = cibaFlowEntryService;
     this.cibaFlowApi =
         TenantAwareEntryServiceProxy.createProxy(
-            new CibaFlowEntryService(
-                new CibaProtocols(protocolContainer.resolveAll(CibaProtocol.class)),
-                authenticationInteractors,
-                userQueryRepository,
-                tenantQueryRepository,
-                authenticationTransactionCommandRepository,
-                authenticationTransactionQueryRepository,
-                authenticationPolicyConfigurationQueryRepository,
-                cibaFlowEventPublisher,
-                userLifecycleEventPublisher,
-                passwordVerificationDelegation),
-            CibaFlowApi.class,
-            databaseTypeProvider);
+            cibaFlowEntryService, CibaFlowApi.class, databaseTypeProvider);
 
     this.authenticationMetaDataApi =
         TenantAwareEntryServiceProxy.createProxy(
@@ -683,6 +688,25 @@ public class IdpServerApplication {
     OAuthTokenQueryRepository oAuthTokenQueryRepository =
         applicationComponentContainer.resolve(OAuthTokenQueryRepository.class);
 
+    UserOperationEntryService userOperationEntryService =
+        new UserOperationEntryService(
+            userQueryRepository,
+            userCommandRepository,
+            tenantQueryRepository,
+            authenticationTransactionCommandRepository,
+            authenticationTransactionQueryRepository,
+            authenticationPolicyConfigurationQueryRepository,
+            authenticationInteractors,
+            userEventPublisher,
+            userOperationEventPublisher,
+            userLifecycleEventPublisher,
+            passwordVerificationDelegation,
+            passwordEncodeDelegation);
+    this.rawUserOperationApi = userOperationEntryService;
+    this.userOperationApi =
+        TenantAwareEntryServiceProxy.createProxy(
+            userOperationEntryService, UserOperationApi.class, databaseTypeProvider);
+
     this.authenticationTransactionApi =
         TenantAwareEntryServiceProxy.createProxy(
             new AuthenticationTransactionEntryService(
@@ -690,7 +714,10 @@ public class IdpServerApplication {
                 authenticationTransactionCommandRepository,
                 authenticationTransactionQueryRepository,
                 oAuthTokenQueryRepository,
-                userQueryRepository),
+                userQueryRepository,
+                oAuthFlowEntryService,
+                cibaFlowEntryService,
+                userOperationEntryService),
             AuthenticationTransactionApi.class,
             databaseTypeProvider);
 
@@ -792,24 +819,6 @@ public class IdpServerApplication {
             new TenantInvitationMetaDataEntryService(
                 tenantInvitationQueryRepository, tenantQueryRepository),
             TenantInvitationMetaDataApi.class,
-            databaseTypeProvider);
-
-    this.userOperationApi =
-        TenantAwareEntryServiceProxy.createProxy(
-            new UserOperationEntryService(
-                userQueryRepository,
-                userCommandRepository,
-                tenantQueryRepository,
-                authenticationTransactionCommandRepository,
-                authenticationTransactionQueryRepository,
-                authenticationPolicyConfigurationQueryRepository,
-                authenticationInteractors,
-                userEventPublisher,
-                userOperationEventPublisher,
-                userLifecycleEventPublisher,
-                passwordVerificationDelegation,
-                passwordEncodeDelegation),
-            UserOperationApi.class,
             databaseTypeProvider);
 
     this.userLifecycleEventApi =
@@ -1281,6 +1290,10 @@ public class IdpServerApplication {
     return oAuthFlowApi;
   }
 
+  public OAuthFlowApi rawOAuthFlowApi() {
+    return rawOAuthFlowApi;
+  }
+
   public TokenApi tokenAPi() {
     return tokenApi;
   }
@@ -1295,6 +1308,10 @@ public class IdpServerApplication {
 
   public CibaFlowApi cibaFlowApi() {
     return cibaFlowApi;
+  }
+
+  public CibaFlowApi rawCibaFlowApi() {
+    return rawCibaFlowApi;
   }
 
   public AuthenticationMetaDataApi authenticationMetaDataApi() {
@@ -1343,6 +1360,10 @@ public class IdpServerApplication {
 
   public UserOperationApi userOperationApi() {
     return userOperationApi;
+  }
+
+  public UserOperationApi rawUserOperationApi() {
+    return rawUserOperationApi;
   }
 
   public SharedSignalsFrameworkMetaDataApi sharedSignalsFrameworkMetaDataApi() {

--- a/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/application/enduser/AuthenticationTransactionEntryService.java
+++ b/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/application/enduser/AuthenticationTransactionEntryService.java
@@ -19,6 +19,10 @@ package org.idp.server.usecases.application.enduser;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.idp.server.core.extension.ciba.CibaFlowApi;
+import org.idp.server.core.openid.authentication.AuthenticationInteractionRequest;
+import org.idp.server.core.openid.authentication.AuthenticationInteractionRequestResult;
+import org.idp.server.core.openid.authentication.AuthenticationInteractionType;
 import org.idp.server.core.openid.authentication.AuthenticationTransaction;
 import org.idp.server.core.openid.authentication.AuthenticationTransactionApi;
 import org.idp.server.core.openid.authentication.AuthenticationTransactionIdentifier;
@@ -26,10 +30,12 @@ import org.idp.server.core.openid.authentication.AuthenticationTransactionQuerie
 import org.idp.server.core.openid.authentication.io.AuthenticationTransactionFindingResponse;
 import org.idp.server.core.openid.authentication.repository.AuthenticationTransactionCommandRepository;
 import org.idp.server.core.openid.authentication.repository.AuthenticationTransactionQueryRepository;
+import org.idp.server.core.openid.identity.UserOperationApi;
 import org.idp.server.core.openid.identity.device.AuthenticationDeviceIdentifier;
 import org.idp.server.core.openid.identity.device.authentication.DeviceAuthenticationDeviceFinder;
 import org.idp.server.core.openid.identity.device.authentication.DeviceEndpointAuthenticationHandler;
 import org.idp.server.core.openid.identity.repository.UserQueryRepository;
+import org.idp.server.core.openid.oauth.OAuthFlowApi;
 import org.idp.server.core.openid.token.repository.OAuthTokenQueryRepository;
 import org.idp.server.platform.datasource.Transaction;
 import org.idp.server.platform.multi_tenancy.tenant.Tenant;
@@ -56,19 +62,28 @@ public class AuthenticationTransactionEntryService implements AuthenticationTran
   AuthenticationTransactionCommandRepository authenticationTransactionCommandRepository;
   AuthenticationTransactionQueryRepository authenticationTransactionQueryRepository;
   DeviceEndpointAuthenticationHandler deviceEndpointAuthenticationHandler;
+  OAuthFlowApi rawOAuthFlowApi;
+  CibaFlowApi rawCibaFlowApi;
+  UserOperationApi rawUserOperationApi;
 
   public AuthenticationTransactionEntryService(
       TenantQueryRepository tenantQueryRepository,
       AuthenticationTransactionCommandRepository authenticationTransactionCommandRepository,
       AuthenticationTransactionQueryRepository authenticationTransactionQueryRepository,
       OAuthTokenQueryRepository oAuthTokenQueryRepository,
-      UserQueryRepository userQueryRepository) {
+      UserQueryRepository userQueryRepository,
+      OAuthFlowApi rawOAuthFlowApi,
+      CibaFlowApi rawCibaFlowApi,
+      UserOperationApi rawUserOperationApi) {
     this.tenantQueryRepository = tenantQueryRepository;
     this.authenticationTransactionCommandRepository = authenticationTransactionCommandRepository;
     this.authenticationTransactionQueryRepository = authenticationTransactionQueryRepository;
     this.deviceEndpointAuthenticationHandler =
         new DeviceEndpointAuthenticationHandler(
             oAuthTokenQueryRepository, new DeviceAuthenticationDeviceFinder(userQueryRepository));
+    this.rawOAuthFlowApi = rawOAuthFlowApi;
+    this.rawCibaFlowApi = rawCibaFlowApi;
+    this.rawUserOperationApi = rawUserOperationApi;
   }
 
   public AuthenticationTransaction get(
@@ -78,6 +93,36 @@ public class AuthenticationTransactionEntryService implements AuthenticationTran
     Tenant tenant = tenantQueryRepository.get(tenantIdentifier);
     return authenticationTransactionQueryRepository.get(
         tenant, authenticationTransactionIdentifier);
+  }
+
+  @Override
+  public AuthenticationInteractionRequestResult interact(
+      TenantIdentifier tenantIdentifier,
+      AuthenticationTransactionIdentifier authenticationTransactionIdentifier,
+      AuthenticationInteractionType type,
+      AuthenticationInteractionRequest request,
+      RequestAttributes requestAttributes) {
+
+    Tenant tenant = tenantQueryRepository.get(tenantIdentifier);
+
+    // Single getForUpdate for the entire interact flow. The lock is held across the dispatched
+    // flow-specific handler since the downstream interactInternal runs within this transaction.
+    AuthenticationTransaction lockedTransaction =
+        authenticationTransactionQueryRepository.getForUpdate(
+            tenant, authenticationTransactionIdentifier);
+
+    String flow = lockedTransaction.flow().name();
+    return switch (flow) {
+      case "oauth" ->
+          rawOAuthFlowApi.interactInternal(
+              tenant, lockedTransaction, type, request, requestAttributes);
+      case "ciba" ->
+          rawCibaFlowApi.interactInternal(
+              tenant, lockedTransaction, type, request, requestAttributes);
+      default ->
+          rawUserOperationApi.interactInternal(
+              tenant, lockedTransaction, type, request, requestAttributes);
+    };
   }
 
   @Override

--- a/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/application/enduser/CibaFlowEntryService.java
+++ b/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/application/enduser/CibaFlowEntryService.java
@@ -165,6 +165,21 @@ public class CibaFlowEntryService implements CibaFlowApi {
         authenticationTransactionQueryRepository.getForUpdate(
             tenant, authenticationTransaction.identifier());
 
+    return interactInternal(tenant, lockedTransaction, type, request, requestAttributes);
+  }
+
+  @Override
+  public AuthenticationInteractionRequestResult interactInternal(
+      Tenant tenant,
+      AuthenticationTransaction lockedTransaction,
+      AuthenticationInteractionType type,
+      AuthenticationInteractionRequest request,
+      RequestAttributes requestAttributes) {
+
+    BackchannelAuthenticationRequestIdentifier backchannelAuthenticationRequestIdentifier =
+        new BackchannelAuthenticationRequestIdentifier(
+            lockedTransaction.authorizationIdentifier().value());
+
     CibaProtocol cibaProtocol = cibaProtocols.get(tenant.authorizationProvider());
     BackchannelAuthenticationRequest backchannelAuthenticationRequest =
         cibaProtocol.get(tenant, backchannelAuthenticationRequestIdentifier);

--- a/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/application/enduser/OAuthFlowEntryService.java
+++ b/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/application/enduser/OAuthFlowEntryService.java
@@ -237,33 +237,43 @@ public class OAuthFlowEntryService implements OAuthFlowApi, OAuthUserDelegate {
 
     Tenant tenant = tenantQueryRepository.get(tenantIdentifier);
 
+    AuthorizationIdentifier authorizationIdentifier =
+        new AuthorizationIdentifier(authorizationRequestIdentifier.value());
+    AuthenticationTransaction lockedTransaction =
+        authenticationTransactionQueryRepository.getForUpdate(tenant, authorizationIdentifier);
+
+    return interactInternal(tenant, lockedTransaction, type, request, requestAttributes);
+  }
+
+  @Override
+  public AuthenticationInteractionRequestResult interactInternal(
+      Tenant tenant,
+      AuthenticationTransaction lockedTransaction,
+      AuthenticationInteractionType type,
+      AuthenticationInteractionRequest request,
+      RequestAttributes requestAttributes) {
+
+    AuthorizationRequestIdentifier authorizationRequestIdentifier =
+        new AuthorizationRequestIdentifier(lockedTransaction.authorizationIdentifier().value());
+
     OAuthProtocol oAuthProtocol = oAuthProtocols.get(tenant.authorizationProvider());
     AuthorizationRequest authorizationRequest =
         oAuthProtocol.get(tenant, authorizationRequestIdentifier);
 
     AuthenticationInteractor authenticationInteractor = authenticationInteractors.get(type);
-    AuthorizationIdentifier authorizationIdentifier =
-        new AuthorizationIdentifier(authorizationRequestIdentifier.value());
-    AuthenticationTransaction authenticationTransaction =
-        authenticationTransactionQueryRepository.getForUpdate(tenant, authorizationIdentifier);
 
     // Validate AUTH_SESSION cookie to prevent session fixation attacks
     // Skip validation for device-based interactors (e.g., push notification) as they don't have the
     // cookie
     if (authenticationInteractor.isBrowserBased()) {
-      validateAuthSession(authenticationTransaction);
+      validateAuthSession(lockedTransaction);
     }
 
     AuthenticationInteractionRequestResult result =
         authenticationInteractor.interact(
-            tenant,
-            authenticationTransaction,
-            type,
-            request,
-            requestAttributes,
-            userQueryRepository);
+            tenant, lockedTransaction, type, request, requestAttributes, userQueryRepository);
 
-    AuthenticationTransaction updatedTransaction = authenticationTransaction.updateWith(result);
+    AuthenticationTransaction updatedTransaction = lockedTransaction.updateWith(result);
     authenticationTransactionCommandRepository.update(tenant, updatedTransaction);
 
     if (updatedTransaction.isSuccess()) {

--- a/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/application/enduser/UserOperationEntryService.java
+++ b/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/application/enduser/UserOperationEntryService.java
@@ -143,40 +143,42 @@ public class UserOperationEntryService implements UserOperationApi {
       RequestAttributes requestAttributes) {
     Tenant tenant = tenantQueryRepository.get(tenantIdentifier);
 
-    AuthenticationInteractor authenticationInteractor = authenticationInteractors.get(type);
-
-    AuthenticationTransaction authenticationTransaction =
+    AuthenticationTransaction lockedTransaction =
         authenticationTransactionQueryRepository.getForUpdate(
             tenant, authenticationTransactionIdentifier);
 
+    return interactInternal(tenant, lockedTransaction, type, request, requestAttributes);
+  }
+
+  @Override
+  public AuthenticationInteractionRequestResult interactInternal(
+      Tenant tenant,
+      AuthenticationTransaction lockedTransaction,
+      AuthenticationInteractionType type,
+      AuthenticationInteractionRequest request,
+      RequestAttributes requestAttributes) {
+
+    AuthenticationInteractor authenticationInteractor = authenticationInteractors.get(type);
+
     AuthenticationInteractionRequestResult result =
         authenticationInteractor.interact(
-            tenant,
-            authenticationTransaction,
-            type,
-            request,
-            requestAttributes,
-            userQueryRepository);
+            tenant, lockedTransaction, type, request, requestAttributes, userQueryRepository);
 
-    AuthenticationTransaction updatedTransaction = authenticationTransaction.updateWith(result);
+    AuthenticationTransaction updatedTransaction = lockedTransaction.updateWith(result);
 
     if (result.isError()) {
       userOperationEventPublisher.publish(
-          tenant,
-          authenticationTransaction,
-          result.eventType(),
-          result.response(),
-          requestAttributes);
+          tenant, lockedTransaction, result.eventType(), result.response(), requestAttributes);
     } else {
       userOperationEventPublisher.publish(
-          tenant, authenticationTransaction, result.eventType(), requestAttributes);
+          tenant, lockedTransaction, result.eventType(), requestAttributes);
     }
 
     if (updatedTransaction.isSuccess()) {
       // IMPORTANT: User is MUTABLE - addAuthenticationDevice() modifies the same instance
-      // authenticationTransaction.user(), updatedTransaction.user(), and result.user()
+      // lockedTransaction.user(), updatedTransaction.user(), and result.user()
       // all reference the same User instance, so any of them will have the updated devices.
-      userCommandRepository.update(tenant, authenticationTransaction.user());
+      userCommandRepository.update(tenant, lockedTransaction.user());
     }
 
     if (updatedTransaction.isLocked()) {
@@ -186,8 +188,7 @@ public class UserOperationEntryService implements UserOperationApi {
     }
 
     if (updatedTransaction.isComplete()) {
-      authenticationTransactionCommandRepository.delete(
-          tenant, authenticationTransactionIdentifier);
+      authenticationTransactionCommandRepository.delete(tenant, lockedTransaction.identifier());
     } else {
       authenticationTransactionCommandRepository.update(tenant, updatedTransaction);
     }


### PR DESCRIPTION
## Summary

- Controller が `authenticationTransactionApi.get()` で transaction を先読みし、flow に応じて 3 つの downstream EntryService に dispatch していたパターンを、`AuthenticationTransactionEntryService.interact()` に統合
- 1 interact あたりのトランザクション数を **2 → 1**、`set_config` 呼出しを **2 → 1** に削減
- AWS の高接続数環境（ProcArrayLock 律速）での効果検証を目的とした基盤改修

## 背景

CIBA / OAuth / UserOperation の interact フローでは：

1. Controller が `authenticationTransactionApi.get(...)` で AuthenticationTransaction を先読み（tx#1）
2. flow 種別を判定して `cibaFlowApi.interact(...)` / `oAuthFlowApi.interact(...)` / `userOperationApi.interact(...)` に dispatch
3. 各 EntryService 内で `getForUpdate()` で**同じ行を再ロック取得**（tx#2）

この構造により：
- 同じ authentication_transaction 行を **2 回 SELECT**
- トランザクションが **2 回**開かれる
- `set_config('app.tenant_id', ...)` が **2 回**呼ばれる
- HikariCP コネクション取得が **2 回**

AWS Writer の高接続数下では `set_config` が数百 ms かかる症状が観測されており、回数自体を減らすことで ProcArrayLock 競合の軽減を狙う。

## 変更内容

### 1. 各 EntryService に `interactInternal()` を追加

- `CibaFlowEntryService`
- `OAuthFlowEntryService`
- `UserOperationEntryService`

シグネチャ：
\`\`\`java
AuthenticationInteractionRequestResult interactInternal(
    Tenant tenant,
    AuthenticationTransaction lockedTransaction,
    AuthenticationInteractionType type,
    AuthenticationInteractionRequest request,
    RequestAttributes requestAttributes);
\`\`\`

引数で受け取った Tenant と locked transaction を使い、内部で `tenantQueryRepository.get()` / `getForUpdate()` を呼ばない。

既存の `interact()` は wrapper として残し、内部で `interactInternal()` を呼ぶ形に変更（後方互換）。

### 2. `AuthenticationTransactionEntryService` に統合 `interact()` を追加

- `tenantQueryRepository.get()` を 1 回だけ実施
- `authenticationTransactionQueryRepository.getForUpdate()` を 1 回だけ実施
- `lockedTransaction.flow().name()` を見て raw (非 proxy) API に dispatch

### 3. `IdpServerApplication` に raw アクセサを追加

`SecurityEventPublisherService.publishSync` で既出の `rawSecurityEventApi` パターン踏襲：

- `rawOAuthFlowApi()`
- `rawCibaFlowApi()`
- `rawUserOperationApi()`

非 proxy のため、`AuthenticationTransactionEntryService` の `@Transaction` 内から呼んだ際に「Transaction already started」例外を回避し、親 tx に join する。

### 4. `AuthenticationV1Api` Controller を薄くする

flow 分岐ロジックを削除し、`authenticationTransactionApi.interact()` を直接呼ぶだけに。

## 期待効果

| 指標 | Before | After |
|------|-------:|------:|
| transaction 数 / interact | 2 | **1** |
| connection 取得回数 / interact | 2 | **1** |
| `set_config` 呼出し / interact | 2 | **1** |
| `authentication_transaction` SELECT 回数 | 2 (1 はロック無、1 は FOR UPDATE) | **1 (FOR UPDATE のみ)** |
| Controller のロジック | flow 分岐あり | なし |

ローカル環境では `set_config` が律速にならないため数値変動は小さい (CIBA 系で約 ±5% のノイズレベル) が、**AWS の ProcArrayLock 競合下では効果が見込まれる**。

## 後方互換性

- `CibaFlowApi.interact(...)` / `OAuthFlowApi.interact(...)` / `UserOperationApi.interact(...)` の既存シグネチャはそのまま残存
- 外部呼び出し元（E2E テスト等）への影響なし

## Test plan

- [x] \`./gradlew spotlessApply build\` SUCCESS
- [x] \`./gradlew test\` SUCCESS (全モジュール)
- [x] ローカル CIBA 6 シナリオ (1.9M users / 120 VU / 30s) 実行で regression がないこと確認
- [ ] AWS staging で `set_config` Avg Time / Wait Events 観測（レビュアー / 別タスクで実施）

🤖 Generated with [Claude Code](https://claude.com/claude-code)