### PR TITLE
perf: トークン introspection の user status 確認を軽量化 + キャッシュ化

### DIFF
--- a/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/identity/MysqlExecutor.java
+++ b/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/identity/MysqlExecutor.java
@@ -531,6 +531,18 @@ public class MysqlExecutor implements UserSqlExecutor {
     return sqlExecutor.selectOne(sqlTemplate, params);
   }
 
+  @Override
+  public Map<String, String> selectStatus(Tenant tenant, UserIdentifier userIdentifier) {
+    SqlExecutor sqlExecutor = new SqlExecutor();
+
+    String sqlTemplate = "SELECT status FROM idp_user WHERE tenant_id = ? AND id = ?";
+    List<Object> params = new ArrayList<>();
+    params.add(tenant.identifierValue());
+    params.add(userIdentifier.valueAsUuid().toString());
+
+    return sqlExecutor.selectOne(sqlTemplate, params);
+  }
+
   private static final String SELECT_BASE_FIELDS =
       """
                    idp_user.id,

--- a/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/identity/PostgresqlExecutor.java
+++ b/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/identity/PostgresqlExecutor.java
@@ -529,6 +529,18 @@ public class PostgresqlExecutor implements UserSqlExecutor {
     return sqlExecutor.selectOne(sqlTemplate, params);
   }
 
+  @Override
+  public Map<String, String> selectStatus(Tenant tenant, UserIdentifier userIdentifier) {
+    SqlExecutor sqlExecutor = new SqlExecutor();
+
+    String sqlTemplate = "SELECT status FROM idp_user WHERE tenant_id = ?::uuid AND id = ?::uuid";
+    List<Object> params = new ArrayList<>();
+    params.add(tenant.identifierUUID());
+    params.add(userIdentifier.valueAsUuid());
+
+    return sqlExecutor.selectOne(sqlTemplate, params);
+  }
+
   private static final String SELECT_BASE_FIELDS =
       """
               idp_user.id,

--- a/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/identity/UserDataSourceProvider.java
+++ b/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/identity/UserDataSourceProvider.java
@@ -18,6 +18,7 @@ package org.idp.server.core.adapters.datasource.identity;
 
 import org.idp.server.core.openid.identity.repository.UserQueryRepository;
 import org.idp.server.platform.datasource.ApplicationDatabaseTypeProvider;
+import org.idp.server.platform.datasource.cache.CacheStore;
 import org.idp.server.platform.dependency.ApplicationComponentDependencyContainer;
 import org.idp.server.platform.dependency.ApplicationComponentProvider;
 
@@ -34,6 +35,7 @@ public class UserDataSourceProvider implements ApplicationComponentProvider<User
         container.resolve(ApplicationDatabaseTypeProvider.class);
     UserSqlExecutors executors = new UserSqlExecutors();
     UserSqlExecutor executor = executors.get(databaseTypeProvider.provide());
-    return new UserQueryDataSource(executor);
+    CacheStore cacheStore = container.resolve(CacheStore.class);
+    return new UserQueryDataSource(executor, cacheStore);
   }
 }

--- a/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/identity/UserQueryDataSource.java
+++ b/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/identity/UserQueryDataSource.java
@@ -20,24 +20,35 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import org.idp.server.core.openid.identity.User;
 import org.idp.server.core.openid.identity.UserIdentifier;
 import org.idp.server.core.openid.identity.UserQueries;
+import org.idp.server.core.openid.identity.UserStatus;
 import org.idp.server.core.openid.identity.device.AuthenticationDeviceIdentifier;
 import org.idp.server.core.openid.identity.exception.UserNotFoundException;
 import org.idp.server.core.openid.identity.exception.UserTooManyFoundResultException;
 import org.idp.server.core.openid.identity.repository.UserQueryRepository;
 import org.idp.server.platform.datasource.SqlTooManyResultsException;
