### PR TITLE
docs(oauth): scopes_supported は Discovery 広告メタデータと明記 + 未使用 filteredScope 削除 (#1353)

### DIFF
--- a/documentation/docs/content_03_concepts/01-foundation/concept-04-client.md
+++ b/documentation/docs/content_03_concepts/01-foundation/concept-04-client.md
@@ -204,10 +204,10 @@ flowchart LR
 ### Scopeとの関係
 
 **役割分担**:
-- **Client**: 利用可能なスコープを定義（`scope`フィールド）
-- **Tenant**: テナント全体で利用可能なスコープを定義（`scopes_supported`）
+- **Client**: 利用可能なスコープを定義（`scope`フィールド）＝ スコープ制御の主体
+- **Tenant**: `scopes_supported` は Discovery 広告用メタデータ（OpenID Connect Discovery / RFC 8414）。サーバーは未広告のスコープもサポート可能で、付与スコープの enforcement allowlist ではない
 
-**検証ルール**: 認証リクエストのスコープは、ClientとTenantの両方の設定範囲内である必要がある
+**検証ルール**: 認証リクエストのスコープは、クライアントの登録スコープ（`scope`）の範囲に絞られる（`scopes_supported` は広告用であり、付与可否の検証には用いない）
 
 ---
 

--- a/documentation/docs/content_05_how-to/phase-1-foundation/04-client-registration.md
+++ b/documentation/docs/content_05_how-to/phase-1-foundation/04-client-registration.md
@@ -545,11 +545,11 @@ curl -X PUT "${IDP_SERVER_URL}/v1/management/organizations/${ORGANIZATION_ID}/te
 }
 ```
 
-**原因**: Authorization Requestで要求したスコープがクライアントの`scope`またはテナントの`scopes_supported`に含まれていない
+**原因**: Authorization Requestで要求したスコープがクライアントの`scope`（登録スコープ）に含まれていない。スコープの付与はクライアント登録スコープで制御される（`scopes_supported` は Discovery 広告用メタデータで、付与スコープの制御には影響しない）
 
 **解決策**:
-1. クライアントのスコープを更新
-2. テナントの`scopes_supported`に追加
+1. クライアントの`scope`に必要なスコープを追加する（スコープ付与の制御点）
+2. （任意）Discoveryで正しく広告するため、テナントの`scopes_supported`にも追加する（広告用であり付与可否には影響しない）
 
 ```bash
 # クライアントのスコープを更新

--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/oauth/configuration/AuthorizationServerConfiguration.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/oauth/configuration/AuthorizationServerConfiguration.java
@@ -134,6 +134,18 @@ public class AuthorizationServerConfiguration implements JsonReadable, Configura
     return registrationEndpoint;
   }
 
+  /**
+   * The {@code scopes_supported} OpenID Provider / Authorization Server metadata.
+   *
+   * <p>Per OpenID Connect Discovery 1.0 and RFC 8414 this is RECOMMENDED, <em>informational</em>
+   * metadata advertised at the discovery endpoint: "Servers MAY choose not to advertise some
+   * supported scope values even when this parameter is used." It is therefore <strong>not</strong>
+   * an enforcement allowlist — a server may grant scopes that are not listed here.
+   *
+   * <p>Per-client scope filtering (the actual control point) is performed against the client's
+   * registered scope via {@link
+   * org.idp.server.core.openid.oauth.configuration.client.ClientConfiguration#filteredScope}.
+   */
   public List<String> scopesSupported() {
     return scopesSupported;
   }
@@ -292,15 +304,6 @@ public class AuthorizationServerConfiguration implements JsonReadable, Configura
 
   public boolean authorizationResponseIssParameterSupported() {
     return authorizationResponseIssParameterSupported;
-  }
-
-  public List<String> filteredScope(String spacedScopes) {
-    List<String> scopes = Arrays.stream(spacedScopes.split(" ")).toList();
-    return scopes.stream().filter(scope -> scopesSupported.contains(scope)).toList();
-  }
-
-  public List<String> filteredScope(List<String> scopes) {
-    return scopes.stream().filter(scope -> scopesSupported.contains(scope)).toList();
   }
 
   public boolean hasFapiBaselineScope(Set<String> scopes) {


### PR DESCRIPTION
## 概要

#1353（Close 済み / by-design）の調査結論を **Javadoc とドキュメントに記録**し、誤解を招く未使用コードを除去する。

`scopes_supported` は OpenID Connect Discovery 1.0 / RFC 8414 で **RECOMMENDED な広告メタデータ**と定義され、

> "Servers MAY choose not to advertise some supported scope values even when this parameter is used"

とされる。つまり**サポートするが広告しないスコープを許容**しており、付与スコープを縛る enforcement allowlist ではない。スコープ制御はクライアント登録 `scope`（`ClientConfiguration#filteredScope`）で行うのが仕様の主モデルで、idp-server も既にそうしている。

> 背景: enforcement 版（`scopes_supported` を全 grant 経路でフィルタ）は PR #1600 で実装・検証したが、仕様の advisory モデルに反する方向＋運用コスト（全テナントで管理/カスタムスコープを列挙、空 scopes_supported の fail-closed 地雷）のため不採用とした。本PRはその判断を恒久的に残すためのドキュメント整備。

## 変更

- **Javadoc**: `AuthorizationServerConfiguration#scopesSupported()` に「広告メタデータであり enforcement allowlist ではない／制御は client 登録 scope」を明記（仕様文言を引用）
- **未使用コード削除**: `AuthorizationServerConfiguration#filteredScope(String)` / `filteredScope(List)` を削除
  - 呼び出し元ゼロの dead code。残すと「scopes_supported を enforce する helper」と誤解され再配線される罠になる（実際 #1353/#1600 で一度配線しかけた）
- **ドキュメント修正（矛盾解消）**:
  - `04-client-registration.md`: invalid_scope の原因/解決策を「`scopes_supported` に追加すれば付与される」→「付与は client.scope で制御、`scopes_supported` は広告用」に修正
  - `concept-04-client.md`: 「Tenant が利用可能スコープを定義」「Client と Tenant 両方の範囲内で検証」→「`scopes_supported` は広告メタデータ、検証は client 登録 scope」に修正

## 動作確認

- `./gradlew :libs:idp-server-core:compileJava`（dead method 削除後もコンパイル OK）/ `spotlessApply` 済み
- 挙動変更なし（削除したのは未使用メソッドのみ。スコープフィルタは従来どおり client 側）

関連: #1353（by-design Close）、#1600（enforcement 版・不採用 Close）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
