### PR TITLE
fix(token): クレーム判定のコピペバグ4件を修正（別クレームの has() 参照）(#1594)

### DIFF
--- a/e2e/src/tests/usecase/standard/standard-22-claims-param-standard-claims.test.js
+++ b/e2e/src/tests/usecase/standard/standard-22-claims-param-standard-claims.test.js
@@ -1,0 +1,366 @@
+import { describe, expect, it, beforeAll } from "@jest/globals";
+import { onboarding } from "../../../api/managementClient";
+import { deletion, postWithJson } from "../../../lib/http";
+import {
+  requestToken,
+  getAuthorizations,
+  postAuthentication,
+  authorize,
+  getUserinfo,
+} from "../../../api/oauthClient";
+import { generateECP256JWKS } from "../../../lib/jose";
+import { adminServerConfig, backendUrl } from "../../testConfig";
+import { v4 as uuidv4 } from "uuid";
+import crypto from "crypto";
+import {
+  convertNextAction,
+  convertToAuthorizationResponse,
+  createBearerHeader,
+} from "../../../lib/util";
+
+/**
+ * Standard Use Case: `claims` request parameter for individual standard claims
+ *
+ * Regression for #1594: GrantUserinfoClaims / GrantIdTokenClaims のクレーム要否判定が
+ * コピペ起因で別クレームの has() を参照していた。scope ベース（profile 等）の通常経路では
+ * OR 左辺で吸収されて表面化しないため、`claims` リクエストパラメータ / id_token_strict_mode の
+ * 経路を直接踏んで検証する。
+ *
+ * カバー範囲:
+ * - GrantUserinfoClaims#shouldAddFamilyName: profile scope 無しで claims に family_name を要求 → UserInfo に出る
+ *   （旧バグ: hasMiddleName を参照 → family_name を要求しても出ず、middle_name 要求で誤混入）
+ * - GrantIdTokenClaims#shouldAddFamilyName (strict): claims id_token に family_name → ID Token に出る（旧: hasGivenName）
+ * - GrantIdTokenClaims#shouldAddWebsite   (strict): claims id_token に website     → ID Token に出る（旧: hasProfile）
+ * - GrantIdTokenClaims#shouldAddPhoneNumber(strict): claims id_token に phone_number→ ID Token に出る（旧: hasName）
+ */
+describe("Standard Use Case: claims request parameter (individual standard claims) #1594", () => {
+  let systemAccessToken;
+  const redirectUri =
+    "https://www.certification.openid.net/test/a/idp_oidc_basic/callback";
+
+  // 検証対象クレームに区別できる値を持たせる
+  const FAMILY_NAME = "FamilyTarget";
+  const MIDDLE_NAME = "MiddleDecoy";
+  const GIVEN_NAME = "GivenDecoy";
+  const NAME = "Name Decoy";
+  const WEBSITE = "https://example.com/website-target";
+  const PROFILE = "https://example.com/profile-decoy";
+  const PHONE_NUMBER = "+81-90-1111-2222";
+
+  beforeAll(async () => {
+    const tokenResponse = await requestToken({
+      endpoint: adminServerConfig.tokenEndpoint,
+      grantType: "password",
+      username: adminServerConfig.oauth.username,
+      password: adminServerConfig.oauth.password,
+      scope: adminServerConfig.adminClient.scope,
+      clientId: adminServerConfig.adminClient.clientId,
+      clientSecret: adminServerConfig.adminClient.clientSecret,
+    });
+    expect(tokenResponse.status).toBe(200);
+    systemAccessToken = tokenResponse.data.access_token;
+  });
+
+  /**
+   * テナント + クライアント + 管理者を onboarding し、password 認証設定を登録、
+   * 全標準クレームを持つエンドユーザーを作成して、ログイン可能な状態にする。
+   */
+  async function setupTenant({ strictMode, claimsSupported, scopesSupported }) {
+    const ts = Date.now();
+    const organizationId = uuidv4();
+    const tenantId = uuidv4();
+    const clientId = uuidv4();
+    const clientSecret = `cs-${crypto.randomBytes(16).toString("hex")}`;
+    const jwks = await generateECP256JWKS();
+    const adminEmail = `cp-admin-${ts}@claims-param.example.com`;
+    const adminPassword = `Admin_${ts}!`;
+
+    const onboardResp = await onboarding({
+      body: {
+        organization: {
+          id: organizationId,
+          name: `Claims Param Test Org ${ts}`,
+          description: "#1594 claims request parameter regression",
+        },
+        tenant: {
+          id: tenantId,
+          name: `Claims Param Tenant ${ts}`,
+          domain: backendUrl,
+          authorization_provider: "idp-server",
+          identity_policy_config: { identity_unique_key_type: "EMAIL" },
+          session_config: {
+            cookie_name: `CP_${tenantId.substring(0, 8)}`,
+            use_secure_cookie: false,
+          },
+          cors_config: { allow_origins: [backendUrl] },
+        },
+        authorization_server: {
+          issuer: `${backendUrl}/${tenantId}`,
+          authorization_endpoint: `${backendUrl}/${tenantId}/v1/authorizations`,
+          token_endpoint: `${backendUrl}/${tenantId}/v1/tokens`,
+          token_endpoint_auth_methods_supported: ["client_secret_post"],
+          userinfo_endpoint: `${backendUrl}/${tenantId}/v1/userinfo`,
+          jwks_uri: `${backendUrl}/${tenantId}/v1/jwks`,
+          jwks,
+          grant_types_supported: ["authorization_code", "password"],
+          token_signed_key_id: "signing_key_1",
+          id_token_signed_key_id: "signing_key_1",
+          scopes_supported: scopesSupported,
+          claims_supported: claimsSupported,
+          claims_parameter_supported: true,
+          response_types_supported: ["code"],
+          response_modes_supported: ["query"],
+          subject_types_supported: ["public"],
+          id_token_signing_alg_values_supported: ["ES256"],
+          extension: {
+            access_token_type: "JWT",
+            ...(strictMode ? { id_token_strict_mode: true } : {}),
+          },
+        },
+        user: {
+          sub: uuidv4(),
+          provider_id: "idp-server",
+          name: "Admin",
+          email: adminEmail,
+          email_verified: true,
+          raw_password: adminPassword,
+        },
+        client: {
+          client_id: clientId,
+          client_secret: clientSecret,
+          redirect_uris: [redirectUri],
+          response_types: ["code"],
+          grant_types: ["authorization_code", "password"],
+          scope: scopesSupported.join(" "),
+          client_name: "Claims Param Client",
+          token_endpoint_auth_method: "client_secret_post",
+          application_type: "web",
+        },
+      },
+      headers: { Authorization: `Bearer ${systemAccessToken}` },
+    });
+    if (onboardResp.status !== 201) {
+      console.error("onboarding failed:", JSON.stringify(onboardResp.data, null, 2));
+    }
+    expect(onboardResp.status).toBe(201);
+
+    const mgmtResp = await requestToken({
+      endpoint: `${backendUrl}/${tenantId}/v1/tokens`,
+      grantType: "password",
+      username: adminEmail,
+      password: adminPassword,
+      scope: "management",
+      clientId,
+      clientSecret,
+    });
+    expect(mgmtResp.status).toBe(200);
+    const mgmtToken = mgmtResp.data.access_token;
+
+    // password 認証設定（インタラクティブログイン用）
+    await postWithJson({
+      url: `${backendUrl}/v1/management/organizations/${organizationId}/tenants/${tenantId}/authentication-configurations`,
+      headers: { Authorization: `Bearer ${mgmtToken}` },
+      body: {
+        id: uuidv4(),
+        type: "password",
+        attributes: {},
+        metadata: { type: "password" },
+        interactions: {
+          "password-authentication": {
+            request: {
+              schema: {
+                type: "object",
+                properties: { username: { type: "string" }, password: { type: "string" } },
+                required: ["username", "password"],
+              },
+            },
+            pre_hook: {},
+            execution: { function: "password_verification" },
+            post_hook: {},
+            response: {
+              body_mapping_rules: [
+                { from: "$.user_id", to: "user_id" },
+                { from: "$.error", to: "error" },
+                { from: "$.error_description", to: "error_description" },
+              ],
+            },
+          },
+        },
+      },
+    });
+
+    // 全標準クレームを持つエンドユーザーを作成
+    const userEmail = `user-${ts}@claims-param.example.com`;
+    const userPassword = "ClaimsParam_1!";
+    const createUserResp = await postWithJson({
+      url: `${backendUrl}/v1/management/organizations/${organizationId}/tenants/${tenantId}/users`,
+      headers: { Authorization: `Bearer ${mgmtToken}` },
+      body: {
+        sub: uuidv4(),
+        provider_id: "idp-server",
+        name: NAME,
+        given_name: GIVEN_NAME,
+        family_name: FAMILY_NAME,
+        middle_name: MIDDLE_NAME,
+        profile: PROFILE,
+        website: WEBSITE,
+        email: userEmail,
+        email_verified: true,
+        phone_number: PHONE_NUMBER,
+        phone_number_verified: true,
+        raw_password: userPassword,
+      },
+    });
+    if (createUserResp.status !== 201) {
+      console.error("create user failed:", JSON.stringify(createUserResp.data, null, 2));
+    }
+    expect(createUserResp.status).toBe(201);
+
+    return { organizationId, tenantId, clientId, clientSecret, userEmail, userPassword };
+  }
+
+  /** インタラクティブ password ログイン → token 取得（claims パラメータ対応） */
+  async function loginAndGetTokens({ tenantId, clientId, clientSecret, scope, claims, userEmail, userPassword }) {
+    const authResp = await getAuthorizations({
+      endpoint: `${backendUrl}/${tenantId}/v1/authorizations`,
+      clientId,
+      responseType: "code",
+      state: `s-${Date.now()}-${Math.floor(Math.random() * 100000)}`,
+      scope,
+      redirectUri,
+      claims,
+      prompt: "login",
+    });
+    const { params } = convertNextAction(authResp.headers.location);
+    const authId = params.get("id");
+    await postAuthentication({
+      endpoint: `${backendUrl}/${tenantId}/v1/authorizations/{id}/password-authentication`,
+      id: authId,
+      body: { username: userEmail, password: userPassword },
+    });
+    const authorizeResp = await authorize({
+      endpoint: `${backendUrl}/${tenantId}/v1/authorizations/{id}/authorize`,
+      id: authId,
+      body: {},
+    });
+    const result = convertToAuthorizationResponse(authorizeResp.data.redirect_uri);
+    const tokenResp = await requestToken({
+      endpoint: `${backendUrl}/${tenantId}/v1/tokens`,
+      grantType: "authorization_code",
+      code: result.code,
+      redirectUri,
+      clientId,
+      clientSecret,
+    });
+    expect(tokenResp.status).toBe(200);
+    return tokenResp.data;
+  }
+
+  const decodeIdToken = (idToken) =>
+    JSON.parse(Buffer.from(idToken.split(".")[1], "base64url").toString());
+
+  it("UserInfo: family_name requested via claims param (no profile scope) is returned", async () => {
+    const ctx = await setupTenant({
+      strictMode: false,
+      scopesSupported: ["openid", "profile", "email", "management"],
+      claimsSupported: ["sub", "iss", "name", "given_name", "family_name", "middle_name", "email"],
+    });
+
+    try {
+      // family_name のみ claims で要求（profile scope は付けない）
+      const tokens = await loginAndGetTokens({
+        ...ctx,
+        scope: "openid",
+        claims: JSON.stringify({ userinfo: { family_name: { essential: true } } }),
+      });
+      const userinfo = await getUserinfo({
+        endpoint: `${backendUrl}/${ctx.tenantId}/v1/userinfo`,
+        authorizationHeader: createBearerHeader(tokens.access_token),
+      });
+      expect(userinfo.status).toBe(200);
+      console.log("[userinfo family_name] keys:", Object.keys(userinfo.data));
+      // 修正前は family_name が出なかった（shouldAddFamilyName が hasMiddleName を参照）
+      expect(userinfo.data.family_name).toBe(FAMILY_NAME);
+      // profile scope なし & 未要求の標準クレームは出ない
+      expect(userinfo.data.name).toBeUndefined();
+      expect(userinfo.data.given_name).toBeUndefined();
+
+      // 逆ケース: middle_name を要求 → middle_name は出るが family_name は誤混入しない
+      const tokens2 = await loginAndGetTokens({
+        ...ctx,
+        scope: "openid",
+        claims: JSON.stringify({ userinfo: { middle_name: { essential: true } } }),
+      });
+      const userinfo2 = await getUserinfo({
+        endpoint: `${backendUrl}/${ctx.tenantId}/v1/userinfo`,
+        authorizationHeader: createBearerHeader(tokens2.access_token),
+      });
+      expect(userinfo2.status).toBe(200);
+      expect(userinfo2.data.middle_name).toBe(MIDDLE_NAME);
+      expect(userinfo2.data.family_name).toBeUndefined();
+    } finally {
+      await deletion({
+        url: `${backendUrl}/v1/management/orgs/${ctx.organizationId}`,
+        headers: { Authorization: `Bearer ${systemAccessToken}` },
+      }).catch(() => {});
+    }
+  });
+
+  it("ID Token (strict mode): family_name / website / phone_number requested via claims param are returned", async () => {
+    const ctx = await setupTenant({
+      strictMode: true,
+      scopesSupported: ["openid", "profile", "email", "phone", "management"],
+      claimsSupported: [
+        "sub", "iss", "name", "given_name", "family_name",
+        "profile", "website", "phone_number", "phone_number_verified", "email",
+      ],
+    });
+
+    try {
+      // 修正対象の3クレームを claims id_token で要求
+      const tokens = await loginAndGetTokens({
+        ...ctx,
+        scope: "openid",
+        claims: JSON.stringify({
+          id_token: {
+            family_name: { essential: true },
+            website: { essential: true },
+            phone_number: { essential: true },
+          },
+        }),
+      });
+      const payload = decodeIdToken(tokens.id_token);
+      console.log("[id_token positive] keys:", Object.keys(payload));
+      expect(payload.family_name).toBe(FAMILY_NAME); // 旧: hasGivenName 参照で欠落
+      expect(payload.website).toBe(WEBSITE); // 旧: hasProfile 参照で欠落
+      expect(payload.phone_number).toBe(PHONE_NUMBER); // 旧: hasName 参照で欠落
+
+      // 逆ケース: 旧バグが誤参照していたクレーム（given_name/profile/name）を要求
+      // → 要求したものだけ出て、family_name/website/phone_number は混入しない
+      const tokens2 = await loginAndGetTokens({
+        ...ctx,
+        scope: "openid",
+        claims: JSON.stringify({
+          id_token: {
+            given_name: { essential: true },
+            profile: { essential: true },
+            name: { essential: true },
+          },
+        }),
+      });
+      const payload2 = decodeIdToken(tokens2.id_token);
+      console.log("[id_token negative] keys:", Object.keys(payload2));
+      expect(payload2.given_name).toBe(GIVEN_NAME);
+      expect(payload2.profile).toBe(PROFILE);
+      expect(payload2.name).toBe(NAME);
+      expect(payload2.family_name).toBeUndefined(); // 旧: given_name 要求で誤混入
+      expect(payload2.website).toBeUndefined(); // 旧: profile 要求で誤混入
+      expect(payload2.phone_number).toBeUndefined(); // 旧: name 要求で誤混入
+    } finally {
+      await deletion({
+        url: `${backendUrl}/v1/management/orgs/${ctx.organizationId}`,
+        headers: { Authorization: `Bearer ${systemAccessToken}` },
+      }).catch(() => {});
+    }
+  });
+});

--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/grant_management/grant/GrantIdTokenClaims.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/grant_management/grant/GrantIdTokenClaims.java
@@ -252,7 +252,7 @@ public class GrantIdTokenClaims implements Iterable<String> {
       return scopes.contains("profile");
     }
     if (idTokenStrictMode) {
-      return idTokenClaims.hasGivenName();
+      return idTokenClaims.hasFamilyName();
     }
     return scopes.contains("profile");
   }
