### PR TITLE
test(e2e) + perf(bench): user-list の role/permission フィルタ E2E カバレッジ + bench 拡張

### DIFF
--- a/e2e/src/tests/scenario/control_plane/organization/organization_user_management.test.js
+++ b/e2e/src/tests/scenario/control_plane/organization/organization_user_management.test.js
@@ -909,6 +909,83 @@ describe("organization user management api", () => {
       expect(paginatedResponse.data).toHaveProperty("offset", 0);
       expect(Array.isArray(paginatedResponse.data.list)).toBe(true);
     });
+
+    it("filter by role and permission", async () => {
+      const tokenResponse = await requestToken({
+        endpoint: `${backendUrl}/952f6906-3e95-4ed3-86b2-981f90f785f9/v1/tokens`,
+        grantType: "password",
+        username: "ito.ichiro@gmail.com",
+        password: "successUserCode001",
+        scope: "org-management account management",
+        clientId: "org-client",
+        clientSecret: "org-client-001"
+      });
+      expect(tokenResponse.status).toBe(200);
+      const accessToken = tokenResponse.data.access_token;
+
+      const rolesResponse = await get({
+        url: `${backendUrl}/v1/management/organizations/${orgId}/tenants/${tenantId}/roles`,
+        headers: { Authorization: `Bearer ${accessToken}` }
+      });
+      expect(rolesResponse.status).toBe(200);
+      const targetRole = rolesResponse.data.list.find(r => r.permissions && r.permissions.length > 0);
+      expect(targetRole).toBeDefined();
+      const targetPermission = targetRole.permissions[0];
+
+      const timestamp = Date.now();
+      const userSub = uuidv4();
+      const createResponse = await postWithJson({
+        url: `${backendUrl}/v1/management/organizations/${orgId}/tenants/${tenantId}/users`,
+        headers: { Authorization: `Bearer ${accessToken}` },
+        body: {
+          "sub": userSub,
+          "provider_id": "idp-server",
+          "external_user_id": `filter_${timestamp}`,
+          "name": `Filter Test User ${timestamp}`,
+          "email": `filtertest-${timestamp}@example.com`,
+          "email_verified": true,
+          "preferred_username": `filtertest${timestamp}`,
+          "raw_password": "TempPassword123!",
+          "roles": [{
+            "role_id": targetRole.id,
+            "role_name": targetRole.name
+          }]
+        }
+      });
+      expect(createResponse.status).toBe(201);
+
+      const byRoleResponse = await get({
+        url: `${backendUrl}/v1/management/organizations/${orgId}/tenants/${tenantId}/users?role=${encodeURIComponent(targetRole.name)}&limit=100`,
+        headers: { Authorization: `Bearer ${accessToken}` }
+      });
+      expect(byRoleResponse.status).toBe(200);
+      expect(byRoleResponse.data.total_count).toBeGreaterThan(0);
+      expect(byRoleResponse.data.list.some(u => u.sub === userSub)).toBe(true);
+
+      const byPermissionResponse = await get({
+        url: `${backendUrl}/v1/management/organizations/${orgId}/tenants/${tenantId}/users?permission=${encodeURIComponent(targetPermission.name)}&limit=100`,
+        headers: { Authorization: `Bearer ${accessToken}` }
+      });
+      expect(byPermissionResponse.status).toBe(200);
+      expect(byPermissionResponse.data.total_count).toBeGreaterThan(0);
+      expect(byPermissionResponse.data.list.some(u => u.sub === userSub)).toBe(true);
+
+      const byBothResponse = await get({
+        url: `${backendUrl}/v1/management/organizations/${orgId}/tenants/${tenantId}/users?role=${encodeURIComponent(targetRole.name)}&permission=${encodeURIComponent(targetPermission.name)}&limit=100`,
+        headers: { Authorization: `Bearer ${accessToken}` }
+      });
+      expect(byBothResponse.status).toBe(200);
+      expect(byBothResponse.data.total_count).toBeGreaterThan(0);
+      expect(byBothResponse.data.list.some(u => u.sub === userSub)).toBe(true);
+
+      const noMatchResponse = await get({
+        url: `${backendUrl}/v1/management/organizations/${orgId}/tenants/${tenantId}/users?role=__non_existent_role_${timestamp}__&limit=10`,
+        headers: { Authorization: `Bearer ${accessToken}` }
+      });
+      expect(noMatchResponse.status).toBe(200);
+      expect(noMatchResponse.data.total_count).toBe(0);
+      expect(noMatchResponse.data.list).toHaveLength(0);
+    });
   });
 
   describe("error cases", () => {

--- a/libs/idp-server-database/postgresql/operation/idp-user-tenant-created-at-index/README.md
+++ b/libs/idp-server-database/postgresql/operation/idp-user-tenant-created-at-index/README.md
@@ -92,15 +92,25 @@ LIMIT 20;
 
 ## 付録: ベンチマーク再現
 
-ローカル / ステージング限定で再現可能なスクリプトを同梱:
+ローカル / ステージング限定で再現可能なスクリプトを同梱。データ投入と計測を分離して、データ投入は 1 回 / 計測は何度でも繰り返せる構成にしている。
 
 ```bash
-# 1. ベンチ実行 (200 万行ダミー挿入 → 統計更新 → before/after EXPLAIN ANALYZE)
+# 1. データ投入 (200 万行ダミー + role/permission + idp_user_roles + index + ANALYZE)
+#    冪等 (ON CONFLICT DO NOTHING) なので再実行 OK
+psql -f bench_setup.sql
+
+# 2. 計測 (EXPLAIN ANALYZE のみ。状態を変えないので何度でも実行可)
 psql -f bench.sql
 
-# 2. 完了後の後片付け (ダミーユーザー DELETE + 検証用 index DROP)
+# 3. 完了後の後片付け (ダミーデータ DELETE + 検証用 index DROP)
 psql -f bench_cleanup.sql
 ```
+
+| ファイル | 役割 | 冪等 |
+|---------|------|------|
+| `bench_setup.sql` | データ投入 (1 回) | ✅ |
+| `bench.sql` | 計測のみ (何度でも) | ✅ |
+| `bench_cleanup.sql` | 後片付け | ✅ |
 
 ### 計測結果 (ローカル / 同一テナントに 200 万行追加)
 

--- a/libs/idp-server-database/postgresql/operation/idp-user-tenant-created-at-index/bench.sql
+++ b/libs/idp-server-database/postgresql/operation/idp-user-tenant-created-at-index/bench.sql
@@ -6,41 +6,25 @@
  */
 
 -- =====================================================
--- idp_user index benchmark (Issue #1460 再現用)
+-- idp_user 検索性能ベンチ (計測のみ)
 --
--- 200 万行のダミーユーザーを既存テナント (TARGET_TENANT) に挿入し、
--- ORDER BY created_at DESC LIMIT 20 の性能を before/after 比較する。
+-- 前提: bench_setup.sql を先に実行してデータ + index + ANALYZE を済ませる
 --
--- 使い方:
---   1. TARGET_TENANT に既存テナント UUID を設定 (psql 変数で渡してもよい)
---   2. psql -f bench.sql で実行
---   3. ベンチ後は cleanup セクションをコメントアウト解除して片付ける
+-- 計測内容:
+--   Step 1   : selectList (#1460) - ORDER BY created_at DESC LIMIT 20
+--   Step 2-3 : selectCount 絞込なし (#1565) 現状 4-way JOIN vs 単表 COUNT(*)
+--   Step 4-6 : selectCount role 絞込 (5% / 0.5% / 0.05%)
+--   Step 7   : selectCount permission 絞込
+--   Step 8   : selectList role 絞込 + LIMIT 20 (現状 DISTINCT JOIN)
+--   Step 9-10: 改善案 B (EXISTS) selectCount / selectList
 --
--- 注意: ローカル / ステージング以外では実行しないこと
+-- 何度でも繰り返し実行可能。状態を変えない。
 -- =====================================================
 
 \set TARGET_TENANT '\'67e7eae6-62b0-4500-9eff-87459f63fc66\''
 \set ON_ERROR_STOP on
 
-\echo '=== Step 1: 200 万行ダミーユーザー挿入 (provider_id = bench-1460) ==='
-INSERT INTO idp_user (id, tenant_id, provider_id, preferred_username, status, created_at, updated_at)
-SELECT
-    gen_random_uuid(),
-    :TARGET_TENANT::uuid,
-    'bench-1460',
-    'bench_user_' || g,
-    'REGISTERED',
-    NOW() - (random() * interval '365 days'),
-    NOW()
-FROM generate_series(1, 2000000) g;
-
-\echo ''
-\echo '=== Step 2: 統計更新 ==='
-ANALYZE idp_user;
-
-\echo ''
-\echo '=== Step 3: index なしの計測 ==='
-DROP INDEX IF EXISTS idx_idp_user_tenant_created_at;
+\echo '=== Step 1: selectList (index あり, 絞込なし) ==='
 EXPLAIN (ANALYZE, BUFFERS, TIMING)
 SELECT id FROM idp_user
 WHERE tenant_id = :TARGET_TENANT::uuid
@@ -48,26 +32,7 @@ ORDER BY created_at DESC
 LIMIT 20;
 
 \echo ''
-\echo '=== Step 4: index ありの計測 ==='
-CREATE INDEX idx_idp_user_tenant_created_at
-    ON idp_user (tenant_id, created_at DESC);
-EXPLAIN (ANALYZE, BUFFERS, TIMING)
-SELECT id FROM idp_user
-WHERE tenant_id = :TARGET_TENANT::uuid
-ORDER BY created_at DESC
-LIMIT 20;
-
--- =====================================================
--- Issue #1565: ページネーション総件数取得 selectCount のベンチ
---
--- selectCount は role/permission 絞り込みが無くても 4-way LEFT JOIN を
--- 実行している。selectList と同じ hasRoleOrPermissionFilter 分岐で
--- JOIN を外すと、絞り込み無し時は単表 COUNT(*) で済む。
--- (tenant_id, created_at DESC) index も index-only scan に活用される。
--- =====================================================
-
-\echo ''
-\echo '=== Step 5: selectCount 現状 (常に 4-way JOIN + COUNT(DISTINCT)) ==='
+\echo '=== Step 2: selectCount 現状 (4-way JOIN + COUNT DISTINCT, 絞込なし) ==='
 EXPLAIN (ANALYZE, BUFFERS, TIMING)
 SELECT COUNT(DISTINCT idp_user.id)
 FROM idp_user
@@ -78,14 +43,192 @@ LEFT JOIN permission      ON role_permission.permission_id = permission.id
 WHERE idp_user.tenant_id = :TARGET_TENANT::uuid;
 
 \echo ''
-\echo '=== Step 6: selectCount 改善後 (role/permission 絞り込み無しなら単表 COUNT(*)) ==='
+\echo '=== Step 3: selectCount 改善後 #1568 (単表 COUNT(*), 絞込なし) ==='
 EXPLAIN (ANALYZE, BUFFERS, TIMING)
-SELECT COUNT(*)
-FROM idp_user
+SELECT COUNT(*) FROM idp_user
 WHERE tenant_id = :TARGET_TENANT::uuid;
 
+\echo ''
+\echo '=== Step 4: selectCount role 絞込 5% (bench-role-1 / 100,000 ユーザー) ==='
+EXPLAIN (ANALYZE, BUFFERS, TIMING)
+SELECT COUNT(DISTINCT idp_user.id)
+FROM idp_user
+LEFT JOIN idp_user_roles  ON idp_user.id = idp_user_roles.user_id
+LEFT JOIN role            ON idp_user_roles.role_id = role.id
+LEFT JOIN role_permission ON role.id = role_permission.role_id
+LEFT JOIN permission      ON role_permission.permission_id = permission.id
+WHERE idp_user.tenant_id = :TARGET_TENANT::uuid
+  AND role.name ILIKE '%bench-role-1%';
+
+\echo ''
+\echo '=== Step 5: selectCount role 絞込 0.5% (bench-role-2 / 10,000 ユーザー) ==='
+EXPLAIN (ANALYZE, BUFFERS, TIMING)
+SELECT COUNT(DISTINCT idp_user.id)
+FROM idp_user
+LEFT JOIN idp_user_roles  ON idp_user.id = idp_user_roles.user_id
+LEFT JOIN role            ON idp_user_roles.role_id = role.id
+LEFT JOIN role_permission ON role.id = role_permission.role_id
+LEFT JOIN permission      ON role_permission.permission_id = permission.id
+WHERE idp_user.tenant_id = :TARGET_TENANT::uuid
+  AND role.name ILIKE '%bench-role-2%';
+
+\echo ''
+\echo '=== Step 6: selectCount role 絞込 0.05% (bench-role-3 / 1,000 ユーザー) ==='
+EXPLAIN (ANALYZE, BUFFERS, TIMING)
+SELECT COUNT(DISTINCT idp_user.id)
+FROM idp_user
+LEFT JOIN idp_user_roles  ON idp_user.id = idp_user_roles.user_id
+LEFT JOIN role            ON idp_user_roles.role_id = role.id
+LEFT JOIN role_permission ON role.id = role_permission.role_id
+LEFT JOIN permission      ON role_permission.permission_id = permission.id
+WHERE idp_user.tenant_id = :TARGET_TENANT::uuid
+  AND role.name ILIKE '%bench-role-3%';
+
+\echo ''
+\echo '=== Step 7: selectCount permission 絞込 (bench-perm-3 = bench-role-2 経由 / 10,000) ==='
+EXPLAIN (ANALYZE, BUFFERS, TIMING)
+SELECT COUNT(DISTINCT idp_user.id)
+FROM idp_user
+LEFT JOIN idp_user_roles  ON idp_user.id = idp_user_roles.user_id
+LEFT JOIN role            ON idp_user_roles.role_id = role.id
+LEFT JOIN role_permission ON role.id = role_permission.role_id
+LEFT JOIN permission      ON role_permission.permission_id = permission.id
+WHERE idp_user.tenant_id = :TARGET_TENANT::uuid
+  AND permission.name ILIKE '%bench-perm-3%';
+
+\echo ''
+\echo '=== Step 8: selectList role 絞込 (現状: DISTINCT JOIN, bench-role-2, LIMIT 20) ==='
+EXPLAIN (ANALYZE, BUFFERS, TIMING)
+WITH paged_users AS (
+  SELECT DISTINCT idp_user.id, idp_user.created_at FROM idp_user
+  LEFT JOIN idp_user_roles  ON idp_user.id = idp_user_roles.user_id
+  LEFT JOIN role            ON idp_user_roles.role_id = role.id
+  LEFT JOIN role_permission ON role.id = role_permission.role_id
+  LEFT JOIN permission      ON role_permission.permission_id = permission.id
+  WHERE idp_user.tenant_id = :TARGET_TENANT::uuid
+    AND role.name ILIKE '%bench-role-2%'
+  ORDER BY idp_user.created_at DESC, idp_user.id DESC
+  LIMIT 20 OFFSET 0
+)
+SELECT idp_user.id, idp_user.created_at
+FROM idp_user
+WHERE idp_user.id IN (SELECT id FROM paged_users)
+ORDER BY idp_user.created_at DESC, idp_user.id DESC;
+
 -- =====================================================
--- ベンチ完了後は bench_cleanup.sql を実行してダミーデータと
--- 検証用 index を片付ける。
---   psql -f bench_cleanup.sql
+-- 改善案 B: DISTINCT JOIN → EXISTS 書き換え
+--
+-- 狙い: idp_user (tenant_id, created_at DESC) index を直接活用し、
+--       Sort/Unique をスキップする。
 -- =====================================================
+
+\echo ''
+\echo '=== Step 9: 【B案】selectCount role 絞込 (EXISTS, bench-role-2) ==='
+EXPLAIN (ANALYZE, BUFFERS, TIMING)
+SELECT COUNT(*) FROM idp_user
+WHERE tenant_id = :TARGET_TENANT::uuid
+  AND EXISTS (
+    SELECT 1 FROM idp_user_roles ur
+    JOIN role r ON ur.role_id = r.id
+    WHERE ur.user_id = idp_user.id
+      AND r.name ILIKE '%bench-role-2%'
+  );
+
+\echo ''
+\echo '=== Step 10: 【B案】selectList role 絞込 (EXISTS, bench-role-2, LIMIT 20) ==='
+EXPLAIN (ANALYZE, BUFFERS, TIMING)
+WITH paged_users AS (
+  SELECT idp_user.id, idp_user.created_at FROM idp_user
+  WHERE idp_user.tenant_id = :TARGET_TENANT::uuid
+    AND EXISTS (
+      SELECT 1 FROM idp_user_roles ur
+      JOIN role r ON ur.role_id = r.id
+      WHERE ur.user_id = idp_user.id
+        AND r.name ILIKE '%bench-role-2%'
+    )
+  ORDER BY idp_user.created_at DESC, idp_user.id DESC
+  LIMIT 20 OFFSET 0
+)
+SELECT idp_user.id, idp_user.created_at
+FROM idp_user
+WHERE idp_user.id IN (SELECT id FROM paged_users)
+ORDER BY idp_user.created_at DESC, idp_user.id DESC;
+
+\echo ''
+\echo '=== Step 11: 【B案】selectCount permission 絞込 (EXISTS, bench-perm-3) ==='
+EXPLAIN (ANALYZE, BUFFERS, TIMING)
+SELECT COUNT(*) FROM idp_user
+WHERE tenant_id = :TARGET_TENANT::uuid
+  AND EXISTS (
+    SELECT 1 FROM idp_user_roles ur
+    JOIN role r ON ur.role_id = r.id
+    JOIN role_permission rp ON r.id = rp.role_id
+    JOIN permission p ON rp.permission_id = p.id
+    WHERE ur.user_id = idp_user.id
+      AND p.name ILIKE '%bench-perm-3%'
+  );
+
+-- =====================================================
+-- 改善案 A: ILIKE '%xxx%' (部分一致) → = (完全一致)
+--
+-- 狙い: role.name / permission.name を 1 行に絞り込み、
+--       idp_user_roles.role_id index を効かせて Seq Scan を回避する。
+-- =====================================================
+
+\echo ''
+\echo '=== Step 12: 【A案】selectCount role 絞込 (DISTINCT JOIN + =, bench-role-2) ==='
+EXPLAIN (ANALYZE, BUFFERS, TIMING)
+SELECT COUNT(DISTINCT idp_user.id)
+FROM idp_user
+LEFT JOIN idp_user_roles  ON idp_user.id = idp_user_roles.user_id
+LEFT JOIN role            ON idp_user_roles.role_id = role.id
+LEFT JOIN role_permission ON role.id = role_permission.role_id
+LEFT JOIN permission      ON role_permission.permission_id = permission.id
+WHERE idp_user.tenant_id = :TARGET_TENANT::uuid
+  AND role.name = 'bench-role-2';
+
+\echo ''
+\echo '=== Step 13: 【A+B案】selectCount role 絞込 (EXISTS + =, bench-role-2) ==='
+EXPLAIN (ANALYZE, BUFFERS, TIMING)
+SELECT COUNT(*) FROM idp_user
+WHERE tenant_id = :TARGET_TENANT::uuid
+  AND EXISTS (
+    SELECT 1 FROM idp_user_roles ur
+    JOIN role r ON ur.role_id = r.id
+    WHERE ur.user_id = idp_user.id
+      AND r.name = 'bench-role-2'
+  );
+
+\echo ''
+\echo '=== Step 14: 【A+B案】selectList role 絞込 (EXISTS + =, bench-role-2, LIMIT 20) ==='
+EXPLAIN (ANALYZE, BUFFERS, TIMING)
+WITH paged_users AS (
+  SELECT idp_user.id, idp_user.created_at FROM idp_user
+  WHERE idp_user.tenant_id = :TARGET_TENANT::uuid
+    AND EXISTS (
+      SELECT 1 FROM idp_user_roles ur
+      JOIN role r ON ur.role_id = r.id
+      WHERE ur.user_id = idp_user.id
+        AND r.name = 'bench-role-2'
+    )
+  ORDER BY idp_user.created_at DESC, idp_user.id DESC
+  LIMIT 20 OFFSET 0
+)
+SELECT idp_user.id, idp_user.created_at
+FROM idp_user
+WHERE idp_user.id IN (SELECT id FROM paged_users)
+ORDER BY idp_user.created_at DESC, idp_user.id DESC;
+
+\echo ''
+\echo '=== Step 15: 【A+B案】selectCount permission 絞込 (EXISTS + =, bench-perm-3) ==='
+EXPLAIN (ANALYZE, BUFFERS, TIMING)
+SELECT COUNT(*) FROM idp_user
+WHERE tenant_id = :TARGET_TENANT::uuid
+  AND EXISTS (
+    SELECT 1 FROM idp_user_roles ur
+    JOIN role r ON ur.role_id = r.id
+    JOIN role_permission rp ON r.id = rp.role_id
+    JOIN permission p ON rp.permission_id = p.id
+    WHERE ur.user_id = idp_user.id
+      AND p.name = 'bench-perm-3'
+  );

--- a/libs/idp-server-database/postgresql/operation/idp-user-tenant-created-at-index/bench_cleanup.sql
+++ b/libs/idp-server-database/postgresql/operation/idp-user-tenant-created-at-index/bench_cleanup.sql
@@ -12,6 +12,17 @@
 
 \set ON_ERROR_STOP on
 
+\echo '=== ベンチ用 role/permission 関連データ削除 ==='
+-- idp_user_roles は idp_user 削除より先に消す (user_id 経由なので残骸残らないが明示)
+DELETE FROM idp_user_roles
+WHERE role_id IN (SELECT id FROM role WHERE name LIKE 'bench-role-%');
+DELETE FROM role_permission
+WHERE role_id IN (SELECT id FROM role WHERE name LIKE 'bench-role-%')
+   OR permission_id IN (SELECT id FROM permission WHERE name LIKE 'bench-perm-%');
+DELETE FROM role WHERE name LIKE 'bench-role-%';
+DELETE FROM permission WHERE name LIKE 'bench-perm-%';
+
+\echo ''
 \echo '=== ベンチ用ダミーユーザー削除 (provider_id = bench-1460) ==='
 DELETE FROM idp_user WHERE provider_id = 'bench-1460';
 
@@ -20,10 +31,18 @@ DELETE FROM idp_user WHERE provider_id = 'bench-1460';
 DROP INDEX IF EXISTS idx_idp_user_tenant_created_at;
 
 \echo ''
-\echo '=== 残存確認 (どちらも 0 のはず) ==='
+\echo '=== 残存確認 (全て 0 のはず) ==='
 SELECT COUNT(*) AS remaining_bench_users
 FROM idp_user
 WHERE provider_id = 'bench-1460';
+
+SELECT COUNT(*) AS remaining_bench_roles
+FROM role
+WHERE name LIKE 'bench-role-%';
+
+SELECT COUNT(*) AS remaining_bench_permissions
+FROM permission
+WHERE name LIKE 'bench-perm-%';
 
 SELECT COUNT(*) AS remaining_bench_index
 FROM pg_indexes

--- a/libs/idp-server-database/postgresql/operation/idp-user-tenant-created-at-index/bench_setup.sql
+++ b/libs/idp-server-database/postgresql/operation/idp-user-tenant-created-at-index/bench_setup.sql
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2025 Hirokazu Kobayashi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ */
+
+-- =====================================================
+-- bench データ投入 (200 万行 + role/permission + idp_user_roles)
+--
+-- bench.sql で計測を流す前に 1 回だけ実行する。
+-- 冪等: 既にデータがあれば再投入はスキップ (ON CONFLICT DO NOTHING)。
+-- 投入後、idx_idp_user_tenant_created_at も作成して ANALYZE まで実行する。
+--
+-- 注意: ローカル / ステージング以外では実行しないこと
+-- =====================================================
+
+\set TARGET_TENANT '\'67e7eae6-62b0-4500-9eff-87459f63fc66\''
+\set ON_ERROR_STOP on
+
+\echo '=== Step 1: 200 万行ダミーユーザー挿入 (provider_id = bench-1460) ==='
+INSERT INTO idp_user (id, tenant_id, provider_id, preferred_username, status, created_at, updated_at)
+SELECT
+    gen_random_uuid(),
+    :TARGET_TENANT::uuid,
+    'bench-1460',
+    'bench_user_' || g,
+    'REGISTERED',
+    NOW() - (random() * interval '365 days'),
+    NOW()
+FROM generate_series(1, 2000000) g
+ON CONFLICT DO NOTHING;
+
+\echo ''
+\echo '=== Step 2: role / permission / role_permission 投入 ==='
+-- 5 個の role (bench-role-1 〜 5)
+INSERT INTO role (id, tenant_id, name, description, created_at, updated_at)
+SELECT gen_random_uuid(), :TARGET_TENANT::uuid, 'bench-role-' || g, 'bench role', NOW(), NOW()
+FROM generate_series(1, 5) g
+ON CONFLICT DO NOTHING;
+
+-- 10 個の permission (bench-perm-1 〜 10)
+INSERT INTO permission (id, tenant_id, name, description, created_at, updated_at)
+SELECT gen_random_uuid(), :TARGET_TENANT::uuid, 'bench-perm-' || g, 'bench permission', NOW(), NOW()
+FROM generate_series(1, 10) g
+ON CONFLICT DO NOTHING;
+
+-- 各 bench-role に bench-perm を 2 個ずつ割り当て (1=>1,2 / 2=>3,4 / ... / 5=>9,10)
+INSERT INTO role_permission (id, tenant_id, role_id, permission_id, created_at)
+SELECT gen_random_uuid(), :TARGET_TENANT::uuid, r.id, p.id, NOW()
+FROM role r
+JOIN permission p ON p.tenant_id = r.tenant_id
+WHERE r.name LIKE 'bench-role-%' AND p.name LIKE 'bench-perm-%'
+  AND CAST(SUBSTRING(p.name FROM 12) AS INT) IN (
+    CAST(SUBSTRING(r.name FROM 12) AS INT) * 2 - 1,
+    CAST(SUBSTRING(r.name FROM 12) AS INT) * 2
+  )
+ON CONFLICT DO NOTHING;
+
+\echo ''
+\echo '=== Step 3: idp_user_roles 割り当て (5% / 0.5% / 0.05%) ==='
+\echo '  - bench-role-1 に 100,000 ユーザー'
+INSERT INTO idp_user_roles (id, tenant_id, user_id, role_id, assigned_at)
+SELECT gen_random_uuid(), :TARGET_TENANT::uuid, u.id, r.id, NOW()
+FROM (SELECT id FROM idp_user WHERE tenant_id = :TARGET_TENANT::uuid AND provider_id = 'bench-1460' LIMIT 100000) u,
+     (SELECT id FROM role WHERE tenant_id = :TARGET_TENANT::uuid AND name = 'bench-role-1') r
+WHERE NOT EXISTS (
+    SELECT 1 FROM idp_user_roles existing
+    WHERE existing.user_id = u.id AND existing.role_id = r.id
+  );
+
+\echo '  - bench-role-2 に 10,000 ユーザー'
+INSERT INTO idp_user_roles (id, tenant_id, user_id, role_id, assigned_at)
+SELECT gen_random_uuid(), :TARGET_TENANT::uuid, u.id, r.id, NOW()
+FROM (SELECT id FROM idp_user WHERE tenant_id = :TARGET_TENANT::uuid AND provider_id = 'bench-1460' OFFSET 100000 LIMIT 10000) u,
+     (SELECT id FROM role WHERE tenant_id = :TARGET_TENANT::uuid AND name = 'bench-role-2') r
+WHERE NOT EXISTS (
+    SELECT 1 FROM idp_user_roles existing
+    WHERE existing.user_id = u.id AND existing.role_id = r.id
+  );
+
+\echo '  - bench-role-3 に 1,000 ユーザー'
+INSERT INTO idp_user_roles (id, tenant_id, user_id, role_id, assigned_at)
+SELECT gen_random_uuid(), :TARGET_TENANT::uuid, u.id, r.id, NOW()
+FROM (SELECT id FROM idp_user WHERE tenant_id = :TARGET_TENANT::uuid AND provider_id = 'bench-1460' OFFSET 110000 LIMIT 1000) u,
+     (SELECT id FROM role WHERE tenant_id = :TARGET_TENANT::uuid AND name = 'bench-role-3') r
+WHERE NOT EXISTS (
+    SELECT 1 FROM idp_user_roles existing
+    WHERE existing.user_id = u.id AND existing.role_id = r.id
+  );
+
+\echo ''
+\echo '=== Step 4: idx_idp_user_tenant_created_at 作成 ==='
+CREATE INDEX IF NOT EXISTS idx_idp_user_tenant_created_at
+    ON idp_user (tenant_id, created_at DESC);
+
+\echo ''
+\echo '=== Step 5: 統計更新 ==='
+ANALYZE idp_user;
+ANALYZE idp_user_roles;
+ANALYZE role;
+ANALYZE role_permission;
+ANALYZE permission;
+
+\echo ''
+\echo '=== 投入結果 ==='
+SELECT 'idp_user (bench)' AS t, COUNT(*) AS n FROM idp_user WHERE provider_id = 'bench-1460'
+UNION ALL SELECT 'role (bench)', COUNT(*) FROM role WHERE name LIKE 'bench-role-%'
+UNION ALL SELECT 'permission (bench)', COUNT(*) FROM permission WHERE name LIKE 'bench-perm-%'
+UNION ALL SELECT 'idp_user_roles (bench)', COUNT(*) FROM idp_user_roles
+  WHERE role_id IN (SELECT id FROM role WHERE name LIKE 'bench-role-%');


### PR DESCRIPTION
## Summary

- E2E (`organization_user_management.test.js`) に role/permission フィルタ検索のカバレッジを追加。PR #1568 で導入した `selectCount` の絞込分岐 (4-way JOIN 側) が E2E で叩かれておらず退行検知できていなかったため。
- ベンチを「データ投入 / 計測 / 後片付け」の 3 ファイル構成に分割し、role/permission ありデータでの 4-way JOIN / EXISTS / 完全一致の性能比較を可能にする。
- bench で得た結果は Issue #1569 (role/permission 検索の完全一致モード追加提案) に記載。

## E2E 追加 (`organization_user_management.test.js`)

`describe("success pattern")` 配下の `pagination support` 直後に `filter by role and permission` テストを追加。

- `?role=<name>` で対象 user が含まれる + `total_count > 0`
- `?permission=<name>` で対象 user が含まれる + `total_count > 0`
- `?role=<name>&permission=<name>` 両方フィルタで対象 user が含まれる
- `?role=__non_existent__` で `total_count: 0` + `list: []`

## Bench 構成 (`libs/idp-server-database/postgresql/operation/idp-user-tenant-created-at-index/`)

| ファイル | 役割 | 冪等 |
|---|---|---|
| `bench_setup.sql` 🆕 | 200 万ユーザー + 5 role + 10 permission + idp_user_roles 投入 (5% / 0.5% / 0.05%) | ✅ `WHERE NOT EXISTS` |
| `bench.sql` | 計測のみ。何度でも実行可 | ✅ |
| `bench_cleanup.sql` | role/permission/idp_user_roles の後片付け追加 | ✅ |

計測ステップ:
- 絞込なし selectCount (現状 4-way JOIN vs 改善 #1568 単表 COUNT)
- role 絞込 selectCount (5% / 0.5% / 0.05% ボリューム)
- permission 絞込 selectCount
- 改善案 B (DISTINCT JOIN → EXISTS) selectCount / selectList
- 改善案 A (`ILIKE '%%' → '='` 完全一致)
- A+B 組み合わせ

## 計測結果ハイライト (200 万ユーザー / 10,000 hits)

| パターン | role Count | permission Count |
|---|---|---|
| 現状 (DISTINCT JOIN + ILIKE) | 37.4 ms | 47.3 ms |
| B (EXISTS + ILIKE) | 30.8 ms (-18%) | 48.5 ms |
| **A+B (EXISTS + =)** | **30.7 ms** | **24.8 ms (-48%)** ⭐ |

Sort メモリも DISTINCT JOIN の 2,019 kB → EXISTS の 27 kB (75 倍削減)。
詳細は Issue #1569 参照。

## Test plan

- [x] `npm test -- --testPathPattern="organization_user_management" --testNamePattern="filter by role and permission"` パス
- [x] `bench_setup.sql` → `bench.sql` → `bench_cleanup.sql` の流れがローカル PostgreSQL で動作
- [x] `bench_setup.sql` を再実行しても重複投入されないこと確認 (`WHERE NOT EXISTS`)
- [x] `bench_cleanup.sql` 完了後、bench 系データが全て 0 件であること確認

## 関連

- Closes #1565 の E2E カバレッジ補完
- Refs #1568 (E2E 退行検知の元になった改善)
- Refs #1569 (bench 結果から派生した次の改善提案)

🤖 Generated with [Claude Code](https://claude.com/claude-code)