### PR TITLE
perf(ida): create_index.sql の所要時間 bench を整備 + 想定実行時間を実測値に更新

### DIFF
--- a/libs/idp-server-database/postgresql/operation/identity-verification-external-application-id-backfill/README.md
+++ b/libs/idp-server-database/postgresql/operation/identity-verification-external-application-id-backfill/README.md
@@ -157,3 +157,62 @@ WHERE external_application_id IS NOT NULL;
 ```
 
 その後 `psql -f migrate_data.sql` を再実行 (`IS NULL` のみ更新するので idempotent)。
+
+---
+
+## 付録: ローカル性能計測 (bench)
+
+本番手順 (Step 2 `create_index.sql`) で使う `CREATE UNIQUE INDEX CONCURRENTLY` の所要時間をローカルで実測するためのスクリプト。
+
+### ファイル
+
+| ファイル | 役割 |
+|---------|------|
+| `bench_setup.sql` | bench マーカー (`verification_type = 'BENCH-EXTERNAL-APP-ID'`) で `ROW_COUNT` 行のダミーを投入。半数の `external_application_id` は `NULL`、半数は UUID テキスト |
+| `bench.sql` | DROP CONCURRENTLY → `CREATE UNIQUE INDEX CONCURRENTLY` を `\timing on` 込みで計測 |
+| `bench_cleanup.sql` | bench 用 index と行を削除 |
+
+### 実行例 (1M 行)
+
+```bash
+cd libs/idp-server-database/postgresql/operation/identity-verification-external-application-id-backfill
+
+psql -v ROW_COUNT=1000000 -f bench_setup.sql
+psql -f bench.sql
+psql -f bench_cleanup.sql
+```
+
+200万行で計測したいときは `-v ROW_COUNT=2000000`。
+
+### 注意
+
+- bench の対象テナント ID は `bench_setup.sql` 冒頭の `:TARGET_TENANT` で固定 (e2e admin tenant)。必要に応じて書き換える
+- `CREATE INDEX CONCURRENTLY` はトランザクション内で実行できないため、`psql -f` で直接流す形 (`BEGIN/COMMIT` を入れない)
+- ローカル / ステージング以外では実行しないこと
+
+### 計測結果 (ローカル / Apple Silicon + NVMe SSD)
+
+| 行数 | テーブルサイズ | `CREATE UNIQUE INDEX CONCURRENTLY` | index サイズ | 半数 NULL の内訳 |
+|------|---------------|-----------------------------------|-------------|---------------|
+| 1,000,000 | 336 MB | **1,060 ms** (1.06 s) | 56 MB | 500,000 値あり / 500,000 NULL |
+| 2,000,000 | 676 MB | **2,171 ms** (2.17 s) | 113 MB | 1,000,000 値あり / 1,000,000 NULL |
+
+行数に比例してほぼ線形 (約 2 倍)。
+
+### 本番想定
+
+本番 (AWS RDS 等) では heap scan の I/O コストが支配的で、ローカル SSD よりは遅くなる。実用上は **AWS 環境での `idp_user` の同等規模 index 作成時間と同じレンジ** で見積もるのが現実的:
+
+- 基本想定: 数十秒〜数分のオーダー
+- テーブル幅が大きい本番 (`application_details` の JSONB が太い) の場合、`idp_user` よりサイズ比に応じて伸びる
+- 同時 write 負荷が高い時間帯は `CONCURRENTLY` の wait で更に伸びる可能性
+
+予測したい場合は事前に本番でテーブルサイズを確認し、`idp_user` の実績時間と比例計算するのが安全:
+
+```bash
+# 本番でテーブルサイズを確認
+psql -c "SELECT
+    pg_size_pretty(pg_total_relation_size('identity_verification_application')) AS app_size,
+    pg_size_pretty(pg_total_relation_size('idp_user'))                          AS user_size"
+```
+

--- a/libs/idp-server-database/postgresql/operation/identity-verification-external-application-id-backfill/bench.sql
+++ b/libs/idp-server-database/postgresql/operation/identity-verification-external-application-id-backfill/bench.sql
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2025 Hirokazu Kobayashi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ */
+
+-- =====================================================
+-- create_index.sql 性能計測 (CREATE INDEX CONCURRENTLY)
+--
+-- 前提: bench_setup.sql を ROW_COUNT 指定で実行済みであること。
+--
+-- CREATE INDEX CONCURRENTLY はトランザクション内で実行不可なので、
+-- このスクリプトは BEGIN/COMMIT を使わず psql から直接流す。
+--
+-- 何度でも繰り返し実行可能。
+-- =====================================================
+
+\set ON_ERROR_STOP on
+\timing on
+
+\echo '=== 計測前: テーブル状態 ==='
+SELECT
+    COUNT(*)                                       AS row_count_total,
+    COUNT(external_application_id)                 AS rows_with_value,
+    COUNT(*) - COUNT(external_application_id)      AS rows_with_null,
+    pg_size_pretty(pg_total_relation_size('identity_verification_application')) AS table_size_total,
+    pg_size_pretty(pg_relation_size('identity_verification_application'))       AS table_size_heap
+FROM identity_verification_application;
+
+\echo ''
+\echo '=== Step 1: 既存 idx_verification_external_application_id を DROP CONCURRENTLY ==='
+DROP INDEX CONCURRENTLY IF EXISTS idx_verification_external_application_id;
+
+\echo ''
+\echo '=== Step 2: CREATE UNIQUE INDEX CONCURRENTLY (計測対象) ==='
+\echo '  別 session で進行状況を見るなら:'
+\echo '    SELECT phase, blocks_done, blocks_total,'
+\echo '           round(100.0 * blocks_done / NULLIF(blocks_total, 0), 1) AS pct'
+\echo '    FROM pg_stat_progress_create_index;'
+CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS idx_verification_external_application_id
+    ON identity_verification_application (tenant_id, external_application_id);
+
+\echo ''
+\echo '=== 計測後: index 状態 ==='
+SELECT
+    i.indexrelid::regclass                                 AS index_name,
+    i.indisvalid                                           AS is_valid,
+    pg_size_pretty(pg_relation_size(i.indexrelid))         AS index_size
+FROM pg_index i
+WHERE i.indrelid = 'identity_verification_application'::regclass
+  AND i.indexrelid::regclass::text = 'idx_verification_external_application_id';

--- a/libs/idp-server-database/postgresql/operation/identity-verification-external-application-id-backfill/bench_cleanup.sql
+++ b/libs/idp-server-database/postgresql/operation/identity-verification-external-application-id-backfill/bench_cleanup.sql
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2025 Hirokazu Kobayashi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ */
+
+-- =====================================================
+-- bench データ + index の後片付け
+-- =====================================================
+
+\set ON_ERROR_STOP on
+
+\echo '=== ベンチ用 index を DROP CONCURRENTLY ==='
+DROP INDEX CONCURRENTLY IF EXISTS idx_verification_external_application_id;
+
+\echo ''
+\echo '=== ベンチ用 identity_verification_application 削除 (verification_type = BENCH-EXTERNAL-APP-ID) ==='
+DELETE FROM identity_verification_application
+WHERE verification_type = 'BENCH-EXTERNAL-APP-ID';
+
+\echo ''
+\echo '=== 残存確認 (全て 0 のはず) ==='
+SELECT COUNT(*) AS remaining_bench_rows
+FROM identity_verification_application
+WHERE verification_type = 'BENCH-EXTERNAL-APP-ID';
+
+SELECT COUNT(*) AS remaining_bench_index
+FROM pg_indexes
+WHERE tablename = 'identity_verification_application'
+  AND indexname = 'idx_verification_external_application_id';

--- a/libs/idp-server-database/postgresql/operation/identity-verification-external-application-id-backfill/bench_setup.sql
+++ b/libs/idp-server-database/postgresql/operation/identity-verification-external-application-id-backfill/bench_setup.sql
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2025 Hirokazu Kobayashi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ */
+
+-- =====================================================
+-- create_index.sql ベンチ用データ投入
+--
+-- identity_verification_application に ROW_COUNT 行のダミーを投入する。
+-- 半数の external_application_id は NULL、半数は UUID テキスト (重複なし)。
+-- bench マーカー: verification_type = 'BENCH-EXTERNAL-APP-ID' で識別 (cleanup 用)
+--
+-- 注意:
+--   - ローカル / ステージング以外では実行しないこと
+--   - external_application_id カラムは V0_10_0_2 で追加済みの前提
+--   - ROW_COUNT はコマンドラインで指定 (例: psql -v ROW_COUNT=1000000)
+-- =====================================================
+
+\set ON_ERROR_STOP on
+\set TARGET_TENANT '\'67e7eae6-62b0-4500-9eff-87459f63fc66\''
+
+\echo '=== Step 1: ダミー identity_verification_application 投入 ==='
+\echo '  verification_type = BENCH-EXTERNAL-APP-ID'
+\echo '  external_application_id = 半数 NULL / 半数 UUID テキスト'
+
+INSERT INTO identity_verification_application (
+    id,
+    tenant_id,
+    client_id,
+    user_id,
+    verification_type,
+    external_application_id,
+    application_details,
+    processes,
+    status,
+    requested_at,
+    created_at,
+    updated_at
+)
+SELECT
+    gen_random_uuid(),
+    :TARGET_TENANT::uuid,
+    'bench-client',
+    gen_random_uuid(),
+    'BENCH-EXTERNAL-APP-ID',
+    CASE WHEN g % 2 = 0 THEN gen_random_uuid()::text ELSE NULL END,
+    '{}'::jsonb,
+    '{}'::jsonb,
+    'requested',
+    NOW(),
+    NOW(),
+    NOW()
+FROM generate_series(1, :ROW_COUNT) g
+ON CONFLICT DO NOTHING;
+
+\echo ''
+\echo '=== Step 2: 統計更新 ==='
+ANALYZE identity_verification_application;
+
+\echo ''
+\echo '=== 投入結果 ==='
+SELECT
+    COUNT(*)                                       AS bench_rows_total,
+    COUNT(external_application_id)                 AS bench_rows_with_value,
+    COUNT(*) - COUNT(external_application_id)      AS bench_rows_with_null,
+    pg_size_pretty(pg_total_relation_size('identity_verification_application')) AS table_size_total
+FROM identity_verification_application
+WHERE verification_type = 'BENCH-EXTERNAL-APP-ID';

--- a/libs/idp-server-database/postgresql/operation/identity-verification-external-application-id-backfill/create_index.sql
+++ b/libs/idp-server-database/postgresql/operation/identity-verification-external-application-id-backfill/create_index.sql
@@ -9,8 +9,14 @@
 -- external_application_id index 追加 (本番運用向け)
 --
 -- CREATE INDEX CONCURRENTLY: 書き込みブロックなしで index を構築する。
--- 想定実行時間: 100万行で 5-30 分 (テーブルサイズ・I/O 次第)。
 -- トランザクション内で実行不可なので psql から直接流す。
+--
+-- 想定実行時間:
+--   - localhost SSD で 100万行 約 1 秒 / 200万行 約 2 秒 (bench 実測)
+--   - AWS RDS では idp_user の同等規模 index 作成時間と同レンジで想定 (数十秒〜数分)
+--   - テーブル幅 (JSONB サイズ) が大きい場合はそのサイズ比に応じて伸びる
+--   - 同時 write 負荷が高い時間帯は CONCURRENTLY の wait で更に伸びる可能性
+--   - 詳細な計測は README 末尾の「付録: ローカル性能計測」を参照
 --
 -- 進行状況の監視 (別 session):
 --   SELECT phase, blocks_done, blocks_total,


### PR DESCRIPTION
## Summary

`external_application_id` の UNIQUE index を `CREATE INDEX CONCURRENTLY` で作る運用手順 (`create_index.sql`) について、所要時間 bench が未整備で コメントの想定値「100万行で 5-30 分」が実測と桁違いに pessimistic だった。bench を整備して実測ベースに更新する。

## 追加スクリプト (PG のみ、3 ファイル分割)

| ファイル | 役割 |
|---------|------|
| `bench_setup.sql` | bench マーカー (`verification_type = 'BENCH-EXTERNAL-APP-ID'`) で `ROW_COUNT` 行のダミーを投入。半数の `external_application_id` は `NULL`、半数は UUID テキスト |
| `bench.sql` | `DROP INDEX CONCURRENTLY` → `CREATE UNIQUE INDEX CONCURRENTLY` を `\timing on` で計測 |
| `bench_cleanup.sql` | bench 用 index + 行を削除 |

実行例:
```bash
psql -v ROW_COUNT=1000000 -f bench_setup.sql
psql -f bench.sql
psql -f bench_cleanup.sql
```

200万行は `-v ROW_COUNT=2000000`。

## 計測結果 (localhost / Apple Silicon + NVMe SSD)

| 行数 | テーブルサイズ | `CREATE UNIQUE INDEX CONCURRENTLY` | index サイズ |
|------|---------------|-----------------------------------|-------------|
| 1,000,000 | 336 MB | **1,060 ms** (1.06 s) | 56 MB |
| 2,000,000 | 676 MB | **2,171 ms** (2.17 s) | 113 MB |

行数に対してほぼ線形。半数 NULL は UNIQUE index の対象外なので index サイズは実有効件数 (500K / 1M) に比例。

## `create_index.sql` のコメント更新

旧:
```
-- 想定実行時間: 100万行で 5-30 分 (テーブルサイズ・I/O 次第)。
```

新:
```
-- localhost SSD で 100万行 約 1 秒 / 200万行 約 2 秒 (bench 実測)
-- AWS RDS では idp_user の同等規模 index 作成時間と同レンジで想定 (数十秒〜数分)
-- テーブル幅 (JSONB) が大きい場合はサイズ比に応じて伸びる
-- 同時 write 負荷が高い時間帯は CONCURRENTLY の wait で更に伸びる可能性
```

## MySQL 側について

bench スクリプトは PG のみ。MySQL 側は将来必要になったら同じ 3 ファイルパターンで追加する想定。本番運用フローの `create_index.mysql.sql` 自体は無変更。

## Test plan

- [x] `psql -v ROW_COUNT=1000000 -f bench_setup.sql` 動作
- [x] `psql -v ROW_COUNT=2000000 -f bench_setup.sql` 動作
- [x] `psql -f bench.sql` で `\timing` が CREATE INDEX 時間を計測
- [x] `psql -f bench_cleanup.sql` で bench 行と index が 0 件に
- [ ] レビュー対応

🤖 Generated with [Claude Code](https://claude.com/claude-code)