### PR TITLE
refactor(ida): Verifier から configurationRepository 依存を除去し、SQL 重複取得を解消

### DIFF
--- a/libs/idp-server-core-extension-ida/src/main/java/org/idp/server/core/extension/identity/verification/application/IdentityVerificationApplicationHandler.java
+++ b/libs/idp-server-core-extension-ida/src/main/java/org/idp/server/core/extension/identity/verification/application/IdentityVerificationApplicationHandler.java
@@ -33,7 +33,6 @@ import org.idp.server.core.extension.identity.verification.configuration.Identit
 import org.idp.server.core.extension.identity.verification.configuration.process.IdentityVerificationExecutionConfig;
 import org.idp.server.core.extension.identity.verification.configuration.process.IdentityVerificationProcessConfiguration;
 import org.idp.server.core.extension.identity.verification.io.IdentityVerificationRequest;
-import org.idp.server.core.extension.identity.verification.repository.IdentityVerificationConfigurationQueryRepository;
 import org.idp.server.core.openid.identity.User;
 import org.idp.server.platform.http.HttpRequestExecutor;
 import org.idp.server.platform.log.LoggerWrapper;
@@ -51,10 +50,8 @@ public class IdentityVerificationApplicationHandler {
 
   public IdentityVerificationApplicationHandler(
       Map<String, AdditionalRequestParameterResolver> additional,
-      HttpRequestExecutor httpRequestExecutor,
-      IdentityVerificationConfigurationQueryRepository configurationRepository) {
-    this.requestVerifiers =
-        new IdentityVerificationApplicationRequestVerifiers(configurationRepository);
+      HttpRequestExecutor httpRequestExecutor) {
+    this.requestVerifiers = new IdentityVerificationApplicationRequestVerifiers();
     this.additionalRequestParameterResolvers =
         new AdditionalRequestParameterResolvers(additional, httpRequestExecutor);
     this.executors = new IdentityVerificationApplicationExecutors(httpRequestExecutor);

--- a/libs/idp-server-core-extension-ida/src/main/java/org/idp/server/core/extension/identity/verification/application/pre_hook/verification/ContinuousCustomerDueDiligenceIdentityVerificationApplicationVerifier.java
+++ b/libs/idp-server-core-extension-ida/src/main/java/org/idp/server/core/extension/identity/verification/application/pre_hook/verification/ContinuousCustomerDueDiligenceIdentityVerificationApplicationVerifier.java
@@ -21,6 +21,7 @@ import org.idp.server.core.extension.identity.verification.IdentityVerificationT
 import org.idp.server.core.extension.identity.verification.application.model.IdentityVerificationApplication;
 import org.idp.server.core.extension.identity.verification.application.model.IdentityVerificationApplications;
 import org.idp.server.core.extension.identity.verification.configuration.IdentityVerificationConfig;
+import org.idp.server.core.extension.identity.verification.configuration.IdentityVerificationConfiguration;
 import org.idp.server.core.extension.identity.verification.io.IdentityVerificationRequest;
 import org.idp.server.core.openid.identity.User;
 import org.idp.server.platform.multi_tenancy.tenant.Tenant;
@@ -44,7 +45,8 @@ public class ContinuousCustomerDueDiligenceIdentityVerificationApplicationVerifi
       IdentityVerificationProcess processes,
       IdentityVerificationRequest request,
       RequestAttributes requestAttributes,
-      IdentityVerificationConfig verificationConfig) {
+      IdentityVerificationConfig verificationConfig,
+      IdentityVerificationConfiguration verificationConfiguration) {
 
     return IdentityVerificationApplicationRequestVerifiedResult.success();
   }

--- a/libs/idp-server-core-extension-ida/src/main/java/org/idp/server/core/extension/identity/verification/application/pre_hook/verification/DenyDuplicateIdentityVerificationApplicationVerifier.java
+++ b/libs/idp-server-core-extension-ida/src/main/java/org/idp/server/core/extension/identity/verification/application/pre_hook/verification/DenyDuplicateIdentityVerificationApplicationVerifier.java
@@ -22,6 +22,7 @@ import org.idp.server.core.extension.identity.verification.IdentityVerificationT
 import org.idp.server.core.extension.identity.verification.application.model.IdentityVerificationApplication;
 import org.idp.server.core.extension.identity.verification.application.model.IdentityVerificationApplications;
 import org.idp.server.core.extension.identity.verification.configuration.IdentityVerificationConfig;
+import org.idp.server.core.extension.identity.verification.configuration.IdentityVerificationConfiguration;
 import org.idp.server.core.extension.identity.verification.io.IdentityVerificationRequest;
 import org.idp.server.core.openid.identity.User;
 import org.idp.server.platform.log.LoggerWrapper;
@@ -49,7 +50,8 @@ public class DenyDuplicateIdentityVerificationApplicationVerifier
       IdentityVerificationProcess processes,
       IdentityVerificationRequest request,
       RequestAttributes requestAttributes,
-      IdentityVerificationConfig verificationConfig) {
+      IdentityVerificationConfig verificationConfig,
+      IdentityVerificationConfiguration verificationConfiguration) {
 
     if (previousApplications.containsRunningState(type)) {
       log.warn(

--- a/libs/idp-server-core-extension-ida/src/main/java/org/idp/server/core/extension/identity/verification/application/pre_hook/verification/IdentityVerificationApplicationRequestVerifier.java
+++ b/libs/idp-server-core-extension-ida/src/main/java/org/idp/server/core/extension/identity/verification/application/pre_hook/verification/IdentityVerificationApplicationRequestVerifier.java
@@ -21,6 +21,7 @@ import org.idp.server.core.extension.identity.verification.IdentityVerificationT
 import org.idp.server.core.extension.identity.verification.application.model.IdentityVerificationApplication;
 import org.idp.server.core.extension.identity.verification.application.model.IdentityVerificationApplications;
 import org.idp.server.core.extension.identity.verification.configuration.IdentityVerificationConfig;
+import org.idp.server.core.extension.identity.verification.configuration.IdentityVerificationConfiguration;
 import org.idp.server.core.extension.identity.verification.io.IdentityVerificationRequest;
 import org.idp.server.core.openid.identity.User;
 import org.idp.server.platform.multi_tenancy.tenant.Tenant;
@@ -30,6 +31,12 @@ public interface IdentityVerificationApplicationRequestVerifier {
 
   String type();
 
+  /**
+   * The full {@code verificationConfiguration} is passed in so verifiers can read process-level
+   * settings (dependencies, transitions, etc.) without hitting the configuration repository at
+   * verification time. Keeping verifiers DB-free is what lets the {@code process} flow run its
+   * external-HTTP region completely transaction-free.
+   */
   IdentityVerificationApplicationRequestVerifiedResult verify(
       Tenant tenant,
       User user,
@@ -39,5 +46,6 @@ public interface IdentityVerificationApplicationRequestVerifier {
       IdentityVerificationProcess processes,
       IdentityVerificationRequest request,
       RequestAttributes requestAttributes,
-      IdentityVerificationConfig verificationConfig);
+      IdentityVerificationConfig verificationConfig,
+      IdentityVerificationConfiguration verificationConfiguration);
 }

--- a/libs/idp-server-core-extension-ida/src/main/java/org/idp/server/core/extension/identity/verification/application/pre_hook/verification/IdentityVerificationApplicationRequestVerifiers.java
+++ b/libs/idp-server-core-extension-ida/src/main/java/org/idp/server/core/extension/identity/verification/application/pre_hook/verification/IdentityVerificationApplicationRequestVerifiers.java
@@ -28,7 +28,6 @@ import org.idp.server.core.extension.identity.verification.configuration.Identit
 import org.idp.server.core.extension.identity.verification.configuration.IdentityVerificationConfiguration;
 import org.idp.server.core.extension.identity.verification.configuration.process.IdentityVerificationProcessConfiguration;
 import org.idp.server.core.extension.identity.verification.io.IdentityVerificationRequest;
-import org.idp.server.core.extension.identity.verification.repository.IdentityVerificationConfigurationQueryRepository;
 import org.idp.server.core.openid.identity.User;
 import org.idp.server.platform.json.JsonNodeWrapper;
 import org.idp.server.platform.json.path.JsonPathWrapper;
@@ -42,16 +41,14 @@ public class IdentityVerificationApplicationRequestVerifiers {
   LoggerWrapper log =
       LoggerWrapper.getLogger(IdentityVerificationApplicationRequestVerifiers.class);
 
-  public IdentityVerificationApplicationRequestVerifiers(
-      IdentityVerificationConfigurationQueryRepository configurationRepository) {
+  public IdentityVerificationApplicationRequestVerifiers() {
     this.verifiers = new HashMap<>();
     DenyDuplicateIdentityVerificationApplicationVerifier denyDuplicate =
         new DenyDuplicateIdentityVerificationApplicationVerifier();
     this.verifiers.put(denyDuplicate.type(), denyDuplicate);
     UserClaimVerifier userClaimVerifier = new UserClaimVerifier();
     this.verifiers.put(userClaimVerifier.type(), userClaimVerifier);
-    ProcessSequenceVerifier processSequenceVerifier =
-        new ProcessSequenceVerifier(configurationRepository);
+    ProcessSequenceVerifier processSequenceVerifier = new ProcessSequenceVerifier();
     this.verifiers.put(processSequenceVerifier.type(), processSequenceVerifier);
     Map<String, IdentityVerificationApplicationRequestVerifier> loaded =
         IdentityVerificationApplicationRequestVerifierPluginLoader.load();
@@ -105,7 +102,8 @@ public class IdentityVerificationApplicationRequestVerifiers {
               processes,
               request,
               requestAttributes,
-              verificationConfig);
+              verificationConfig,
+              verificationConfiguration);
 
       if (verifyResult.isError()) {
         return verifyResult;

--- a/libs/idp-server-core-extension-ida/src/main/java/org/idp/server/core/extension/identity/verification/application/pre_hook/verification/ProcessSequenceVerifier.java
+++ b/libs/idp-server-core-extension-ida/src/main/java/org/idp/server/core/extension/identity/verification/application/pre_hook/verification/ProcessSequenceVerifier.java
@@ -27,7 +27,6 @@ import org.idp.server.core.extension.identity.verification.configuration.Identit
 import org.idp.server.core.extension.identity.verification.configuration.process.IdentityVerificationProcessConfiguration;
 import org.idp.server.core.extension.identity.verification.configuration.process.ProcessDependencies;
 import org.idp.server.core.extension.identity.verification.io.IdentityVerificationRequest;
-import org.idp.server.core.extension.identity.verification.repository.IdentityVerificationConfigurationQueryRepository;
 import org.idp.server.core.openid.identity.User;
 import org.idp.server.platform.log.LoggerWrapper;
 import org.idp.server.platform.multi_tenancy.tenant.Tenant;
@@ -93,12 +92,7 @@ public class ProcessSequenceVerifier implements IdentityVerificationApplicationR
 
   private static final LoggerWrapper log = LoggerWrapper.getLogger(ProcessSequenceVerifier.class);
 
-  private final IdentityVerificationConfigurationQueryRepository configurationRepository;
-
-  public ProcessSequenceVerifier(
-      IdentityVerificationConfigurationQueryRepository configurationRepository) {
-    this.configurationRepository = configurationRepository;
-  }
+  public ProcessSequenceVerifier() {}
 
   @Override
   public String type() {
@@ -115,12 +109,11 @@ public class ProcessSequenceVerifier implements IdentityVerificationApplicationR
       IdentityVerificationProcess process,
       IdentityVerificationRequest request,
       RequestAttributes requestAttributes,
-      IdentityVerificationConfig verificationConfig) {
+      IdentityVerificationConfig verificationConfig,
+      IdentityVerificationConfiguration verificationConfiguration) {
 
-    // Get full configuration to access process dependencies
-    IdentityVerificationConfiguration configuration = configurationRepository.get(tenant, type);
     IdentityVerificationProcessConfiguration processConfig =
-        configuration.getProcessConfig(process);
+        verificationConfiguration.getProcessConfig(process);
     ProcessDependencies dependencies = processConfig.dependencies();
 
     log.debug(

--- a/libs/idp-server-core-extension-ida/src/main/java/org/idp/server/core/extension/identity/verification/application/pre_hook/verification/UserClaimVerifier.java
+++ b/libs/idp-server-core-extension-ida/src/main/java/org/idp/server/core/extension/identity/verification/application/pre_hook/verification/UserClaimVerifier.java
@@ -26,6 +26,7 @@ import org.idp.server.core.extension.identity.verification.application.model.Ide
 import org.idp.server.core.extension.identity.verification.application.pre_hook.UserClaimPreHook;
 import org.idp.server.core.extension.identity.verification.application.pre_hook.UserClaimVerificationRule;
 import org.idp.server.core.extension.identity.verification.configuration.IdentityVerificationConfig;
+import org.idp.server.core.extension.identity.verification.configuration.IdentityVerificationConfiguration;
 import org.idp.server.core.extension.identity.verification.io.IdentityVerificationRequest;
 import org.idp.server.core.openid.identity.User;
 import org.idp.server.platform.json.JsonConverter;
@@ -55,7 +56,8 @@ public class UserClaimVerifier implements IdentityVerificationApplicationRequest
       IdentityVerificationProcess processes,
       IdentityVerificationRequest request,
       RequestAttributes requestAttributes,
-      IdentityVerificationConfig verificationConfig) {
+      IdentityVerificationConfig verificationConfig,
+      IdentityVerificationConfiguration verificationConfiguration) {
 
     String requestJson = request.toJson();
     String userJson = jsonConverter.write(user);

--- a/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/application/enduser/IdentityVerificationApplicationEntryService.java
+++ b/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/application/enduser/IdentityVerificationApplicationEntryService.java
@@ -85,8 +85,7 @@ public class IdentityVerificationApplicationEntryService
     this.userQueryRepository = userQueryRepository;
     this.userCommandRepository = userCommandRepository;
     this.identityVerificationApplicationHandler =
-        new IdentityVerificationApplicationHandler(
-            additional, httpRequestExecutor, configurationQueryRepository);
+        new IdentityVerificationApplicationHandler(additional, httpRequestExecutor);
     this.eventPublisher = eventPublisher;
   }
 

--- a/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/application/identity_verification_service/IdentityVerificationCallbackEntryService.java
+++ b/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/application/identity_verification_service/IdentityVerificationCallbackEntryService.java
@@ -80,8 +80,7 @@ public class IdentityVerificationCallbackEntryService implements IdentityVerific
     this.userQueryRepository = userQueryRepository;
     this.userCommandRepository = userCommandRepository;
     this.identityVerificationApplicationHandler =
-        new IdentityVerificationApplicationHandler(
-            additional, httpRequestExecutor, configurationQueryRepository);
+        new IdentityVerificationApplicationHandler(additional, httpRequestExecutor);
     this.eventPublisher = eventPublisher;
   }
 


### PR DESCRIPTION
## Summary

`IdentityVerificationApplicationEntryService.process` で同じ `identity_verification_configuration` が 1 リクエスト中に 2 回 SELECT される無駄を解消する。Verifier interface に `verificationConfiguration` 引数を追加し、Verifier 内で repository を引き直すのをやめる。

Closes #1574 / Refs https://github.com/hirokazu-kobayashi-koba-hiro/idp-server/discussions/1573

## 変更点

| ファイル | 内容 |
|---------|------|
| `IdentityVerificationApplicationRequestVerifier` (interface) | `verificationConfiguration` 引数追加 |
| `ProcessSequenceVerifier` | `configurationRepository` 依存削除、引数の `verificationConfiguration.getProcessConfig(process)` を使う |
| `DenyDuplicate.../UserClaim/ContinuousCustomerDueDiligence...Verifier` | 新引数を受け取る (内部実装は無変更) |
| `IdentityVerificationApplicationRequestVerifiers` | コンストラクタから `configurationRepository` 削除、`verifyAll` が `verificationConfiguration` を verifier に渡す |
| `IdentityVerificationApplicationHandler` | コンストラクタから `configurationRepository` 削除 |
| `IdentityVerificationApplicationEntryService` / `IdentityVerificationCallbackEntryService` | Handler 構築時の引数を縮減 |

9 ファイル / +30 -30

## 効果

| 観点 | 効果 |
|------|------|
| **重複 SELECT 削減** | apply / process / callback 全フローで `identity_verification_configuration` SELECT が 1 回減 |
| **Verifier の DB-free 化** | Verifier がドメイン判定に専念、データ取得は Caller 側に集約 |
| **テスト容易性** | `ProcessSequenceVerifier` の単体テストでモック不要 |
| **TX 境界分割への布石** | `process` フローを read / external HTTP / write に分割するときに、外部 HTTP 区間を完全 DB-free にできる前提条件 |

## Test plan

- [x] `./gradlew spotlessApply build -x test` 通過
- [x] e2e `integration/ida` 全 53 ケース pass
- [ ] レビュー対応

🤖 Generated with [Claude Code](https://claude.com/claude-code)