+import org.idp.server.platform.datasource.cache.CacheStore;
+import org.idp.server.platform.datasource.cache.NoOperationCacheStore;
 import org.idp.server.platform.multi_tenancy.tenant.Tenant;
+import org.idp.server.platform.multi_tenancy.tenant.TenantIdentifier;
 import org.idp.server.platform.multi_tenancy.tenant.policy.UserAttributeLoadRule;
 
 public class UserQueryDataSource implements UserQueryRepository {
 
   UserSqlExecutor executor;
+  CacheStore cacheStore;
 
   public UserQueryDataSource(UserSqlExecutor executor) {
+    this(executor, new NoOperationCacheStore());
+  }
+
+  public UserQueryDataSource(UserSqlExecutor executor, CacheStore cacheStore) {
     this.executor = executor;
+    this.cacheStore = cacheStore;
   }
 
   @Override
@@ -244,6 +255,33 @@ public class UserQueryDataSource implements UserQueryRepository {
     } catch (SqlTooManyResultsException exception) {
       throw new UserTooManyFoundResultException(exception.getMessage());
     }
+  }
+
+  @Override
+  public UserStatus findStatusById(Tenant tenant, UserIdentifier userIdentifier) {
+    String key = statusKey(tenant.identifier(), userIdentifier);
+    Optional<UserStatus> cached = cacheStore.find(key, UserStatus.class);
+    if (cached.isPresent()) {
+      return cached.get();
+    }
+
+    Map<String, String> result = executor.selectStatus(tenant, userIdentifier);
+    if (Objects.isNull(result) || result.isEmpty()) {
+      return null;
+    }
+
+    String statusName = result.get("status");
+    if (statusName == null) {
+      return null;
+    }
+
+    UserStatus status = UserStatus.valueOf(statusName);
+    cacheStore.put(key, status);
+    return status;
+  }
+
+  public static String statusKey(TenantIdentifier tenantIdentifier, UserIdentifier userIdentifier) {
+    return "tenantId:" + tenantIdentifier.value() + ":UserStatus:" + userIdentifier.value();
   }
 
   private User collectAssignedDataAndConvert(

--- a/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/identity/UserQueryDataSourceProvider.java
+++ b/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/identity/UserQueryDataSourceProvider.java
@@ -19,6 +19,7 @@ package org.idp.server.core.adapters.datasource.identity;
 import org.idp.server.core.openid.authentication.plugin.AuthenticationDependencyProvider;
 import org.idp.server.core.openid.identity.repository.UserQueryRepository;
 import org.idp.server.platform.datasource.ApplicationDatabaseTypeProvider;
+import org.idp.server.platform.datasource.cache.CacheStore;
 import org.idp.server.platform.dependency.ApplicationComponentDependencyContainer;
 import org.idp.server.platform.dependency.ApplicationComponentProvider;
 
@@ -37,7 +38,8 @@ public class UserQueryDataSourceProvider
         container.resolve(ApplicationDatabaseTypeProvider.class);
     UserSqlExecutors executors = new UserSqlExecutors();
     UserSqlExecutor executor = executors.get(databaseTypeProvider.provide());
-    return new UserQueryDataSource(executor);
+    CacheStore cacheStore = container.resolve(CacheStore.class);
+    return new UserQueryDataSource(executor, cacheStore);
   }
 
   @Override

--- a/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/identity/UserSqlExecutor.java
+++ b/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/identity/UserSqlExecutor.java
@@ -57,4 +57,6 @@ public interface UserSqlExecutor {
   Map<String, String> selectAssignedTenant(Tenant tenant, UserIdentifier userIdentifier);
 
   Map<String, String> selectByFidoCredentialId(Tenant tenant, String credentialId);
+
+  Map<String, String> selectStatus(Tenant tenant, UserIdentifier userIdentifier);
 }

