### PR TITLE
fix(token): password / jwt-bearer grant の UserInfo が sub しか返さない問題を修正 (#1440)

### DIFF
--- a/config/templates/use-cases/login-password-only/EXPERIMENTS-basics.md
+++ b/config/templates/use-cases/login-password-only/EXPERIMENTS-basics.md
@@ -405,6 +405,89 @@ get_userinfo | jq .
 
 ---
 
+## Experiment 7: password grant でも UserInfo が scope ベースのクレームを返すことを確認する (#1440)
+
+> **やりたいこと**: password grant (ROPC) で取得したトークンでも、Authorization Code Grant と同じく
+> scope に応じた UserInfo クレームが返ることを確認したい
+>
+> **変わる設定**: `authorization_server.grant_types_supported` と client の `grant_types` に `password` を追加
+>
+> **背景**: 以前は password grant / JWT Bearer grant で取得したトークンの UserInfo が `sub` しか
+> 返らなかった（#1440）。grant に `GrantUserinfoClaims` を設定するよう修正され、Experiment 3 と同じ
+> 「UserInfo = scope ∩ `claims_supported`」の契約が grant type を問わず成立するようになった。
+>
+> **注意**: ROPC（Resource Owner Password Credentials）は OAuth 2.0 Security BCP で非推奨です。
+> ここでは挙動確認のため一時的に有効化し、確認後に必ず restore します。本番では使わないでください。
+
+### 1. password grant を一時的に有効化
+
+```bash
+update_auth_server '.grant_types_supported += ["password"]' \
+  | jq '.result.grant_types_supported // .'
+update_client '.grant_types += ["password"]' \
+  | jq '.result.grant_types // .'
+```
+
+### 2. ROPC 用のユーザーを用意
+
+```bash
+ROPC_EMAIL="ropc-$(date +%s)@example.com"
+ROPC_PASSWORD="TestPass123"
+
+# initial-registration だけではユーザーは確定しない。authorize まで通して永続化する
+start_auth_flow
+register_user "${ROPC_EMAIL}" "${ROPC_PASSWORD}" "ROPC User" > /dev/null
+complete_auth_flow > /dev/null
+echo "Created user: ${ROPC_EMAIL}"
+```
+
+### 3. password grant でトークンを取得
+
+```bash
+ROPC_TOKEN_RESPONSE=$(curl -s -X POST "${TENANT_BASE}/v1/tokens" \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  --data-urlencode "grant_type=password" \
+  --data-urlencode "username=${ROPC_EMAIL}" \
+  --data-urlencode "password=${ROPC_PASSWORD}" \
+  --data-urlencode "scope=openid profile email" \
+  --data-urlencode "client_id=${CLIENT_ID}" \
+  --data-urlencode "client_secret=${CLIENT_SECRET}")
+
+echo "${ROPC_TOKEN_RESPONSE}" | jq '{token_type, scope, expires_in}'
+ROPC_ACCESS_TOKEN=$(echo "${ROPC_TOKEN_RESPONSE}" | jq -r '.access_token')
+```
+
+### 4. 取得したトークンで UserInfo を確認
+
+```bash
+echo "--- password grant の UserInfo ---"
+get_userinfo "${ROPC_ACCESS_TOKEN}" | jq .
+```
+
+### 5. 期待結果
+
+| grant_type | UserInfo の内容 |
+|-----------|----------------|
+| password（#1440 修正前） | `sub` のみ（email, name が欠落）|
+| password（#1440 修正後） | `sub`, `email`, `name` 等（scope に応じる）|
+
+> Experiment 3 / 6 と同じ結果になれば OK。scope を `openid` だけにすれば `sub` のみ、
+> `claims_supported` を絞れば対応するクレームが消える挙動も grant type を問わず一致します。
+
+### 6. 元に戻す
+
+```bash
+restore_client
+restore_auth_server
+```
+
+> **うまくいかない場合**:
+> - `unsupported_grant_type` → 手順1の `update_auth_server` が未反映（数秒待って再実行）
+> - `unauthorized_client` → 手順1の `update_client` が未反映
+> - `invalid_grant`（"does not found user ... or invalid password"）→ 手順2のユーザー作成が未完了、またはメール/パスワード不一致
+
+---
+
 ## 実験一覧
 
 | # | やりたいこと | 変わる設定 | 確認できること |
@@ -415,3 +498,4 @@ get_userinfo | jq .
 | 4 | AT 有効期限を短くしたい | `access_token_duration` | 期限切れで 401 → RT で復活 |
 | 5 | セッションを短くしたい | `session_config.timeout_seconds` | 期限切れで再認証を要求 |
 | 6 | スコープで出し分けたい | 認可リクエストの `scope` | scope による UserInfo の違い |
+| 7 | password grant でも UserInfo を返したい | `grant_types` に `password` | grant type を問わず scope ベースで返る (#1440) |

--- a/e2e/src/tests/spec/oidc_core_5_userinfo.test.js
+++ b/e2e/src/tests/spec/oidc_core_5_userinfo.test.js
@@ -47,6 +47,33 @@ describe("OpenID Connect Core 1.0 incorporating errata set 1 userinfo", () => {
     expect(postUserinfoResponse.data).toHaveProperty("sub");
   });
 
+  it("5.3.2. password grant token returns scope-based claims from userinfo (#1440)", async () => {
+    // Regression for #1440: GrantUserinfoClaims was empty for password grant, so userinfo
+    // returned only sub. Claims must be returned based on the access token scope regardless
+    // of grant type (OIDC Core 5.3.2).
+    const tokenResponse = await requestToken({
+      endpoint: serverConfig.tokenEndpoint,
+      grantType: "password",
+      username: serverConfig.oauth.username,
+      password: serverConfig.oauth.password,
+      scope: "openid profile email",
+      clientId: clientSecretPostClient.clientId,
+      clientSecret: clientSecretPostClient.clientSecret,
+    });
+    expect(tokenResponse.status).toBe(200);
+
+    const userinfoResponse = await getUserinfo({
+      endpoint: serverConfig.userinfoEndpoint,
+      authorizationHeader: createBearerHeader(tokenResponse.data.access_token),
+    });
+    console.log("Password grant userinfo:", JSON.stringify(userinfoResponse.data));
+    expect(userinfoResponse.status).toBe(200);
+    expect(userinfoResponse.data).toHaveProperty("sub");
+    // Before the fix this was {"sub": "..."} only.
+    expect(userinfoResponse.data).toHaveProperty("email");
+    expect(Object.keys(userinfoResponse.data).length).toBeGreaterThan(1);
+  });
+
   it("5.3.1. token without openid scope is rejected with insufficient_scope", async () => {
     const { authorizationResponse } = await requestAuthorizations({
       endpoint: serverConfig.authorizationEndpoint,

--- a/e2e/src/tests/usecase/device-credential/device-credential-01-jwt-bearer-grant.test.js
+++ b/e2e/src/tests/usecase/device-credential/device-credential-01-jwt-bearer-grant.test.js
@@ -101,6 +101,16 @@ describe("Device Credential Use Case: JWT Bearer Grant with Device Credentials",
         token_signed_key_id: "signing_key_1",
         id_token_signed_key_id: "signing_key_1",
         scopes_supported: ["openid", "profile", "email", "management"],
+        claims_supported: [
+          "sub",
+          "name",
+          "given_name",
+          "family_name",
+          "preferred_username",
+          "email",
+          "email_verified",
+          "updated_at",
+        ],
         response_types_supported: ["code"],
         subject_types_supported: ["public"],
         id_token_signing_alg_values_supported: ["RS256", "ES256"],
@@ -281,6 +291,10 @@ describe("Device Credential Use Case: JWT Bearer Grant with Device Credentials",
     expect(userinfoResponse.status).toBe(200);
     expect(userinfoResponse.data).toHaveProperty("sub");
     expect(userinfoResponse.data.sub).toBe(userId);
+    // #1440: JWT Bearer grant must set GrantUserinfoClaims so userinfo returns scope-based
+    // claims (the grant requested "openid profile email"), not just sub.
+    expect(userinfoResponse.data).toHaveProperty("email");
+    expect(Object.keys(userinfoResponse.data).length).toBeGreaterThan(1);
     console.log("Userinfo response:", JSON.stringify(userinfoResponse.data, null, 2));
     console.log("Userinfo request successful - access token is valid");
 
@@ -376,6 +390,16 @@ describe("Device Credential Use Case: JWT Bearer Grant with Device Credentials",
         token_signed_key_id: "signing_key_1",
         id_token_signed_key_id: "signing_key_1",
         scopes_supported: ["openid", "profile", "email", "management"],
+        claims_supported: [
+          "sub",
+          "name",
+          "given_name",
+          "family_name",
+          "preferred_username",
+          "email",
+          "email_verified",
+          "updated_at",
+        ],
         response_types_supported: ["code"],
         subject_types_supported: ["public"],
         id_token_signing_alg_values_supported: ["RS256", "ES256"],

--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/token/service/JwtBearerGrantService.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/token/service/JwtBearerGrantService.java
@@ -18,15 +18,20 @@ package org.idp.server.core.openid.token.service;
 
 import java.net.URI;
 import java.net.http.HttpRequest;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import org.idp.server.core.openid.grant_management.grant.AuthorizationGrant;
 import org.idp.server.core.openid.grant_management.grant.AuthorizationGrantBuilder;
+import org.idp.server.core.openid.grant_management.grant.GrantIdTokenClaims;
+import org.idp.server.core.openid.grant_management.grant.GrantUserinfoClaims;
 import org.idp.server.core.openid.identity.User;
 import org.idp.server.core.openid.identity.device.AuthenticationDevice;
 import org.idp.server.core.openid.identity.device.AuthenticationDeviceIdentifier;
 import org.idp.server.core.openid.identity.device.authentication.DeviceAuthenticationVerifier;
+import org.idp.server.core.openid.identity.id_token.RequestedIdTokenClaims;
+import org.idp.server.core.openid.identity.id_token.RequestedUserinfoClaims;
 import org.idp.server.core.openid.oauth.clientauthenticator.clientcredentials.ClientCredentials;
 import org.idp.server.core.openid.oauth.configuration.AuthorizationServerConfiguration;
 import org.idp.server.core.openid.oauth.configuration.client.AvailableFederation;
@@ -34,6 +39,7 @@ import org.idp.server.core.openid.oauth.configuration.client.ClientConfiguration
 import org.idp.server.core.openid.oauth.type.extension.CustomProperties;
 import org.idp.server.core.openid.oauth.type.oauth.GrantType;
 import org.idp.server.core.openid.oauth.type.oauth.JwtBearerAssertion;
+import org.idp.server.core.openid.oauth.type.oauth.ResponseType;
 import org.idp.server.core.openid.oauth.type.oauth.Scopes;
 import org.idp.server.core.openid.token.*;
 import org.idp.server.core.openid.token.exception.TokenBadRequestException;
@@ -123,6 +129,19 @@ public class JwtBearerGrantService implements OAuthTokenCreationService, Refresh
       Scopes scopes = new Scopes(filteredScopes);
 
       CustomProperties customProperties = context.customProperties();
+
+      List<String> supportedClaims = serverConfiguration.claimsSupported();
+      boolean idTokenStrictMode = serverConfiguration.isIdTokenStrictMode();
+      GrantIdTokenClaims grantIdTokenClaims =
+          GrantIdTokenClaims.create(
+              scopes,
+              ResponseType.undefined,
+              supportedClaims,
+              new RequestedIdTokenClaims(),
+              idTokenStrictMode);
+      GrantUserinfoClaims grantUserinfoClaims =
+          GrantUserinfoClaims.create(scopes, supportedClaims, new RequestedUserinfoClaims());
+
       AuthorizationGrant authorizationGrant =
           new AuthorizationGrantBuilder(
                   context.tenantIdentifier(),
@@ -132,6 +151,8 @@ public class JwtBearerGrantService implements OAuthTokenCreationService, Refresh
               .add(customProperties)
               .add(clientConfiguration.clientAttributes())
               .add(user)
+              .add(grantIdTokenClaims)
+              .add(grantUserinfoClaims)
               .build();
 
       AccessToken accessToken =

--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/token/service/ResourceOwnerPasswordCredentialsGrantService.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/token/service/ResourceOwnerPasswordCredentialsGrantService.java
@@ -16,6 +16,7 @@
 
 package org.idp.server.core.openid.token.service;
 
+import java.util.List;
 import java.util.UUID;
 import org.idp.server.core.openid.authentication.Authentication;
 import org.idp.server.core.openid.grant_management.AuthorizationGranted;
@@ -23,16 +24,21 @@ import org.idp.server.core.openid.grant_management.AuthorizationGrantedIdentifie
 import org.idp.server.core.openid.grant_management.AuthorizationGrantedRepository;
 import org.idp.server.core.openid.grant_management.grant.AuthorizationGrant;
 import org.idp.server.core.openid.grant_management.grant.AuthorizationGrantBuilder;
+import org.idp.server.core.openid.grant_management.grant.GrantIdTokenClaims;
+import org.idp.server.core.openid.grant_management.grant.GrantUserinfoClaims;
 import org.idp.server.core.openid.identity.User;
 import org.idp.server.core.openid.identity.id_token.IdTokenCreator;
 import org.idp.server.core.openid.identity.id_token.IdTokenCustomClaims;
 import org.idp.server.core.openid.identity.id_token.IdTokenCustomClaimsBuilder;
 import org.idp.server.core.openid.identity.id_token.RequestedClaimsPayload;
+import org.idp.server.core.openid.identity.id_token.RequestedIdTokenClaims;
+import org.idp.server.core.openid.identity.id_token.RequestedUserinfoClaims;
 import org.idp.server.core.openid.oauth.clientauthenticator.clientcredentials.ClientCredentials;
 import org.idp.server.core.openid.oauth.configuration.AuthorizationServerConfiguration;
 import org.idp.server.core.openid.oauth.configuration.client.ClientConfiguration;
 import org.idp.server.core.openid.oauth.type.extension.CustomProperties;
 import org.idp.server.core.openid.oauth.type.oauth.GrantType;
+import org.idp.server.core.openid.oauth.type.oauth.ResponseType;
 import org.idp.server.core.openid.oauth.type.oauth.Scopes;
 import org.idp.server.core.openid.oauth.type.oidc.IdToken;
 import org.idp.server.core.openid.token.*;
@@ -100,12 +106,27 @@ public class ResourceOwnerPasswordCredentialsGrantService
     verifier.verify();
 
     CustomProperties customProperties = context.customProperties();
+
+    List<String> supportedClaims = authorizationServerConfiguration.claimsSupported();
+    boolean idTokenStrictMode = authorizationServerConfiguration.isIdTokenStrictMode();
+    GrantIdTokenClaims grantIdTokenClaims =
+        GrantIdTokenClaims.create(
+            scopes,
+            ResponseType.undefined,
+            supportedClaims,
+            new RequestedIdTokenClaims(),
+            idTokenStrictMode);
+    GrantUserinfoClaims grantUserinfoClaims =
+        GrantUserinfoClaims.create(scopes, supportedClaims, new RequestedUserinfoClaims());
+
     AuthorizationGrant authorizationGrant =
         new AuthorizationGrantBuilder(
                 context.tenantIdentifier(), context.requestedClientId(), GrantType.password, scopes)
             .add(user)
             .add(clientConfiguration.clientAttributes())
             .add(customProperties)
+            .add(grantIdTokenClaims)
+            .add(grantUserinfoClaims)
             .build();
 
     AccessToken accessToken =


### PR DESCRIPTION
## 概要

Password Grant（ROPC）と JWT Bearer Grant で取得したアクセストークンで UserInfo を呼び出すと `sub` しか返らない問題（#1440）を修正。`openid profile email` scope を指定しても `email` や `name` が含まれなかった。

## 原因

`ResourceOwnerPasswordCredentialsGrantService` と `JwtBearerGrantService` が `AuthorizationGrant` を構築する際に `GrantUserinfoClaims` をデフォルトの空のまま設定していたため、scope に関わらず UserInfo から全クレームが除外されていた（`GrantUserinfoClaims.create` は `claims_supported` ∩ scope でクレームを決定するが、そもそも生成されていなかった）。

Authorization Code Grant では元々 `GrantUserinfoClaims.create()` で scope ベースのクレームを設定しており、正常だった。

## 修正

両 Grant Service で `authorization_code` と同様に `GrantUserinfoClaims` / `GrantIdTokenClaims` を `scope` と `claims_supported` から生成して grant に設定。

OIDC Core 5.3.2 に従い、返却クレームは grant type ではなくアクセストークンの scope に基づく。

> Issue 本文では Token Exchange Grant も対象に挙げていたが、本リポジトリに該当 grant は存在しない（実際に同じバグを抱えていたのは JWT Bearer Grant）。`client_credentials` は user 不在で UserInfo 対象外、`refresh_token` は元トークンの grant を引き継ぐため修正後の挙動が自動的に伝播する。

## 変更ファイル

- `ResourceOwnerPasswordCredentialsGrantService` / `JwtBearerGrantService`: `GrantUserinfoClaims` / `GrantIdTokenClaims` を追加
- `e2e`: password grant（`oidc_core_5_userinfo`）と jwt-bearer（`device-credential-01`）の回帰テストを追加
- `docs`: `login-password-only` EXPERIMENTS に password grant の UserInfo 確認手順（Experiment 7）を追加

## 動作確認

- ローカルデプロイ環境で password grant → UserInfo が scope ベースのクレーム（sub/name/email/email_verified/preferred_username/updated_at）を返すことを確認
- `npm test -- --testPathPattern="device-credential-01-jwt-bearer-grant"` → 2 passed

Closes #1440

🤖 Generated with [Claude Code](https://claude.com/claude-code)
