### PR TITLE
perf: 認証ポリシー/認証コンフィグに Redis キャッシュを追加

### DIFF
--- a/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/authentication/config/command/AuthenticationConfigurationCommandDataSource.java
+++ b/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/authentication/config/command/AuthenticationConfigurationCommandDataSource.java
@@ -16,8 +16,10 @@
 
 package org.idp.server.core.adapters.datasource.authentication.config.command;
 
+import org.idp.server.core.adapters.datasource.authentication.config.query.AuthenticationConfigurationQueryDataSource;
 import org.idp.server.core.openid.authentication.config.AuthenticationConfiguration;
 import org.idp.server.core.openid.authentication.repository.AuthenticationConfigurationCommandRepository;
+import org.idp.server.platform.datasource.cache.CacheStore;
 import org.idp.server.platform.json.JsonConverter;
 import org.idp.server.platform.multi_tenancy.tenant.Tenant;
 
@@ -26,25 +28,39 @@ public class AuthenticationConfigurationCommandDataSource
 
   AuthenticationConfigCommandSqlExecutor executor;
   JsonConverter jsonConverter;
+  CacheStore cacheStore;
 
   public AuthenticationConfigurationCommandDataSource(
-      AuthenticationConfigCommandSqlExecutor executor, JsonConverter jsonConverter) {
+      AuthenticationConfigCommandSqlExecutor executor,
+      JsonConverter jsonConverter,
+      CacheStore cacheStore) {
     this.executor = executor;
     this.jsonConverter = jsonConverter;
+    this.cacheStore = cacheStore;
   }
 
   @Override
   public void register(Tenant tenant, AuthenticationConfiguration configuration) {
     executor.insert(tenant, configuration);
+    invalidate(tenant, configuration);
   }
 
   @Override
   public void update(Tenant tenant, AuthenticationConfiguration configuration) {
     executor.update(tenant, configuration);
+    invalidate(tenant, configuration);
   }
 
   @Override
   public void delete(Tenant tenant, AuthenticationConfiguration configuration) {
     executor.delete(tenant, configuration);
+    invalidate(tenant, configuration);
+  }
+
+  private void invalidate(Tenant tenant, AuthenticationConfiguration configuration) {
+    String key =
+        AuthenticationConfigurationQueryDataSource.typeKey(
+            tenant.identifier(), configuration.type());
+    cacheStore.delete(key);
   }
 }

--- a/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/authentication/config/command/AuthenticationConfigurationCommandDataSourceProvider.java
+++ b/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/authentication/config/command/AuthenticationConfigurationCommandDataSourceProvider.java
@@ -18,6 +18,7 @@ package org.idp.server.core.adapters.datasource.authentication.config.command;
 
 import org.idp.server.core.openid.authentication.repository.AuthenticationConfigurationCommandRepository;
 import org.idp.server.platform.datasource.ApplicationDatabaseTypeProvider;
+import org.idp.server.platform.datasource.cache.CacheStore;
 import org.idp.server.platform.dependency.ApplicationComponentDependencyContainer;
 import org.idp.server.platform.dependency.ApplicationComponentProvider;
 import org.idp.server.platform.json.JsonConverter;
@@ -39,6 +40,7 @@ public class AuthenticationConfigurationCommandDataSourceProvider
         new AuthenticationConfigCommandSqlExecutors();
     AuthenticationConfigCommandSqlExecutor executor = executors.get(databaseTypeProvider.provide());
     JsonConverter jsonConverter = JsonConverter.snakeCaseInstance();
-    return new AuthenticationConfigurationCommandDataSource(executor, jsonConverter);
+    CacheStore cacheStore = container.resolve(CacheStore.class);
+    return new AuthenticationConfigurationCommandDataSource(executor, jsonConverter, cacheStore);
   }
 }

--- a/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/authentication/config/query/AuthenticationConfigurationDataSourceAppProvider.java
+++ b/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/authentication/config/query/AuthenticationConfigurationDataSourceAppProvider.java
@@ -18,6 +18,7 @@ package org.idp.server.core.adapters.datasource.authentication.config.query;
 
 import org.idp.server.core.openid.authentication.repository.AuthenticationConfigurationQueryRepository;
 import org.idp.server.platform.datasource.ApplicationDatabaseTypeProvider;
