### PR TITLE
perf: ユーザー一覧の selectCount が role/permission を絞らない場合も 4-way JOIN を実行する問題を解消

### DIFF
--- a/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/identity/MysqlExecutor.java
+++ b/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/identity/MysqlExecutor.java
@@ -232,15 +232,25 @@ public class MysqlExecutor implements UserSqlExecutor {
       params.add("%" + queries.permission() + "%");
     }
 
-    String sql =
-        """
-    SELECT COUNT(DISTINCT idp_user.id) as count
-    FROM idp_user
-    LEFT JOIN idp_user_roles ON idp_user.id = idp_user_roles.user_id
-    LEFT JOIN role ON idp_user_roles.role_id = role.id
-    LEFT JOIN role_permission ON role.id = role_permission.role_id
-    LEFT JOIN permission ON role_permission.permission_id = permission.id
-    """;
+    // Mirror selectList: only JOIN role/permission tables when the filter actually uses them.
+    // Without this, every count incurs a 4-way LEFT JOIN + COUNT(DISTINCT) even on the common
+    // "no role/permission filter" path.
+    boolean hasRoleOrPermissionFilter = queries.hasRole() || queries.hasPermission();
+
+    String sql;
+    if (hasRoleOrPermissionFilter) {
+      sql =
+          """
+      SELECT COUNT(DISTINCT idp_user.id) as count
+      FROM idp_user
+      LEFT JOIN idp_user_roles ON idp_user.id = idp_user_roles.user_id
+      LEFT JOIN role ON idp_user_roles.role_id = role.id
+      LEFT JOIN role_permission ON role.id = role_permission.role_id
+      LEFT JOIN permission ON role_permission.permission_id = permission.id
+      """;
+    } else {
+      sql = "SELECT COUNT(*) as count FROM idp_user ";
+    }
 
     return sqlExecutor.selectOne(sql + where, params);
   }

--- a/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/identity/PostgresqlExecutor.java
+++ b/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/identity/PostgresqlExecutor.java
@@ -231,15 +231,25 @@ public class PostgresqlExecutor implements UserSqlExecutor {
       params.add("%" + queries.permission() + "%");
     }
 
-    String sql =
-        """
-    SELECT COUNT(DISTINCT idp_user.id)
-    FROM idp_user
-    LEFT JOIN idp_user_roles ON idp_user.id = idp_user_roles.user_id
-    LEFT JOIN role ON idp_user_roles.role_id = role.id
-    LEFT JOIN role_permission ON role.id = role_permission.role_id
-    LEFT JOIN permission ON role_permission.permission_id = permission.id
-    """;
+    // Mirror selectList: only JOIN role/permission tables when the filter actually uses them.
+    // Without this, every count incurs a 4-way LEFT JOIN + COUNT(DISTINCT) even on the common
+    // "no role/permission filter" path.
+    boolean hasRoleOrPermissionFilter = queries.hasRole() || queries.hasPermission();
+
+    String sql;
+    if (hasRoleOrPermissionFilter) {
+      sql =
+          """
+      SELECT COUNT(DISTINCT idp_user.id)
+      FROM idp_user
+      LEFT JOIN idp_user_roles ON idp_user.id = idp_user_roles.user_id
+      LEFT JOIN role ON idp_user_roles.role_id = role.id
+      LEFT JOIN role_permission ON role.id = role_permission.role_id
+      LEFT JOIN permission ON role_permission.permission_id = permission.id
+      """;
+    } else {
+      sql = "SELECT COUNT(*) FROM idp_user ";
+    }
 
     return sqlExecutor.selectOne(sql + where, params);
   }

--- a/libs/idp-server-database/postgresql/operation/idp-user-tenant-created-at-index/README.md
+++ b/libs/idp-server-database/postgresql/operation/idp-user-tenant-created-at-index/README.md
@@ -104,9 +104,15 @@ psql -f bench_cleanup.sql
 
 ### 計測結果 (ローカル / 同一テナントに 200 万行追加)
 
+#### `selectList` (Issue #1460): `ORDER BY created_at DESC LIMIT 20`
+
 | 状態 | Execution Time | Plan |
 |------|---------------|------|
 | index なし | 340.568 ms | Parallel Seq Scan + top-N heapsort |
 | index あり |   1.280 ms | Index Scan using idx_idp_user_tenant_created_at |
 
 約 266 倍の改善。Issue #1460 で報告された 75 倍 (185ms → 2.5ms) よりも幅が大きいのは、テナント分散の差 (Issue は 200 万 = 1 テナント想定、ローカルは 200 万 + 既存 4070 行 + 1500 テナント混在) によるものと推測。
+
+#### `selectCount` (Issue #1565): role/permission 絞り込み無しの総件数取得
+
+bench.sql Step 5 (現状: 常に 4-way JOIN + COUNT(DISTINCT)) と Step 6 (改善後: 単表 COUNT(*)) を `(tenant_id, created_at DESC)` index あり状態で比較する。テーブル状態は Step 4 と同じ (200 万行 + index あり)。実行は `psql -f bench.sql` で連続計測可能。

--- a/libs/idp-server-database/postgresql/operation/idp-user-tenant-created-at-index/bench.sql
+++ b/libs/idp-server-database/postgresql/operation/idp-user-tenant-created-at-index/bench.sql
@@ -58,6 +58,33 @@ ORDER BY created_at DESC
 LIMIT 20;
 
 -- =====================================================
