### PR TITLE
chore: MySQL Connector/J → MariaDB Connector/J (LGPL 化)

### DIFF
--- a/docker-compose-mysql.yaml
+++ b/docker-compose-mysql.yaml
@@ -29,14 +29,14 @@ services:
       ENCRYPTION_KEY: ${ENCRYPTION_KEY?Encryption key is required. Set ENCRYPTION_KEY environment variable.}
       ADMIN_TENANT_ID: ${ADMIN_TENANT_ID:-67e7eae6-62b0-4500-9eff-87459f63fc66}
       DATABASE_TYPE: MYSQL
-      DB_WRITER_URL: jdbc:mysql://mysql:3306/idpserver
-      CONTROL_PLANE_DB_WRITER_URL: jdbc:mysql://mysql:3306/idpserver
+      DB_WRITER_URL: jdbc:mariadb://mysql:3306/idpserver
+      CONTROL_PLANE_DB_WRITER_URL: jdbc:mariadb://mysql:3306/idpserver
       CONTROL_PLANE_DB_WRITER_USER_NAME: idpserver
       CONTROL_PLANE_DB_WRITER_PASSWORD: ${MYSQL_PASSWORD?MySQL password is required. Set MYSQL_PASSWORD environment variable.}
       CONTROL_PLANE_DB_WRITER_TIMEOUT: 2000
       CONTROL_PLANE_DB_WRITER_MAX_POOL_SIZE: 10
       CONTROL_PLANE_DB_WRITER_MIN_IDLE: 5
-      CONTROL_PLANE_DB_READER_URL: jdbc:mysql://mysql:3306/idpserver
+      CONTROL_PLANE_DB_READER_URL: jdbc:mariadb://mysql:3306/idpserver
       CONTROL_PLANE_DB_READER_USER_NAME: idpserver
       CONTROL_PLANE_DB_READER_PASSWORD: ${MYSQL_PASSWORD?MySQL password is required. Set MYSQL_PASSWORD environment variable.}
       CONTROL_PLANE_DB_READER_TIMEOUT: 2000
@@ -47,7 +47,7 @@ services:
       DB_WRITER_TIMEOUT: 2000
       DB_WRITER_MAX_POOL_SIZE: 30
       DB_WRITER_MIN_IDLE: 10
-      DB_READER_URL: jdbc:mysql://mysql:3306/idpserver
+      DB_READER_URL: jdbc:mariadb://mysql:3306/idpserver
       DB_READER_USER_NAME: idpserver
       DB_READER_PASSWORD: ${MYSQL_PASSWORD?MySQL password is required. Set MYSQL_PASSWORD environment variable.}
       DB_READER_TIMEOUT: 2000
@@ -132,14 +132,14 @@ services:
       ENCRYPTION_KEY: ${ENCRYPTION_KEY:-JjN9c6N4STeA+g9d+TtBGp5MC3sbqOWs+S9qzJG42iY=}
       ADMIN_TENANT_ID: ${ADMIN_TENANT_ID:-67e7eae6-62b0-4500-9eff-87459f63fc66}
       DATABASE_TYPE: MYSQL
-      DB_WRITER_URL: jdbc:mysql://mysql:3306/idpserver
-      CONTROL_PLANE_DB_WRITER_URL: jdbc:mysql://mysql:3306/idpserver
+      DB_WRITER_URL: jdbc:mariadb://mysql:3306/idpserver
+      CONTROL_PLANE_DB_WRITER_URL: jdbc:mariadb://mysql:3306/idpserver
       CONTROL_PLANE_DB_WRITER_USER_NAME: idpserver
       CONTROL_PLANE_DB_WRITER_PASSWORD: ${MYSQL_PASSWORD?MySQL password is required. Set MYSQL_PASSWORD environment variable.}
       CONTROL_PLANE_DB_WRITER_TIMEOUT: 2000
       CONTROL_PLANE_DB_WRITER_MAX_POOL_SIZE: 10
       CONTROL_PLANE_DB_WRITER_MIN_IDLE: 5
-      CONTROL_PLANE_DB_READER_URL: jdbc:mysql://mysql:3306/idpserver
+      CONTROL_PLANE_DB_READER_URL: jdbc:mariadb://mysql:3306/idpserver
       CONTROL_PLANE_DB_READER_USER_NAME: idpserver
       CONTROL_PLANE_DB_READER_PASSWORD: ${MYSQL_PASSWORD?MySQL password is required. Set MYSQL_PASSWORD environment variable.}
       CONTROL_PLANE_DB_READER_TIMEOUT: 2000
