### PR TITLE
feat(oauth): scopes_supported によるスコープフィルタを全 grant 経路で有効化 (#1353)

### DIFF
--- a/config/examples/financial-grade/onboarding-request.json
+++ b/config/examples/financial-grade/onboarding-request.json
@@ -132,7 +132,9 @@
       "account",
       "transfers",
       "read",
-      "write"
+      "write",
+      "management",
+      "org-management"
     ],
     "response_types_supported": [
       "code",

--- a/config/templates/tenant-template.json
+++ b/config/templates/tenant-template.json
@@ -109,7 +109,14 @@
       "identity_verification_application_delete",
       "identity_verification_result",
       "identity_credentials_update",
-      "management"
+      "management",
+      "claims:roles",
+      "claims:permissions",
+      "claims:status",
+      "claims:authentication_devices",
+      "claims:assigned_tenants",
+      "claims:assigned_organizations",
+      "verified_claims:family_name"
     ],
     "response_types_supported": [
       "code",

--- a/e2e/src/tests/usecase/ciba/ciba-01-require-rar.test.js
+++ b/e2e/src/tests/usecase/ciba/ciba-01-require-rar.test.js
@@ -351,7 +351,7 @@ describe("CIBA Use Case: Client-Level RAR Requirement", () => {
         grant_types_supported: ["urn:openid:params:grant-type:ciba", "password"],
         token_signed_key_id: "signing_key_1",
         id_token_signed_key_id: "signing_key_1",
-        scopes_supported: ["openid", "profile", "email"],
+        scopes_supported: ["openid", "profile", "email", "management"],
         response_types_supported: ["code"],
         subject_types_supported: ["public"],
         backchannel_authentication_endpoint: `${backendUrl}/${tenantId}/v1/backchannel/authentications`,

--- a/e2e/src/tests/usecase/standard/standard-21-claims-and-token-config.test.js
+++ b/e2e/src/tests/usecase/standard/standard-21-claims-and-token-config.test.js
@@ -29,6 +29,7 @@ import {
  * - B-05: access_token_duration 短縮 → 期限切れ 401 → RT で復活
  * - B-10: id_token_strict_mode → ID Token からクレーム除外
  * - B-14: クライアント scope 制限 → UserInfo からクレーム消滅
+ * - B-15: scopes_supported 制限 → 付与スコープから除外（server レベル, #1353）
  */
 describe("Standard Use Case: Claims & Token Configuration Effects", () => {
   let systemAccessToken;
@@ -510,5 +511,97 @@ describe("Standard Use Case: Claims & Token Configuration Effects", () => {
     console.log("id_token_strict_mode=true: UserInfo still has standard claims (name, email)");
 
     await deletion({ url: `${backendUrl}/v1/management/organizations/${strictOrganizationId}/tenants/${strictTenantId}`, headers: { Authorization: `Bearer ${strictMgmtToken}` } }).catch(() => {});
+  });
+
+  it("B-15: scopes_supported filters granted scope even when client allows it (#1353)", async () => {
+    console.log("\n=== scopes_supported filtering (server-level) ===");
+
+    // email を scopes_supported に含めない（profile は含む）。client は email を許可。
+    const scTenantId = uuidv4();
+    const scClientId = uuidv4();
+    const scClientSecret = `cs-${crypto.randomBytes(16).toString("hex")}`;
+    const scJwks = await generateECP256JWKS();
+    const tsc = Date.now();
+    const scAdminEmail = `scopefilter-admin-${tsc}@claims-test.example.com`;
+    const scAdminPassword = `ScopeFilter_${tsc}!`;
+
+    const onboardSc = await onboarding({
+      body: {
+        organization: { id: uuidv4(), name: `Scope Filter Org ${tsc}`, description: "scopes_supported filtering test" },
+        tenant: {
+          id: scTenantId, name: `Scope Filter Tenant ${tsc}`, domain: backendUrl,
+          authorization_provider: "idp-server",
+          identity_policy_config: { identity_unique_key_type: "EMAIL" },
+          session_config: { cookie_name: `SCF_${scTenantId.substring(0, 8)}`, use_secure_cookie: false },
+          cors_config: { allow_origins: [backendUrl] },
+        },
+        authorization_server: {
+          issuer: `${backendUrl}/${scTenantId}`,
+          authorization_endpoint: `${backendUrl}/${scTenantId}/v1/authorizations`,
+          token_endpoint: `${backendUrl}/${scTenantId}/v1/tokens`,
+          token_endpoint_auth_methods_supported: ["client_secret_post"],
+          userinfo_endpoint: `${backendUrl}/${scTenantId}/v1/userinfo`,
+          jwks_uri: `${backendUrl}/${scTenantId}/v1/jwks`,
+          jwks: scJwks,
+          grant_types_supported: ["authorization_code", "password"],
+          token_signed_key_id: "signing_key_1",
+          id_token_signed_key_id: "signing_key_1",
+          // KEY: email を scopes_supported に含めない
+          scopes_supported: ["openid", "profile", "management"],
+          // claims_supported には email を含める（落ちるのは scope 側の制御であることを示す）
+          claims_supported: ["sub", "iss", "auth_time", "acr", "name", "email", "email_verified"],
+          response_types_supported: ["code"],
+          response_modes_supported: ["query"],
+          subject_types_supported: ["public"],
+          id_token_signing_alg_values_supported: ["ES256"],
+          extension: { access_token_type: "JWT" },
+        },
+        user: { sub: uuidv4(), provider_id: "idp-server", name: "Admin", email: scAdminEmail, email_verified: true, raw_password: scAdminPassword },
+        client: {
+          client_id: scClientId, client_secret: scClientSecret, redirect_uris: [redirectUri],
+          response_types: ["code"], grant_types: ["authorization_code", "password"],
+          // client は email を許可している（落とすのは server の scopes_supported）
+          scope: "openid profile email management", client_name: "Scope Filter Client",
+          token_endpoint_auth_method: "client_secret_post", application_type: "web",
+        },
+      },
+      headers: { Authorization: `Bearer ${systemAccessToken}` },
+    });
+    if (onboardSc.status !== 201) {
+      console.error("B-15 onboarding failed:", JSON.stringify(onboardSc.data, null, 2));
+    }
+    expect(onboardSc.status).toBe(201);
+
+    const scMgmt = await requestToken({ endpoint: `${backendUrl}/${scTenantId}/v1/tokens`, grantType: "password", username: scAdminEmail, password: scAdminPassword, scope: "management", clientId: scClientId, clientSecret: scClientSecret });
+    const scMgmtToken = scMgmt.data.access_token;
+
+    await postWithJson({ url: `${backendUrl}/v1/management/organizations/${organizationId}/tenants/${scTenantId}/authentication-configurations`, headers: { Authorization: `Bearer ${scMgmtToken}` }, body: { id: uuidv4(), type: "password", attributes: {}, metadata: { type: "password" }, interactions: { "password-authentication": { request: { schema: { type: "object", properties: { username: { type: "string" }, password: { type: "string" } }, required: ["username", "password"] } }, pre_hook: {}, execution: { function: "password_verification" }, post_hook: {}, response: { body_mapping_rules: [{ from: "$.user_id", to: "user_id" }, { from: "$.error", to: "error" }] } } } } });
+    await postWithJson({ url: `${backendUrl}/v1/management/organizations/${organizationId}/tenants/${scTenantId}/authentication-configurations`, headers: { Authorization: `Bearer ${scMgmtToken}` }, body: { id: uuidv4(), type: "initial-registration", attributes: {}, metadata: {}, interactions: { "initial-registration": { request: { schema: { type: "object", required: ["email", "password", "name"], properties: { name: { type: "string" }, email: { type: "string", format: "email" }, password: { type: "string", minLength: 8 } } } } } } } });
+
+    // openid profile email を要求（client 許可、server 未サポート email）
+    const scEmail = `scopefilter-${tsc}@claims-test.example.com`;
+    const scAuth = await getAuthorizations({ endpoint: `${backendUrl}/${scTenantId}/v1/authorizations`, clientId: scClientId, responseType: "code", state: `scf-${tsc}`, scope: "openid profile email", redirectUri });
+    const { params: scp } = convertNextAction(scAuth.headers.location);
+    await postWithJson({ url: `${backendUrl}/${scTenantId}/v1/authorizations/${scp.get("id")}/initial-registration`, body: { email: scEmail, password: "ScopeUser_1!", name: "Scope Filter User" } });
+    const scAuthorize = await authorize({ endpoint: `${backendUrl}/${scTenantId}/v1/authorizations/{id}/authorize`, id: scp.get("id"), body: {} });
+    const scResult = convertToAuthorizationResponse(scAuthorize.data.redirect_uri);
+    const scTokens = await requestToken({ endpoint: `${backendUrl}/${scTenantId}/v1/tokens`, grantType: "authorization_code", code: scResult.code, redirectUri, clientId: scClientId, clientSecret: scClientSecret });
+    expect(scTokens.status).toBe(200);
+
+    console.log("B-15 granted scope:", JSON.stringify(scTokens.data.scope));
+    const grantedScopes = (scTokens.data.scope || "").split(" ").filter(Boolean);
+    expect(grantedScopes).toContain("openid");
+    expect(grantedScopes).toContain("profile");
+    // scopes_supported に email が無いので、client が許可していても付与されない
+    expect(grantedScopes).not.toContain("email");
+
+    // email スコープ未付与なので UserInfo にも email は出ない（claims_supported に email はあるのに）
+    const scUserinfo = await getUserinfo({ endpoint: `${backendUrl}/${scTenantId}/v1/userinfo`, authorizationHeader: createBearerHeader(scTokens.data.access_token) });
+    expect(scUserinfo.status).toBe(200);
+    expect(scUserinfo.data).not.toHaveProperty("email");
+    expect(scUserinfo.data.name).toBe("Scope Filter User");
+    console.log("B-15: email dropped from granted scope & UserInfo (scopes_supported filter works)");
+
+    await deletion({ url: `${backendUrl}/v1/management/organizations/${organizationId}/tenants/${scTenantId}`, headers: { Authorization: `Bearer ${scMgmtToken}` } }).catch(() => {});
   });
 });

--- a/libs/idp-server-core-extension-ciba/src/main/java/org/idp/server/core/extension/ciba/context/CibaRequestContextCreator.java
+++ b/libs/idp-server-core-extension-ciba/src/main/java/org/idp/server/core/extension/ciba/context/CibaRequestContextCreator.java
@@ -57,6 +57,7 @@ public interface CibaRequestContextCreator {
       CibaRequestPattern pattern,
       CibaRequestParameters parameters,
       JoseContext joseContext,
+      AuthorizationServerConfiguration authorizationServerConfiguration,
       ClientConfiguration clientConfiguration) {
 
     String scope = parameters.getValueOrEmpty(OAuthRequestKey.scope);
@@ -65,6 +66,8 @@ public interface CibaRequestContextCreator {
     String targetScope =
         (pattern.isRequestParameter() || clientConfiguration.isSupportedJar()) ? joseScope : scope;
 
-    return clientConfiguration.filteredScope(targetScope);
+    // client.scope then server scopes_supported (both must permit the scope).
+    return authorizationServerConfiguration.filteredScope(
+        clientConfiguration.filteredScope(targetScope));
   }
 }

--- a/libs/idp-server-core-extension-ciba/src/main/java/org/idp/server/core/extension/ciba/context/NormalPatternContextCreator.java
+++ b/libs/idp-server-core-extension-ciba/src/main/java/org/idp/server/core/extension/ciba/context/NormalPatternContextCreator.java
@@ -44,7 +44,12 @@ public class NormalPatternContextCreator implements CibaRequestContextCreator {
     JoseContext joseContext = new JoseContext();
     CibaRequestPattern pattern = CibaRequestPattern.NORMAL;
     Set<String> filteredScopes =
-        filterScopes(pattern, parameters, joseContext, clientConfiguration);
+        filterScopes(
+            pattern,
+            parameters,
+            joseContext,
+            authorizationServerConfiguration,
+            clientConfiguration);
     CibaProfile profile = analyze(filteredScopes, authorizationServerConfiguration);
 
     BackchannelAuthenticationRequest backchannelAuthenticationRequest =

--- a/libs/idp-server-core-extension-ciba/src/main/java/org/idp/server/core/extension/ciba/context/RequestObjectPatternContextCreator.java
+++ b/libs/idp-server-core-extension-ciba/src/main/java/org/idp/server/core/extension/ciba/context/RequestObjectPatternContextCreator.java
@@ -63,7 +63,12 @@ public class RequestObjectPatternContextCreator implements CibaRequestContextCre
 
       CibaRequestPattern pattern = CibaRequestPattern.REQUEST_OBJECT;
       Set<String> filteredScopes =
-          filterScopes(pattern, parameters, joseContext, clientConfiguration);
+          filterScopes(
+              pattern,
+              parameters,
+              joseContext,
+              authorizationServerConfiguration,
+              clientConfiguration);
       CibaProfile profile = analyze(filteredScopes, authorizationServerConfiguration);
 
       BackchannelAuthenticationRequest backchannelAuthenticationRequest =

--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/oauth/configuration/AuthorizationServerConfiguration.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/oauth/configuration/AuthorizationServerConfiguration.java
@@ -303,6 +303,16 @@ public class AuthorizationServerConfiguration implements JsonReadable, Configura
     return scopes.stream().filter(scope -> scopesSupported.contains(scope)).toList();
   }
 
+  public Set<String> filteredScope(Set<String> scopes) {
+    Set<String> filtered = new LinkedHashSet<>();
+    for (String scope : scopes) {
+      if (scopesSupported.contains(scope)) {
+        filtered.add(scope);
+      }
+    }
+    return filtered;
+  }
+
   public boolean hasFapiBaselineScope(Set<String> scopes) {
     return extension.hasFapiBaselineScope(scopes);
   }

--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/oauth/context/NormalPatternContextCreator.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/oauth/context/NormalPatternContextCreator.java
@@ -44,7 +44,12 @@ public class NormalPatternContextCreator implements OAuthRequestContextCreator {
     JoseContext joseContext = new JoseContext();
     OAuthRequestPattern pattern = OAuthRequestPattern.NORMAL;
     Set<String> filteredScopes =
-        filterScopes(pattern, parameters, joseContext, clientConfiguration);
+        filterScopes(
+            pattern,
+            parameters,
+            joseContext,
+            authorizationServerConfiguration,
+            clientConfiguration);
     AuthorizationProfile profile = analyze(filteredScopes, authorizationServerConfiguration);
 
     AuthorizationRequest authorizationRequest =

--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/oauth/context/OAuthRequestContextCreator.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/oauth/context/OAuthRequestContextCreator.java
@@ -59,6 +59,7 @@ public interface OAuthRequestContextCreator {
       OAuthRequestPattern pattern,
       OAuthRequestParameters parameters,
       JoseContext joseContext,
+      AuthorizationServerConfiguration authorizationServerConfiguration,
       ClientConfiguration clientConfiguration) {
 
     String scope = parameters.getValueOrEmpty(OAuthRequestKey.scope);
@@ -67,7 +68,10 @@ public interface OAuthRequestContextCreator {
     String targetScope =
         (pattern.isRequestParameter() || clientConfiguration.isSupportedJar()) ? joseScope : scope;
 
-    return clientConfiguration.filteredScope(targetScope);
+    // Filter by client-allowed scopes (client.scope), then by server-supported scopes
+    // (authorization_server.scopes_supported). A scope must be permitted by both.
+    return authorizationServerConfiguration.filteredScope(
+        clientConfiguration.filteredScope(targetScope));
   }
 
   default RequestObjectFactoryType selectRequestObjectType(

--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/oauth/context/RequestObjectPatternContextCreator.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/oauth/context/RequestObjectPatternContextCreator.java
@@ -67,7 +67,12 @@ public class RequestObjectPatternContextCreator implements OAuthRequestContextCr
 
       OAuthRequestPattern pattern = OAuthRequestPattern.REQUEST_OBJECT;
       Set<String> filteredScopes =
-          filterScopes(pattern, parameters, joseContext, clientConfiguration);
+          filterScopes(
+              pattern,
+              parameters,
+              joseContext,
+              authorizationServerConfiguration,
+              clientConfiguration);
       AuthorizationProfile profile = analyze(filteredScopes, authorizationServerConfiguration);
 
       RequestObjectFactoryType requestObjectFactoryType =

--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/oauth/context/RequestUriPatternContextCreator.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/oauth/context/RequestUriPatternContextCreator.java
@@ -75,7 +75,12 @@ public class RequestUriPatternContextCreator implements OAuthRequestContextCreat
 
       OAuthRequestPattern pattern = OAuthRequestPattern.REQUEST_URI;
       Set<String> filteredScopes =
-          filterScopes(pattern, parameters, joseContext, clientConfiguration);
+          filterScopes(
+              pattern,
+              parameters,
+              joseContext,
+              authorizationServerConfiguration,
+              clientConfiguration);
 
       AuthorizationProfile profile = analyze(filteredScopes, authorizationServerConfiguration);
 

--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/token/service/ClientCredentialsGrantService.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/token/service/ClientCredentialsGrantService.java
@@ -56,7 +56,9 @@ public class ClientCredentialsGrantService implements OAuthTokenCreationService 
     ClientConfiguration clientConfiguration = context.clientConfiguration();
 
     Scopes scopes =
-        new Scopes(clientConfiguration.filteredScope(context.scopes().toStringValues()));
+        new Scopes(
+            authorizationServerConfiguration.filteredScope(
+                clientConfiguration.filteredScope(context.scopes().toStringValues())));
     ClientCredentialsGrantVerifier verifier = new ClientCredentialsGrantVerifier(scopes);
     verifier.verify();
 

--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/token/service/JwtBearerGrantService.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/token/service/JwtBearerGrantService.java
@@ -125,7 +125,8 @@ public class JwtBearerGrantService implements OAuthTokenCreationService, Refresh
       }
 
       Set<String> filteredScopes =
-          clientConfiguration.filteredScope(context.scopes().toStringValues());
+          serverConfiguration.filteredScope(
+              clientConfiguration.filteredScope(context.scopes().toStringValues()));
       Scopes scopes = new Scopes(filteredScopes);
 
       CustomProperties customProperties = context.customProperties();

--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/token/service/ResourceOwnerPasswordCredentialsGrantService.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/token/service/ResourceOwnerPasswordCredentialsGrantService.java
@@ -100,7 +100,9 @@ public class ResourceOwnerPasswordCredentialsGrantService
     User user =
         delegate.findAndAuthenticate(context.tenant(), context.username(), context.password());
     Scopes scopes =
-        new Scopes(clientConfiguration.filteredScope(context.scopes().toStringValues()));
+        new Scopes(
+            authorizationServerConfiguration.filteredScope(
+                clientConfiguration.filteredScope(context.scopes().toStringValues())));
     ResourceOwnerPasswordGrantVerifier verifier =
         new ResourceOwnerPasswordGrantVerifier(user, scopes);
     verifier.verify();


### PR DESCRIPTION
## 概要

`AuthorizationServerConfiguration.filteredScope()` が未使用で、`authorization_server.scopes_supported` がスコープフィルタリングに反映されていなかった（#1353）。Discovery 表示専用で、`scope=openid profile email` のように `scopes_supported` 外のスコープを要求しても素通りしていた。

本PRでは **client フィルタ（`client.scope`）の後に server フィルタ（`scopes_supported`）を適用**し、**両方が許可したスコープのみ付与**する（default-deny / 2段 allowlist）。

## 設計判断（A2: 全経路 / 列挙方式）

スコープフィルタを **全 grant 経路で一貫**させる：

| 経路 | 対象 |
|---|---|
| authorization endpoint | Normal / RequestObject / RequestUri |
| CIBA backchannel | Normal / RequestObject |
| token endpoint grant | password / client_credentials / jwt-bearer |

> 当初 authz フローのみ（A1）も検討したが、「authz では落ちるのに password grant では通る」非対称を避け、全経路に統一。セキュリティ的には default-deny・2段 allowlist・fail-closed で最も堅牢。

## 実装

- `AuthorizationServerConfiguration#filteredScope(Set)` を追加し各経路から共通利用（コピペ分散回避）
- `OAuthRequestContextCreator` / `CibaRequestContextCreator` の `filterScopes` に `AuthorizationServerConfiguration` を渡して server フィルタを適用
- `ResourceOwnerPassword` / `ClientCredentials` / `JwtBearer` の3 grant で client フィルタ結果を server フィルタに通す

## 設定の追従

`scopes_supported` が **完全な allowlist** になったため、利用スコープを列挙する必要がある（書き漏れると fail-closed で drop）。管理トークンを発行する organizer テナントは `management` 等を、カスタムクレームを使うテナントは `claims:*` を `scopes_supported` に列挙する規約。

- `config/examples/financial-grade/onboarding-request.json`: organizer に `management` / `org-management` 追加
- `config/templates/tenant-template.json`: リファレンス client が使う `claims:*`（6種）/ `verified_claims:family_name` 追加

> `config/templates/use-cases/*`（setup.sh が使う実体）は監査済みで既に整合（gap なし）。`config/examples` も organizer 監査済み。

## テスト

- **e2e standard-21 B-15（新規）**: `scopes_supported` に無いスコープは client が許可していても付与されず UserInfo にも出ない
- **e2e ciba-01**: 管理トークン用テナントの `scopes_supported` に `management` 追加（A2 で顕在化した漏れを修正）

## 動作確認（実機 / A2 デプロイ）

- standard-21 B-15: before（フィルタ無し）で email 残存 → after で `granted scope = "openid profile"`（email drop）
- usecase 152 / spec 472 / scenario+integration 831 全 green（scenario の2件は data 増加ページング・read replica 遅延の環境フレークで A2 無関係。再実行で green）
- financial-grade-02/03・ciba-01: A2 で管理トークンの scope drop により一時 fail → 該当テナントの `scopes_supported` に `management` 追記で green
- `./gradlew :libs:idp-server-core:compileJava :libs:idp-server-core-extension-ciba:compileJava` / `spotlessApply` 済み

Closes #1353

🤖 Generated with [Claude Code](https://claude.com/claude-code)