--- a/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/identity/command/UserCommandDataSource.java
+++ b/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/identity/command/UserCommandDataSource.java
@@ -16,17 +16,26 @@
 
 package org.idp.server.core.adapters.datasource.identity.command;
 
+import org.idp.server.core.adapters.datasource.identity.UserQueryDataSource;
 import org.idp.server.core.openid.identity.User;
 import org.idp.server.core.openid.identity.UserIdentifier;
 import org.idp.server.core.openid.identity.repository.UserCommandRepository;
+import org.idp.server.platform.datasource.cache.CacheStore;
+import org.idp.server.platform.datasource.cache.NoOperationCacheStore;
 import org.idp.server.platform.multi_tenancy.tenant.Tenant;
 
 public class UserCommandDataSource implements UserCommandRepository {
 
   UserCommandSqlExecutor executor;
+  CacheStore cacheStore;
 
   public UserCommandDataSource(UserCommandSqlExecutor executor) {
+    this(executor, new NoOperationCacheStore());
+  }
+
+  public UserCommandDataSource(UserCommandSqlExecutor executor, CacheStore cacheStore) {
     this.executor = executor;
+    this.cacheStore = cacheStore;
   }
 
   @Override
@@ -47,11 +56,13 @@ public class UserCommandDataSource implements UserCommandRepository {
     if (user.hasCurrentOrganizationId()) {
       executor.upsertCurrentOrganization(tenant, user);
     }
+    invalidateStatusCache(tenant, user.userIdentifier());
   }
 
   @Override
   public void update(Tenant tenant, User user) {
     executor.update(tenant, user);
+    invalidateStatusCache(tenant, user.userIdentifier());
   }
 
   @Override
@@ -94,5 +105,13 @@ public class UserCommandDataSource implements UserCommandRepository {
   @Override
   public void delete(Tenant tenant, UserIdentifier userIdentifier) {
     executor.delete(tenant, userIdentifier);
+    invalidateStatusCache(tenant, userIdentifier);
+  }
+
+  private void invalidateStatusCache(Tenant tenant, UserIdentifier userIdentifier) {
+    if (userIdentifier == null || userIdentifier.value() == null) {
+      return;
+    }
+    cacheStore.delete(UserQueryDataSource.statusKey(tenant.identifier(), userIdentifier));
   }
 }

--- a/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/identity/command/UserCommandDataSourceProvider.java
+++ b/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/identity/command/UserCommandDataSourceProvider.java
@@ -18,6 +18,7 @@ package org.idp.server.core.adapters.datasource.identity.command;
 
 import org.idp.server.core.openid.identity.repository.UserCommandRepository;
 import org.idp.server.platform.datasource.ApplicationDatabaseTypeProvider;
+import org.idp.server.platform.datasource.cache.CacheStore;
 import org.idp.server.platform.dependency.ApplicationComponentDependencyContainer;
 import org.idp.server.platform.dependency.ApplicationComponentProvider;
 
@@ -35,6 +36,7 @@ public class UserCommandDataSourceProvider
         container.resolve(ApplicationDatabaseTypeProvider.class);
     UserCommandSqlExecutors executors = new UserCommandSqlExecutors();
     UserCommandSqlExecutor executor = executors.get(databaseTypeProvider.provide());
-    return new UserCommandDataSource(executor);
+    CacheStore cacheStore = container.resolve(CacheStore.class);
+    return new UserCommandDataSource(executor, cacheStore);
   }
 }

--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/identity/repository/UserQueryRepository.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/identity/repository/UserQueryRepository.java
@@ -20,6 +20,7 @@ import java.util.List;
 import org.idp.server.core.openid.identity.User;
 import org.idp.server.core.openid.identity.UserIdentifier;
 import org.idp.server.core.openid.identity.UserQueries;
+import org.idp.server.core.openid.identity.UserStatus;
 import org.idp.server.core.openid.identity.device.AuthenticationDeviceIdentifier;
 import org.idp.server.platform.multi_tenancy.tenant.Tenant;
 
