### PR TITLE
fix(config): authentication_devices の preferred_for_notification を priority に統一 (#1322)

### DIFF
--- a/config/examples/e2e/tenant-1/initial.json
+++ b/config/examples/e2e/tenant-1/initial.json
@@ -233,7 +233,7 @@
         "model": "iPhone15",
         "notification_channel": "fcm",
         "notification_token": "test token",
-        "preferred_for_notification": true
+        "priority": 1
       }
     ],
     "custom_properties": {

--- a/config/examples/e2e/tenant-1e68932e-ed4a-43e7-b412-460665e42df3/user/admin.json
+++ b/config/examples/e2e/tenant-1e68932e-ed4a-43e7-b412-460665e42df3/user/admin.json
@@ -34,7 +34,7 @@
       "model": "iPhone15",
       "notification_channel": "fcm",
       "notification_token": "test token",
-      "preferred_for_notification": true
+      "priority": 1
     }
   ],
   "custom_properties": {

--- a/config/examples/financial-grade/financial-user.json
+++ b/config/examples/financial-grade/financial-user.json
@@ -16,7 +16,7 @@
       "model": "iPhone15",
       "notification_channel": "fcm",
       "notification_token": "fapi-ciba-test-fcm-token",
-      "preferred_for_notification": true
+      "priority": 1
     }
   ],
   "raw_password": "FapiCibaTestSecure123!"

--- a/config/templates/user-template.json
+++ b/config/templates/user-template.json
@@ -34,7 +34,7 @@
       "model": "iPhone15",
       "notification_channel": "fcm",
       "notification_token": "test token",
-      "preferred_for_notification": true
+      "priority": 1
     }
   ],
   "verified_claims": {"claims": {"address": {"country": "UK", "locality": "Edinburgh", "postal_code": "EH1 9GP", "street_address": "122 Burns Crescent"}, "birthdate": "1976-03-11", "given_name": "Sarah", "family_name": "Meredyth", "place_of_birth": {"country": "UK"}}, "verification": {"evidence": [{"time": "2021-04-09T14:12Z", "type": "electronic_record", "record": {"type": "mortgage_account", "source": {"name": "TheCreditBureau"}}, "check_details": [{"txn": "kbv1-hf934hn09234ng03jj3", "check_method": "kbv", "organization": "TheCreditBureau"}]}, {"time": "2021-04-09T14:12Z", "type": "electronic_record", "record": {"type": "bank_account", "source": {"name": "TheBank"}}, "check_details": [{"txn": "kbv2-nm0f23u9459fj38u5j6", "check_method": "kbv", "organization": "OpenBankingTPP"}]}], "trust_framework": "eidas"}},