+-- Issue #1565: ページネーション総件数取得 selectCount のベンチ
+--
+-- selectCount は role/permission 絞り込みが無くても 4-way LEFT JOIN を
+-- 実行している。selectList と同じ hasRoleOrPermissionFilter 分岐で
+-- JOIN を外すと、絞り込み無し時は単表 COUNT(*) で済む。
+-- (tenant_id, created_at DESC) index も index-only scan に活用される。
+-- =====================================================
+
+\echo ''
+\echo '=== Step 5: selectCount 現状 (常に 4-way JOIN + COUNT(DISTINCT)) ==='
+EXPLAIN (ANALYZE, BUFFERS, TIMING)
+SELECT COUNT(DISTINCT idp_user.id)
+FROM idp_user
+LEFT JOIN idp_user_roles  ON idp_user.id = idp_user_roles.user_id
+LEFT JOIN role            ON idp_user_roles.role_id = role.id
+LEFT JOIN role_permission ON role.id = role_permission.role_id
+LEFT JOIN permission      ON role_permission.permission_id = permission.id
+WHERE idp_user.tenant_id = :TARGET_TENANT::uuid;
+
+\echo ''
+\echo '=== Step 6: selectCount 改善後 (role/permission 絞り込み無しなら単表 COUNT(*)) ==='
+EXPLAIN (ANALYZE, BUFFERS, TIMING)
+SELECT COUNT(*)
+FROM idp_user
+WHERE tenant_id = :TARGET_TENANT::uuid;
+
+-- =====================================================
 -- ベンチ完了後は bench_cleanup.sql を実行してダミーデータと
 -- 検証用 index を片付ける。
 --   psql -f bench_cleanup.sql


### PR DESCRIPTION
## Summary

`UserQueryDataSource#selectCount` が role/permission 絞り込みの有無に関わらず常に 4-way LEFT JOIN + `COUNT(DISTINCT)` を実行していた問題を、`selectList` と同じ `hasRoleOrPermissionFilter` 分岐で解消。

## 背景

- `selectList` は既に分岐済み (絞り込み無し時は JOIN なし) なのに `selectCount` だけ取り残しの非対称状態
- ユーザー一覧 API のページネーションは「総件数 + ページ取得」の 2 クエリ構成なので、`selectCount` が JOIN 爆発のままだと体感が件数取得に引きずられる
- #1562 で追加した `(tenant_id, created_at DESC)` index は走査は改善するが、不要 JOIN そのものは解消しない

## 修正

```java
// PostgresqlExecutor / MysqlExecutor の selectCount に分岐追加
boolean hasRoleOrPermissionFilter = queries.hasRole() || queries.hasPermission();
String sql = hasRoleOrPermissionFilter
    ? """
      SELECT COUNT(DISTINCT idp_user.id) FROM idp_user
      LEFT JOIN idp_user_roles  ON idp_user.id = idp_user_roles.user_id
      LEFT JOIN role            ON idp_user_roles.role_id = role.id
      LEFT JOIN role_permission ON role.id = role_permission.role_id
      LEFT JOIN permission      ON role_permission.permission_id = permission.id
      """
    : "SELECT COUNT(*) FROM idp_user ";  // 絞り込み無し: 単表
```

## ローカル計測結果 (PostgreSQL / 200 万行 / 1 テナント集中)

| 状態 | Execution Time | Buffers | Plan |
|------|---------------|---------|------|
| 現状 (4-way JOIN + COUNT(DISTINCT)) | **810.366 ms** | shared hit=32213, **temp read/written 4898** | Hash Left Join + Aggregate |
| 改善後 (単表 COUNT(*)) | **262.697 ms** | shared hit=32171 | Parallel Seq Scan + Aggregate |

**約 3.1 倍の改善**。JOIN 中間結果 (200 万行) が work_mem に収まらず一時ファイル I/O が発生していたのを丸ごと削減した効果が支配的。

## 同等性確認

- 旧 SQL `COUNT(DISTINCT idp_user.id)` + JOIN = 新 SQL `COUNT(*)` 単表 → **完全一致 (2,001,663 = 2,001,663)**
- 列名 (PG/MySQL とも `count`) 互換、`findTotalCount.result.get("count")` 経路に変更なし
- E2E (`organization_user_management.test.js`) はグリーン

## 補足 (より根本的な選択肢)

総件数取得自体をやめ `LIMIT N+1` での `has_more` 判定 + カーソルページネーションに寄せる根本対応は #1257 (security_event) で進行中。ユーザー一覧 API でも同パターンに揃えるなら、本 PR は **その前段として互換維持しつつ即効性のある最小修正** の位置付け。

## Test plan

- [x] `./gradlew spotlessApply build -x test` 通過
- [x] bench.sql 実行で計測値確認 (810ms → 262ms)
- [x] 同等性確認 (旧/新 SQL で count 値完全一致)
- [x] e2e (`organization_user_management.test.js`) グリーン
- [x] `bench_cleanup.sql` でダミーデータ・index 0 確認
- [ ] レビュー対応

## Closes

- Closes #1565

🤖 Generated with [Claude Code](https://claude.com/claude-code)