### PR TITLE
perf: idp_user に (tenant_id, created_at DESC) index 追加 + v0.10.0 リリース runbook 整理

### DIFF
--- a/libs/idp-server-database/mysql/V0_10_0_4__idp_user_tenant_created_at_index.mysql.sql
+++ b/libs/idp-server-database/mysql/V0_10_0_4__idp_user_tenant_created_at_index.mysql.sql
@@ -1,0 +1,14 @@
+-- =====================================================
+-- Issue #1460: idp_user に (tenant_id, created_at DESC) index 追加 (MySQL)
+--
+-- See postgresql/V0_10_0_4__idp_user_tenant_created_at_index.sql for context.
+--
+-- MySQL 8.0+ では CREATE INDEX のデフォルトが ALGORITHM=INPLACE で
+-- 書き込みブロックなしの online build となるため、Flyway 適用でもほぼ
+-- 影響なし。確実性を求める場合は事前に runbook の create_index.mysql.sql
+-- (ALGORITHM=INPLACE LOCK=NONE 明示) を実行しておくこと。
+-- `CREATE INDEX IF NOT EXISTS` なので本ファイルは no-op となり安全。
+-- =====================================================
+
+CREATE INDEX IF NOT EXISTS idx_idp_user_tenant_created_at
+    ON idp_user (tenant_id, created_at DESC);

--- a/libs/idp-server-database/mysql/operation/idp-user-tenant-created-at-index/create_index.mysql.sql
+++ b/libs/idp-server-database/mysql/operation/idp-user-tenant-created-at-index/create_index.mysql.sql
@@ -1,0 +1,10 @@
+-- =====================================================
+-- idp_user (tenant_id, created_at DESC) index 追加 (本番運用向け / MySQL)
+--
+-- ALGORITHM=INPLACE, LOCK=NONE で書き込みブロックなしの online build。
+-- 想定実行時間: 200 万行で 5-30 分 (テーブルサイズ・I/O 次第)。
+-- =====================================================
+
+CREATE INDEX idx_idp_user_tenant_created_at
+    ON idp_user (tenant_id, created_at DESC)
+    ALGORITHM=INPLACE LOCK=NONE;

