### PR TITLE
test(security): multi-tenant isolation の userinfo テストに openid scope を追加

### DIFF
--- a/e2e/src/tests/security/multi_tenant_isolation.test.js
+++ b/e2e/src/tests/security/multi_tenant_isolation.test.js
@@ -45,7 +45,7 @@ describe("Security: Multi-Tenant API Isolation (Issue #734)", () => {
 
     const authResult = await requestAuthorizations({
       endpoint: serverConfig.authorizationEndpoint,
-      scope: clientSecretPostClient.scope,
+      scope: clientSecretPostClient.scope + " openid",
       responseType: "code",
       clientId: clientSecretPostClient.clientId,
       redirectUri: clientSecretPostClient.redirectUri,


### PR DESCRIPTION
## 概要

#1588（UserInfo エンドポイントに `openid` scope を必須化）の影響で、`multi_tenant_isolation.test.js` の cross-tenant userinfo アクセステストが **`openid` なしトークンを使用しており 403 `insufficient_scope` で失敗**していた（main 上で回帰）。

## 変更内容

- `should not access other tenant's user information`（userinfo を叩くケース）のスコープに `openid` を追加
- introspection / resource owner endpoint のケースは userinfo に依存しないため変更なし

## 検証

- `multi_tenant_isolation`: 3/3 pass

## 関連

- #1588 の fallout（マージ時にテスト修正が漏れていたもの）

🤖 Generated with [Claude Code](https://claude.com/claude-code)