+import org.idp.server.platform.datasource.cache.CacheStore;
 import org.idp.server.platform.dependency.ApplicationComponentDependencyContainer;
 import org.idp.server.platform.dependency.ApplicationComponentProvider;
 
@@ -36,6 +37,7 @@ public class AuthenticationConfigurationDataSourceAppProvider
         container.resolve(ApplicationDatabaseTypeProvider.class);
     AuthenticationConfigSqlExecutors executors = new AuthenticationConfigSqlExecutors();
     AuthenticationConfigSqlExecutor executor = executors.get(databaseTypeProvider.provide());
-    return new AuthenticationConfigurationQueryDataSource(executor);
+    CacheStore cacheStore = container.resolve(CacheStore.class);
+    return new AuthenticationConfigurationQueryDataSource(executor, cacheStore);
   }
 }

--- a/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/authentication/config/query/AuthenticationConfigurationDataSourceProvider.java
+++ b/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/authentication/config/query/AuthenticationConfigurationDataSourceProvider.java
@@ -19,6 +19,7 @@ package org.idp.server.core.adapters.datasource.authentication.config.query;
 import org.idp.server.core.openid.authentication.plugin.AuthenticationDependencyProvider;
 import org.idp.server.core.openid.authentication.repository.AuthenticationConfigurationQueryRepository;
 import org.idp.server.platform.datasource.ApplicationDatabaseTypeProvider;
+import org.idp.server.platform.datasource.cache.CacheStore;
 import org.idp.server.platform.dependency.ApplicationComponentDependencyContainer;
 import org.idp.server.platform.dependency.ApplicationComponentProvider;
 
@@ -38,7 +39,8 @@ public class AuthenticationConfigurationDataSourceProvider
         container.resolve(ApplicationDatabaseTypeProvider.class);
     AuthenticationConfigSqlExecutors executors = new AuthenticationConfigSqlExecutors();
     AuthenticationConfigSqlExecutor executor = executors.get(databaseTypeProvider.provide());
-    return new AuthenticationConfigurationQueryDataSource(executor);
+    CacheStore cacheStore = container.resolve(CacheStore.class);
+    return new AuthenticationConfigurationQueryDataSource(executor, cacheStore);
   }
 
   @Override

--- a/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/authentication/config/query/AuthenticationConfigurationQueryDataSource.java
+++ b/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/authentication/config/query/AuthenticationConfigurationQueryDataSource.java
@@ -19,26 +19,39 @@ package org.idp.server.core.adapters.datasource.authentication.config.query;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import org.idp.server.core.openid.authentication.config.AuthenticationConfiguration;
 import org.idp.server.core.openid.authentication.config.AuthenticationConfigurationIdentifier;
 import org.idp.server.core.openid.authentication.exception.AuthenticationConfigurationNotFoundException;
 import org.idp.server.core.openid.authentication.repository.AuthenticationConfigurationQueryRepository;
+import org.idp.server.platform.datasource.cache.CacheStore;
 import org.idp.server.platform.json.JsonConverter;
 import org.idp.server.platform.multi_tenancy.tenant.Tenant;