--- a/libs/idp-server-database/operation/v0.10.0-release/README.md
+++ b/libs/idp-server-database/operation/v0.10.0-release/README.md
@@ -1,0 +1,172 @@
+# v0.10.0 リリース Runbook
+
+v0.10.0 で導入される DB スキーマ変更と性能改善のための運用手順をまとめる。
+
+## 含まれる変更
+
+| Flyway | 内容 | 関連 PR / Issue |
+|--------|------|----------------|
+| `V0_10_0_1` | `statistics_event_buckets` テーブル作成 (空) | PR #1558 / Issue #1443 |
+| `V0_10_0_2` | `identity_verification_application` に `external_application_id` カラム追加 | PR #1561 / Issue #1550 |
+| `V0_10_0_3` | 同テーブルに `(tenant_id, external_application_id) UNIQUE INDEX` | PR #1561 |
+| `V0_10_0_4` | `idp_user (tenant_id, created_at DESC)` index | Issue #1460 |
+
+`V0_10_0_3` / `V0_10_0_4` は **大量レコードがあるテーブルに対する `CREATE INDEX`** なので、本番では Flyway 適用前に `CONCURRENTLY` で先打ちする (詳細後述)。
+
+---
+
+## リリース全体フロー
+
+```
+Phase 1: V0_10_0_1 + V0_10_0_2 のみ Flyway 適用 (スキーマ追加、瞬時)
+   ↓
+Phase 2: アプリリリース (新コードデプロイ)
+   ↓
+Phase 3: 全 Pod 入れ替え確認
+   ↓
+Phase 4: index 作成 (CONCURRENTLY) ← V0_10_0_3 / V0_10_0_4 相当を runbook で実行
+   ↓
+Phase 5: 残りの Flyway 適用 (V0_10_0_3 / V0_10_0_4 は no-op で通過)
+   ↓
+Phase 6: データ移行 (PR #1558 / PR #1561 の各 backfill)
+   ↓
+Phase 7: 検証 (各 verify_migration)
+```
+
+---
+
+## Phase 1: V0_10_0_2 までを適用
+
+```bash
+# 現状確認
+./gradlew flywayInfo
+# → V0_10_0_1, V0_10_0_2, V0_10_0_3, V0_10_0_4 が Pending
+
+# target を指定して V0_10_0_2 までで止める
+FLYWAY_TARGET=0.10.0.2 ./gradlew flywayMigrate
+
+# 適用結果確認
+./gradlew flywayInfo
+# → V0_10_0_1, V0_10_0_2: Success / V0_10_0_3, V0_10_0_4: Pending
+```
+
+---
+
+## Phase 2-3: アプリリリース + 入れ替え確認
+
+```bash
+kubectl apply -f deployment.yaml
+kubectl rollout status deployment/idp-server -n <namespace>
+kubectl get pods -l app=idp-server -o jsonpath='{.items[*].spec.containers[*].image}'
+# → 全 Pod が新イメージタグになっていること
+```
+
+---
+
+## Phase 4: index 作成 (CONCURRENTLY)
+
+並列実行可能。順序自由。
+
+### `statistics_event_buckets` 関連は事前作成 index なし
+
+PR #1558 のテーブルは `V0_10_0_1` で `CREATE INDEX` 含めて適用済み (空テーブルなので書き込みブロックなし)。Phase 4 では何もしない。
+
+### `identity_verification_application` UNIQUE INDEX (V0_10_0_3 相当)
+
+```bash
+cd libs/idp-server-database/postgresql/operation/identity-verification-external-application-id-backfill
+psql -f create_index.sql
+# → CREATE UNIQUE INDEX CONCURRENTLY (書き込みブロックなし)
+```
+
+### `idp_user` (tenant_id, created_at DESC) index (V0_10_0_4 相当)
+
+```bash
+cd libs/idp-server-database/postgresql/operation/idp-user-tenant-created-at-index
+psql -f create_index.sql
+# → CREATE INDEX CONCURRENTLY (書き込みブロックなし)
+```
+
+### 進行状況の監視 (別 session)
+
+```bash
+psql -c "
+  SELECT phase, blocks_done, blocks_total,
+         round(100.0 * blocks_done / NULLIF(blocks_total, 0), 1) AS pct
+  FROM pg_stat_progress_create_index;
+"
+```
+
+200 万行で 5-30 分目安。INVALID 検出時は各 runbook の指示に従う。
+
+---
+
+## Phase 5: 残りの Flyway 適用 (no-op で通過)
+
+```bash
+unset FLYWAY_TARGET
+./gradlew flywayMigrate
+# → V0_10_0_3, V0_10_0_4 が IF NOT EXISTS で no-op
+./gradlew flywayInfo
+# → 全部 Success
+```
+
+---
+
+## Phase 6: データ移行 (backfill)
+
+各 runbook を独立に実行可能。順序自由。
+
+### statistics_events → statistics_event_buckets
+
+```bash
+cd libs/idp-server-database/postgresql/operation/statistics-events-bucket-migration
+psql -f migrate_data.sql
+```
+
+詳細: `statistics-events-bucket-migration/README.md`
+
+### identity_verification_application backfill
+
+```bash
+cd libs/idp-server-database/postgresql/operation/identity-verification-external-application-id-backfill
+psql -f migrate_data.sql
+```
+
+詳細: `identity-verification-external-application-id-backfill/README.md`
+
+### idp_user の backfill
+
+不要 (既存行は変更しないため)。
+
+---
+
+## Phase 7: 検証
+
+```bash
+psql -f libs/idp-server-database/postgresql/operation/statistics-events-bucket-migration/verify_migration.sql
+psql -f libs/idp-server-database/postgresql/operation/identity-verification-external-application-id-backfill/verify_migration.sql
+```
+
+それぞれの runbook で「期待 = 0 行」のクエリが 0 行で返ることを確認。
+
+---
+
+## ロールバック
+
+各 PR の runbook にロールバック手順あり。アプリのロールバックは本リリースで導入された SQL の互換性を踏まえて段階的に判断する。
+
+| 変更 | ロールバック可否 |
+|------|---------------|
+| V0_10_0_1 (新テーブル) | アプリのロールバックで旧コードに戻れば旧経路に切替、新テーブルは無視される。必要なら DROP TABLE |
+| V0_10_0_2 (新カラム) | アプリのロールバックでも DROP COLUMN 不要。旧コードは新カラムを使わない |
+| V0_10_0_3 (UNIQUE INDEX) | DROP INDEX CONCURRENTLY で外せる |
+| V0_10_0_4 (B-tree index) | 同上 |
+
+---
+
+## MySQL を本番で使う場合
+
+各 runbook の `mysql/operation/.../*.mysql.sql` を psql の代わりに `mysql` クライアントで実行する。手順は同じ。
+
+Phase 4 の CONCURRENTLY は MySQL では `ALGORITHM=INPLACE LOCK=NONE` の online build (`create_index.mysql.sql` に明示済み)。

