### PR TITLE
feat(ida): pre-hook verifier 用の config-driven history パイプライン (Phase 1: duplicate prevention)

### DIFF
--- a/documentation/docs/content_05_how-to/phase-4-extensions/identity-verification/02-application.md
+++ b/documentation/docs/content_05_how-to/phase-4-extensions/identity-verification/02-application.md
@@ -238,6 +238,7 @@ POST /{tenant-id}/internal/v1/identity-verification/callback/{verification-type}
 | フェーズ名             | 役割・目的                      | 主な設定項目                                                    | 必須 |
 |-------------------|----------------------------|-----------------------------------------------------------|----|
 | **1. request**    | リクエストの構造・形式を検証             | `schema`（JSON Schema）                                     | -  |
+| **history**       | pre_hook に渡す過去申込み read model の取得条件（[詳細](../../../content_06_developer-guide/05-configuration/identity-verification.md#history過去申込みの取得条件)） | `filters`                                                 | -  |
 | **2. pre_hook**   | 実行前の事前検証・外部パラメータ取得・外部API実行 | `verifications`, `additional_parameters`                  | -  |
 | **3. execution**  | メイン業務処理（外部連携 or 内部処理）      | `type`, `http_request`, `mock`, `no_action` など（処理タイプに応じて） | ✅  |
 | **4. post_hook**  | 実行後の検証・外部API実行             | `verifications` `additional_parameters`                   | -  |
@@ -700,7 +701,7 @@ flowchart TD
 | `process_sequence`            | プロセス依存関係とリトライ制御の検証。詳細は「プロセス依存関係とシーケンス制御」セクション参照。 |
 | `user_claim`                  | リクエスト内容とユーザークレームの一致確認。                        |
 | `application_limitation` （予定） | 申込み可能数チェック。                                   |
-| `duplicate_application` （予定）  | 過去の申請と重複がないかをチェック。                            |
+| `duplicate_application`        | 同一 type に進行中（running）の申請があれば拒否。`history` と連携（[詳細](../../../content_06_developer-guide/05-configuration/identity-verification.md#history過去申込みの取得条件)）。 |
 | `http_request`（予定）            | 外部APIと連携して検証を行う。                              |
 
 **user_claim の詳細構造**

--- a/documentation/docs/content_06_developer-guide/05-configuration/identity-verification.md
+++ b/documentation/docs/content_06_developer-guide/05-configuration/identity-verification.md
@@ -150,6 +150,7 @@ POST /{tenant-id}/v1/me/identity-verification/applications/{type}/cancel
 | フェーズ | 説明 | 必須 |
 |---------|------|------|
 | `request` | リクエストスキーマ定義 | ❌ |
+| `history` | pre_hook フェーズ（verifications / additional_parameters）に渡す過去申込み read model の取得条件（[詳細](#history過去申込みの取得条件)） | ❌ |
 | `pre_hook` | 実行前処理 | ❌ |
 | `execution` | メイン処理（外部API呼び出し等） | ✅ |
 | `post_hook` | 実行後処理 | ❌ |
@@ -353,6 +354,65 @@ POST /{tenant-id}/v1/me/identity-verification/applications/account-opening/abc-1
 
 ---
 
+### history（過去申込みの取得条件） {#history過去申込みの取得条件}
+
+**用途**: pre_hook フェーズに渡す「過去申込みの read model」を、宣言した条件で絞り込んで取得する
+
+execution（メイン処理）の前に、`history.filters` で宣言した条件に一致する**過去の申込み**を1回の SQL で取得し、pre_hook フェーズ（`verifications` / `additional_parameters`）に渡します。これにより verifier 等は過去申込みを参照したドメイン判定ができます。
+
+> **現状の利用範囲**: read model を実際に読むのは `duplicate_application` 検証のみ（Phase 1）。他の verifier・`additional_parameters` リゾルバは受け取り口を持つが未使用。execution / response / store の mapping からは**まだ参照できません**（[#1592](https://github.com/hirokazu-kobayashi-koba-hiro/idp-server/issues/1592) で対応予定）。
+
+#### 設定構造
+
+```json
+{
+  "processes": {
+    "apply": {
+      "history": {
+        "filters": [
+          { "types": ["investment-account-opening"], "statuses": "running" }
+        ]
+      },
+      "pre_hook": {
+        "verifications": [
+          { "type": "duplicate_application" }
+        ]
+      },
+      "execution": { "type": "no_action" }
+    }
+  }
+}
+```
+
+| フィールド | 型 | 説明 | 必須 |
+|-----------|----|------|------|
+| `filters` | object[] | 取得条件の配列。複数指定すると **OR 結合**で union を取得 | ✅ |
+| `filters[].types` | string[] | 対象の `verification_type`（少なくとも1件必須。空のフィルタは無視される） | ✅ |
+| `filters[].statuses` | string \| string[] | `"running"` キーワード、または明示的なステータス値の配列 | ✅ |
+
+- **`"running"` キーワード** は進行中ステータス `requested` / `applying` / `applied` / `examination_processing` に展開されます。
+- `types` か `statuses` が空のフィルタは取得対象から除外されます。
+
+#### duplicate_application との連携（マージ挙動）
+
+`duplicate_application` 検証は「同一 type に進行中（running）の申込みがあれば拒否」します。この検証が動くには「当該 type の running」を観測している必要があるため、`history` の宣言有無に関わらず **`{ types:[当該type], statuses:"running" }` が常にマージ**されます（置換ではなく追加。同一フィルタは重複排除）。
+
+| explicit `history` | `duplicate_application` | 取得される履歴 |
+|---|---|---|
+| なし | なし | 取得しない |
+| なし | あり | `running(当該type)` のみ |
+| あり | なし | explicit filters のみ |
+| あり | あり | explicit filters ＋ `running(当該type)`（マージ） |
+
+これにより、`history` 未宣言でも、また explicit `history` が当該 type をカバーしていなくても、**重複防止が無効化されません**（後方互換）。
+
+#### 注意事項
+
+- `history` を宣言しない場合、`duplicate_application` 以外の用途では過去申込みは取得されません（無駄なクエリを避ける設計）。
+- `types` 必須・`"running"` キーワード展開はコード上の仕様です（`IdentityVerificationApplicationStatus.isRunning()`）。
+
+---
+
 ### Pre Hook（実行前処理）
 
 **用途**: メイン処理（execution）の前にビジネスロジック検証や追加データ取得を実行
@@ -376,7 +436,7 @@ Pre Hookは2つのコンポーネントで構成されます：
 | `process_sequence` | プロセス依存関係とリトライ制御の検証 | なし |
 | `user_claim` | リクエスト内容とユーザークレームの一致確認 | `details.verification_parameters` |
 | `application_limitation` | 申込み可能数チェック（予定） | - |
-| `duplicate_application` | 重複申請チェック（予定） | - |
+| `duplicate_application` | 重複申請チェック（同一 type の進行中申込みがあれば拒否）。[history](#history過去申込みの取得条件) と連携 | なし |
 
 ##### process_sequence 検証
 

--- a/e2e/src/tests/integration/ida/integration-10-identity-verification-history-duplicate.test.js
+++ b/e2e/src/tests/integration/ida/integration-10-identity-verification-history-duplicate.test.js
@@ -1,0 +1,142 @@
+import { describe, expect, it, beforeAll, afterAll } from "@jest/globals";
+import { postWithJson, deletion } from "../../../lib/http";
+import { requestToken } from "../../../api/oauthClient";
+import {
+  backendUrl,
+  clientSecretPostClient,
+  serverConfig,
+  federationServerConfig
+} from "../../testConfig";
+import { createFederatedUser, registerFidoUaf } from "../../../user";
+import { v4 as uuidv4 } from "uuid";
+
+/**
+ * Phase 1 verification for the config-driven history pipeline.
+ *
+ * The `apply` process declares `history.running_check` and a `duplicate_application` verifier.
+ * The first apply succeeds (status becomes REQUESTED, which counts as "running"); the second
+ * apply for the same user/type must be blocked by the verifier — proving that:
+ *   1. the new `history` section is parsed and translated into a HistoryQueryPlan,
+ *   2. `findHistory` returns the running application,
+ *   3. `DenyDuplicateIdentityVerificationApplicationVerifier` reads it via `containsRunningState`.
+ */
+describe("Identity Verification: history-driven duplicate prevention", () => {
+  const orgId = serverConfig.organizationId;
+  const tenantId = serverConfig.tenantId;
+
+  let orgAccessToken;
+  let userAccessToken;
+  let configId;
+  let configurationType;
+
+  beforeAll(async () => {
+    const orgAuthResponse = await requestToken({
+      endpoint: `${backendUrl}/${tenantId}/v1/tokens`,
+      grantType: "password",
+      username: "ito.ichiro@gmail.com",
+      password: "successUserCode001",
+      clientId: clientSecretPostClient.clientId,
+      clientSecret: clientSecretPostClient.clientSecret,
+      scope: "org-management account management"
+    });
+    expect(orgAuthResponse.status).toBe(200);
+    orgAccessToken = orgAuthResponse.data.access_token;
+
+    const userResult = await createFederatedUser({
+      serverConfig: serverConfig,
+      federationServerConfig: federationServerConfig,
+      client: clientSecretPostClient,
+      adminClient: clientSecretPostClient,
+      scope: "openid profile phone email identity_verification_application " + clientSecretPostClient.identityVerificationScope
+    });
+    userAccessToken = userResult.accessToken;
+    await registerFidoUaf({ accessToken: userAccessToken });
+  });
+
+  afterAll(async () => {
+    if (configId) {
+      await deletion({
+        url: `${backendUrl}/v1/management/organizations/${orgId}/tenants/${tenantId}/identity-verification-configurations/${configId}`,
+        headers: { Authorization: `Bearer ${orgAccessToken}` }
+      });
+    }
+  });
+
+  it("blocks a second apply when a running application already exists for the same type", async () => {
+    configId = uuidv4();
+    configurationType = uuidv4();
+
+    const configurationData = {
+      id: configId,
+      type: configurationType,
+      attributes: { enabled: true },
+      common: { auth_type: "none" },
+      processes: {
+        apply: {
+          request: {
+            schema: {
+              type: "object",
+              properties: {
+                trust_framework: { type: "string" }
+              },
+              required: ["trust_framework"]
+            }
+          },
+          // New section under test: each entry declares a filter for the past-application
+          // read model. The planner OR-combines all entries into a single SQL fetch
+          // executed before the pre_hook verifiers run. Verifiers consume the resulting
+          // Applications via the existing domain API (e.g. containsRunningState).
+          history: {
+            filters: [
+              { types: [configurationType], statuses: "running" }
+            ]
+          },
+          pre_hook: {
+            verifications: [
+              { type: "duplicate_application" }
+            ]
+          },
+          execution: {
+            type: "no_action"
+          }
+        }
+      }
+    };
+
+    const createResponse = await postWithJson({
+      url: `${backendUrl}/v1/management/organizations/${orgId}/tenants/${tenantId}/identity-verification-configurations`,
+      headers: {
+        Authorization: `Bearer ${orgAccessToken}`,
+        "Content-Type": "application/json"
+      },
+      body: configurationData
+    });
+    expect(createResponse.status).toBe(201);
+
+    const applyUrl = serverConfig.identityVerificationApplyEndpoint
+      .replace("{type}", configurationType)
+      .replace("{process}", "apply");
+
+    const firstResponse = await postWithJson({
+      url: applyUrl,
+      body: { trust_framework: "eidas" },
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${userAccessToken}`
+      }
+    });
+    expect(firstResponse.status).toBe(200);
+
+    const secondResponse = await postWithJson({
+      url: applyUrl,
+      body: { trust_framework: "eidas" },
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${userAccessToken}`
+      }
+    });
+    expect(secondResponse.status).not.toBe(200);
+    const body = JSON.stringify(secondResponse.data || {});
+    expect(body.toLowerCase()).toContain("duplicate");
+  });
+});

--- a/e2e/src/tests/integration/ida/integration-10-identity-verification-history-duplicate.test.js
+++ b/e2e/src/tests/integration/ida/integration-10-identity-verification-history-duplicate.test.js
@@ -28,6 +28,7 @@ describe("Identity Verification: history-driven duplicate prevention", () => {
   let userAccessToken;
   let configId;
   let configurationType;
+  const createdConfigIds = [];
 
   beforeAll(async () => {
     const orgAuthResponse = await requestToken({
@@ -54,9 +55,9 @@ describe("Identity Verification: history-driven duplicate prevention", () => {
   });
 
   afterAll(async () => {
-    if (configId) {
+    for (const id of createdConfigIds) {
       await deletion({
-        url: `${backendUrl}/v1/management/organizations/${orgId}/tenants/${tenantId}/identity-verification-configurations/${configId}`,
+        url: `${backendUrl}/v1/management/organizations/${orgId}/tenants/${tenantId}/identity-verification-configurations/${id}`,
         headers: { Authorization: `Bearer ${orgAccessToken}` }
       });
     }
@@ -65,6 +66,7 @@ describe("Identity Verification: history-driven duplicate prevention", () => {
   it("blocks a second apply when a running application already exists for the same type", async () => {
     configId = uuidv4();
     configurationType = uuidv4();
+    createdConfigIds.push(configId);
 
     const configurationData = {
       id: configId,
@@ -135,7 +137,85 @@ describe("Identity Verification: history-driven duplicate prevention", () => {
         Authorization: `Bearer ${userAccessToken}`
       }
     });
-    expect(secondResponse.status).not.toBe(200);
+    // Pre-hook validation failure (duplicate) maps to CLIENT_ERROR = 400.
+    expect(secondResponse.status).toBe(400);
+    const body = JSON.stringify(secondResponse.data || {});
+    expect(body.toLowerCase()).toContain("duplicate");
+  });
+
+  it("falls back to running-of-type when duplicate_application is configured WITHOUT a history section (backward compatibility)", async () => {
+    // Regression guard for the findAll -> findHistory change: a config that enables the
+    // duplicate_application verifier but declares NO `history` section must still block
+    // duplicates. historyPlan(type) falls back to observing running applications of the
+    // requested type, preserving the pre-`history` behavior instead of silently no-op'ing.
+    const fallbackConfigId = uuidv4();
+    const fallbackType = uuidv4();
+    createdConfigIds.push(fallbackConfigId);
+
+    const configurationData = {
+      id: fallbackConfigId,
+      type: fallbackType,
+      attributes: { enabled: true },
+      common: { auth_type: "none" },
+      processes: {
+        apply: {
+          request: {
+            schema: {
+              type: "object",
+              properties: {
+                trust_framework: { type: "string" }
+              },
+              required: ["trust_framework"]
+            }
+          },
+          // NOTE: intentionally no `history` section — exercises the fallback path.
+          pre_hook: {
+            verifications: [
+              { type: "duplicate_application" }
+            ]
+          },
+          execution: {
+            type: "no_action"
+          }
+        }
+      }
+    };
+
+    const createResponse = await postWithJson({
+      url: `${backendUrl}/v1/management/organizations/${orgId}/tenants/${tenantId}/identity-verification-configurations`,
+      headers: {
+        Authorization: `Bearer ${orgAccessToken}`,
+        "Content-Type": "application/json"
+      },
+      body: configurationData
+    });
+    expect(createResponse.status).toBe(201);
+
+    const applyUrl = serverConfig.identityVerificationApplyEndpoint
+      .replace("{type}", fallbackType)
+      .replace("{process}", "apply");
+
+    const firstResponse = await postWithJson({
+      url: applyUrl,
+      body: { trust_framework: "eidas" },
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${userAccessToken}`
+      }
+    });
+    expect(firstResponse.status).toBe(200);
+
+    const secondResponse = await postWithJson({
+      url: applyUrl,
+      body: { trust_framework: "eidas" },
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${userAccessToken}`
+      }
+    });
+    // Without the fallback this would be 200 (duplicate silently allowed).
+    // Pre-hook validation failure (duplicate) maps to CLIENT_ERROR = 400.
+    expect(secondResponse.status).toBe(400);
     const body = JSON.stringify(secondResponse.data || {});
     expect(body.toLowerCase()).toContain("duplicate");
   });

--- a/e2e/src/tests/integration/ida/integration-10-identity-verification-history-duplicate.test.js
+++ b/e2e/src/tests/integration/ida/integration-10-identity-verification-history-duplicate.test.js
@@ -219,4 +219,86 @@ describe("Identity Verification: history-driven duplicate prevention", () => {
     const body = JSON.stringify(secondResponse.data || {});
     expect(body.toLowerCase()).toContain("duplicate");
   });
+
+  it("still blocks duplicates when an explicit history section does NOT cover the request type (merge, not replace)", async () => {
+    // Guards the "explicit history replaces the duplicate fallback" hole: a process declares
+    // duplicate_application AND an explicit history section that observes an UNRELATED type only.
+    // historyPlan(type) must MERGE the running-of-request-type filter (not be replaced by the
+    // explicit one), otherwise the duplicate check silently no-ops for this type.
+    const mergeConfigId = uuidv4();
+    const mergeType = uuidv4();
+    const unrelatedType = uuidv4();
+    createdConfigIds.push(mergeConfigId);
+
+    const configurationData = {
+      id: mergeConfigId,
+      type: mergeType,
+      attributes: { enabled: true },
+      common: { auth_type: "none" },
+      processes: {
+        apply: {
+          request: {
+            schema: {
+              type: "object",
+              properties: {
+                trust_framework: { type: "string" }
+              },
+              required: ["trust_framework"]
+            }
+          },
+          // Explicit history observes an UNRELATED type — it does NOT cover mergeType's running.
+          history: {
+            filters: [
+              { types: [unrelatedType], statuses: "running" }
+            ]
+          },
+          pre_hook: {
+            verifications: [
+              { type: "duplicate_application" }
+            ]
+          },
+          execution: {
+            type: "no_action"
+          }
+        }
+      }
+    };
+
+    const createResponse = await postWithJson({
+      url: `${backendUrl}/v1/management/organizations/${orgId}/tenants/${tenantId}/identity-verification-configurations`,
+      headers: {
+        Authorization: `Bearer ${orgAccessToken}`,
+        "Content-Type": "application/json"
+      },
+      body: configurationData
+    });
+    expect(createResponse.status).toBe(201);
+
+    const applyUrl = serverConfig.identityVerificationApplyEndpoint
+      .replace("{type}", mergeType)
+      .replace("{process}", "apply");
+
+    const firstResponse = await postWithJson({
+      url: applyUrl,
+      body: { trust_framework: "eidas" },
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${userAccessToken}`
+      }
+    });
+    expect(firstResponse.status).toBe(200);
+
+    const secondResponse = await postWithJson({
+      url: applyUrl,
+      body: { trust_framework: "eidas" },
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${userAccessToken}`
+      }
+    });
+    // With "replace" semantics this would be 200 (explicit history hides the duplicate filter).
+    expect(secondResponse.status).toBe(400);
+    const body = JSON.stringify(secondResponse.data || {});
+    expect(body.toLowerCase()).toContain("duplicate");
+  });
 });

--- a/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/identity/verification/application/query/IdentityVerificationApplicationQueryDataSource.java
+++ b/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/identity/verification/application/query/IdentityVerificationApplicationQueryDataSource.java
@@ -19,6 +19,7 @@ package org.idp.server.core.adapters.datasource.identity.verification.applicatio
 import java.util.List;
 import java.util.Map;
 import org.idp.server.core.extension.identity.exception.IdentityVerificationApplicationNotFoundException;
+import org.idp.server.core.extension.identity.verification.application.history.HistoryQueryPlan;
 import org.idp.server.core.extension.identity.verification.application.model.IdentityVerificationApplication;
 import org.idp.server.core.extension.identity.verification.application.model.IdentityVerificationApplicationIdentifier;
 import org.idp.server.core.extension.identity.verification.application.model.IdentityVerificationApplicationQueries;
@@ -167,5 +168,23 @@ public class IdentityVerificationApplicationQueryDataSource
     }
 
     return Long.parseLong(result.get("count"));
+  }
+
+  @Override
+  public IdentityVerificationApplications findHistory(
+      Tenant tenant, User user, HistoryQueryPlan plan) {
+    if (plan.isEmpty()) {
+      return new IdentityVerificationApplications();
+    }
+
+    List<Map<String, String>> result = executor.selectHistory(tenant, user, plan);
+
+    if (result == null || result.isEmpty()) {
+      return new IdentityVerificationApplications();
+    }
+
+    List<IdentityVerificationApplication> applicationList =
+        result.stream().map(ModelConverter::convert).toList();
+    return new IdentityVerificationApplications(applicationList);
   }
 }

--- a/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/identity/verification/application/query/IdentityVerificationApplicationQuerySqlExecutor.java
+++ b/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/identity/verification/application/query/IdentityVerificationApplicationQuerySqlExecutor.java
@@ -18,6 +18,7 @@ package org.idp.server.core.adapters.datasource.identity.verification.applicatio
 
 import java.util.List;
 import java.util.Map;
+import org.idp.server.core.extension.identity.verification.application.history.HistoryQueryPlan;
 import org.idp.server.core.extension.identity.verification.application.model.IdentityVerificationApplicationIdentifier;
 import org.idp.server.core.extension.identity.verification.application.model.IdentityVerificationApplicationQueries;
 import org.idp.server.core.extension.identity.verification.application.model.IdentityVerificationExternalApplicationIdentifier;
@@ -58,4 +59,11 @@ public interface IdentityVerificationApplicationQuerySqlExecutor {
       Tenant tenant, IdentityVerificationApplicationQueries queries);
 
   Map<String, String> selectCount(Tenant tenant, IdentityVerificationApplicationQueries queries);
+
+  /**
+   * Materialize the rows matching observations declared by {@code plan} as a single SQL statement.
+   * Callers must check {@link HistoryQueryPlan#isEmpty()} before invoking — implementations may
+   * assume the plan declares at least one observation.
+   */
+  List<Map<String, String>> selectHistory(Tenant tenant, User user, HistoryQueryPlan plan);
 }

--- a/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/identity/verification/application/query/MysqlExecutor.java
+++ b/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/identity/verification/application/query/MysqlExecutor.java
@@ -19,6 +19,8 @@ package org.idp.server.core.adapters.datasource.identity.verification.applicatio
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import org.idp.server.core.extension.identity.verification.application.history.HistoryFilter;
+import org.idp.server.core.extension.identity.verification.application.history.HistoryQueryPlan;
 import org.idp.server.core.extension.identity.verification.application.model.IdentityVerificationApplicationIdentifier;
 import org.idp.server.core.extension.identity.verification.application.model.IdentityVerificationApplicationQueries;
 import org.idp.server.core.extension.identity.verification.application.model.IdentityVerificationExternalApplicationIdentifier;
@@ -359,6 +361,42 @@ public class MysqlExecutor implements IdentityVerificationApplicationQuerySqlExe
 
     String sql = sqlBuilder.toString();
     return sqlExecutor.selectOne(sql, params);
+  }
+
+  @Override
+  public List<Map<String, String>> selectHistory(Tenant tenant, User user, HistoryQueryPlan plan) {
+    SqlExecutor sqlExecutor = new SqlExecutor();
+
+    StringBuilder sqlBuilder = new StringBuilder();
+    sqlBuilder.append(selectSql);
+    sqlBuilder.append(" WHERE tenant_id = ? AND user_id = ? AND (");
+
+    List<Object> params = new ArrayList<>();
+    params.add(tenant.identifier().value());
+    params.add(user.sub());
+
+    List<String> filterClauses = new ArrayList<>();
+
+    for (HistoryFilter filter : plan.filters()) {
+      List<String> types = filter.types();
+      List<String> statuses = filter.resolvedStatuses();
+      String typePlaceholders = String.join(",", java.util.Collections.nCopies(types.size(), "?"));
+      String statusPlaceholders =
+          String.join(",", java.util.Collections.nCopies(statuses.size(), "?"));
+      filterClauses.add(
+          "(verification_type IN ("
+              + typePlaceholders
+              + ") AND status IN ("
+              + statusPlaceholders
+              + "))");
+      params.addAll(types);
+      params.addAll(statuses);
+    }
+
+    sqlBuilder.append(String.join(" OR ", filterClauses));
+    sqlBuilder.append(") ORDER BY requested_at DESC;");
+
+    return sqlExecutor.selectList(sqlBuilder.toString(), params);
   }
 
   String selectSql =

--- a/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/identity/verification/application/query/PostgresqlExecutor.java
+++ b/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/identity/verification/application/query/PostgresqlExecutor.java
@@ -19,6 +19,8 @@ package org.idp.server.core.adapters.datasource.identity.verification.applicatio
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import org.idp.server.core.extension.identity.verification.application.history.HistoryFilter;
+import org.idp.server.core.extension.identity.verification.application.history.HistoryQueryPlan;
 import org.idp.server.core.extension.identity.verification.application.model.IdentityVerificationApplicationIdentifier;
 import org.idp.server.core.extension.identity.verification.application.model.IdentityVerificationApplicationQueries;
 import org.idp.server.core.extension.identity.verification.application.model.IdentityVerificationExternalApplicationIdentifier;
@@ -359,6 +361,42 @@ public class PostgresqlExecutor implements IdentityVerificationApplicationQueryS
 
     String sql = sqlBuilder.toString();
     return sqlExecutor.selectOne(sql, params);
+  }
+
+  @Override
+  public List<Map<String, String>> selectHistory(Tenant tenant, User user, HistoryQueryPlan plan) {
+    SqlExecutor sqlExecutor = new SqlExecutor();
+
+    StringBuilder sqlBuilder = new StringBuilder();
+    sqlBuilder.append(selectSql);
+    sqlBuilder.append(" WHERE tenant_id = ?::uuid AND user_id = ?::uuid AND (");
+
+    List<Object> params = new ArrayList<>();
+    params.add(tenant.identifierUUID());
+    params.add(user.subAsUuid());
+
+    List<String> filterClauses = new ArrayList<>();
+
+    for (HistoryFilter filter : plan.filters()) {
+      List<String> types = filter.types();
+      List<String> statuses = filter.resolvedStatuses();
+      String typePlaceholders = String.join(",", java.util.Collections.nCopies(types.size(), "?"));
+      String statusPlaceholders =
+          String.join(",", java.util.Collections.nCopies(statuses.size(), "?"));
+      filterClauses.add(
+          "(verification_type IN ("
+              + typePlaceholders
+              + ") AND status IN ("
+              + statusPlaceholders
+              + "))");
+      params.addAll(types);
+      params.addAll(statuses);
+    }
+
+    sqlBuilder.append(String.join(" OR ", filterClauses));
+    sqlBuilder.append(") ORDER BY requested_at DESC;");
+
+    return sqlExecutor.selectList(sqlBuilder.toString(), params);
   }
 
   String selectSql =

--- a/libs/idp-server-core-extension-ida/src/main/java/org/idp/server/core/extension/identity/verification/application/history/HistoryFilter.java
+++ b/libs/idp-server-core-extension-ida/src/main/java/org/idp/server/core/extension/identity/verification/application/history/HistoryFilter.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2025 Hirokazu Kobayashi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.idp.server.core.extension.identity.verification.application.history;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.idp.server.core.extension.identity.verification.application.model.IdentityVerificationApplicationStatus;
+import org.idp.server.platform.json.JsonReadable;
+
+/**
+ * One filter specification declaring a subset of past applications that must be fetched. Multiple
+ * filters are combined with OR at the SQL level so the repository fetches the union in a single
+ * statement, and the {@code Applications} model is left as the boundary where verifiers express
+ * their domain judgement.
+ */
+public class HistoryFilter implements JsonReadable {
+
+  /** Shorthand keyword for the four "still being processed" statuses. */
+  public static final String STATUSES_RUNNING = "running";
+
+  List<String> types = new ArrayList<>();
+  Object statuses;
+
+  public HistoryFilter() {}
+
+  public List<String> types() {
+    return types != null ? types : new ArrayList<>();
+  }
+
+  /**
+   * Resolve {@code statuses} into a concrete status value list. Supports a single keyword string
+   * (currently only {@code "running"}) or an explicit list of status values.
+   */
+  public List<String> resolvedStatuses() {
+    if (statuses == null) {
+      return List.of();
+    }
+    if (statuses instanceof String keyword) {
+      if (STATUSES_RUNNING.equals(keyword)) {
+        return IdentityVerificationApplicationStatus.runningValues();
+      }
+      return List.of(keyword);
+    }
+    if (statuses instanceof List<?> list) {
+      List<String> values = new ArrayList<>();
+      for (Object item : list) {
+        if (item != null) {
+          values.add(item.toString());
+        }
+      }
+      return values;
+    }
+    return List.of();
+  }
+
+  public boolean isEmpty() {
+    return types().isEmpty() || resolvedStatuses().isEmpty();
+  }
+
+  public Map<String, Object> toMap() {
+    Map<String, Object> map = new HashMap<>();
+    map.put("types", types());
+    if (statuses != null) {
+      map.put("statuses", statuses);
+    }
+    return map;
+  }
+
+  /** Serialize a list of filters for {@code toMap()} output, dropping empty entries. */
+  public static List<Object> toMapList(List<HistoryFilter> filters) {
+    List<Object> serialized = new ArrayList<>();
+    if (filters == null) {
+      return serialized;
+    }
+    for (HistoryFilter filter : filters) {
+      if (filter != null && !filter.isEmpty()) {
+        serialized.add(filter.toMap());
+      }
+    }
+    return serialized;
+  }
+}

--- a/libs/idp-server-core-extension-ida/src/main/java/org/idp/server/core/extension/identity/verification/application/history/HistoryFilter.java
+++ b/libs/idp-server-core-extension-ida/src/main/java/org/idp/server/core/extension/identity/verification/application/history/HistoryFilter.java
@@ -85,6 +85,26 @@ public class HistoryFilter implements JsonReadable {
     return types().isEmpty() || resolvedStatuses().isEmpty();
   }
 
+  /** Equality by the effective observation set (types + resolved statuses), order-independent. */
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof HistoryFilter other)) {
+      return false;
+    }
+    return new java.util.HashSet<>(types()).equals(new java.util.HashSet<>(other.types()))
+        && new java.util.HashSet<>(resolvedStatuses())
+            .equals(new java.util.HashSet<>(other.resolvedStatuses()));
+  }
+
+  @Override
+  public int hashCode() {
+    return java.util.Objects.hash(
+        new java.util.HashSet<>(types()), new java.util.HashSet<>(resolvedStatuses()));
+  }
+
   public Map<String, Object> toMap() {
     Map<String, Object> map = new HashMap<>();
     map.put("types", types());

--- a/libs/idp-server-core-extension-ida/src/main/java/org/idp/server/core/extension/identity/verification/application/history/HistoryFilter.java
+++ b/libs/idp-server-core-extension-ida/src/main/java/org/idp/server/core/extension/identity/verification/application/history/HistoryFilter.java
@@ -39,6 +39,18 @@ public class HistoryFilter implements JsonReadable {
 
   public HistoryFilter() {}
 
+  /**
+   * Build a filter that observes the running-state applications of a single type. Used as the
+   * backward-compatible default when a {@code duplicate_application} verifier is configured without
+   * an explicit {@code history} section.
+   */
+  public static HistoryFilter running(String type) {
+    HistoryFilter filter = new HistoryFilter();
+    filter.types = new ArrayList<>(List.of(type));
+    filter.statuses = STATUSES_RUNNING;
+    return filter;
+  }
+
   public List<String> types() {
     return types != null ? types : new ArrayList<>();
   }

--- a/libs/idp-server-core-extension-ida/src/main/java/org/idp/server/core/extension/identity/verification/application/history/HistoryQueryPlan.java
+++ b/libs/idp-server-core-extension-ida/src/main/java/org/idp/server/core/extension/identity/verification/application/history/HistoryQueryPlan.java
@@ -35,7 +35,9 @@ public class HistoryQueryPlan {
     List<HistoryFilter> effective = new ArrayList<>();
     if (source != null) {
       for (HistoryFilter filter : source) {
-        if (filter != null && !filter.isEmpty()) {
+        // Drop empty filters, and de-duplicate equal ones so a fallback filter merged on top of an
+        // explicit history section does not produce a redundant OR clause.
+        if (filter != null && !filter.isEmpty() && !effective.contains(filter)) {
           effective.add(filter);
         }
       }

--- a/libs/idp-server-core-extension-ida/src/main/java/org/idp/server/core/extension/identity/verification/application/history/HistoryQueryPlan.java
+++ b/libs/idp-server-core-extension-ida/src/main/java/org/idp/server/core/extension/identity/verification/application/history/HistoryQueryPlan.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2025 Hirokazu Kobayashi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.idp.server.core.extension.identity.verification.application.history;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Execution-time projection of the {@code history} config section. Carries the filter list the
+ * repository should fetch the union of, with empty filters already dropped.
+ */
+public class HistoryQueryPlan {
+
+  List<HistoryFilter> filters;
+
+  HistoryQueryPlan(List<HistoryFilter> filters) {
+    this.filters = filters;
+  }
+
+  public static HistoryQueryPlan from(List<HistoryFilter> source) {
+    List<HistoryFilter> effective = new ArrayList<>();
+    if (source != null) {
+      for (HistoryFilter filter : source) {
+        if (filter != null && !filter.isEmpty()) {
+          effective.add(filter);
+        }
+      }
+    }
+    return new HistoryQueryPlan(effective);
+  }
+
+  public List<HistoryFilter> filters() {
+    return filters;
+  }
+
+  public boolean isEmpty() {
+    return filters.isEmpty();
+  }
+}

--- a/libs/idp-server-core-extension-ida/src/main/java/org/idp/server/core/extension/identity/verification/application/history/IdentityVerificationHistoryConfig.java
+++ b/libs/idp-server-core-extension-ida/src/main/java/org/idp/server/core/extension/identity/verification/application/history/IdentityVerificationHistoryConfig.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2025 Hirokazu Kobayashi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.idp.server.core.extension.identity.verification.application.history;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.idp.server.platform.json.JsonReadable;
+
+public class IdentityVerificationHistoryConfig implements JsonReadable {
+
+  List<HistoryFilter> filters = new ArrayList<>();
+
+  public IdentityVerificationHistoryConfig() {}
+
+  public List<HistoryFilter> filters() {
+    return filters != null ? filters : new ArrayList<>();
+  }
+
+  public HistoryQueryPlan plan() {
+    return HistoryQueryPlan.from(filters());
+  }
+
+  public boolean isEmpty() {
+    return filters == null || filters.isEmpty();
+  }
+
+  public Map<String, Object> toMap() {
+    Map<String, Object> map = new HashMap<>();
+    List<Object> filterList = HistoryFilter.toMapList(filters);
+    if (!filterList.isEmpty()) {
+      map.put("filters", filterList);
+    }
+    return map;
+  }
+}

--- a/libs/idp-server-core-extension-ida/src/main/java/org/idp/server/core/extension/identity/verification/application/model/IdentityVerificationApplicationStatus.java
+++ b/libs/idp-server-core-extension-ida/src/main/java/org/idp/server/core/extension/identity/verification/application/model/IdentityVerificationApplicationStatus.java
@@ -16,6 +16,9 @@
 
 package org.idp.server.core.extension.identity.verification.application.model;
 
+import java.util.Arrays;
+import java.util.List;
+
 public enum IdentityVerificationApplicationStatus {
   REQUESTED("requested"),
   APPLYING("applying"),
@@ -53,6 +56,13 @@ public enum IdentityVerificationApplicationStatus {
         || this == APPLYING
         || this == APPLIED
         || this == EXAMINATION_PROCESSING;
+  }
+
+  public static List<String> runningValues() {
+    return Arrays.stream(values())
+        .filter(IdentityVerificationApplicationStatus::isRunning)
+        .map(IdentityVerificationApplicationStatus::value)
+        .toList();
   }
 
   public boolean isApproved() {

--- a/libs/idp-server-core-extension-ida/src/main/java/org/idp/server/core/extension/identity/verification/configuration/process/IdentityVerificationProcessConfiguration.java
+++ b/libs/idp-server-core-extension-ida/src/main/java/org/idp/server/core/extension/identity/verification/configuration/process/IdentityVerificationProcessConfiguration.java
@@ -17,7 +17,10 @@
 package org.idp.server.core.extension.identity.verification.configuration.process;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import org.idp.server.core.extension.identity.verification.IdentityVerificationType;
+import org.idp.server.core.extension.identity.verification.application.history.HistoryFilter;
 import org.idp.server.core.extension.identity.verification.application.history.HistoryQueryPlan;
 import org.idp.server.core.extension.identity.verification.application.history.IdentityVerificationHistoryConfig;
 import org.idp.server.core.extension.identity.verification.configuration.common.IdentityVerificationBasicAuthConfig;
@@ -68,8 +71,32 @@ public class IdentityVerificationProcessConfiguration implements JsonReadable {
     return history;
   }
 
-  public HistoryQueryPlan historyPlan() {
-    return history().plan();
+  /**
+   * Build the history fetch plan for the given request type.
+   *
+   * <p>When an explicit {@code history} section is declared it is used as-is. Otherwise, if this
+   * process runs a {@code duplicate_application} verifier, fall back to observing the running-state
+   * applications of the requested type — this preserves the pre-{@code history}
+   * duplicate-prevention behavior for existing configs instead of silently disabling it. When
+   * neither applies, the plan is empty (no history fetch).
+   */
+  public HistoryQueryPlan historyPlan(IdentityVerificationType type) {
+    HistoryQueryPlan plan = history().plan();
+    if (!plan.isEmpty()) {
+      return plan;
+    }
+    if (requiresDuplicateApplicationCheck()) {
+      return HistoryQueryPlan.from(List.of(HistoryFilter.running(type.name())));
+    }
+    return plan;
+  }
+
+  private boolean requiresDuplicateApplicationCheck() {
+    // "duplicate_application" is the type() of
+    // DenyDuplicateIdentityVerificationApplicationVerifier,
+    // the only verifier that consumes the past-application read model.
+    return preHook().verifications().stream()
+        .anyMatch(verification -> "duplicate_application".equals(verification.type()));
   }
 
   public IdentityVerificationPreHookConfig preHook() {

--- a/libs/idp-server-core-extension-ida/src/main/java/org/idp/server/core/extension/identity/verification/configuration/process/IdentityVerificationProcessConfiguration.java
+++ b/libs/idp-server-core-extension-ida/src/main/java/org/idp/server/core/extension/identity/verification/configuration/process/IdentityVerificationProcessConfiguration.java
@@ -18,6 +18,8 @@ package org.idp.server.core.extension.identity.verification.configuration.proces
 
 import java.util.HashMap;
 import java.util.Map;
+import org.idp.server.core.extension.identity.verification.application.history.HistoryQueryPlan;
+import org.idp.server.core.extension.identity.verification.application.history.IdentityVerificationHistoryConfig;
 import org.idp.server.core.extension.identity.verification.configuration.common.IdentityVerificationBasicAuthConfig;
 import org.idp.server.platform.http.HmacAuthenticationConfig;
 import org.idp.server.platform.json.JsonNodeWrapper;
@@ -27,6 +29,7 @@ import org.idp.server.platform.oauth.OAuthAuthorizationConfiguration;
 
 public class IdentityVerificationProcessConfiguration implements JsonReadable {
   IdentityVerificationRequestConfig request = new IdentityVerificationRequestConfig();
+  IdentityVerificationHistoryConfig history = new IdentityVerificationHistoryConfig();
   IdentityVerificationPreHookConfig preHook = new IdentityVerificationPreHookConfig();
   IdentityVerificationExecutionConfig execution = new IdentityVerificationExecutionConfig();
   IdentityVerificationPostHookConfig postHook = new IdentityVerificationPostHookConfig();
@@ -56,6 +59,17 @@ public class IdentityVerificationProcessConfiguration implements JsonReadable {
       return new JsonSchemaDefinition(JsonNodeWrapper.empty());
     }
     return request.requestSchemaAsDefinition();
+  }
+
+  public IdentityVerificationHistoryConfig history() {
+    if (history == null) {
+      return new IdentityVerificationHistoryConfig();
+    }
+    return history;
+  }
+
+  public HistoryQueryPlan historyPlan() {
+    return history().plan();
   }
 
   public IdentityVerificationPreHookConfig preHook() {
@@ -161,6 +175,7 @@ public class IdentityVerificationProcessConfiguration implements JsonReadable {
   public Map<String, Object> toMap() {
     Map<String, Object> map = new HashMap<>();
     if (request != null) map.put("request", request.toMap());
+    if (history != null) map.put("history", history.toMap());
     if (preHook != null) map.put("pre_hook", preHook.toMap());
     if (execution != null) map.put("execution", execution.toMap());
     if (postHook != null) map.put("post_hook", postHook.toMap());

--- a/libs/idp-server-core-extension-ida/src/main/java/org/idp/server/core/extension/identity/verification/configuration/process/IdentityVerificationProcessConfiguration.java
+++ b/libs/idp-server-core-extension-ida/src/main/java/org/idp/server/core/extension/identity/verification/configuration/process/IdentityVerificationProcessConfiguration.java
@@ -16,6 +16,7 @@
 
 package org.idp.server.core.extension.identity.verification.configuration.process;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -31,6 +32,13 @@ import org.idp.server.platform.json.schema.JsonSchemaDefinition;
 import org.idp.server.platform.oauth.OAuthAuthorizationConfiguration;
 
 public class IdentityVerificationProcessConfiguration implements JsonReadable {
+
+  // Must match DenyDuplicateIdentityVerificationApplicationVerifier.type(); it is the only verifier
+  // that consumes the past-application read model. When a new verifier starts consuming it, update
+  // this detection (or generalize it from the consuming-verifier declaration — see #1268 / Phase
+  // 2).
+  private static final String DUPLICATE_APPLICATION_VERIFIER = "duplicate_application";
+
   IdentityVerificationRequestConfig request = new IdentityVerificationRequestConfig();
   IdentityVerificationHistoryConfig history = new IdentityVerificationHistoryConfig();
   IdentityVerificationPreHookConfig preHook = new IdentityVerificationPreHookConfig();
@@ -74,29 +82,24 @@ public class IdentityVerificationProcessConfiguration implements JsonReadable {
   /**
    * Build the history fetch plan for the given request type.
    *
-   * <p>When an explicit {@code history} section is declared it is used as-is. Otherwise, if this
-   * process runs a {@code duplicate_application} verifier, fall back to observing the running-state
-   * applications of the requested type — this preserves the pre-{@code history}
-   * duplicate-prevention behavior for existing configs instead of silently disabling it. When
-   * neither applies, the plan is empty (no history fetch).
+   * <p>The explicit {@code history} filters (if any) are always honored. Additionally, when this
+   * process runs a {@code duplicate_application} verifier, a "running-of-request-type" filter is
+   * <b>merged in</b> (not used only as an empty-config fallback). This guarantees the duplicate
+   * check always observes the running state of the requested type — it cannot be silently disabled
+   * by an absent {@code history} section, nor by an explicit {@code history} section that happens
+   * not to cover this type. Duplicate filters are de-duplicated by {@link HistoryQueryPlan#from}.
    */
   public HistoryQueryPlan historyPlan(IdentityVerificationType type) {
-    HistoryQueryPlan plan = history().plan();
-    if (!plan.isEmpty()) {
-      return plan;
-    }
+    List<HistoryFilter> filters = new ArrayList<>(history().filters());
     if (requiresDuplicateApplicationCheck()) {
-      return HistoryQueryPlan.from(List.of(HistoryFilter.running(type.name())));
+      filters.add(HistoryFilter.running(type.name()));
     }
-    return plan;
+    return HistoryQueryPlan.from(filters);
   }
 
   private boolean requiresDuplicateApplicationCheck() {
-    // "duplicate_application" is the type() of
-    // DenyDuplicateIdentityVerificationApplicationVerifier,
-    // the only verifier that consumes the past-application read model.
     return preHook().verifications().stream()
-        .anyMatch(verification -> "duplicate_application".equals(verification.type()));
+        .anyMatch(verification -> DUPLICATE_APPLICATION_VERIFIER.equals(verification.type()));
   }
 
   public IdentityVerificationPreHookConfig preHook() {

--- a/libs/idp-server-core-extension-ida/src/main/java/org/idp/server/core/extension/identity/verification/repository/IdentityVerificationApplicationQueryRepository.java
+++ b/libs/idp-server-core-extension-ida/src/main/java/org/idp/server/core/extension/identity/verification/repository/IdentityVerificationApplicationQueryRepository.java
@@ -16,6 +16,7 @@
 
 package org.idp.server.core.extension.identity.verification.repository;
 
+import org.idp.server.core.extension.identity.verification.application.history.HistoryQueryPlan;
 import org.idp.server.core.extension.identity.verification.application.model.IdentityVerificationApplication;
 import org.idp.server.core.extension.identity.verification.application.model.IdentityVerificationApplicationIdentifier;
 import org.idp.server.core.extension.identity.verification.application.model.IdentityVerificationApplicationQueries;
@@ -44,4 +45,12 @@ public interface IdentityVerificationApplicationQueryRepository {
       Tenant tenant, IdentityVerificationApplicationQueries queries);
 
   long findTotalCount(Tenant tenant, IdentityVerificationApplicationQueries queries);
+
+  /**
+   * Find past applications matching observations declared by the {@code history} configuration
+   * section. Returns only the rows that satisfy at least one observation (e.g. running applications
+   * for the declared types), so the result set stays small even for heavy users — unlike {@link
+   * #findAll(Tenant, User)} which hydrates the full history including heavy JSONB columns.
+   */
+  IdentityVerificationApplications findHistory(Tenant tenant, User user, HistoryQueryPlan plan);
 }

--- a/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/application/enduser/IdentityVerificationApplicationEntryService.java
+++ b/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/application/enduser/IdentityVerificationApplicationEntryService.java
@@ -116,7 +116,7 @@ public class IdentityVerificationApplicationEntryService
     }
 
     IdentityVerificationApplications applications =
-        applicationQueryRepository.findAll(tenant, user);
+        applicationQueryRepository.findHistory(tenant, user, processConfig.historyPlan());
 
     IdentityVerificationApplyingResult applyingResult =
         identityVerificationApplicationHandler.executeRequest(
@@ -252,7 +252,7 @@ public class IdentityVerificationApplicationEntryService
     }
 
     IdentityVerificationApplications applications =
-        applicationQueryRepository.findAll(tenant, user);
+        applicationQueryRepository.findHistory(tenant, user, processConfig.historyPlan());
 
     IdentityVerificationApplyingResult applyingResult =
         identityVerificationApplicationHandler.executeRequest(

--- a/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/application/enduser/IdentityVerificationApplicationEntryService.java
+++ b/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/application/enduser/IdentityVerificationApplicationEntryService.java
@@ -116,7 +116,7 @@ public class IdentityVerificationApplicationEntryService
     }
 
     IdentityVerificationApplications applications =
-        applicationQueryRepository.findHistory(tenant, user, processConfig.historyPlan());
+        applicationQueryRepository.findHistory(tenant, user, processConfig.historyPlan(type));
 
     IdentityVerificationApplyingResult applyingResult =
         identityVerificationApplicationHandler.executeRequest(
@@ -252,7 +252,7 @@ public class IdentityVerificationApplicationEntryService
     }
 
     IdentityVerificationApplications applications =
-        applicationQueryRepository.findHistory(tenant, user, processConfig.historyPlan());
+        applicationQueryRepository.findHistory(tenant, user, processConfig.historyPlan(type));
 
     IdentityVerificationApplyingResult applyingResult =
         identityVerificationApplicationHandler.executeRequest(


### PR DESCRIPTION
## Summary

Identity Verification の `apply` プロセスで、過去のアプリ履歴に基づく判断 (例: 同じ user/type で既に running 状態のアプリがあれば 2 回目を拒否) を verifier に declarative に組み込む仕組みを追加。

## 設計

1. 設定 (`process.apply.history`) で「履歴の引き条件」を declarative に表現
2. 設定を実行時に `HistoryQueryPlan` (複数 filter を OR 結合) に変換
3. pre_hook verifier 実行前に **1 つの SQL fetch** で `Applications` を取得
4. verifier は domain API (`containsRunningState` 等) で取得済み Applications を参照

### 設定 JSON 例

```json
{
  "apply": {
    "history": {
      "filters": [
        { "types": ["identity-verification-type-a"], "statuses": "running" }
      ]
    },
    "pre_hook": {
      "verifications": [
        { "type": "duplicate_application" }
      ]
    }
  }
}
```

## 含まれる変更

**新規**
- `HistoryFilter` (types + statuses の組)
- `HistoryQueryPlan` (filter リストを OR 結合した実行プラン)
- `IdentityVerificationHistoryConfig` (history セクションの Config 形式 — 他の `IdentityVerificationXxxConfig` と命名揃え)
- `findHistory(...)` in `QueryRepository` + PG/MySQL Executor 実装 (両 DB 対応)
- e2e: `integration-10-identity-verification-history-duplicate.test.js`

**修正**
- `IdentityVerificationProcessConfiguration`: `history` フィールドを object 形式に (`{"history": {"filters": [...]}}`)
- `IdentityVerificationApplicationEntryService`: pre-hook verifier 実行前に history fetch
- `IdentityVerificationApplicationStatus`: running 判定値を `runningValues()` に集約

## Test plan

- [x] `./gradlew spotlessApply build -x test` 通過
- [x] e2e (integration-10) pass: `cd e2e && npm test -- --testPathPattern='integration-10'`
- [ ] レビュー対応

## 将来の Phase

- Phase 2 以降で他の verifier (status_restriction, required_processes 等) を同じ history pipeline 上で表現する

## 関連

- Closes #1566

🤖 Generated with [Claude Code](https://claude.com/claude-code)