### PR TITLE
fix(token): refresh_token 非対応の grant_types では refresh_token を発行しない (#1355)

### DIFF
--- a/e2e/src/tests/usecase/standard/standard-23-refresh-token-grant-type.test.js
+++ b/e2e/src/tests/usecase/standard/standard-23-refresh-token-grant-type.test.js
@@ -1,0 +1,262 @@
+import { describe, expect, it, beforeAll } from "@jest/globals";
+import { onboarding } from "../../../api/managementClient";
+import { deletion, postWithJson } from "../../../lib/http";
+import { requestToken, getAuthorizations, authorize } from "../../../api/oauthClient";
+import { generateECP256JWKS } from "../../../lib/jose";
+import { adminServerConfig, backendUrl } from "../../testConfig";
+import { v4 as uuidv4 } from "uuid";
+import crypto from "crypto";
+import { convertNextAction, convertToAuthorizationResponse } from "../../../lib/util";
+
+/**
+ * Standard Use Case: refresh_token issuance gated by grant_types (#1355)
+ *
+ * authorization_code grant のトークンレスポンスに refresh_token を含めるのは、
+ * 認可サーバー(grant_types_supported) と クライアント(grant_types) の両方が refresh_token を
+ * 許可している場合のみ。どちらかが許可していなければ、使えない refresh_token を発行しない。
+ *
+ * （RefreshTokenGrantValidator は使用時に server/client 両方を弾くため、発行ゲートはそれと対称）
+ */
+describe("Standard Use Case: refresh_token issuance gated by grant_types (#1355)", () => {
+  let systemAccessToken;
+  const redirectUri =
+    "https://www.certification.openid.net/test/a/idp_oidc_basic/callback";
+
+  beforeAll(async () => {
+    const tokenResponse = await requestToken({
+      endpoint: adminServerConfig.tokenEndpoint,
+      grantType: "password",
+      username: adminServerConfig.oauth.username,
+      password: adminServerConfig.oauth.password,
+      scope: adminServerConfig.adminClient.scope,
+      clientId: adminServerConfig.adminClient.clientId,
+      clientSecret: adminServerConfig.adminClient.clientSecret,
+    });
+    expect(tokenResponse.status).toBe(200);
+    systemAccessToken = tokenResponse.data.access_token;
+  });
+
+  /**
+   * 指定の grant_types でテナント/クライアントを onboarding し、authorization_code フローを実行して
+   * トークンレスポンスを返す。クリーンアップ用に organizationId も返す。
+   */
+  async function authorizationCodeTokenResponse({ serverGrantTypes, clientGrantTypes }) {
+    const ts = Date.now();
+    const organizationId = uuidv4();
+    const tenantId = uuidv4();
+    const clientId = uuidv4();
+    const clientSecret = `cs-${crypto.randomBytes(16).toString("hex")}`;
+    const jwks = await generateECP256JWKS();
+    const adminEmail = `rt-admin-${ts}@example.com`;
+    const adminPassword = `Admin_${ts}!`;
+
+    const onboardResp = await onboarding({
+      body: {
+        organization: { id: organizationId, name: `RT Gate Org ${ts}`, description: "#1355" },
+        tenant: {
+          id: tenantId,
+          name: `RT Gate Tenant ${ts}`,
+          domain: backendUrl,
+          authorization_provider: "idp-server",
+          identity_policy_config: { identity_unique_key_type: "EMAIL" },
+          session_config: { cookie_name: `RT_${tenantId.substring(0, 8)}`, use_secure_cookie: false },
+          cors_config: { allow_origins: [backendUrl] },
+        },
+        authorization_server: {
+          issuer: `${backendUrl}/${tenantId}`,
+          authorization_endpoint: `${backendUrl}/${tenantId}/v1/authorizations`,
+          token_endpoint: `${backendUrl}/${tenantId}/v1/tokens`,
+          token_endpoint_auth_methods_supported: ["client_secret_post"],
+          userinfo_endpoint: `${backendUrl}/${tenantId}/v1/userinfo`,
+          jwks_uri: `${backendUrl}/${tenantId}/v1/jwks`,
+          jwks,
+          grant_types_supported: serverGrantTypes,
+          token_signed_key_id: "signing_key_1",
+          id_token_signed_key_id: "signing_key_1",
+          scopes_supported: ["openid", "profile", "email", "management"],
+          claims_supported: ["sub", "iss", "name", "email"],
+          response_types_supported: ["code"],
+          response_modes_supported: ["query"],
+          subject_types_supported: ["public"],
+          id_token_signing_alg_values_supported: ["ES256"],
+          extension: { access_token_type: "JWT" },
+        },
+        user: {
+          sub: uuidv4(),
+          provider_id: "idp-server",
+          name: "Admin",
+          email: adminEmail,
+          email_verified: true,
+          raw_password: adminPassword,
+        },
+        client: {
+          client_id: clientId,
+          client_secret: clientSecret,
+          redirect_uris: [redirectUri],
+          response_types: ["code"],
+          grant_types: clientGrantTypes,
+          scope: "openid profile email management",
+          client_name: "RT Gate Client",
+          token_endpoint_auth_method: "client_secret_post",
+          application_type: "web",
+        },
+      },
+      headers: { Authorization: `Bearer ${systemAccessToken}` },
+    });
+    if (onboardResp.status !== 201) {
+      console.error("onboarding failed:", JSON.stringify(onboardResp.data, null, 2));
+    }
+    expect(onboardResp.status).toBe(201);
+
+    // password grant で管理トークンを取得（認証設定登録用）
+    const mgmtResp = await requestToken({
+      endpoint: `${backendUrl}/${tenantId}/v1/tokens`,
+      grantType: "password",
+      username: adminEmail,
+      password: adminPassword,
+      scope: "management",
+      clientId,
+      clientSecret,
+    });
+    expect(mgmtResp.status).toBe(200);
+    const mgmtToken = mgmtResp.data.access_token;
+
+    await postWithJson({
+      url: `${backendUrl}/v1/management/organizations/${organizationId}/tenants/${tenantId}/authentication-configurations`,
+      headers: { Authorization: `Bearer ${mgmtToken}` },
+      body: {
+        id: uuidv4(),
+        type: "password",
+        attributes: {},
+        metadata: { type: "password" },
+        interactions: {
+          "password-authentication": {
+            request: {
+              schema: {
+                type: "object",
+                properties: { username: { type: "string" }, password: { type: "string" } },
+                required: ["username", "password"],
+              },
+            },
+            pre_hook: {},
+            execution: { function: "password_verification" },
+            post_hook: {},
+            response: {
+              body_mapping_rules: [
+                { from: "$.user_id", to: "user_id" },
+                { from: "$.error", to: "error" },
+              ],
+            },
+          },
+        },
+      },
+    });
+    await postWithJson({
+      url: `${backendUrl}/v1/management/organizations/${organizationId}/tenants/${tenantId}/authentication-configurations`,
+      headers: { Authorization: `Bearer ${mgmtToken}` },
+      body: {
+        id: uuidv4(),
+        type: "initial-registration",
+        attributes: {},
+        metadata: {},
+        interactions: {
+          "initial-registration": {
+            request: {
+              schema: {
+                type: "object",
+                required: ["email", "password", "name"],
+                properties: {
+                  name: { type: "string" },
+                  email: { type: "string", format: "email" },
+                  password: { type: "string", minLength: 8 },
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    // authorization_code フロー（ユーザー登録 → authorize → token）
+    const userEmail = `rt-user-${ts}@example.com`;
+    const auth = await getAuthorizations({
+      endpoint: `${backendUrl}/${tenantId}/v1/authorizations`,
+      clientId,
+      responseType: "code",
+      state: `rt-${ts}`,
+      scope: "openid profile email",
+      redirectUri,
+    });
+    const { params } = convertNextAction(auth.headers.location);
+    const authId = params.get("id");
+    await postWithJson({
+      url: `${backendUrl}/${tenantId}/v1/authorizations/${authId}/initial-registration`,
+      body: { email: userEmail, password: "RtUser_1!", name: "RT User" },
+    });
+    const authorizeResp = await authorize({
+      endpoint: `${backendUrl}/${tenantId}/v1/authorizations/{id}/authorize`,
+      id: authId,
+      body: {},
+    });
+    const result = convertToAuthorizationResponse(authorizeResp.data.redirect_uri);
+    const tokenResp = await requestToken({
+      endpoint: `${backendUrl}/${tenantId}/v1/tokens`,
+      grantType: "authorization_code",
+      code: result.code,
+      redirectUri,
+      clientId,
+      clientSecret,
+    });
+    return { tokenResp, organizationId };
+  }
+
+  const cleanup = async (organizationId) => {
+    await deletion({
+      url: `${backendUrl}/v1/management/orgs/${organizationId}`,
+      headers: { Authorization: `Bearer ${systemAccessToken}` },
+    }).catch(() => {});
+  };
+
+  it("issues refresh_token when both server and client allow refresh_token", async () => {
+    const { tokenResp, organizationId } = await authorizationCodeTokenResponse({
+      serverGrantTypes: ["authorization_code", "password", "refresh_token"],
+      clientGrantTypes: ["authorization_code", "password", "refresh_token"],
+    });
+    try {
+      expect(tokenResp.status).toBe(200);
+      expect(tokenResp.data.access_token).toBeDefined();
+      expect(tokenResp.data.refresh_token).toBeDefined();
+    } finally {
+      await cleanup(organizationId);
+    }
+  });
+
+  it("does NOT issue refresh_token when client lacks refresh_token grant (#1355)", async () => {
+    const { tokenResp, organizationId } = await authorizationCodeTokenResponse({
+      serverGrantTypes: ["authorization_code", "password", "refresh_token"],
+      clientGrantTypes: ["authorization_code", "password"],
+    });
+    try {
+      expect(tokenResp.status).toBe(200);
+      expect(tokenResp.data.access_token).toBeDefined();
+      // 修正前は使えない refresh_token がレスポンスに含まれていた
+      expect(tokenResp.data.refresh_token).toBeUndefined();
+    } finally {
+      await cleanup(organizationId);
+    }
+  });
+
+  it("does NOT issue refresh_token when authorization server lacks refresh_token grant", async () => {
+    const { tokenResp, organizationId } = await authorizationCodeTokenResponse({
+      serverGrantTypes: ["authorization_code", "password"],
+      clientGrantTypes: ["authorization_code", "password", "refresh_token"],
+    });
+    try {
+      expect(tokenResp.status).toBe(200);
+      expect(tokenResp.data.access_token).toBeDefined();
+      expect(tokenResp.data.refresh_token).toBeUndefined();
+    } finally {
+      await cleanup(organizationId);
+    }
+  });
+});

--- a/libs/idp-server-core-extension-ciba/src/main/java/org/idp/server/core/extension/ciba/handler/ClientNotificationService.java
+++ b/libs/idp-server-core-extension-ciba/src/main/java/org/idp/server/core/extension/ciba/handler/ClientNotificationService.java
@@ -86,7 +86,7 @@ public class ClientNotificationService implements RefreshTokenCreatable {
               clientConfiguration,
               new ClientCredentials());
       RefreshToken refreshToken =
-          createRefreshToken(authorizationServerConfiguration, clientConfiguration);
+          createRefreshTokenIfGranted(authorizationServerConfiguration, clientConfiguration);
 
       IdTokenCustomClaims idTokenCustomClaims = new IdTokenCustomClaimsBuilder().build();
       IdToken idToken =

--- a/libs/idp-server-core-extension-ciba/src/main/java/org/idp/server/core/extension/ciba/token/CibaGrantService.java
+++ b/libs/idp-server-core-extension-ciba/src/main/java/org/idp/server/core/extension/ciba/token/CibaGrantService.java
@@ -102,7 +102,7 @@ public class CibaGrantService implements OAuthTokenCreationService, RefreshToken
             clientConfiguration,
             clientCredentials);
     RefreshToken refreshToken =
-        createRefreshToken(authorizationServerConfiguration, clientConfiguration);
+        createRefreshTokenIfGranted(authorizationServerConfiguration, clientConfiguration);
     OAuthTokenBuilder oAuthTokenBuilder =
         new OAuthTokenBuilder(new OAuthTokenIdentifier(UUID.randomUUID().toString()))
             .add(accessToken)

--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/token/RefreshToken.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/token/RefreshToken.java
@@ -29,6 +29,14 @@ public class RefreshToken {
 
   public RefreshToken() {}
 
+  /**
+   * An empty refresh token. Used when the client is not authorized for the {@code refresh_token}
+   * grant, so no usable refresh token should be issued.
+   */
+  public static RefreshToken empty() {
+    return new RefreshToken();
+  }
+
   public RefreshToken(
       RefreshTokenEntity refreshTokenEntity, CreatedAt createdAt, ExpiresAt expiresAt) {
     this.refreshTokenEntity = refreshTokenEntity;

--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/token/RefreshTokenCreatable.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/token/RefreshTokenCreatable.java
@@ -21,6 +21,7 @@ import org.idp.server.core.openid.oauth.configuration.AuthorizationServerConfigu
 import org.idp.server.core.openid.oauth.configuration.client.ClientConfiguration;
 import org.idp.server.core.openid.oauth.type.extension.CreatedAt;
 import org.idp.server.core.openid.oauth.type.extension.ExpiresAt;
+import org.idp.server.core.openid.oauth.type.oauth.GrantType;
 import org.idp.server.core.openid.oauth.type.oauth.RefreshTokenEntity;
 import org.idp.server.platform.date.SystemDateTime;
 import org.idp.server.platform.random.RandomStringGenerator;
@@ -65,6 +66,23 @@ public interface RefreshTokenCreatable {
     ExpiresAt expiresAt = new ExpiresAt(localDateTime.plusSeconds(refreshTokenDuration));
 
     return new RefreshToken(refreshTokenEntity, createdAt, expiresAt);
+  }
+
+  /**
+   * Creates a refresh token only when both the authorization server and the client are authorized
+   * for the {@code refresh_token} grant. Otherwise returns an empty refresh token so that no
+   * unusable refresh token is issued — such a token would be rejected on use by the refresh_token
+   * grant's server/client checks anyway.
+   */
+  default RefreshToken createRefreshTokenIfGranted(
+      AuthorizationServerConfiguration authorizationServerConfiguration,
+      ClientConfiguration clientConfiguration) {
+    boolean supported =
+        authorizationServerConfiguration.isSupportedGrantType(GrantType.refresh_token)
+            && clientConfiguration.isSupportedGrantType(GrantType.refresh_token);
+    return supported
+        ? createRefreshToken(authorizationServerConfiguration, clientConfiguration)
+        : RefreshToken.empty();
   }
 
   /**

--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/token/service/AuthorizationCodeGrantService.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/token/service/AuthorizationCodeGrantService.java
@@ -153,7 +153,7 @@ public class AuthorizationCodeGrantService
             clientConfiguration,
             clientCredentials);
     RefreshToken refreshToken =
-        createRefreshToken(authorizationServerConfiguration, clientConfiguration);
+        createRefreshTokenIfGranted(authorizationServerConfiguration, clientConfiguration);
     OAuthTokenBuilder oAuthTokenBuilder =
         new OAuthTokenBuilder(new OAuthTokenIdentifier(UUID.randomUUID().toString()))
             .add(accessToken)

--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/token/service/JwtBearerGrantService.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/token/service/JwtBearerGrantService.java
@@ -159,7 +159,8 @@ public class JwtBearerGrantService implements OAuthTokenCreationService, Refresh
           accessTokenCreator.create(
               authorizationGrant, serverConfiguration, clientConfiguration, clientCredentials);
 
-      RefreshToken refreshToken = createRefreshToken(serverConfiguration, clientConfiguration);
+      RefreshToken refreshToken =
+          createRefreshTokenIfGranted(serverConfiguration, clientConfiguration);
 
       OAuthTokenBuilder tokenBuilder =
           new OAuthTokenBuilder(new OAuthTokenIdentifier(UUID.randomUUID().toString()))

--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/token/service/ResourceOwnerPasswordCredentialsGrantService.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/token/service/ResourceOwnerPasswordCredentialsGrantService.java
@@ -136,7 +136,7 @@ public class ResourceOwnerPasswordCredentialsGrantService
             clientConfiguration,
             clientCredentials);
     RefreshToken refreshToken =
-        createRefreshToken(authorizationServerConfiguration, clientConfiguration);
+        createRefreshTokenIfGranted(authorizationServerConfiguration, clientConfiguration);
     OAuthTokenBuilder oAuthTokenBuilder =
         new OAuthTokenBuilder(new OAuthTokenIdentifier(UUID.randomUUID().toString()))
             .add(accessToken)

--- a/libs/idp-server-core/src/test/java/org/idp/server/core/openid/token/RefreshTokenCreatableTest.java
+++ b/libs/idp-server-core/src/test/java/org/idp/server/core/openid/token/RefreshTokenCreatableTest.java
@@ -257,4 +257,75 @@ class RefreshTokenCreatableTest {
       assertEquals(tenantDuration, actualDuration);
     }
   }
+
+  @Nested
+  @DisplayName("createRefreshTokenIfGranted: grant_types によるRT発行ゲート (#1355)")
+  class CreateRefreshTokenIfGranted {
+
+    private AuthorizationServerConfiguration serverWith(boolean supportsRefreshToken) {
+      String grants =
+          supportsRefreshToken
+              ? "[\"authorization_code\", \"refresh_token\"]"
+              : "[\"authorization_code\"]";
+      String json =
+          String.format(
+              """
+          {
+            "grantTypesSupported": %s,
+            "extension": { "refreshTokenDuration": 3600 }
+          }
+          """,
+              grants);
+      return JsonConverter.defaultInstance().read(json, AuthorizationServerConfiguration.class);
+    }
+
+    private ClientConfiguration clientWith(boolean supportsRefreshToken) {
+      String grants =
+          supportsRefreshToken
+              ? "[\"authorization_code\", \"refresh_token\"]"
+              : "[\"authorization_code\"]";
+      String json =
+          String.format(
+              """
+          {
+            "clientId": "test-client",
+            "grantTypes": %s,
+            "extension": {}
+          }
+          """,
+              grants);
+      return JsonConverter.defaultInstance().read(json, ClientConfiguration.class);
+    }
+
+    @Test
+    @DisplayName("server+client 両方が refresh_token 対応: RTを発行する")
+    void issuesWhenBothSupport() {
+      RefreshToken result = creator.createRefreshTokenIfGranted(serverWith(true), clientWith(true));
+      assertTrue(result.exists());
+    }
+
+    @Test
+    @DisplayName("client が refresh_token 非対応: RTを発行しない")
+    void noTokenWhenClientUnsupported() {
+      RefreshToken result =
+          creator.createRefreshTokenIfGranted(serverWith(true), clientWith(false));
+      assertFalse(result.exists());
+    }
+
+    @Test
+    @DisplayName("認可サーバーが refresh_token 非対応: RTを発行しない")
+    void noTokenWhenServerUnsupported() {
+      RefreshToken result =
+          creator.createRefreshTokenIfGranted(serverWith(false), clientWith(true));
+      assertFalse(result.exists());
+    }
+
+    @Test
+    @DisplayName("両方が refresh_token 非対応: RTを発行しない")
+    void noTokenWhenNeitherSupports() {
+      RefreshToken result =
+          creator.createRefreshTokenIfGranted(serverWith(false), clientWith(false));
+      assertFalse(result.exists());
+    }
+  }
 }


### PR DESCRIPTION
## 概要

`grant_types` に `refresh_token` を含まないクライアントに対して、トークンレスポンスに使えない `refresh_token` が発行されていた問題（#1355）を修正。発行された RT は `grant_type=refresh_token` で使うと `unauthorized_client`（クライアント非対応）/ `unsupported_grant_type`（サーバー非対応）で弾かれるため、混乱とムダなトークン生成・保存を招いていた。

## 原因

各 Grant Service が `createRefreshToken()` を**無条件**で呼び、grant_types のチェックなしに RT を `OAuthTokenBuilder` へ追加していた。同じパターンが authorization_code 以外にも存在。

## 修正

`RefreshTokenGrantValidator` が **使用時** に認可サーバー / クライアント両方の grant_types を検証するのと対称に、**発行時** も「認可サーバー AND クライアントが `refresh_token` を許可」する場合のみ発行する。

判定ロジックは共通インタフェース `RefreshTokenCreatable` の default メソッドに集約し、各サービスから1行で利用：

```java
default RefreshToken createRefreshTokenIfGranted(server, client) {
  boolean supported =
      server.isSupportedGrantType(GrantType.refresh_token)
          && client.isSupportedGrantType(GrantType.refresh_token);
  return supported ? createRefreshToken(server, client) : RefreshToken.empty();
}
```

`TokenResponseBuilder` は空の `RefreshTokenEntity` をレスポンスから除外する作りのため、空 RT を渡すと `refresh_token` は自然に省かれる。

> Issue は authorization_code のみ言及していたが、同型バグが **5サービス**（authorization_code / password / jwt-bearer / CIBA poll / CIBA push）に存在したため一括修正。判定を1箇所に集約してコピペ分岐の再発を防止（`refresh_token` grant 自体の `RefreshTokenGrantService` はクライアントが必ず対応するため対象外）。

## 変更

- `RefreshTokenCreatable`: `createRefreshTokenIfGranted`（server AND client ゲート）を追加
- `RefreshToken`: `empty()` ファクトリを追加
- `AuthorizationCodeGrantService` / `ResourceOwnerPasswordCredentialsGrantService` / `JwtBearerGrantService` / `CibaGrantService` / `ClientNotificationService`: 無条件発行を共通メソッド呼び出しに置換

## テスト

### JUnit
- `RefreshTokenCreatableTest` に `createRefreshTokenIfGranted` の発行ゲートを追加（server × client の全4通り：両対応のみ発行、それ以外は空）

### E2E
- `standard-23-refresh-token-grant-type.test.js` を追加。authorization_code フローで
  - server+client 両対応 → `refresh_token` あり
  - client 非対応 → `refresh_token` なし（#1355）
  - 認可サーバー非対応 → `refresh_token` なし

## 動作確認

- `./gradlew :libs:idp-server-core:test --tests "*RefreshTokenCreatableTest"` → green
- E2E `standard-23`: 修正前デプロイで client/server 非対応の2件が失敗（バグ捕捉）→ 修正後デプロイで **3 passed**
- `./gradlew spotlessApply` 済み

## 根拠

- RFC 6749 Section 5.1: `refresh_token` は OPTIONAL
- 使えない RT の発行はクライアント開発者の混乱・不要なトークン生成/保存コストを招く

Closes #1355

🤖 Generated with [Claude Code](https://claude.com/claude-code)