--- a/libs/idp-server-database/postgresql/V0_10_0_4__idp_user_tenant_created_at_index.sql
+++ b/libs/idp-server-database/postgresql/V0_10_0_4__idp_user_tenant_created_at_index.sql
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2025 Hirokazu Kobayashi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+-- =====================================================
+-- Issue #1460: idp_user に (tenant_id, created_at DESC) index 追加
+--
+-- 背景:
+--   ユーザー検索 API のページネーションで ORDER BY created_at DESC が
+--   使われるが、対応 index がないため 200 万行規模で Parallel Seq Scan
+--   になる。計測: 185ms → 2.5ms (75x 改善)。
+--
+-- 開発 / ステージング環境では Flyway 適用でそのまま作成して問題ない。
+--
+-- 本番運用 (大量レコードがあるテーブル) では、通常の CREATE INDEX が
+-- 書き込みブロックを引き起こすため、Flyway 適用前に
+-- libs/idp-server-database/postgresql/operation/
+--   idp-user-tenant-created-at-index/create_index.sql
+-- で CONCURRENTLY を先に実行しておくこと。`CREATE INDEX IF NOT EXISTS`
+-- なので本ファイルは no-op となり安全。
+-- =====================================================
+
+CREATE INDEX IF NOT EXISTS idx_idp_user_tenant_created_at
+    ON idp_user (tenant_id, created_at DESC);

