### PR TITLE
fix: READ パスで replica DB の xact_rollback 誤集計を修正 (#1552)

### DIFF
--- a/libs/idp-server-platform/src/main/java/org/idp/server/platform/datasource/TransactionManager.java
+++ b/libs/idp-server-platform/src/main/java/org/idp/server/platform/datasource/TransactionManager.java
@@ -111,6 +111,32 @@ public class TransactionManager {
     }
   }
 
+  /**
+   * READ パス専用の終了処理。
+   *
+   * <p>HikariCP の {@code autoCommit=false} 設定下では、{@link #setTenantId} の {@code set_config()}
+   * 呼び出し（または最初の SELECT）で暗黙的に transaction が開始される。READ パスでも明示的に {@code commit()} を呼ばずに connection を
+   * close すると、HikariCP が pool 返却時に強制 rollback を発行し、特に reader (replica) DB の {@code
+   * pg_stat_database.xact_rollback} が READ 操作ごとに加算されてしまう（commit 成功率メトリクスの汚染）。
+   *
+   * <p>このメソッドは READ パスでも {@code commit()} を発行することで、上記のメトリクス汚染を防ぐ。 例外時は {@code finally} 側の {@link
+   * #closeConnection} に任せて HikariCP の rollback で破棄させる構造。
+   *
+   * @see <a href="https://github.com/hirokazu-kobayashi-koba-hiro/idp-server/issues/1552">Issue
+   *     #1552</a>
+   */
+  public static void endReadTransaction() {
+    Connection conn = connectionHolder.get();
+    if (conn == null) return;
+    try {
+      conn.commit();
+    } catch (SQLException e) {
+      throw new SqlRuntimeException("Failed to commit read transaction", e);
+    } finally {
+      closeConnection();
+    }
+  }
+
   public static void closeConnection() {
     Connection conn = connectionHolder.get();
     if (conn != null) {

--- a/libs/idp-server-platform/src/main/java/org/idp/server/platform/datasource/TransactionManager.java
+++ b/libs/idp-server-platform/src/main/java/org/idp/server/platform/datasource/TransactionManager.java
@@ -119,8 +119,13 @@ public class TransactionManager {
    * close すると、HikariCP が pool 返却時に強制 rollback を発行し、特に reader (replica) DB の {@code
    * pg_stat_database.xact_rollback} が READ 操作ごとに加算されてしまう（commit 成功率メトリクスの汚染）。
    *
-   * <p>このメソッドは READ パスでも {@code commit()} を発行することで、上記のメトリクス汚染を防ぐ。 例外時は {@code finally} 側の {@link
-   * #closeConnection} に任せて HikariCP の rollback で破棄させる構造。
+   * <p>このメソッドは READ パスでも {@code commit()} を発行することで、上記のメトリクス汚染を防ぐ。
+   *
+   * <p><strong>例外時に explicit rollback を呼ばない理由</strong>: explicit rollback を発行しても、HikariCP が close
+   * 時に reset 処理として rollback を発行しても、どちらも DB 側では同じ 1 件の {@code xact_rollback} としてカウントされる。READ
+   * パスの例外は元々まれであり、本 PR の主目的である「正常系の commit 集計回復」には寄与しない。シンプルさのため {@code finally} 側の {@link
+   * #closeConnection} 経由で HikariCP の reset rollback に任せる構造を採用している（WRITE パスは正常系・例外系の意味論的差を明示するため
+   * explicit に commit/rollback を発行する）。
    *
    * @see <a href="https://github.com/hirokazu-kobayashi-koba-hiro/idp-server/issues/1552">Issue
    *     #1552</a>

--- a/libs/idp-server-platform/src/test/java/org/idp/server/platform/datasource/TransactionManagerTest.java
+++ b/libs/idp-server-platform/src/test/java/org/idp/server/platform/datasource/TransactionManagerTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2025 Hirokazu Kobayashi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.idp.server.platform.datasource;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("TransactionManager")
+class TransactionManagerTest {
+
+  @AfterEach
+  void cleanUp() {
+    // ThreadLocal リーク防止: 各テスト後に必ず close
+    try {
+      TransactionManager.closeConnection();
+    } catch (Exception ignored) {
+      // テスト失敗時の保険、無視してよい
+    }
+  }
+
+  @Nested
+  @DisplayName("endReadTransaction")
+  class EndReadTransactionTest {
+
+    @Test
+    @DisplayName("connectionHolder が空の場合は no-op で例外を投げない")
+    void noOpWhenConnectionHolderIsEmpty() {
+      assertDoesNotThrow(() -> TransactionManager.endReadTransaction());
+    }
+
+    @Test
+    @DisplayName("正常時: commit() と close() が両方呼ばれる")
+    void commitAndCloseOnSuccess() throws Exception {
+      Connection mockConn = mock(Connection.class);
+      DbConnectionProvider mockProvider = mock(DbConnectionProvider.class);
+      when(mockProvider.getConnection(any(DatabaseType.class), anyBoolean())).thenReturn(mockConn);
+      TransactionManager.configure(mockProvider);
+
+      // admin=true 経由で createConnection し、setTenantId をスキップ
+      TransactionManager.createConnection(DatabaseType.POSTGRESQL);
+
+      TransactionManager.endReadTransaction();
+
+      verify(mockConn, times(1)).commit();
+      verify(mockConn, times(1)).close();
+    }
+
+    @Test
+    @DisplayName("commit 失敗時: SqlRuntimeException がスローされ、かつ close() は呼ばれる (ThreadLocal リーク防止)")
+    void throwsAndClosesOnCommitFailure() throws Exception {
+      Connection mockConn = mock(Connection.class);
+      doThrow(new SQLException("commit failed")).when(mockConn).commit();
+      DbConnectionProvider mockProvider = mock(DbConnectionProvider.class);
+      when(mockProvider.getConnection(any(DatabaseType.class), anyBoolean())).thenReturn(mockConn);
+      TransactionManager.configure(mockProvider);
+
+      TransactionManager.createConnection(DatabaseType.POSTGRESQL);
+
+      assertThrows(SqlRuntimeException.class, () -> TransactionManager.endReadTransaction());
+
+      // commit が失敗しても close は finally 経由で必ず呼ばれる
+      verify(mockConn, times(1)).close();
+    }
+  }
+}

--- a/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/ManagementTypeEntryServiceProxy.java
+++ b/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/ManagementTypeEntryServiceProxy.java
@@ -124,7 +124,7 @@ public class ManagementTypeEntryServiceProxy implements InvocationHandler {
         TransactionManager.createConnection(databaseType);
         Object result = method.invoke(target, args);
 
-        TransactionManager.closeConnection();
+        TransactionManager.endReadTransaction();
         log.trace("READ end: class={}, method={}", target.getClass().getName(), method.getName());
 
         return result;

--- a/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/TenantAwareEntryServiceProxy.java
+++ b/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/TenantAwareEntryServiceProxy.java
@@ -126,7 +126,7 @@ public class TenantAwareEntryServiceProxy implements InvocationHandler {
         TransactionManager.createConnection(databaseType, tenantIdentifier);
         Object result = method.invoke(target, args);
 
-        TransactionManager.closeConnection();
+        TransactionManager.endReadTransaction();
 
         long duration = System.currentTimeMillis() - startTime;
         if (duration > 1000) {


### PR DESCRIPTION
Closes #1552

## Summary
- `@Transaction(readOnly = true)` の READ パスで replica DB の `xact_rollback` が READ 操作ごとに加算され、commit 成功率メトリクスが汚染される問題を修正
- `TransactionManager.endReadTransaction()` を新規追加し、READ パスでも明示的に `commit()` を発行
- `TenantAwareEntryServiceProxy` / `ManagementTypeEntryServiceProxy` の READ ブロックでこれを呼ぶように変更

## 原因
HikariCP の `autoCommit=false` 設定下で、`set_config('app.tenant_id', ?, true)` または最初の SELECT で暗黙 transaction が開始されるが、READ パスで `commit()`/`rollback()` を呼ばずに `closeConnection()` していたため、HikariCP が pool 返却時に強制 rollback を発行していた。

## 修正
- `TransactionManager#endReadTransaction()` 追加: READ パスで明示的 `commit()` 発行
- 2 つの Proxy の `closeConnection()` を `endReadTransaction()` に置き換え（READ ブロックのみ）
- 例外時は既存の `finally` 側の `closeConnection()` に任せて HikariCP の rollback で破棄させる構造
- WRITE パス・既存の API は無変更

## 検証 (ローカル PostgreSQL primary + replica)

E2E 1 セット流して比較:

| Role | | commit | rollback | rollback_pct |
|------|---|------:|--------:|------------:|
| **Primary** | 修正前 | 18646 | 397 | 2.08% |
|             | 修正後 | 19540 | 421 | **2.11%** (ほぼ変化なし、想定通り) |
| **Replica** | 修正前 | 813 | **6327** | **88.61%** |
|             | 修正後 | **8583** | **11** | **0.13%** |

- Replica の rollback: **6327 → 11** (約 575 倍減少)
- Replica の commit: 813 → 8583 (誤集計が解消)
- Replica の rollback_pct: 88.61% → **0.13%**
- Primary はほぼ変化なし (WRITE パスは影響外)

## 機能影響
- 機能的な影響なし: `set_config('app.tenant_id', ?, true)` の `is_local=true` で意図通り tx 終了時に破棄されるため RLS は正常動作
- E2E 全テスト pass を維持

## Test plan
- [x] ローカル primary + replica で修正前後の `pg_stat_database` 比較
- [x] E2E (scenario-05 含む) で機能 regression なし
- [ ] レビュアーで本番想定環境（RDS 等）での影響確認
- [ ] マージ後、本番 (or staging) で `xact_rollback` 改善を計測