@@ -360,7 +360,7 @@ public class GrantIdTokenClaims implements Iterable<String> {
       return scopes.contains("profile");
     }
     if (idTokenStrictMode) {
-      return idTokenClaims.hasProfile();
+      return idTokenClaims.hasWebsite();
     }
     return scopes.contains("profile");
   }
@@ -486,7 +486,7 @@ public class GrantIdTokenClaims implements Iterable<String> {
       return scopes.contains("phone");
     }
     if (idTokenStrictMode) {
-      return idTokenClaims.hasName();
+      return idTokenClaims.hasPhoneNumber();
     }
     return scopes.contains("phone");
   }

--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/grant_management/grant/GrantUserinfoClaims.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/grant_management/grant/GrantUserinfoClaims.java
@@ -191,7 +191,7 @@ public class GrantUserinfoClaims implements Iterable<String> {
     if (!supportedClaims.contains("family_name")) {
       return false;
     }
-    return scopes.contains("profile") || userinfoClaims.hasMiddleName();
+    return scopes.contains("profile") || userinfoClaims.hasFamilyName();
   }
 
   private static boolean shouldAddMiddleName(

--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/identity/id_token/RequestedIdTokenClaims.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/identity/id_token/RequestedIdTokenClaims.java
@@ -27,6 +27,7 @@ public class RequestedIdTokenClaims implements JsonReadable {
   ClaimsObject sub;
   ClaimsObject name;
   ClaimsObject givenName;
+  ClaimsObject familyName;
   ClaimsObject middleName;
   ClaimsObject nickname;
   ClaimsObject preferredUsername;
@@ -73,6 +74,10 @@ public class RequestedIdTokenClaims implements JsonReadable {
 
   public ClaimsObject givenName() {
     return givenName;
+  }
+
+  public ClaimsObject familyName() {
+    return familyName;
   }
 
   public ClaimsObject middleName() {
@@ -169,6 +174,10 @@ public class RequestedIdTokenClaims implements JsonReadable {
 
   public boolean hasGivenName() {
     return Objects.nonNull(givenName);
+  }
+
+  public boolean hasFamilyName() {
+    return Objects.nonNull(familyName);
   }
 
   public boolean hasMiddleName() {

--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/identity/id_token/RequestedUserinfoClaims.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/identity/id_token/RequestedUserinfoClaims.java
@@ -24,6 +24,7 @@ public class RequestedUserinfoClaims implements JsonReadable {
   ClaimsObject sub;
   ClaimsObject name;
   ClaimsObject givenName;
+  ClaimsObject familyName;
   ClaimsObject middleName;
   ClaimsObject nickname;
   ClaimsObject preferredUsername;
@@ -54,6 +55,10 @@ public class RequestedUserinfoClaims implements JsonReadable {
 
   public ClaimsObject givenName() {
     return givenName;
+  }
+
+  public ClaimsObject familyName() {
+    return familyName;
   }
 
   public ClaimsObject middleName() {
@@ -134,6 +139,10 @@ public class RequestedUserinfoClaims implements JsonReadable {
 
   public boolean hasGivenName() {
     return Objects.nonNull(givenName);
+  }
+
+  public boolean hasFamilyName() {
+    return Objects.nonNull(familyName);
   }
 
   public boolean hasMiddleName() {

--- a/libs/idp-server-core/src/test/java/org/idp/server/core/openid/grant_management/grant/GrantIdTokenClaimsTest.java
+++ b/libs/idp-server-core/src/test/java/org/idp/server/core/openid/grant_management/grant/GrantIdTokenClaimsTest.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2025 Hirokazu Kobayashi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.idp.server.core.openid.grant_management.grant;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Stream;
+import org.idp.server.core.openid.identity.id_token.RequestedIdTokenClaims;
+import org.idp.server.core.openid.oauth.type.oauth.ResponseType;
+import org.idp.server.core.openid.oauth.type.oauth.Scopes;
+import org.idp.server.platform.json.JsonConverter;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * Regression for #1594.
+ *
+ * <p>{@code id_token_strict_mode=true} では、各 {@code shouldAddXxx} は scope ではなく {@code claims}
+ * リクエストパラメータの {@code hasXxx()} を参照する。コピペで別クレームの has() を参照していると、strict mode で
+ * クレームの出し分けが無関係なクレームの要求有無に連動してしまう。
+ *
+ * <p>表駆動で「クレーム X を単独要求 → 出力が {X} だけ」を全標準クレームについて検証する。
+ */
+class GrantIdTokenClaimsTest {
+
+  private static final JsonConverter JSON = JsonConverter.snakeCaseInstance();
+
+  /** ID Token で scope/claims から出し分けされる標準クレーム一覧。 */
+  private static final List<String> STANDARD_CLAIMS =
+      List.of(
+          "name",
+          "given_name",
+          "family_name",
+          "middle_name",
+          "nickname",
+          "preferred_username",
+          "profile",
+          "picture",
+          "website",
+          "email",
+          "email_verified",
+          "gender",
+          "birthdate",
+          "zoneinfo",
+          "locale",
+          "phone_number",
+          "phone_number_verified",
+          "address",
+          "updated_at");
+
+  static Stream<String> standardClaims() {
+    return STANDARD_CLAIMS.stream();
+  }
+
+  private static RequestedIdTokenClaims requestOnly(String claim) {
+    return JSON.read("{\"" + claim + "\":{\"essential\":true}}", RequestedIdTokenClaims.class);
+  }
+
+  @ParameterizedTest(name = "strict mode: request only [{0}] -> grant id_token claims == [{0}]")
+  @MethodSource("standardClaims")
+  void strictModeClaimsParameterMapsEachClaimToItself(String claim) {
+    GrantIdTokenClaims result =
+        GrantIdTokenClaims.create(
+            new Scopes(), ResponseType.code, STANDARD_CLAIMS, requestOnly(claim), true);
+
+    assertEquals(
+        Set.of(claim),
+        result.toStringSet(),
+        "strict mode: requesting only '" + claim + "' must yield exactly that claim");
+  }
+
+  @Test
+  void nonStrictProfileScopeIncludesFamilyName() {
+    GrantIdTokenClaims result =
+        GrantIdTokenClaims.create(
+            new Scopes(Set.of("profile")),
+            ResponseType.code,
+            STANDARD_CLAIMS,
+            new RequestedIdTokenClaims(),
+            false);
+
+    assertTrue(result.contains("name"));
+    assertTrue(result.contains("family_name"));
+    assertTrue(result.contains("website"));
+  }
+
+  @Test
+  void strictModeWithoutClaimsParameterExcludesScopeBasedClaims() {
+    // strict mode では scope だけではクレームは付与されない（claims パラメータが必須）
+    GrantIdTokenClaims result =
+        GrantIdTokenClaims.create(
+            new Scopes(Set.of("profile")),
+            ResponseType.code,
+            STANDARD_CLAIMS,
+            new RequestedIdTokenClaims(),
+            true);
+
+    assertFalse(result.contains("family_name"));
+    assertFalse(result.contains("name"));
+  }
+
+  @Test
+  void requestedClaimNotInSupportedIsExcluded() {
+    List<String> supportedWithoutFamilyName =
+        STANDARD_CLAIMS.stream().filter(c -> !c.equals("family_name")).toList();
+
+    GrantIdTokenClaims result =
+        GrantIdTokenClaims.create(
+            new Scopes(),
+            ResponseType.code,
+            supportedWithoutFamilyName,
+            requestOnly("family_name"),
+            true);
+
+    assertFalse(result.contains("family_name"));
+  }
+}

--- a/libs/idp-server-core/src/test/java/org/idp/server/core/openid/grant_management/grant/GrantUserinfoClaimsTest.java
+++ b/libs/idp-server-core/src/test/java/org/idp/server/core/openid/grant_management/grant/GrantUserinfoClaimsTest.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2025 Hirokazu Kobayashi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.idp.server.core.openid.grant_management.grant;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Stream;
+import org.idp.server.core.openid.identity.id_token.RequestedUserinfoClaims;
+import org.idp.server.core.openid.oauth.type.oauth.Scopes;
+import org.idp.server.platform.json.JsonConverter;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * Regression for #1594.
+ *
+ * <p>各 {@code shouldAddXxx} は自分自身のクレームの {@code hasXxx()} を参照しなければならない。コピペで別クレームの has()
+ * を参照していると、{@code claims} リクエストパラメータ経由の個別要求で「要求したクレームが出ない / 別クレーム要求で 誤混入する」という不具合になる。
+ *
+ * <p>表駆動で「クレーム X を単独要求 → 出力が {X} だけ」を全標準クレームについて検証することで、対応のズレを構造的に検出する。
+ */
+class GrantUserinfoClaimsTest {
+
+  private static final JsonConverter JSON = JsonConverter.snakeCaseInstance();
+
+  /** UserInfo で scope/claims から出し分けされる標準クレーム一覧。 */
+  private static final List<String> STANDARD_CLAIMS =
+      List.of(
+          "name",
+          "given_name",
+          "family_name",
+          "middle_name",
+          "nickname",
+          "preferred_username",
+          "profile",
+          "picture",
+          "website",
+          "email",
+          "email_verified",
+          "gender",
+          "birthdate",
+          "zoneinfo",
+          "locale",
+          "phone_number",
+          "phone_number_verified",
+          "address",
+          "updated_at");
+
+  static Stream<String> standardClaims() {
+    return STANDARD_CLAIMS.stream();
+  }
+
+  private static RequestedUserinfoClaims requestOnly(String claim) {
+    return JSON.read("{\"" + claim + "\":{\"essential\":true}}", RequestedUserinfoClaims.class);
+  }
+
+  @ParameterizedTest(name = "request only [{0}] -> grant userinfo claims == [{0}]")
+  @MethodSource("standardClaims")
+  void claimsParameterMapsEachClaimToItself(String claim) {
+    GrantUserinfoClaims result =
+        GrantUserinfoClaims.create(new Scopes(), STANDARD_CLAIMS, requestOnly(claim));
+
+    assertEquals(
+        Set.of(claim),
+        result.toStringSet(),
+        "requesting only '" + claim + "' must yield exactly that claim");
+  }
+
+  @Test
+  void profileScopeIncludesProfileFamilyClaims() {
+    GrantUserinfoClaims result =
+        GrantUserinfoClaims.create(
+            new Scopes(Set.of("profile")), STANDARD_CLAIMS, new RequestedUserinfoClaims());
+
+    assertTrue(result.contains("name"));
+    assertTrue(result.contains("given_name"));
+    assertTrue(result.contains("family_name"));
+    assertTrue(result.contains("middle_name"));
+    assertFalse(result.contains("email"));
+    assertFalse(result.contains("phone_number"));
+    assertFalse(result.contains("address"));
+  }
+
+  @Test
+  void emailScopeIncludesEmailClaims() {
+    GrantUserinfoClaims result =
+        GrantUserinfoClaims.create(
+            new Scopes(Set.of("email")), STANDARD_CLAIMS, new RequestedUserinfoClaims());
+
+    assertTrue(result.contains("email"));
+    assertTrue(result.contains("email_verified"));
+    assertFalse(result.contains("name"));
+  }
+
+  @Test
+  void requestedClaimNotInSupportedIsExcluded() {
+    List<String> supportedWithoutFamilyName =
+        STANDARD_CLAIMS.stream().filter(c -> !c.equals("family_name")).toList();
+
+    GrantUserinfoClaims result =
+        GrantUserinfoClaims.create(
+            new Scopes(), supportedWithoutFamilyName, requestOnly("family_name"));
+
+    assertFalse(result.contains("family_name"));
+  }
+}


### PR DESCRIPTION
## 概要

`GrantUserinfoClaims` / `GrantIdTokenClaims` のクレーム要否判定（`shouldAddXxx`）が、コピペ起因で **別クレームの `has()` を参照していた4件**を修正（#1594）。

scope ベース（`profile` 等）の通常経路では OR 左辺（`scopes.contains(...)`）で吸収されるため表面化しないが、**`claims` リクエストパラメータによる個別要求** または **`id_token_strict_mode`** の経路で、要求クレームの欠落・別クレームの誤混入が起きていた。PR #1593（#1440）のレビュー中に発見した既存バグ。

## 修正内容

| ファイル | メソッド | 誤 | 正 |
|---|---|---|---|
| `GrantUserinfoClaims` | `shouldAddFamilyName` | `userinfoClaims.hasMiddleName()` | `hasFamilyName()` |
| `GrantIdTokenClaims` | `shouldAddFamilyName`（strict） | `idTokenClaims.hasGivenName()` | `hasFamilyName()` |
| `GrantIdTokenClaims` | `shouldAddWebsite`（strict） | `idTokenClaims.hasProfile()` | `hasWebsite()` |
| `GrantIdTokenClaims` | `shouldAddPhoneNumber`（strict） | `idTokenClaims.hasName()` | `hasPhoneNumber()` |

### 付随修正（family_name の欠落）

調査の結果、`family_name` は `RequestedUserinfoClaims` / `RequestedIdTokenClaims` に **field/getter/has がそもそも欠落**していた（`given_name`・`middle_name` はあるのに `family_name` だけ無い）。`claims` パラメータで個別要求できない状態だったため、`familyName` の field/getter/`hasFamilyName()` を両クラスに追加。

> Issue は「has() を直すだけ」としていたが、`hasFamilyName()` 自体が存在しなかったため field 追加が必須だった。

## テスト

### JUnit（表駆動）
- `GrantUserinfoClaimsTest` / `GrantIdTokenClaimsTest` を追加（各22ケース）
- 全標準クレームについて「**X を単独要求 → 出力が `{X}` だけ**」を総当たりで検証
  - positive: X を要求 → X が出る（has の取り違えを検出）
  - negative: 他クレーム要求時に X が混入しない
- 今回の4件に加え、将来のコピペ退行・フィールド欠落も構造的に捕捉

### E2E
- `standard-22-claims-param-standard-claims.test.js` を追加
- `claims` パラメータ / `id_token_strict_mode` 経由で `family_name`（UserInfo）・`family_name`/`website`/`phone_number`（ID Token）の出し分けを検証
- 修正前デプロイで本テストが失敗すること（バグ捕捉）を確認済み

## 動作確認

- `./gradlew :libs:idp-server-core:test --tests "*GrantUserinfoClaimsTest" --tests "*GrantIdTokenClaimsTest"` → 各22 tests / failures=0
- `./gradlew spotlessApply` 済み

Closes #1594

🤖 Generated with [Claude Code](https://claude.com/claude-code)