@@ -52,4 +53,14 @@ public interface UserQueryRepository {
   User findByPreferredUsernameNoProvider(Tenant tenant, String preferredUsername);
 
   User findByFidoCredentialId(Tenant tenant, String credentialId);
+
+  /**
+   * Lightweight lookup that returns only the user's {@link UserStatus}.
+   *
+   * <p>Used by hot-path checks (e.g., token introspection) where the full user payload is not
+   * needed. The query reads a single column and skips role / permission JOINs.
+   *
+   * @return current {@link UserStatus}, or {@code null} if the user does not exist
+   */
+  UserStatus findStatusById(Tenant tenant, UserIdentifier userIdentifier);
 }

--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/token/TokenUserFindingDelegate.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/token/TokenUserFindingDelegate.java
@@ -17,6 +17,7 @@
 package org.idp.server.core.openid.token;
 
 import org.idp.server.core.openid.identity.User;
+import org.idp.server.core.openid.identity.UserStatus;
 import org.idp.server.core.openid.oauth.type.oauth.Subject;
 import org.idp.server.platform.multi_tenancy.tenant.Tenant;
 
@@ -38,4 +39,16 @@ public interface TokenUserFindingDelegate {
    * @return the user object (may be empty if not found)
    */
   User findUser(Tenant tenant, Subject subject);
+
+  /**
+   * Lightweight lookup that returns only the user's {@link UserStatus}.
+   *
+   * <p>Used by hot-path checks (e.g., token introspection) where only the active-state needs to be
+   * verified. Implementations should avoid loading the full user payload.
+   *
+   * @param tenant the tenant context
+   * @param subject the user's subject identifier
+   * @return current {@link UserStatus}, or {@code null} if the user does not exist
+   */
+  UserStatus findUserStatus(Tenant tenant, Subject subject);
 }

--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/token/handler/tokenintrospection/TokenIntrospectionExtensionHandler.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/token/handler/tokenintrospection/TokenIntrospectionExtensionHandler.java
@@ -18,6 +18,7 @@ package org.idp.server.core.openid.token.handler.tokenintrospection;
 
 import java.util.Map;
 import org.idp.server.core.openid.identity.User;
+import org.idp.server.core.openid.identity.UserStatus;
 import org.idp.server.core.openid.oauth.clientauthenticator.ClientAuthenticationHandler;
 import org.idp.server.core.openid.oauth.configuration.AuthorizationServerConfiguration;
 import org.idp.server.core.openid.oauth.configuration.AuthorizationServerConfigurationQueryRepository;