--- a/e2e/src/tests/scenario/application/scenario-03-mfa-registration.test.js
+++ b/e2e/src/tests/scenario/application/scenario-03-mfa-registration.test.js
@@ -491,8 +491,7 @@ describe("user - mfa registration", () => {
             "os": "Android15",
             "model": "galaxy z fold 6",
             "notification_channel": "fcm",
-            "notification_token": "test token",
-            "preferred_for_notification": true
+            "notification_token": "test token"
           },
           headers: {
             "Authorization": `Bearer ${accessToken}`

--- a/e2e/src/tests/scenario/application/scenario-06-identity_verification-result.test.js
+++ b/e2e/src/tests/scenario/application/scenario-06-identity_verification-result.test.js
@@ -32,8 +32,7 @@ describe("identity-verification result", () => {
             "os": "Android15",
             "model": "galaxy z fold 6",
             "notification_channel": "fcm",
-            "notification_token": "test token",
-            "preferred_for_notification": true
+            "notification_token": "test token"
           },
           headers: {
             "Authorization": `Bearer ${accessToken}`

--- a/e2e/src/tests/scenario/application/scenario-08-multi-app_fido-authn.test.js
+++ b/e2e/src/tests/scenario/application/scenario-08-multi-app_fido-authn.test.js
@@ -32,8 +32,7 @@ describe("multi client", () => {
             "os": "Android15",
             "model": "galaxy z fold 6",
             "notification_channel": "fcm",
-            "notification_token": "test token",
-            "preferred_for_notification": true
+            "notification_token": "test token"
           },
           headers: {
             "Authorization": `Bearer ${accessToken}`

--- a/e2e/src/user/index.js
+++ b/e2e/src/user/index.js
@@ -193,8 +193,7 @@ export const registerFidoUaf = async ({
           "os": "Android15",
           "model": "galaxy z fold 6",
           "notification_channel": "fcm",
-          "notification_token": "test token",
-          "preferred_for_notification": true
+          "notification_token": "test token"
         },
         headers: {
           "Authorization": `Bearer ${accessToken}`

--- a/libs/idp-server-core/src/main/resources/schema/1.0/user.json
+++ b/libs/idp-server-core/src/main/resources/schema/1.0/user.json
@@ -50,7 +50,7 @@
           "model": { "type": "string" },
           "notification_channel": { "type": "string", "enum": ["fcm", "apns"] },
           "notification_token": { "type": "string" },
-          "preferred_for_notification": { "type": "boolean" }
+          "priority": { "type": "integer", "minimum": 1 }
         }
       }
     },

--- a/performance-test/scripts/generate_users.py
+++ b/performance-test/scripts/generate_users.py
@@ -139,8 +139,7 @@ def generate_users(tenants: list, users_per_tenant: int, first_tenant_users: int
                     "platform": "iOS",
                     "priority": 1,
                     "notification_token": "test token",
-                    "notification_channel": "fcm",
-                    "preferred_for_notification": True
+                    "notification_channel": "fcm"
                 }]
                 devices_str = json.dumps(devices, ensure_ascii=False)
                 devices_escaped = '"' + devices_str.replace('"', '""') + '"'


### PR DESCRIPTION
## 概要

`AuthenticationDevice` の Java 実装は `preferred_for_notification`(boolean) から `priority`(Integer) に移行済みだが、JSONスキーマ・設定テンプレート・E2Eテストデータ・性能テスト生成スクリプトに**旧フィールド名が残っていた**（#1322）。Java 側は `priority` のみを読み、`preferred_for_notification` は完全に無視される **dead フィールド**だったため整理する。

## 変更方針

| 区分 | 対象 | 方針 |
|---|---|---|
| schema | `schema/1.0/user.json` | `preferred_for_notification`(boolean) → `priority`(integer, minimum 1) |
| stored config | user-template / financial-user / e2e tenant-1 initial / tenant-1e68932e admin | `priority: 1` に置換（デシリアライズで priority 値になる） |
| e2e リクエストボディ | scenario-03/06/08 + `user/index.js` | **削除**（dead フィールド・挙動不変） |
| 性能テスト生成 | `performance-test/scripts/generate_users.py` | `priority:1` と並存していた dead フィールドを削除 |

### e2e ボディ／生成スクリプトを「置換」でなく「削除」にした理由

`FidoUafRegistrationInteractor` は登録時の priority を **`priority` キーがあればそれを使い、無ければ `authenticationDeviceNextCount()`（1台目=1…）** で決める。`preferred_for_notification` は読まれない。よって `priority:1` を注入すると next-count デフォルト挙動を上書きしてしまうため、**dead フィールドの削除（挙動不変）** を選択。scenario-03/06/08 の priority アサート（1, 10 等）が維持されることを実機確認済み。

## ⚠️ schema 変更（`user.json`）の影響: **runtime 影響なし**

調査の結果、`schema/1.0/user.json` は **dead schema** だった:

- それを読む `ControlPlaneV1SchemaReader#userSchema()` は **呼び出し元ゼロ**（IDE 上も "no usages"）
- 実際の user 管理API（作成/更新/パスワード）の検証は **`admin-user.json`（`adminUserSchema()`）** を使用。`UserRegistrationRequestValidator` も `adminUserSchema()` 参照
- そして `admin-user.json` は**既に `priority`（integer, minimum 1）済み**

よって本 schema 変更は**旧フィールド名の残骸除去**が目的で、検証挙動には一切影響しない。仮に使われていたとしても device オブジェクトは permissive（`additionalProperties` 既定 true・`required` に両フィールド無し）のため、旧/新どちらのフィールドでもリクエストは拒否されない。

> `user.json` 自体が dead schema である点は本PRのスコープ外。別途「dead schema を削除するか」を判断するのが良い（参考: #1601 で `filteredScope` dead code を同様に整理）。

## テスト

- e2e scenario-03/06/08（priority アサートあり）→ **3 passed**（dead フィールド削除後も挙動不変）
- 全拡張子で `preferred_for_notification` の**ソース残存ゼロ**を確認（生成済み `.tsv` は git-ignore・再生成で解消）
- `generate_users.py` py 構文チェック OK / 変更 JSON 妥当性 OK

Closes #1322

🤖 Generated with [Claude Code](https://claude.com/claude-code)