@@ -150,7 +150,7 @@ services:
       DB_WRITER_TIMEOUT: 2000
       DB_WRITER_MAX_POOL_SIZE: 30
       DB_WRITER_MIN_IDLE: 10
-      DB_READER_URL: jdbc:mysql://mysql:3306/idpserver
+      DB_READER_URL: jdbc:mariadb://mysql:3306/idpserver
       DB_READER_USER_NAME: idpserver
       DB_READER_PASSWORD: ${MYSQL_PASSWORD?MySQL password is required. Set MYSQL_PASSWORD environment variable.}
       DB_READER_TIMEOUT: 2000
@@ -216,6 +216,8 @@ services:
       - idp-server-2
       - app-view
       - app-view-crosssite
+      - app-view-context-path
+      - sample-web
     volumes:
       - ./docker/nginx/nginx.conf:/etc/nginx/nginx.conf:ro
       - ./docker/nginx/certs:/etc/nginx/certs:ro
@@ -255,7 +257,7 @@ services:
         condition: service_healthy
     environment:
       DB_TYPE: mysql
-      DB_URL: jdbc:mysql://mysql:3306/idpserver
+      DB_URL: jdbc:mariadb://mysql:3306/idpserver
       DB_USER_NAME: root
       DB_PASSWORD: ${MYSQL_ROOT_PASSWORD?MySQL root password is required. Set MYSQL_ROOT_PASSWORD environment variable.}
     command: [ "migrate" ]    # info / repair / clean
@@ -322,6 +324,43 @@ services:
     container_name: app-view-crosssite
     environment:
       NODE_ENV: production
+    depends_on:
+      - idp-server-1
+
+  # Cross-site Auth UI with API Gateway context path
+  # Tests cookie_path configuration when IDP is behind API Gateway with /idp-admin context path
+  app-view-context-path:
+    build:
+      context: .
+      dockerfile: docker/app-view/Dockerfile
+      args:
+        BASE_PATH: ""
+        NEXT_PUBLIC_BACKEND_URL: "https://api.local.test/idp-admin"
+    container_name: app-view-context-path
+    environment:
+      NODE_ENV: production
+    depends_on:
+      - idp-server-1
+
+  sample-web:
+    build:
+      context: .
+      dockerfile: docker/sample-web/Dockerfile
+    container_name: sample-web
+    environment:
+      NODE_ENV: production
+      AUTH_SECRET: "123"
+      AUTH_TRUST_HOST: "true"
+      AUTH_URL: "https://sample.local.test"
+      NEXT_PUBLIC_IDP_SERVER_ISSUER: "https://api.local.test/a1b2c3d4-5e6f-7a8b-9c0d-1e2f3a4b5c6d"
+      NEXT_PUBLIC_FRONTEND_URL: "https://sample.local.test"
+      NEXT_PUBLIC_IDP_CLIENT_ID: "8a9f5e2c-1b3d-4c6a-9f8e-7d5c3a2b1e4f"
+      NEXT_IDP_CLIENT_SECRET: "local-dev-public-secret-32char"
+      NODE_TLS_REJECT_UNAUTHORIZED: "0"
+    extra_hosts:
+      - "api.local.test:host-gateway"
+      - "auth.local.test:host-gateway"
+      - "sample.local.test:host-gateway"
     depends_on:
       - idp-server-1
 