--- a/libs/idp-server-database/postgresql/operation/idp-user-tenant-created-at-index/README.md
+++ b/libs/idp-server-database/postgresql/operation/idp-user-tenant-created-at-index/README.md
@@ -1,0 +1,112 @@
+# `idp_user` ページネーション index 追加 Runbook
+
+Issue #1460: `idp_user (tenant_id, created_at DESC)` の B-tree index を本番運用に追加する手順。
+
+MySQL を本番で使う場合は `libs/idp-server-database/mysql/operation/idp-user-tenant-created-at-index/` 配下の同名 SQL を使う。手順は同じ。
+
+---
+
+## 0. 目的と前提
+
+- ユーザー検索 API の `ORDER BY created_at DESC` ページネーションで、対応 index がないため大規模テナントで Parallel Seq Scan になる
+- 200 万行規模で **185ms → 2.5ms (75 倍)** の改善 (Issue #1460 計測)
+
+### 前提条件
+
+- [ ] `V0_10_0_4` Flyway ファイルを **本番に deploy する前** に Step 2 (`create_index.sql` で `CONCURRENTLY`) を済ませる。`CREATE INDEX IF NOT EXISTS` なので、index が既にあれば V0_10_0_4 は no-op で安全
+
+---
+
+## 1. 接続情報の準備
+
+### 1.1 環境変数
+
+```bash
+export PGHOST=your-db-host.example.com
+export PGPORT=5432
+export PGDATABASE=idpserver
+export PGUSER=idpserver
+export PGPASSWORD=yourpassword
+```
+
+### 1.2 作業ディレクトリ
+
+```bash
+cd libs/idp-server-database/postgresql/operation/idp-user-tenant-created-at-index
+```
+
+### 1.3 接続確認
+
+```bash
+psql -c "SELECT current_database(), current_user, now();"
+```
+
+---
+
+## 2. index 作成
+
+```bash
+psql -f create_index.sql
+```
+
+`CREATE INDEX CONCURRENTLY` で書き込みブロックなしの online build。200 万行で 5-30 分目安。
+
+進行状況の監視 (別 session):
+
+```bash
+psql -c "
+  SELECT phase, blocks_done, blocks_total,
+         round(100.0 * blocks_done / NULLIF(blocks_total, 0), 1) AS pct
+  FROM pg_stat_progress_create_index;
+"
+```
+
+完了後、`create_index.sql` の末尾の SELECT が空であれば OK。
+INVALID な行が返ったら `DROP INDEX CONCURRENTLY idx_idp_user_tenant_created_at;` で消して再実行。
+
+---
+
+## 3. 動作確認
+
+```bash
+psql -c "
+EXPLAIN (ANALYZE, BUFFERS)
+SELECT id FROM idp_user
+WHERE tenant_id = '<sample-tenant-uuid>'::uuid
+ORDER BY created_at DESC
+LIMIT 20;
+"
+```
+
+`Index Scan using idx_idp_user_tenant_created_at` が出れば成功。
+
+---
+
+## 設計メモ
+
+### `(tenant_id)` 単独 index を追加しなくてよい理由
+
+`(tenant_id, created_at DESC)` の **leftmost prefix** で `WHERE tenant_id = ?` 単独検索もカバーできる (B-tree の標準動作)。追加の `(tenant_id)` 単独 index は冗長になるので不要。
+
+---
+
+## 付録: ベンチマーク再現
+
+ローカル / ステージング限定で再現可能なスクリプトを同梱:
+
+```bash
+# 1. ベンチ実行 (200 万行ダミー挿入 → 統計更新 → before/after EXPLAIN ANALYZE)
+psql -f bench.sql
+
+# 2. 完了後の後片付け (ダミーユーザー DELETE + 検証用 index DROP)
+psql -f bench_cleanup.sql
+```
+
+### 計測結果 (ローカル / 同一テナントに 200 万行追加)
+
+| 状態 | Execution Time | Plan |
+|------|---------------|------|
+| index なし | 340.568 ms | Parallel Seq Scan + top-N heapsort |
+| index あり |   1.280 ms | Index Scan using idx_idp_user_tenant_created_at |
+
+約 266 倍の改善。Issue #1460 で報告された 75 倍 (185ms → 2.5ms) よりも幅が大きいのは、テナント分散の差 (Issue は 200 万 = 1 テナント想定、ローカルは 200 万 + 既存 4070 行 + 1500 テナント混在) によるものと推測。

--- a/libs/idp-server-database/postgresql/operation/idp-user-tenant-created-at-index/bench.sql
+++ b/libs/idp-server-database/postgresql/operation/idp-user-tenant-created-at-index/bench.sql
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2025 Hirokazu Kobayashi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ */
+
+-- =====================================================
+-- idp_user index benchmark (Issue #1460 再現用)
+--
+-- 200 万行のダミーユーザーを既存テナント (TARGET_TENANT) に挿入し、
+-- ORDER BY created_at DESC LIMIT 20 の性能を before/after 比較する。
+--
+-- 使い方:
+--   1. TARGET_TENANT に既存テナント UUID を設定 (psql 変数で渡してもよい)
+--   2. psql -f bench.sql で実行
+--   3. ベンチ後は cleanup セクションをコメントアウト解除して片付ける
+--
+-- 注意: ローカル / ステージング以外では実行しないこと
+-- =====================================================
+
+\set TARGET_TENANT '\'67e7eae6-62b0-4500-9eff-87459f63fc66\''
+\set ON_ERROR_STOP on
+
+\echo '=== Step 1: 200 万行ダミーユーザー挿入 (provider_id = bench-1460) ==='
+INSERT INTO idp_user (id, tenant_id, provider_id, preferred_username, status, created_at, updated_at)
+SELECT
+    gen_random_uuid(),
+    :TARGET_TENANT::uuid,
+    'bench-1460',
+    'bench_user_' || g,
+    'REGISTERED',
+    NOW() - (random() * interval '365 days'),
+    NOW()
+FROM generate_series(1, 2000000) g;
+
+\echo ''
+\echo '=== Step 2: 統計更新 ==='
+ANALYZE idp_user;
+
+\echo ''
+\echo '=== Step 3: index なしの計測 ==='
+DROP INDEX IF EXISTS idx_idp_user_tenant_created_at;
+EXPLAIN (ANALYZE, BUFFERS, TIMING)
+SELECT id FROM idp_user
+WHERE tenant_id = :TARGET_TENANT::uuid
+ORDER BY created_at DESC
+LIMIT 20;
+
+\echo ''
+\echo '=== Step 4: index ありの計測 ==='
+CREATE INDEX idx_idp_user_tenant_created_at
+    ON idp_user (tenant_id, created_at DESC);
+EXPLAIN (ANALYZE, BUFFERS, TIMING)
+SELECT id FROM idp_user
+WHERE tenant_id = :TARGET_TENANT::uuid
+ORDER BY created_at DESC
+LIMIT 20;
+
+-- =====================================================
+-- ベンチ完了後は bench_cleanup.sql を実行してダミーデータと
+-- 検証用 index を片付ける。
+--   psql -f bench_cleanup.sql
+-- =====================================================

--- a/libs/idp-server-database/postgresql/operation/idp-user-tenant-created-at-index/bench_cleanup.sql
+++ b/libs/idp-server-database/postgresql/operation/idp-user-tenant-created-at-index/bench_cleanup.sql
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2025 Hirokazu Kobayashi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ */
+
+-- =====================================================
+-- bench.sql で投入したダミーデータと検証用 index を片付ける。
+-- 本番では絶対に実行しないこと。
+-- =====================================================
+
+\set ON_ERROR_STOP on
+
+\echo '=== ベンチ用ダミーユーザー削除 (provider_id = bench-1460) ==='
+DELETE FROM idp_user WHERE provider_id = 'bench-1460';
+
+\echo ''
+\echo '=== 検証用 index 削除 ==='
+DROP INDEX IF EXISTS idx_idp_user_tenant_created_at;
+
+\echo ''
+\echo '=== 残存確認 (どちらも 0 のはず) ==='
+SELECT COUNT(*) AS remaining_bench_users
+FROM idp_user
+WHERE provider_id = 'bench-1460';
+
+SELECT COUNT(*) AS remaining_bench_index
+FROM pg_indexes
+WHERE tablename = 'idp_user'
+  AND indexname = 'idx_idp_user_tenant_created_at';

--- a/libs/idp-server-database/postgresql/operation/idp-user-tenant-created-at-index/create_index.sql
+++ b/libs/idp-server-database/postgresql/operation/idp-user-tenant-created-at-index/create_index.sql
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2025 Hirokazu Kobayashi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ */
+
+-- =====================================================
+-- idp_user (tenant_id, created_at DESC) index 追加 (本番運用向け)
+--
+-- CREATE INDEX CONCURRENTLY: 書き込みブロックなしで index を構築する。
+-- 想定実行時間: 200 万行で 5-30 分 (テーブルサイズ・I/O 次第)。
+-- トランザクション内で実行不可なので psql から直接流す。
+--
+-- 進行状況の監視 (別 session):
+--   SELECT phase, blocks_done, blocks_total,
+--          round(100.0 * blocks_done / NULLIF(blocks_total, 0), 1) AS pct
+--   FROM pg_stat_progress_create_index;
+-- =====================================================
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_idp_user_tenant_created_at
+    ON idp_user (tenant_id, created_at DESC);
+
+-- 完了後: INVALID な index が残っていないことを確認
+SELECT i.indexrelid::regclass AS index_name, i.indisvalid
+FROM pg_index i
+WHERE i.indrelid = 'idp_user'::regclass
+  AND NOT i.indisvalid;


### PR DESCRIPTION
## Summary

- Issue #1460 対応。`idp_user` のページネーション `ORDER BY created_at DESC LIMIT N` が大規模テナントで Parallel Seq Scan になる問題を、`(tenant_id, created_at DESC)` B-tree index で解消
- 本番運用は `CONCURRENTLY` (PG) / `ALGORITHM=INPLACE LOCK=NONE` (MySQL) の online build runbook 同梱
- v0.10.0 リリース全体の runbook (`PR #1558 + #1561 + 本 PR` を統合) を `libs/idp-server-database/operation/v0.10.0-release/README.md` に整理

## ローカル計測結果 (bench.sql で再現可能)

| 状態 | Execution Time | Plan |
|------|---------------|------|
| index なし | **340.568 ms** | Parallel Seq Scan + top-N heapsort |
| index あり | **1.280 ms** | Index Scan using idx_idp_user_tenant_created_at |

**約 266 倍の改善**。Issue #1460 で報告された 75 倍 (185ms → 2.5ms) を上回るのは、ローカル環境のテナント分散の差と推測。

## 設計判断

### `(tenant_id)` 単独 index は追加しない (Issue コメントへの返答)

`(tenant_id, created_at DESC)` の **leftmost prefix** で `WHERE tenant_id = ?` 単独検索もカバーされるため (B-tree 標準動作)、追加 index は冗長。

### マイグレーション分割 (V0_10_0_4 + operation/)

PR #1561 と同じパターン:
- 開発/CI は `V0_10_0_4` の `CREATE INDEX IF NOT EXISTS` で自動適用
- 本番は `operation/idp-user-tenant-created-at-index/create_index.sql` を **Flyway 適用前に** 先打ち → 後続の Flyway `V0_10_0_4` は `IF NOT EXISTS` で no-op

## Test plan

- [x] `./gradlew spotlessApply build -x test` 通過
- [x] ローカルで `bench.sql` 実行 → before/after 計測値 (340.568 ms → 1.280 ms) 確認
- [x] `bench_cleanup.sql` 動作確認 (ダミーユーザー 0 / 検証用 index 0 に戻る、元の 4070 行に復元)
- [x] EXPLAIN で `Index Scan using idx_idp_user_tenant_created_at` を確認
- [ ] レビュー対応

## 関連

- Closes #1460

🤖 Generated with [Claude Code](https://claude.com/claude-code)