+import org.idp.server.platform.multi_tenancy.tenant.TenantIdentifier;
 
 public class AuthenticationConfigurationQueryDataSource
     implements AuthenticationConfigurationQueryRepository {
 
   AuthenticationConfigSqlExecutor executor;
   JsonConverter jsonConverter;
+  CacheStore cacheStore;
 
-  public AuthenticationConfigurationQueryDataSource(AuthenticationConfigSqlExecutor executor) {
+  public AuthenticationConfigurationQueryDataSource(
+      AuthenticationConfigSqlExecutor executor, CacheStore cacheStore) {
     this.executor = executor;
     this.jsonConverter = JsonConverter.snakeCaseInstance();
+    this.cacheStore = cacheStore;
   }
 
   @Override
   public AuthenticationConfiguration get(Tenant tenant, String type) {
+    String key = typeKey(tenant.identifier(), type);
+    Optional<AuthenticationConfiguration> cached =
+        cacheStore.find(key, AuthenticationConfiguration.class);
+    if (cached.isPresent()) {
+      return cached.get();
+    }
+
     Map<String, String> result = executor.selectOne(tenant, type);
 
     if (Objects.isNull(result) || result.isEmpty()) {
@@ -48,18 +61,31 @@ public class AuthenticationConfigurationQueryDataSource
               tenant.identifierValue(), type));
     }
 
-    return jsonConverter.read(result.get("payload"), AuthenticationConfiguration.class);
+    AuthenticationConfiguration configuration =
+        jsonConverter.read(result.get("payload"), AuthenticationConfiguration.class);
+    cacheStore.put(key, configuration);
+    return configuration;
   }
 
   @Override
   public AuthenticationConfiguration find(Tenant tenant, String type) {
+    String key = typeKey(tenant.identifier(), type);
+    Optional<AuthenticationConfiguration> cached =
+        cacheStore.find(key, AuthenticationConfiguration.class);
+    if (cached.isPresent()) {
+      return cached.get();
+    }
+
     Map<String, String> result = executor.selectOne(tenant, type);
 
     if (Objects.isNull(result) || result.isEmpty()) {
       return new AuthenticationConfiguration();
     }
 
-    return jsonConverter.read(result.get("payload"), AuthenticationConfiguration.class);
+    AuthenticationConfiguration configuration =
+        jsonConverter.read(result.get("payload"), AuthenticationConfiguration.class);
+    cacheStore.put(key, configuration);
+    return configuration;
   }
 
   @Override
@@ -108,5 +134,14 @@ public class AuthenticationConfigurationQueryDataSource
     return results.stream()
         .map(result -> jsonConverter.read(result.get("payload"), AuthenticationConfiguration.class))
         .toList();
+  }
+
+  public static String typeKey(TenantIdentifier tenantIdentifier, String type) {
+    return "tenantId:"
+        + tenantIdentifier.value()
+        + ":"
+        + AuthenticationConfiguration.class.getSimpleName()
+        + ":type:"
+        + type;
   }
 }

--- a/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/authentication/policy/command/AuthenticationPolicyConfigurationCommandDataSource.java
+++ b/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/authentication/policy/command/AuthenticationPolicyConfigurationCommandDataSource.java
@@ -16,8 +16,11 @@
 
 package org.idp.server.core.adapters.datasource.authentication.policy.command;
 
+import org.idp.server.core.adapters.datasource.authentication.policy.query.AuthenticationPolicyConfigurationQueryDataSource;
 import org.idp.server.core.openid.authentication.policy.AuthenticationPolicyConfiguration;
 import org.idp.server.core.openid.authentication.repository.AuthenticationPolicyConfigurationCommandRepository;
+import org.idp.server.core.openid.oauth.type.AuthFlow;
+import org.idp.server.platform.datasource.cache.CacheStore;
 import org.idp.server.platform.json.JsonConverter;
 import org.idp.server.platform.multi_tenancy.tenant.Tenant;
 
@@ -26,25 +29,39 @@ public class AuthenticationPolicyConfigurationCommandDataSource
 
   AuthenticationPolicyConfigurationSqlExecutor executor;
   JsonConverter jsonConverter;
+  CacheStore cacheStore;
 
   public AuthenticationPolicyConfigurationCommandDataSource(
-      AuthenticationPolicyConfigurationSqlExecutor executor, JsonConverter jsonConverter) {
+      AuthenticationPolicyConfigurationSqlExecutor executor,
+      JsonConverter jsonConverter,
+      CacheStore cacheStore) {
     this.executor = executor;
     this.jsonConverter = jsonConverter;
+    this.cacheStore = cacheStore;
   }
 
   @Override
   public void register(Tenant tenant, AuthenticationPolicyConfiguration configuration) {
     executor.insert(tenant, configuration);
+    invalidate(tenant, configuration);
   }
 
   @Override
   public void update(Tenant tenant, AuthenticationPolicyConfiguration configuration) {
     executor.update(tenant, configuration);
+    invalidate(tenant, configuration);
   }
 
   @Override
   public void delete(Tenant tenant, AuthenticationPolicyConfiguration configuration) {
     executor.delete(tenant, configuration);
+    invalidate(tenant, configuration);
+  }
+
+  private void invalidate(Tenant tenant, AuthenticationPolicyConfiguration configuration) {
+    AuthFlow authFlow = new AuthFlow(configuration.flow());
+    String key =
+        AuthenticationPolicyConfigurationQueryDataSource.flowKey(tenant.identifier(), authFlow);
+    cacheStore.delete(key);
   }
 }

