### PR TITLE
fix(client-auth): client_secret 未設定クライアントの matchClientSecret で NPE を回避 (#1480)

### DIFF
--- a/e2e/src/tests/usecase/standard/standard-24-client-secret-null-npe.test.js
+++ b/e2e/src/tests/usecase/standard/standard-24-client-secret-null-npe.test.js
@@ -1,0 +1,130 @@
+import { describe, expect, it, beforeAll, afterAll } from "@jest/globals";
+import { onboarding } from "../../../api/managementClient";
+import { deletion } from "../../../lib/http";
+import { requestToken } from "../../../api/oauthClient";
+import { generateECP256JWKS } from "../../../lib/jose";
+import { adminServerConfig, backendUrl } from "../../testConfig";
+import { v4 as uuidv4 } from "uuid";
+
+/**
+ * Standard Use Case: client_secret_post with no configured client_secret (#1480)
+ *
+ * token_endpoint_auth_method=client_secret_post に設定されているのに client_secret が未設定（null）の
+ * クライアントへ client_secret 付きトークンリクエストを送ると、ClientConfiguration.matchClientSecret で
+ * NullPointerException が発生し HTTP 500 になっていた。
+ *
+ * 期待: 500 ではなく invalid_client (401) を返す。
+ * （クライアント認証は grant 検証より先に走るため、ダミー認可コードで十分にシークレット検証へ到達する）
+ */
+describe("Standard Use Case: client_secret_post without configured secret (#1480)", () => {
+  let systemAccessToken;
+  let organizationId;
+  let tenantId;
+  let clientId;
+  const redirectUri = "http://localhost:3000/callback";
+
+  beforeAll(async () => {
+    const tokenResponse = await requestToken({
+      endpoint: adminServerConfig.tokenEndpoint,
+      grantType: "password",
+      username: adminServerConfig.oauth.username,
+      password: adminServerConfig.oauth.password,
+      scope: adminServerConfig.adminClient.scope,
+      clientId: adminServerConfig.adminClient.clientId,
+      clientSecret: adminServerConfig.adminClient.clientSecret,
+    });
+    expect(tokenResponse.status).toBe(200);
+    systemAccessToken = tokenResponse.data.access_token;
+
+    const ts = Date.now();
+    organizationId = uuidv4();
+    tenantId = uuidv4();
+    clientId = uuidv4();
+    const jwks = await generateECP256JWKS();
+    const adminEmail = `npe-admin-${ts}@example.com`;
+
+    const onboardResp = await onboarding({
+      body: {
+        organization: { id: organizationId, name: `Secret NPE Org ${ts}`, description: "#1480" },
+        tenant: {
+          id: tenantId,
+          name: `Secret NPE Tenant ${ts}`,
+          domain: backendUrl,
+          authorization_provider: "idp-server",
+          identity_policy_config: { identity_unique_key_type: "EMAIL" },
+          session_config: { cookie_name: `NPE_${tenantId.substring(0, 8)}`, use_secure_cookie: false },
+          cors_config: { allow_origins: [backendUrl] },
+        },
+        authorization_server: {
+          issuer: `${backendUrl}/${tenantId}`,
+          authorization_endpoint: `${backendUrl}/${tenantId}/v1/authorizations`,
+          token_endpoint: `${backendUrl}/${tenantId}/v1/tokens`,
+          token_endpoint_auth_methods_supported: ["client_secret_post", "client_secret_basic"],
+          userinfo_endpoint: `${backendUrl}/${tenantId}/v1/userinfo`,
+          jwks_uri: `${backendUrl}/${tenantId}/v1/jwks`,
+          jwks,
+          grant_types_supported: ["authorization_code", "password"],
+          token_signed_key_id: "signing_key_1",
+          id_token_signed_key_id: "signing_key_1",
+          scopes_supported: ["openid", "profile", "email", "management"],
+          claims_supported: ["sub", "iss"],
+          response_types_supported: ["code"],
+          response_modes_supported: ["query"],
+          subject_types_supported: ["public"],
+          id_token_signing_alg_values_supported: ["ES256"],
+          extension: { access_token_type: "JWT" },
+        },
+        // organizer 管理者ユーザー（onboarding に必要）
+        user: {
+          sub: uuidv4(),
+          provider_id: "idp-server",
+          name: "Admin",
+          email: adminEmail,
+          email_verified: true,
+          raw_password: `Admin_${ts}!`,
+        },
+        // ★ 設定矛盾クライアント: client_secret_post なのに client_secret を持たせない
+        client: {
+          client_id: clientId,
+          redirect_uris: [redirectUri],
+          response_types: ["code"],
+          grant_types: ["authorization_code"],
+          scope: "openid profile email",
+          client_name: "Secret NPE Client",
+          token_endpoint_auth_method: "client_secret_post",
+          application_type: "web",
+        },
+      },
+      headers: { Authorization: `Bearer ${systemAccessToken}` },
+    });
+    if (onboardResp.status !== 201) {
+      console.error("onboarding failed:", JSON.stringify(onboardResp.data, null, 2));
+    }
+    expect(onboardResp.status).toBe(201);
+  });
+
+  afterAll(async () => {
+    if (organizationId && systemAccessToken) {
+      await deletion({
+        url: `${backendUrl}/v1/management/orgs/${organizationId}`,
+        headers: { Authorization: `Bearer ${systemAccessToken}` },
+      }).catch(() => {});
+    }
+  });
+
+  it("returns invalid_client (not 500) when config has no client_secret", async () => {
+    const tokenResponse = await requestToken({
+      endpoint: `${backendUrl}/${tenantId}/v1/tokens`,
+      grantType: "authorization_code",
+      code: "dummy-code-1480",
+      redirectUri,
+      clientId,
+      clientSecret: "presented-but-config-has-none",
+    });
+    console.log("status:", tokenResponse.status, "body:", JSON.stringify(tokenResponse.data));
+    // 修正前は matchClientSecret の NPE で 500 になっていた
+    expect(tokenResponse.status).not.toBe(500);
+    expect(tokenResponse.status).toBe(401);
+    expect(tokenResponse.data.error).toBe("invalid_client");
+  });
+});

--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/oauth/configuration/client/ClientConfiguration.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/oauth/configuration/client/ClientConfiguration.java
@@ -241,6 +241,11 @@ public class ClientConfiguration implements JsonReadable, Configurable {
   }
 
   public boolean matchClientSecret(String that) {
+    // A client without a configured secret can never match a presented secret.
+    // Returning false (instead of throwing NPE) lets the authenticator respond with invalid_client.
+    if (!hasSecret()) {
+      return false;
+    }
     return clientSecret.equals(that);
   }
 

--- a/libs/idp-server-core/src/test/java/org/idp/server/core/openid/oauth/configuration/client/ClientConfigurationTest.java
+++ b/libs/idp-server-core/src/test/java/org/idp/server/core/openid/oauth/configuration/client/ClientConfigurationTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2025 Hirokazu Kobayashi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.idp.server.core.openid.oauth.configuration.client;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.idp.server.platform.json.JsonConverter;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Regression for #1480.
+ *
+ * <p>{@code matchClientSecret} must not throw {@link NullPointerException} when the client has no
+ * configured secret. A secret-less client can never match a presented secret, so it must return
+ * {@code false} (which lets the authenticator respond with {@code invalid_client}) instead of
+ * crashing with a 500.
+ */
+class ClientConfigurationTest {
+
+  private static final JsonConverter JSON = JsonConverter.snakeCaseInstance();
+
+  private static ClientConfiguration fromJson(String json) {
+    return JSON.read(json, ClientConfiguration.class);
+  }
+
+  @Test
+  void matchClientSecretReturnsFalseWhenNoSecretConfigured() {
+    ClientConfiguration config = fromJson("{\"client_id\":\"c\"}");
+    assertFalse(config.matchClientSecret("any-secret"));
+  }
+
+  @Test
+  void matchClientSecretReturnsFalseWhenConfiguredSecretIsEmpty() {
+    ClientConfiguration config = fromJson("{\"client_id\":\"c\",\"client_secret\":\"\"}");
+    assertFalse(config.matchClientSecret("any-secret"));
+  }
+
+  @Test
+  void matchClientSecretReturnsTrueWhenSecretsMatch() {
+    ClientConfiguration config = fromJson("{\"client_id\":\"c\",\"client_secret\":\"s3cr3t\"}");
+    assertTrue(config.matchClientSecret("s3cr3t"));
+  }
+
+  @Test
+  void matchClientSecretReturnsFalseWhenSecretsDiffer() {
+    ClientConfiguration config = fromJson("{\"client_id\":\"c\",\"client_secret\":\"s3cr3t\"}");
+    assertFalse(config.matchClientSecret("wrong"));
+  }
+}


### PR DESCRIPTION
## 概要

`token_endpoint_auth_method=client_secret_post`（/ `client_secret_basic`）に設定されているのに `client_secret` が未設定（null）のクライアントへトークンリクエストを送ると、`ClientConfiguration.matchClientSecret()` で `NullPointerException` が発生し **HTTP 500（server_error）** になっていた（#1480）。

```
Cannot invoke "String.equals(Object)" because "this.clientSecret" is null
  at ClientConfiguration.matchClientSecret(ClientConfiguration.java:244)
  at ClientSecretPostAuthenticator.throwExceptionIfUnMatchClientSecret(...)
```

## 原因

```java
public boolean matchClientSecret(String that) {
  return clientSecret.equals(that);  // clientSecret が null で NPE
}
```

クライアント認証は grant 検証より先に実行されるため、認可コードの正否に関わらずこの NPE に到達する。

## 修正

secret 未設定のクライアントは提示されたシークレットと一致し得ないため、`matchClientSecret` を null-safe 化して `false` を返す。これにより各 Authenticator が `ClientUnAuthorizedException` を投げ、`TokenRequestErrorHandler` が **401 invalid_client** にマップする（RFC 6749 準拠）。

```java
public boolean matchClientSecret(String that) {
  if (!hasSecret()) {   // null / empty なら一致しない
    return false;
  }
  return clientSecret.equals(that);
}
```

`matchClientSecret` を呼ぶ `ClientSecretPostAuthenticator` / `ClientSecretBasicAuthenticator` の両方が一括で解消される。

> 補足: authenticator はクライアント設定の `token_endpoint_auth_method` で選択される（提示クレデンシャルではない）。本修正の対象は client_secret 系2方式。`ClientSecretJwtAuthenticator` も null secret で別経路の NPE になりうるが、jose 実装依存かつ本Issueの対象外のため別途とする。

## テスト

### JUnit
- `ClientConfigurationTest`: `matchClientSecret` の null / 空文字 → false、一致 → true、不一致 → false を検証

### E2E
- `standard-24-client-secret-null-npe.test.js`: onboarding で `client_secret_post` ＋ secret 未設定の（設定矛盾した）クライアントを作成し、トークンリクエストが **invalid_client (401)** を返す（500 でない）ことを検証

## 動作確認

- `./gradlew :libs:idp-server-core:test --tests "*ClientConfigurationTest"` → 4 tests green
- E2E `standard-24`: 修正前デプロイで HTTP 500（Issue と同一の NPE メッセージ）を再現 → 修正後デプロイで **401 invalid_client** に変化（1 passed）
- `./gradlew spotlessApply` 済み

## 期待動作（Issue より）

- `client_secret` がないクライアントは 500 ではなく `invalid_client` を返すべき

Closes #1480

🤖 Generated with [Claude Code](https://claude.com/claude-code)
