### PR TITLE
chore: org.json transitive 依存を除外

### DIFF
--- a/libs/idp-server-core-adapter/build.gradle
+++ b/libs/idp-server-core-adapter/build.gradle
@@ -25,7 +25,10 @@ dependencies {
 	runtimeOnly 'org.mariadb.jdbc:mariadb-java-client:3.5.3'
 	implementation 'com.zaxxer:HikariCP:6.3.0'
 	//cache
-	implementation("redis.clients:jedis:5.1.0")
+	implementation("redis.clients:jedis:5.1.0") {
+		// org.json はライセンス審査の観点で transitive 取り込みを避ける (Public Domain 表記の不確実性)
+		exclude group: 'org.json', module: 'json'
+	}
 
 	testImplementation platform('org.junit:junit-bom:5.10.0')
 	testImplementation 'org.junit.jupiter:junit-jupiter'

--- a/libs/idp-server-platform/build.gradle
+++ b/libs/idp-server-platform/build.gradle
@@ -14,7 +14,10 @@ repositories {
 dependencies {
 	//json (Jackson 3: java.time support is built-in, no separate jsr310 module needed)
 	implementation 'tools.jackson.core:jackson-databind:3.1.2'
-	implementation 'com.jayway.jsonpath:json-path:2.9.0'
+	implementation('com.jayway.jsonpath:json-path:2.9.0') {
+		// org.json はライセンス審査の観点で transitive 取り込みを避ける (Public Domain 表記の不確実性)
+		exclude group: 'org.json', module: 'json'
+	}
 	//jose
 	implementation 'com.nimbusds:nimbus-jose-jwt:9.40'
 	// BouncyCastle for PEM key parsing


### PR DESCRIPTION
## Summary

idp-server (Apache 2.0 配布) における `org.json` の transitive 取り込みを抑止。
本プロジェクトのコードでは `org.json` を直接 import していないため、依存除外しても影響なし。

## 経緯

旧 PR #1540 は古い main から fork されたブランチで rebase 不可となったため、
最新 main から **cherry-pick で clean な 1 コミット履歴** として作り直し。

## 背景

- `org.json` は v20220924 で "Good not Evil" 句が撤廃され Public Domain 宣言に変更
- ただし Public Domain は OSI 公式ライセンスではなく、独・仏など一部法域で法的に認められない
- 厳格な OSS 監査ツールでフラグが立つ可能性が残る

→ 完全に問題ないとも言えるが、念のため transitive 取り込みも避け、第三者の法務監査でも疑念を残さない方針とする。

## 変更内容

| ファイル | 内容 |
|---------|------|
| `libs/idp-server-platform/build.gradle` | `com.jayway.jsonpath:json-path:2.9.0` に `exclude(org.json:json)` |
| `libs/idp-server-core-adapter/build.gradle` | `redis.clients:jedis:5.1.0` に `exclude(org.json:json)` |

## 動作確認

- [x] `./gradlew clean test`: BUILD SUCCESSFUL (1032 件、failures=0、errors=0)
  - Mapper / JsonPath 系: ConditionSpec 87、MappingRule 系 29、Function 系
- [x] E2E テスト: 正常動作確認 (ローカル)
- [x] `./gradlew :app:dependencyInsight --dependency org.json:json`: 「No dependencies matching」を確認

## 補足

- `org.json` v20250517 (Maven Central) の license メタデータは Public Domain
- JAR 内に LICENSE/NOTICE ファイル無し、"Good"/"Evil" 文字列も含まれない
- ASF は v20220924 以降を Category X から外している (Apache 公式見解)

## 関連

- 旧 PR: #1540 (rebase 不可のためクローズ予定)

🤖 Generated with [Claude Code](https://claude.com/claude-code)