--- a/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/authentication/policy/command/AuthenticationPolicyConfigurationCommandDataSourceProvider.java
+++ b/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/authentication/policy/command/AuthenticationPolicyConfigurationCommandDataSourceProvider.java
@@ -18,6 +18,7 @@ package org.idp.server.core.adapters.datasource.authentication.policy.command;
 
 import org.idp.server.core.openid.authentication.repository.AuthenticationPolicyConfigurationCommandRepository;
 import org.idp.server.platform.datasource.ApplicationDatabaseTypeProvider;
+import org.idp.server.platform.datasource.cache.CacheStore;
 import org.idp.server.platform.dependency.ApplicationComponentDependencyContainer;
 import org.idp.server.platform.dependency.ApplicationComponentProvider;
 import org.idp.server.platform.json.JsonConverter;
@@ -40,6 +41,8 @@ public class AuthenticationPolicyConfigurationCommandDataSourceProvider
     AuthenticationPolicyConfigurationSqlExecutor executor =
         executors.get(databaseTypeProvider.provide());
     JsonConverter jsonConverter = JsonConverter.snakeCaseInstance();
-    return new AuthenticationPolicyConfigurationCommandDataSource(executor, jsonConverter);
+    CacheStore cacheStore = container.resolve(CacheStore.class);
+    return new AuthenticationPolicyConfigurationCommandDataSource(
+        executor, jsonConverter, cacheStore);
   }
 }

--- a/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/authentication/policy/query/AuthenticationPolicyConfigurationQueryDataSource.java
+++ b/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/authentication/policy/query/AuthenticationPolicyConfigurationQueryDataSource.java
@@ -19,39 +19,61 @@ package org.idp.server.core.adapters.datasource.authentication.policy.query;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import org.idp.server.core.openid.authentication.exception.AuthenticationPolicyNotFoundException;
 import org.idp.server.core.openid.authentication.policy.AuthenticationPolicyConfiguration;
 import org.idp.server.core.openid.authentication.policy.AuthenticationPolicyConfigurationIdentifier;
 import org.idp.server.core.openid.authentication.repository.AuthenticationPolicyConfigurationQueryRepository;
 import org.idp.server.core.openid.oauth.type.AuthFlow;
+import org.idp.server.platform.datasource.cache.CacheStore;
 import org.idp.server.platform.json.JsonConverter;
 import org.idp.server.platform.multi_tenancy.tenant.Tenant;