--- a/e2e/src/tests/integration/ida/integration-05-identity-verification-error-handling.test.js
+++ b/e2e/src/tests/integration/ida/integration-05-identity-verification-error-handling.test.js
@@ -508,10 +508,12 @@ describe("Identity Verification Error Handling", () => {
       console.log(`Response status: ${response.status}`);
       console.log("Response data:", JSON.stringify(response.data, null, 2));
 
-      expect(response.status).toBe(400);
+      // PostgreSQL: UUID型カラムにより400 (型不一致)
+      // MySQL: CHAR(36)のため素通りし404 (レコード不在)
+      expect([400, 404]).toContain(response.status);
       expect(response.data).toHaveProperty("error");
 
-      console.log("✅ Invalid UUID format correctly returns 400");
+      console.log(`✅ Invalid UUID format correctly returns ${response.status}`);
     });
 
     it("should return 200 with filtered results for query parameters", async () => {

--- a/libs/idp-server-core-adapter/build.gradle
+++ b/libs/idp-server-core-adapter/build.gradle
@@ -22,7 +22,7 @@ dependencies {
 
 	//database
 	runtimeOnly 'org.postgresql:postgresql:42.7.2'
-	runtimeOnly 'com.mysql:mysql-connector-j:9.2.0'
+	runtimeOnly 'org.mariadb.jdbc:mariadb-java-client:3.5.3'
 	implementation 'com.zaxxer:HikariCP:6.3.0'
 	//cache
 	implementation("redis.clients:jedis:5.1.0")

--- a/libs/idp-server-database/build.gradle
+++ b/libs/idp-server-database/build.gradle
@@ -17,7 +17,7 @@ repositories {
 
 dependencies {
     implementation 'org.postgresql:postgresql:42.7.2'
-    implementation 'com.mysql:mysql-connector-j:9.2.0'
+    implementation 'org.mariadb.jdbc:mariadb-java-client:3.5.3'
 }
 
 flyway {
@@ -31,7 +31,7 @@ flyway {
         locations = ["filesystem:./postgresql"]
         schemas = ["public"]
     } else if (dbType == "mysql") {
-        url = env.DB_URL ?: "jdbc:mysql://localhost:3306/idpserver"
+        url = env.DB_URL ?: "jdbc:mariadb://localhost:3306/idpserver"
         user = env.DB_USER_NAME ?: "idpserver"
         password = env.DB_PASSWORD ?: "idpserver"
         locations = ["filesystem:./mysql"]

--- a/libs/idp-server-database/entrypoint.sh
+++ b/libs/idp-server-database/entrypoint.sh
@@ -9,7 +9,7 @@ if [ -z "${DB_URL:-}" ]; then
   if [ "$DB_TYPE" = "postgresql" ]; then
     DB_URL="jdbc:postgresql://localhost:5432/idpserver"
   elif [ "$DB_TYPE" = "mysql" ]; then
-    DB_URL="jdbc:mysql://localhost:3306/idpserver"
+    DB_URL="jdbc:mariadb://localhost:3306/idpserver"
   else
     echo "Unknown DB_TYPE: $DB_TYPE" >&2
     exit 1

--- a/libs/idp-server-database/mysql/V0_9_32_2__webauthn.mysql.sql
+++ b/libs/idp-server-database/mysql/V0_9_32_2__webauthn.mysql.sql
@@ -7,7 +7,7 @@ CREATE TABLE webauthn_credentials
     id                       VARCHAR(512) PRIMARY KEY,        -- Credential ID (Base64URL encoded)
 
     -- Multi-Tenant
-    tenant_id                BINARY(16) NOT NULL,             -- Tenant ID for multi-tenancy (UUID as binary)
+    tenant_id                CHAR(36) NOT NULL,               -- Tenant ID for multi-tenancy
 
     -- User Information
     user_id                  VARCHAR(256) NOT NULL,           -- FIDO2 User ID (WebAuthn user.id)


### PR DESCRIPTION
## Summary

**GPL 2.0 の MySQL Connector/J を LGPL 2.1 の MariaDB Connector/J に切り替え**。
MariaDB Connector/J は MySQL Server にそのまま接続可能なため、DB 側の変更は不要。

## 経緯

旧 PR #1509 は約 1 ヶ月前に作成されたが、ブランチが古い main から fork されていて、
その後の main 進化と共通祖先がない (`fatal: no merge base`) 状態となり rebase 不可能になった。

→ 本 PR は **最新 main から cherry-pick** で clean な 1 コミット履歴として作り直したもの。

## 変更内容

| ファイル | 内容 |
|---------|------|
| `libs/idp-server-core-adapter/build.gradle` | `mysql-connector-j` → `mariadb-java-client:3.5.3` |
| `libs/idp-server-database/build.gradle` | 同上 |
| `libs/idp-server-database/entrypoint.sh` | JDBC URL: `jdbc:mysql://` → `jdbc:mariadb://` |
| `libs/idp-server-database/.../V0_9_32_2__webauthn.mysql.sql` | `tenant_id` 型を `BINARY(16)` → `CHAR(36)` に修正 |
| `docker-compose-mysql.yaml` | 不足サービス (`sample-web`, `app-view-context-path`) を追加 |
| `e2e/.../05-identity-verification-error-handling.test.js` | UUID 検証の DB 差異対応 (PostgreSQL: 400, MySQL: 404) |

## Test plan

- [x] cherry-pick で main 上に clean に乗ること確認
- [ ] ローカルで MySQL モードで起動 → MariaDB ドライバで接続成功確認
- [ ] E2E (`cd e2e && npm test`) 通過
- [ ] PostgreSQL モードでの動作にも影響ないことを確認

## 関連

- 旧 PR: #1509 (rebase 不可のためクローズ済み)

🤖 Generated with [Claude Code](https://claude.com/claude-code)