@@ -93,8 +94,13 @@ public class TokenIntrospectionExtensionHandler {
     verifier.verify();
 
     if (!oAuthToken.isClientCredentialsGrant()) {
-      User user = delegate.findUser(tenant, oAuthToken.subject());
-      TokenIntrospectionUserVerifier userVerifier = new TokenIntrospectionUserVerifier(user);
+      UserStatus status = delegate.findUserStatus(tenant, oAuthToken.subject());
+      User minimal = new User();
+      if (status != null) {
+        minimal.setSub(oAuthToken.subject().value());
+        minimal.setStatus(status);
+      }
+      TokenIntrospectionUserVerifier userVerifier = new TokenIntrospectionUserVerifier(minimal);
       userVerifier.verify();
     }
 

--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/token/handler/tokenintrospection/TokenIntrospectionHandler.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/token/handler/tokenintrospection/TokenIntrospectionHandler.java
@@ -18,6 +18,7 @@ package org.idp.server.core.openid.token.handler.tokenintrospection;
 
 import java.util.Map;
 import org.idp.server.core.openid.identity.User;
+import org.idp.server.core.openid.identity.UserStatus;
 import org.idp.server.core.openid.oauth.clientauthenticator.ClientAuthenticationHandler;
 import org.idp.server.core.openid.oauth.configuration.AuthorizationServerConfiguration;
 import org.idp.server.core.openid.oauth.configuration.AuthorizationServerConfigurationQueryRepository;
@@ -92,8 +93,13 @@ public class TokenIntrospectionHandler {
     }
 
     if (!oAuthToken.isClientCredentialsGrant()) {
-      User user = delegate.findUser(tenant, oAuthToken.subject());
-      TokenIntrospectionUserVerifier userVerifier = new TokenIntrospectionUserVerifier(user);
+      UserStatus status = delegate.findUserStatus(tenant, oAuthToken.subject());
+      User minimal = new User();
+      if (status != null) {
+        minimal.setSub(oAuthToken.subject().value());
+        minimal.setStatus(status);
+      }
+      TokenIntrospectionUserVerifier userVerifier = new TokenIntrospectionUserVerifier(minimal);
       userVerifier.verify();
     }
 

--- a/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/application/enduser/TokenEntryService.java
+++ b/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/application/enduser/TokenEntryService.java
@@ -19,6 +19,7 @@ package org.idp.server.usecases.application.enduser;
 import java.util.Map;
 import org.idp.server.core.openid.identity.User;
 import org.idp.server.core.openid.identity.UserIdentifier;
+import org.idp.server.core.openid.identity.UserStatus;
 import org.idp.server.core.openid.identity.repository.UserQueryRepository;
 import org.idp.server.core.openid.oauth.type.oauth.Subject;
 import org.idp.server.core.openid.token.TokenApi;
@@ -161,5 +162,11 @@ public class TokenEntryService implements TokenApi, TokenUserFindingDelegate {
   public User findUser(Tenant tenant, Subject subject) {
     UserIdentifier userIdentifier = new UserIdentifier(subject.value());
     return userQueryRepository.findById(tenant, userIdentifier);
+  }
+
+  @Override
+  public UserStatus findUserStatus(Tenant tenant, Subject subject) {
+    UserIdentifier userIdentifier = new UserIdentifier(subject.value());
+    return userQueryRepository.findStatusById(tenant, userIdentifier);
   }
 }


### PR DESCRIPTION
## Summary

トークン introspection の user status 確認を、`status` カラム単独 SELECT + Redis キャッシュに切り替えて DB 負荷を下げる。

CIBA フローは 1 iteration で introspection が 5 回走るホットパス。従来は status 1 つを見るためだけに full user (JSON カラム + JOIN) をロードしていた。

## Changes

### A. 軽量 status クエリ

- `UserQueryRepository.findStatusById(Tenant, UserIdentifier) → UserStatus` 追加
- PostgreSQL / MySQL Executor に `selectStatus` 実装
  ```sql
  SELECT status FROM idp_user WHERE tenant_id = ? AND id = ?
  ```

### B. Redis キャッシュ

- `UserQueryDataSource.findStatusById` に cache-aside ロジック追加
  - Key: `tenantId:<id>:UserStatus:<userId>`
  - TTL: `CacheConfiguration.timeToLiveSeconds()` 既定値（PR #1544 と同じ）
- `UserCommandDataSource` の `register` / `update` / `delete` で invalidate
- 既存パターン (`AuthenticationConfigurationQueryDataSource`) 踏襲

### introspection ハンドラ

- `TokenUserFindingDelegate` に `findUserStatus` メソッド追加
- `TokenIntrospectionHandler` / `TokenIntrospectionExtensionHandler` を新方式に切替
- 既存 `TokenIntrospectionUserVerifier` はそのまま（sub + status のみセットした minimal User を渡す）

## Stack

このブランチは #1545 (`perf/user-attribute-load-rule`) の上に積んでる。マージ順は 1545 → 本 PR。

## Test plan

- [x] `./gradlew build` 成功
- [x] E2E テスト 成功
- [ ] ローカル perf テスト (k6 CIBA scenario) で TPS 改善確認
- [ ] AWS でも改善確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)