+import org.idp.server.platform.multi_tenancy.tenant.TenantIdentifier;
 
 public class AuthenticationPolicyConfigurationQueryDataSource
     implements AuthenticationPolicyConfigurationQueryRepository {
 
   AuthenticationPolicyConfigurationSqlExecutor executor;
   JsonConverter jsonConverter;
+  CacheStore cacheStore;
 
   public AuthenticationPolicyConfigurationQueryDataSource(
-      AuthenticationPolicyConfigurationSqlExecutor executor) {
+      AuthenticationPolicyConfigurationSqlExecutor executor, CacheStore cacheStore) {
     this.executor = executor;
     this.jsonConverter = JsonConverter.snakeCaseInstance();
+    this.cacheStore = cacheStore;
   }
 
   @Override
   public AuthenticationPolicyConfiguration find(Tenant tenant, AuthFlow authFlow) {
+    String key = flowKey(tenant.identifier(), authFlow);
+    Optional<AuthenticationPolicyConfiguration> cached =
+        cacheStore.find(key, AuthenticationPolicyConfiguration.class);
+    if (cached.isPresent()) {
+      return cached.get();
+    }
+
     Map<String, String> result = executor.selectOne(tenant, authFlow);
 
     if (Objects.isNull(result) || result.isEmpty()) {
       return new AuthenticationPolicyConfiguration();
     }
 
-    return jsonConverter.read(result.get("payload"), AuthenticationPolicyConfiguration.class);
+    AuthenticationPolicyConfiguration configuration =
+        jsonConverter.read(result.get("payload"), AuthenticationPolicyConfiguration.class);
+    cacheStore.put(key, configuration);
+    return configuration;
   }
 
   @Override
   public AuthenticationPolicyConfiguration get(Tenant tenant, AuthFlow authFlow) {
+    String key = flowKey(tenant.identifier(), authFlow);
+    Optional<AuthenticationPolicyConfiguration> cached =
+        cacheStore.find(key, AuthenticationPolicyConfiguration.class);
+    if (cached.isPresent()) {
+      return cached.get();
+    }
+
     Map<String, String> result = executor.selectOne(tenant, authFlow);
 
     if (Objects.isNull(result) || result.isEmpty()) {
@@ -59,7 +81,10 @@ public class AuthenticationPolicyConfigurationQueryDataSource
           "Authentication policy configuration not found");
     }
 
-    return jsonConverter.read(result.get("payload"), AuthenticationPolicyConfiguration.class);
+    AuthenticationPolicyConfiguration configuration =
+        jsonConverter.read(result.get("payload"), AuthenticationPolicyConfiguration.class);
+    cacheStore.put(key, configuration);
+    return configuration;
   }
 
   @Override
@@ -110,5 +135,14 @@ public class AuthenticationPolicyConfigurationQueryDataSource
     return results.stream()
         .map(result -> jsonConverter.read(result, AuthenticationPolicyConfiguration.class))
         .toList();
+  }
+
+  public static String flowKey(TenantIdentifier tenantIdentifier, AuthFlow authFlow) {
+    return "tenantId:"
+        + tenantIdentifier.value()
+        + ":"
+        + AuthenticationPolicyConfiguration.class.getSimpleName()
+        + ":flow:"
+        + authFlow.name();
   }
 }

--- a/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/authentication/policy/query/AuthenticationPolicyConfigurationQueryDataSourceProvider.java
+++ b/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/authentication/policy/query/AuthenticationPolicyConfigurationQueryDataSourceProvider.java
@@ -18,6 +18,7 @@ package org.idp.server.core.adapters.datasource.authentication.policy.query;
 
 import org.idp.server.core.openid.authentication.repository.AuthenticationPolicyConfigurationQueryRepository;
 import org.idp.server.platform.datasource.ApplicationDatabaseTypeProvider;
+import org.idp.server.platform.datasource.cache.CacheStore;
 import org.idp.server.platform.dependency.ApplicationComponentDependencyContainer;
 import org.idp.server.platform.dependency.ApplicationComponentProvider;
 
@@ -38,6 +39,7 @@ public class AuthenticationPolicyConfigurationQueryDataSourceProvider
         new AuthenticationPolicyConfigurationSqlExecutors();
     AuthenticationPolicyConfigurationSqlExecutor executor =
         executors.get(databaseTypeProvider.provide());
-    return new AuthenticationPolicyConfigurationQueryDataSource(executor);
+    CacheStore cacheStore = container.resolve(CacheStore.class);
+    return new AuthenticationPolicyConfigurationQueryDataSource(executor, cacheStore);
   }
 }


### PR DESCRIPTION
## Summary

- `AuthenticationPolicyConfiguration` と `AuthenticationConfiguration` のホットパス参照 (tenant + flow / type) を Redis キャッシュ対象に追加
- 既存の `TenantQueryDataSource` / `AuthorizationServerConfigurationQueryDataSource` と同じパターン
- 高接続数環境で毎回 DB SELECT になっていたコンフィグ参照を Redis ヒットに切り替え、1 リクエストあたりの DB 負荷を削減

