### PR TITLE
fix(userinfo): require openid scope for UserInfo endpoint (OIDC Core 5.3)

### DIFF
--- a/e2e/src/tests/spec/oidc_core_5_userinfo.test.js
+++ b/e2e/src/tests/spec/oidc_core_5_userinfo.test.js
@@ -47,6 +47,48 @@ describe("OpenID Connect Core 1.0 incorporating errata set 1 userinfo", () => {
     expect(postUserinfoResponse.data).toHaveProperty("sub");
   });
 
+  it("5.3.1. token without openid scope is rejected with insufficient_scope", async () => {
+    const { authorizationResponse } = await requestAuthorizations({
+      endpoint: serverConfig.authorizationEndpoint,
+      clientId: clientSecretPostClient.clientId,
+      responseType: "code",
+      state: "aiueo",
+      scope: clientSecretPostClient.scope,
+      redirectUri: clientSecretPostClient.redirectUri,
+    });
+    expect(authorizationResponse.code).not.toBeNull();
+
+    const tokenResponse = await requestToken({
+      endpoint: serverConfig.tokenEndpoint,
+      code: authorizationResponse.code,
+      grantType: "authorization_code",
+      redirectUri: clientSecretPostClient.redirectUri,
+      clientId: clientSecretPostClient.clientId,
+      clientSecret: clientSecretPostClient.clientSecret,
+    });
+    expect(tokenResponse.status).toBe(200);
+    // OIDC was not requested, so no id_token is issued
+    expect(tokenResponse.data).not.toHaveProperty("id_token");
+
+    const headers = createBearerHeader(tokenResponse.data.access_token);
+    const userinfoResponse = await getUserinfo({
+      endpoint: serverConfig.userinfoEndpoint,
+      authorizationHeader: headers,
+    });
+    console.log("UserInfo without openid scope:", userinfoResponse.status, JSON.stringify(userinfoResponse.data));
+
+    // OIDC Core 5.3.1 / RFC 6750 3.1: UserInfo requires the openid scope
+    expect(userinfoResponse.status).toBe(403);
+    expect(userinfoResponse.data.error).toBe("insufficient_scope");
+
+    const postUserinfoResponse = await postUserinfo({
+      endpoint: serverConfig.userinfoEndpoint,
+      authorizationHeader: headers,
+    });
+    expect(postUserinfoResponse.status).toBe(403);
+    expect(postUserinfoResponse.data.error).toBe("insufficient_scope");
+  });
+
   it("5.3.3. UserInfo Error Response - client_credentials token with no subject returns invalid_token", async () => {
     const tokenResponse = await requestToken({
       endpoint: serverConfig.tokenEndpoint,
@@ -64,6 +106,20 @@ describe("OpenID Connect Core 1.0 incorporating errata set 1 userinfo", () => {
     console.log("UserInfo with client_credentials token:", userinfoResponse.status, JSON.stringify(userinfoResponse.data));
 
     // client_credentials token has no subject (no end-user), so UserInfo should reject it
+    expect(userinfoResponse.status).toBe(401);
+    expect(userinfoResponse.data.error).toBe("invalid_token");
+  });
+
+  it("5.3.3. UserInfo Error Response - unknown (non-existent) access token returns invalid_token", async () => {
+    // A syntactically valid Bearer token that does not exist in the token store.
+    // Exercises UserinfoVerifier#throwExceptionIfNotFoundToken, which is a different
+    // code path from the "missing token" case (UserinfoValidator#validate).
+    const userinfoResponse = await getUserinfo({
+      endpoint: serverConfig.userinfoEndpoint,
+      authorizationHeader: createBearerHeader("nonexistent-access-token-0123456789"),
+    });
+    console.log("UserInfo with unknown token:", userinfoResponse.status, JSON.stringify(userinfoResponse.data));
+
     expect(userinfoResponse.status).toBe(401);
     expect(userinfoResponse.data.error).toBe("invalid_token");
   });

--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/userinfo/handler/UserinfoErrorHandler.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/userinfo/handler/UserinfoErrorHandler.java
@@ -22,6 +22,7 @@ import org.idp.server.core.openid.oauth.configuration.exception.ClientConfigurat
 import org.idp.server.core.openid.oauth.configuration.exception.ServerConfigurationNotFoundException;
 import org.idp.server.core.openid.oauth.type.oauth.Error;
 import org.idp.server.core.openid.oauth.type.oauth.ErrorDescription;
+import org.idp.server.core.openid.token.tokenintrospection.exception.TokenInsufficientScopeException;
 import org.idp.server.core.openid.token.tokenintrospection.exception.TokenInvalidException;
 import org.idp.server.core.openid.userinfo.UserinfoErrorResponse;
 import org.idp.server.core.openid.userinfo.handler.io.UserinfoRequestResponse;
@@ -41,6 +42,16 @@ public class UserinfoErrorHandler {
           UserinfoRequestStatus.UNAUTHORIZE,
           new UserinfoErrorResponse(
               new Error("invalid_token"), new ErrorDescription(exception.getMessage())));
+    }
+
+    if (exception instanceof TokenInsufficientScopeException) {
+      log.warn(
+          "Userinfo request failed: status=forbidden, error=insufficient_scope, description={}",
+          exception.getMessage());
+      return new UserinfoRequestResponse(
+          UserinfoRequestStatus.FORBIDDEN,
+          new UserinfoErrorResponse(
+              new Error("insufficient_scope"), new ErrorDescription(exception.getMessage())));
     }
 
     if (exception instanceof UserNotFoundException) {

--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/userinfo/handler/io/UserinfoRequestStatus.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/userinfo/handler/io/UserinfoRequestStatus.java
@@ -20,6 +20,7 @@ public enum UserinfoRequestStatus {
   OK(200),
   BAD_REQUEST(400),
   UNAUTHORIZE(401),
+  FORBIDDEN(403),
   SERVER_ERROR(500);
 
   int statusCode;

--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/userinfo/verifier/UserinfoVerifier.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/userinfo/verifier/UserinfoVerifier.java
@@ -25,6 +25,7 @@ import org.idp.server.core.openid.oauth.type.mtls.ClientCert;
 import org.idp.server.core.openid.oauth.type.oauth.Subject;
 import org.idp.server.core.openid.token.AccessToken;
 import org.idp.server.core.openid.token.OAuthToken;
+import org.idp.server.core.openid.token.tokenintrospection.exception.TokenInsufficientScopeException;
 import org.idp.server.core.openid.token.tokenintrospection.exception.TokenInvalidException;
 import org.idp.server.platform.date.SystemDateTime;
 import org.idp.server.platform.x509.X509CertInvalidException;
@@ -58,10 +59,14 @@ public class UserinfoVerifier {
     this.clientCert = clientCert;
   }
 
-  /** Verify token validity: existence, expiration, subject presence, and client certificate. */
+  /**
+   * Verify token validity: existence, expiration, subject presence, openid scope, and client
+   * certificate.
+   */
   public void verifyToken() {
     throwExceptionIfNotFoundToken();
     throwExceptionIfNoSubject();
+    throwExceptionIfMissingOpenidScope();
     throwExceptionIfUnMatchClientCert();
   }
 
@@ -102,6 +107,27 @@ public class UserinfoVerifier {
     if (subject == null || !subject.exists()) {
       throw new TokenInvalidException(
           "token has no subject; UserInfo endpoint requires a token issued for an end-user");
+    }
+  }
+
+  /**
+   * Reject tokens that were not issued for OpenID Connect.
+   *
+   * <p>OIDC Core 1.0 Section 5.3: The UserInfo Endpoint returns Claims about the authenticated
+   * End-User. Per Section 5.3.1 the Access Token used here MUST be one obtained from an OpenID
+   * Connect Authentication Request, i.e. a request that included the {@code openid} scope. Tokens
+   * granted without the {@code openid} scope (e.g. plain OAuth 2.0 API tokens) are not OpenID
+   * Connect tokens and must not be accepted.
+   *
+   * <p>RFC 6750 Section 3.1: When the request requires higher privileges than provided by the
+   * access token, the resource server responds with the {@code insufficient_scope} error.
+   *
+   * @see <a href="https://www.rfc-editor.org/rfc/rfc6750#section-3.1">RFC 6750 Section 3.1</a>
+   */
+  void throwExceptionIfMissingOpenidScope() {
+    if (!oAuthToken.scopes().hasOpenidScope()) {
+      throw new TokenInsufficientScopeException(
+          "token lacks the 'openid' scope; UserInfo endpoint requires an OpenID Connect token");
     }
   }
 


### PR DESCRIPTION
## 概要

UserInfo エンドポイント (`GET/POST /{tenant-id}/v1/userinfo`) が、アクセストークンに `openid` スコープが付与されているかを検証しておらず、OIDC 認証で発行されていない任意の end-user トークンでも `200 OK` でクレームを返していた（OIDC Core 1.0 §5.3 逸脱）。

Closes #1587

## 変更内容

- **`UserinfoVerifier`**: `throwExceptionIfMissingOpenidScope()` を追加し `verifyToken()` に組み込み（subject チェックの後）。`oAuthToken.scopes().hasOpenidScope()` で判定。
- **エラー種別**: 不足スコープは RFC 6750 §3.1 に従い **`insufficient_scope` / 403**（`invalid_token` / 401 ではない）。
  - `UserinfoRequestStatus` に `FORBIDDEN(403)` を追加
  - `UserinfoErrorHandler` に `TokenInsufficientScopeException` → 403 マッピングを追加
- **E2E spec** (`oidc_core_5_userinfo.test.js`):
  - 「`openid` 無しトークン → 403 `insufficient_scope`」
  - 「実在しない Bearer トークン → 401 `invalid_token`」（`throwExceptionIfNotFoundToken` 分岐の未カバーを補完）

## 検証

- `oidc_core_5_userinfo`: **5/5 pass**
- `ciba_token_request` / `fapi_advance` / `fapi_ciba`: **65/65 pass**（openid 強制で既存 OIDC フロー無影響）

## 補足（横断調査）

`openid` ゲートが必要な箇所を横断確認し、ID Token 発行（認可コード/パスワード/CIBA）・FAPI・認可リクエストのプロファイル判定はいずれも適切にガード済みであることを確認。実害のある抜けは本件 UserInfo のみ（詳細は #1587 のコメント参照）。`response_type=id_token` で `openid` 無しのケースのみ別レイヤーの軽微な適合性逸脱として残るが、ID Token は生成されないため漏洩はなく、別 Issue 候補。

🤖 Generated with [Claude Code](https://claude.com/claude-code)