> **Note**: 本 PR は #1543 (refactor: 認証 interact フローを単一トランザクションに統合) を基盤としています。#1543 を先にマージしてください。

## 背景

CIBA / OAuth フローの interact 経路では以下の Repository が **毎回 DB SELECT** で参照されていた：

| Repository | 呼出し箇所 |
|---|---|
| `AuthenticationPolicyConfigurationQueryRepository.find(Tenant, AuthFlow)` | `CibaFlowEntryService.request()` / `OAuthFlowEntryService.interact()` / `UserOperationEntryService.interact()` |
| `AuthenticationConfigurationQueryRepository.get/find(Tenant, String type)` | 各種 AuthenticationInteractor (FIDO-UAF, SMS, Email, etc.) |

設定データなので変更頻度が低く、Tenant / ServerConfig / ClientConfig と同様にキャッシュ向き。

## 変更内容

### Query 側

| ファイル | 変更 |
|---|---|
| `AuthenticationPolicyConfigurationQueryDataSource` | `find(Tenant, AuthFlow)` / `get(Tenant, AuthFlow)` を CacheStore 経由に |
| `AuthenticationConfigurationQueryDataSource` | `find(Tenant, String)` / `get(Tenant, String)` を CacheStore 経由に |
| 各 Provider (Query + Command 計 4 ファイル) | `CacheStore` を DI 注入 |

キー形式：

\`\`\`
tenantId:<uuid>:AuthenticationPolicyConfiguration:flow:<AuthFlow.name()>
tenantId:<uuid>:AuthenticationConfiguration:type:<type>
\`\`\`

### Command 側

`register` / `update` / `delete` で対応するキーを `cacheStore.delete()` で無効化。

### キャッシュ範囲

| 経路 | キャッシュ |
|---|---|
| `find(Tenant, AuthFlow)` (ホットパス) | ✅ |
| `find(Tenant, type)` (ホットパス) | ✅ |
| `find(Tenant, identifier)` (管理 API) | ❌ |
| `findList(...)` (管理 API) | ❌ |

低頻度 + 無効化粒度が複雑な経路はキャッシュしない方針。

## 動作確認

ローカル (1.9M users) で実機確認：

\`\`\`bash
# 1 リクエスト走らせて Redis db1 を即チェック
docker exec redis redis-cli -n 1 --scan --pattern '*AuthenticationPolicy*'
docker exec redis redis-cli -n 1 --scan --pattern '*AuthenticationConfiguration*'
\`\`\`

→ 該当テナントに `authentication_policy` / `authentication_configuration` レコードが登録されている場合に、`tenantId:<uuid>:AuthenticationPolicyConfiguration:flow:ciba` 等の key が Redis に追加されることを確認。

## 期待効果

ローカル測定 (CIBA 6 シナリオ x 2 セット平均) で **TPS +4.5%、iter_p95 改善 (特に CIBA device で -16%、CIBA sub で -15%)**。

AWS の ProcArrayLock 律速下では set_config 削減と相まって更に大きな効果が見込まれる。

## アンチパターン回避

「空 default を返す」分岐ではキャッシュ put しない設計にしている：

\`\`\`java
if (Objects.isNull(result) || result.isEmpty()) {
    return new AuthenticationPolicyConfiguration();  // empty default, NOT cached
}
// 通常パス: cacheStore.put(key, configuration)
\`\`\`

これにより：
- ✅ 「設定追加後の即時反映」を維持 (TTL 待ち不要)
- ⚠️ ただし「設定が無いテナント」では繰り返し DB SELECT が発生（運用上問題ない範囲と判断）

## Test plan

- [x] `./gradlew spotlessApply build` SUCCESS
- [x] `./gradlew test` SUCCESS (全モジュール)
- [x] ローカル CIBA 6 シナリオ x 2 セット実行、regression なし
- [x] Redis db1 に該当キーが作成されることを実機確認
- [ ] AWS staging で実効果測定（レビュアー / 別タスクで実施）

🤖 Generated with [Claude Code](https://claude.com/claude-code)