### PR TITLE
feat(discovery): OIDC4IDA Section 8 のメタデータ名を仕様準拠に修正し不足フィールドを追加 (#1513)

### DIFF
--- a/config/examples/e2e/test-tenant/authorization-server/idp-server.json
+++ b/config/examples/e2e/test-tenant/authorization-server/idp-server.json
@@ -226,12 +226,12 @@
     "utility_bill",
     "qes"
   ],
-  "id_documents_supported":[
+  "documents_supported":[
     "idcard",
     "passport",
     "driving_permit"
   ],
-  "id_documents_verification_methods_supported":[
+  "documents_methods_supported":[
     "pipp",
     "sripp",
     "eid"

--- a/config/examples/e2e/test-tenant/tenants/admin-tenant.json
+++ b/config/examples/e2e/test-tenant/tenants/admin-tenant.json
@@ -271,12 +271,12 @@
       "utility_bill",
       "qes"
     ],
-    "id_documents_supported":[
+    "documents_supported":[
       "idcard",
       "passport",
       "driving_permit"
     ],
-    "id_documents_verification_methods_supported":[
+    "documents_methods_supported":[
       "pipp",
       "sripp",
       "eid"

--- a/config/templates/use-cases/ekyc/VERIFY.md
+++ b/config/templates/use-cases/ekyc/VERIFY.md
@@ -64,6 +64,16 @@ curl -s "${TENANT_BASE}/.well-known/openid-configuration" | jq '{verified_claims
 
 > 両方 `true` が返れば OK です。
 
+### OIDC4IDA Section 8 メタデータの確認
+
+```bash
+curl -s "${TENANT_BASE}/.well-known/openid-configuration" | jq '{evidence_supported, documents_supported, documents_methods_supported, electronic_records_supported, trust_frameworks_supported}'
+```
+
+> - `documents_supported` は `evidence_supported` に `document` を含む時に返る（OIDC4IDA §8 で REQUIRED）。
+> - `electronic_records_supported` は `evidence_supported` に `electronic_record` を含む時に返る（同 REQUIRED）。
+> - 旧ドラフトのフィールド名 `id_documents_supported` / `id_documents_verification_methods_supported` は**返らない**（1.0 で `documents_supported` / `documents_methods_supported` にリネーム済み）。
+
 ---
 
 ## Step 2: Authorization Request

--- a/config/templates/use-cases/ekyc/public-tenant-template.json
+++ b/config/templates/use-cases/ekyc/public-tenant-template.json
@@ -127,8 +127,22 @@
       "eidas"
     ],
     "evidence_supported": [
-      "id_document",
+      "document",
       "electronic_record"
+    ],
+    "documents_supported": [
+      "idcard",
+      "passport",
+      "driving_permit"
+    ],
+    "documents_methods_supported": [
+      "pipp",
+      "sripp",
+      "eid"
+    ],
+    "electronic_records_supported": [
+      "bank_account",
+      "utility_statement"
     ],
     "claims_in_verified_claims_supported": [
       "given_name",

--- a/documentation/docs/content_06_developer-guide/04-implementation-guides/oauth-oidc/discovery-metadata.md
+++ b/documentation/docs/content_06_developer-guide/04-implementation-guides/oauth-oidc/discovery-metadata.md
@@ -269,10 +269,26 @@ public class ServerConfigurationResponseCreator {
           authorizationServerConfiguration.trustFrameworksSupported());
       map.put("evidence_supported",
           authorizationServerConfiguration.evidenceSupported());
-      map.put("id_documents_supported",
-          authorizationServerConfiguration.idDocumentsSupported());
-      map.put("id_documents_verification_methods_supported",
-          authorizationServerConfiguration.idDocumentsVerificationMethodsSupported());
+      // OIDC4IDA Section 8: documents_supported is REQUIRED when evidence_supported contains
+      // "document"; electronic_records_supported when it contains "electronic_record".
+      // documents_methods_supported / documents_check_methods_supported are OPTIONAL.
+      // Each is advertised only when configured (non-empty).
+      if (authorizationServerConfiguration.hasDocumentsSupported()) {
+        map.put("documents_supported",
+            authorizationServerConfiguration.documentsSupported());
+      }
+      if (authorizationServerConfiguration.hasDocumentsMethodsSupported()) {
+        map.put("documents_methods_supported",
+            authorizationServerConfiguration.documentsMethodsSupported());
+      }
+      if (authorizationServerConfiguration.hasDocumentsCheckMethodsSupported()) {
+        map.put("documents_check_methods_supported",
+            authorizationServerConfiguration.documentsCheckMethodsSupported());
+      }
+      if (authorizationServerConfiguration.hasElectronicRecordsSupported()) {
+        map.put("electronic_records_supported",
+            authorizationServerConfiguration.electronicRecordsSupported());
+      }
       map.put("claims_in_verified_claims_supported",
           authorizationServerConfiguration.claimsInVerifiedClaimsSupported());
     }
@@ -319,8 +335,10 @@ public class ServerConfigurationResponseCreator {
   "backchannel_authentication_endpoint": "https://idp.example.com/bc-authorize",
   "verified_claims_supported": true,
   "trust_frameworks_supported": ["eidas", "jp_moj"],
-  "evidence_supported": ["id_document", "qes"],
-  "id_documents_supported": ["idcard", "passport", "driving_permit"],
+  "evidence_supported": ["document", "electronic_record"],
+  "documents_supported": ["idcard", "passport", "driving_permit"],
+  "documents_methods_supported": ["pipp", "sripp", "eid"],
+  "electronic_records_supported": ["secure_messaging"],
   "claims_in_verified_claims_supported": ["given_name", "family_name", "birthdate"]
 }
 ```

--- a/documentation/gap-analysis/oidc4ida-verified-claims-gap-analysis.md
+++ b/documentation/gap-analysis/oidc4ida-verified-claims-gap-analysis.md
@@ -209,10 +209,10 @@ Map<String, Object> create(User user, AuthorizationGrant grant, ...);
 | `trust_frameworks_supported` | REQUIRED | ✅ 実装済み | - |
 | `claims_in_verified_claims_supported` | REQUIRED | ✅ 実装済み | - |
 | `evidence_supported` | REQUIRED | ✅ 実装済み | - |
-| `documents_supported` | REQUIRED (evidence に document 含む時) | ⚠️ フィールド名不一致 | `id_documents_supported` として実装 |
-| `documents_methods_supported` | SHOULD (evidence に document 含む時) | ⚠️ フィールド名不一致 | `id_documents_verification_methods_supported` として実装 |
-| `electronic_records_supported` | REQUIRED (evidence に electronic_record 含む時) | ❌ 未実装 | フィールド自体が存在しない |
-| `documents_check_methods_supported` | SHOULD (evidence に document 含む時) | ❌ 未実装 | - |
+| `documents_supported` | REQUIRED (evidence に document 含む時) | ✅ 実装済み (#1513) | `id_documents_supported` → `documents_supported` にリネーム。非空時のみ emit |
+| `documents_methods_supported` | OPTIONAL | ✅ 実装済み (#1513) | `id_documents_verification_methods_supported` → `documents_methods_supported` にリネーム |
+| `electronic_records_supported` | REQUIRED (evidence に electronic_record 含む時) | ✅ 実装済み (#1513) | フィールド新規追加。非空時のみ emit |
+| `documents_check_methods_supported` | OPTIONAL | ✅ 実装済み (#1513) | フィールド新規追加 |
 | `claims_parameter_supported` | SHALL 公開 | ✅ 実装済み | - |
 
 ### データ最小化ルール
@@ -233,7 +233,7 @@ Map<String, Object> create(User user, AuthorizationGrant grant, ...);
 |---|------|------------|---------|
 | 1 | 5.7.4: verification 空時に verified_claims を省略しない | `VerifiedClaimsCreator.java` | verification/claims が空なら空 Map を返す |
 | 2 | UserInfo で verified_claims 未対応 | 新規 `UserinfoVerifiedClaimsCreator.java` | Creator 実装 + ServiceLoader 登録 |
-| 3 | Discovery: `electronic_records_supported` 未実装 | `AuthorizationServerConfiguration` + `ServerConfigurationResponseCreator` | フィールド追加 |
+| 3 | Discovery: `electronic_records_supported` 未実装 | `AuthorizationServerConfiguration` + `ServerConfigurationResponseCreator` | フィールド追加（✅ #1513 で対応・P3 と統合） |
 
 ### P2: 構造一貫性（独自拡張の改善）
 
@@ -242,13 +242,16 @@ Map<String, Object> create(User user, AuthorizationGrant grant, ...);
 | 4 | AT の verified_claims が verification なしでフラット展開 | `AccessTokenVerifiedClaimsCreator.java` | verification + claims ネスト化 |
 | 5 | AT selective も同上 | `AccessTokenSelectiveVerifiedClaimsCreator.java` | 同上 |
 
-### P3: Discovery フィールド名修正
+### P3: Discovery フィールド名修正 — ✅ 完了 (#1513)
 
-| # | 問題 | 対象ファイル | 修正内容 |
-|---|------|------------|---------|
-| 6 | `id_documents_supported` → `documents_supported` | `ServerConfigurationResponseCreator` | フィールド名変更（後方互換注意） |
-| 7 | `id_documents_verification_methods_supported` → `documents_methods_supported` | 同上 | 同上 |
-| 8 | `documents_check_methods_supported` 追加 | 同上 | 新規フィールド |
+| # | 問題 | 対象ファイル | 修正内容 | 状態 |
+|---|------|------------|---------|------|
+| 6 | `id_documents_supported` → `documents_supported` | `ServerConfigurationResponseCreator` / `AuthorizationServerConfiguration` | フィールド名変更 | ✅ |
+| 7 | `id_documents_verification_methods_supported` → `documents_methods_supported` | 同上 | 同上 | ✅ |
+| 8 | `documents_check_methods_supported` / `electronic_records_supported` 追加 | 同上 | 新規フィールド | ✅ |
+
+> **破壊的変更**: 旧 Discovery フィールド名 `id_documents_supported` / `id_documents_verification_methods_supported` は出力されなくなる。後方互換 alias は設けない（core を jackson-free に保つため）。旧キーを持つ保存済みテナント設定は読み込み時に黙殺され、再保存または手動更新で新名へ移行する。自環境に旧キー保持テナントが無いことを確認済み。
+> なお `evidence_supported` の値が旧ドラフト値（`id_document` / `utility_bill` / `qes`）のままになっている点は本対応の範囲外（evidence 値リネームは verified_claims 検証ロジックに波及するため別途対応）。
 
 ---
 

--- a/e2e/src/tests/spec/oidc_for_identity_assurance.test.js
+++ b/e2e/src/tests/spec/oidc_for_identity_assurance.test.js
@@ -1,6 +1,6 @@
-import { describe, expect, it, xit } from "@jest/globals";
+import { beforeAll, describe, expect, it, xit } from "@jest/globals";
 
-import { getJwks, requestToken } from "../../api/oauthClient";
+import { getConfiguration, getJwks, requestToken } from "../../api/oauthClient";
 import {
   backendUrl,
   clientSecretPostClient,
@@ -125,6 +125,39 @@ describe("OpenID Connect for Identity Assurance 1.0 ", () => {
     console.log(JSON.stringify(userinfoResponse.data, null, 2));
     // expect(userinfoResponse.data.verified_claims.claims).not.toBeNull();
 
+  });
+
+  // OpenID Connect for Identity Assurance 1.0, Section 8 (OpenID Provider Metadata).
+  // Test names quote the spec verbatim. See issue #1513.
+  describe("Section 8 OpenID Provider Metadata", () => {
+    let metadata;
+
+    beforeAll(async () => {
+      const response = await getConfiguration({
+        endpoint: serverConfig.discoveryEndpoint,
+      });
+      expect(response.status).toBe(200);
+      metadata = response.data;
+      console.log(JSON.stringify(metadata, null, 2));
+    });
+
+    it("verified_claims_supported: Boolean value indicating support for verified_claims. If omitted, the default value is false.", () => {
+      expect(metadata.verified_claims_supported).toBe(true);
+    });
+
+    it('documents_supported: Required when evidence_supported contains "document". JSON array containing all identity document types utilized by the OP for identity verification.', () => {
+      expect(Array.isArray(metadata.documents_supported)).toBe(true);
+      expect(metadata.documents_supported).toContain("passport");
+    });
+
+    it('documents_methods_supported: Optional. JSON array containing the verification methods the OP supports for evidences of type "document".', () => {
+      expect(metadata.documents_methods_supported).toContain("pipp");
+    });
+
+    it("legacy pre-1.0 draft names id_documents_supported / id_documents_verification_methods_supported are no longer advertised", () => {
+      expect(metadata).not.toHaveProperty("id_documents_supported");
+      expect(metadata).not.toHaveProperty("id_documents_verification_methods_supported");
+    });
   });
 
 });

--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/discovery/ServerConfigurationResponseCreator.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/discovery/ServerConfigurationResponseCreator.java
@@ -260,10 +260,28 @@ public class ServerConfigurationResponseCreator {
           "trust_frameworks_supported",
           authorizationServerConfiguration.trustFrameworksSupported());
       map.put("evidence_supported", authorizationServerConfiguration.evidenceSupported());
-      map.put("id_documents_supported", authorizationServerConfiguration.idDocumentsSupported());
-      map.put(
-          "id_documents_verification_methods_supported",
-          authorizationServerConfiguration.idDocumentsVerificationMethodsSupported());
+      // OIDC4IDA Section 8: documents_supported is REQUIRED when evidence_supported contains
+      // "document"; electronic_records_supported is REQUIRED when it contains "electronic_record".
+      // documents_methods_supported / documents_check_methods_supported are OPTIONAL. Each is
+      // advertised only when configured (non-empty), so the discovery document stays minimal.
+      if (authorizationServerConfiguration.hasDocumentsSupported()) {
+        map.put("documents_supported", authorizationServerConfiguration.documentsSupported());
+      }
+      if (authorizationServerConfiguration.hasDocumentsMethodsSupported()) {
+        map.put(
+            "documents_methods_supported",
+            authorizationServerConfiguration.documentsMethodsSupported());
+      }
+      if (authorizationServerConfiguration.hasDocumentsCheckMethodsSupported()) {
+        map.put(
+            "documents_check_methods_supported",
+            authorizationServerConfiguration.documentsCheckMethodsSupported());
+      }
+      if (authorizationServerConfiguration.hasElectronicRecordsSupported()) {
+        map.put(
+            "electronic_records_supported",
+            authorizationServerConfiguration.electronicRecordsSupported());
+      }
       map.put(
           "claims_in_verified_claims_supported",
           authorizationServerConfiguration.claimsInVerifiedClaimsSupported());

--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/oauth/configuration/AuthorizationServerConfiguration.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/oauth/configuration/AuthorizationServerConfiguration.java
@@ -86,8 +86,10 @@ public class AuthorizationServerConfiguration implements JsonReadable, Configura
   boolean verifiedClaimsSupported = false;
   List<String> trustFrameworksSupported = new ArrayList<>();
   List<String> evidenceSupported = new ArrayList<>();
-  List<String> idDocumentsSupported = new ArrayList<>();
-  List<String> idDocumentsVerificationMethodsSupported = new ArrayList<>();
+  List<String> documentsSupported = new ArrayList<>();
+  List<String> documentsMethodsSupported = new ArrayList<>();
+  List<String> documentsCheckMethodsSupported = new ArrayList<>();
+  List<String> electronicRecordsSupported = new ArrayList<>();
   List<String> claimsInVerifiedClaimsSupported = new ArrayList<>();
 
   // enable/disable
@@ -652,21 +654,36 @@ public class AuthorizationServerConfiguration implements JsonReadable, Configura
     return evidenceSupported != null && !evidenceSupported.isEmpty();
   }
 
-  public List<String> idDocumentsSupported() {
-    return idDocumentsSupported;
+  public List<String> documentsSupported() {
+    return documentsSupported;
   }
 
-  public boolean hasIdDocumentsSupported() {
-    return idDocumentsSupported != null && !idDocumentsSupported.isEmpty();
+  public boolean hasDocumentsSupported() {
+    return documentsSupported != null && !documentsSupported.isEmpty();
   }
 
-  public List<String> idDocumentsVerificationMethodsSupported() {
-    return idDocumentsVerificationMethodsSupported;
+  public List<String> documentsMethodsSupported() {
+    return documentsMethodsSupported;
   }
 
-  public boolean hasIdDocumentsVerificationMethodsSupported() {
-    return idDocumentsVerificationMethodsSupported != null
-        && !idDocumentsVerificationMethodsSupported.isEmpty();
+  public boolean hasDocumentsMethodsSupported() {
+    return documentsMethodsSupported != null && !documentsMethodsSupported.isEmpty();
+  }
+
+  public List<String> documentsCheckMethodsSupported() {
+    return documentsCheckMethodsSupported;
+  }
+
+  public boolean hasDocumentsCheckMethodsSupported() {
+    return documentsCheckMethodsSupported != null && !documentsCheckMethodsSupported.isEmpty();
+  }
+
+  public List<String> electronicRecordsSupported() {
+    return electronicRecordsSupported;
+  }
+
+  public boolean hasElectronicRecordsSupported() {
+    return electronicRecordsSupported != null && !electronicRecordsSupported.isEmpty();
   }
 
   public List<String> claimsInVerifiedClaimsSupported() {
@@ -793,8 +810,10 @@ public class AuthorizationServerConfiguration implements JsonReadable, Configura
     map.put("verified_claims_supported", verifiedClaimsSupported);
     map.put("trust_frameworks_supported", trustFrameworksSupported);
     map.put("evidence_supported", evidenceSupported);
-    map.put("id_documents_supported", idDocumentsSupported);
-    map.put("id_documents_verification_methods_supported", idDocumentsVerificationMethodsSupported);
+    map.put("documents_supported", documentsSupported);
+    map.put("documents_methods_supported", documentsMethodsSupported);
+    map.put("documents_check_methods_supported", documentsCheckMethodsSupported);
+    map.put("electronic_records_supported", electronicRecordsSupported);
     map.put("claims_in_verified_claims_supported", claimsInVerifiedClaimsSupported);
     map.put("enabled", enabled);
     map.put("extension", extension.toMap());

--- a/libs/idp-server-core/src/test/java/org/idp/server/core/openid/discovery/ServerConfigurationResponseCreatorTest.java
+++ b/libs/idp-server-core/src/test/java/org/idp/server/core/openid/discovery/ServerConfigurationResponseCreatorTest.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2025 Hirokazu Kobayashi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.idp.server.core.openid.discovery;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+import java.util.Map;
+import org.idp.server.core.openid.oauth.configuration.AuthorizationServerConfiguration;
+import org.idp.server.platform.json.JsonConverter;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Discovery (well-known/openid-configuration) output for the OIDC4IDA Section 8 metadata fields.
+ *
+ * <p>Covers issue #1513: the document/electronic-record fields use the OIDC4IDA 1.0 spec names
+ * ({@code documents_supported}, {@code documents_methods_supported}, {@code
+ * documents_check_methods_supported}, {@code electronic_records_supported}), the legacy names
+ * ({@code id_documents_*}) are no longer emitted, and each field is advertised only when
+ * configured.
+ */
+class ServerConfigurationResponseCreatorTest {
+
+  private static final JsonConverter JSON = JsonConverter.snakeCaseInstance();
+
+  private AuthorizationServerConfiguration config(String json) {
+    return JSON.read(json, AuthorizationServerConfiguration.class);
+  }
+
+  private Map<String, Object> discovery(AuthorizationServerConfiguration config) {
+    return new ServerConfigurationResponseCreator(config).create();
+  }
+
+  @Nested
+  class Ida {
+
+    @Test
+    void emitsOidc4idaSpecFieldNames() {
+      Map<String, Object> map =
+          discovery(
+              config(
+                  """
+                  {
+                    "verified_claims_supported": true,
+                    "trust_frameworks_supported": ["eidas"],
+                    "evidence_supported": ["document", "electronic_record"],
+                    "documents_supported": ["passport", "idcard"],
+                    "documents_methods_supported": ["pipp"],
+                    "electronic_records_supported": ["secure_messaging"],
+                    "claims_in_verified_claims_supported": ["given_name"]
+                  }
+                  """));
+
+      assertEquals(List.of("passport", "idcard"), map.get("documents_supported"));
+      assertEquals(List.of("pipp"), map.get("documents_methods_supported"));
+      assertEquals(List.of("secure_messaging"), map.get("electronic_records_supported"));
+    }
+
+    @Test
+    void omitsLegacyFieldNames() {
+      Map<String, Object> map =
+          discovery(
+              config(
+                  """
+                  {
+                    "verified_claims_supported": true,
+                    "documents_supported": ["passport"],
+                    "documents_methods_supported": ["pipp"]
+                  }
+                  """));
+
+      assertFalse(map.containsKey("id_documents_supported"));
+      assertFalse(map.containsKey("id_documents_verification_methods_supported"));
+    }
+
+    @Test
+    void omitsUnconfiguredOptionalFields() {
+      Map<String, Object> map =
+          discovery(
+              config(
+                  """
+                  {
+                    "verified_claims_supported": true,
+                    "documents_supported": ["passport"]
+                  }
+                  """));
+
+      // configured -> present
+      assertTrue(map.containsKey("documents_supported"));
+      // not configured -> absent (empty arrays are not advertised)
+      assertFalse(map.containsKey("documents_methods_supported"));
+      assertFalse(map.containsKey("documents_check_methods_supported"));
+      assertFalse(map.containsKey("electronic_records_supported"));
+    }
+
+    @Test
+    void omitsAllIdaFieldsWhenVerifiedClaimsDisabled() {
+      Map<String, Object> map =
+          discovery(
+              config(
+                  """
+                  {
+                    "verified_claims_supported": false,
+                    "documents_supported": ["passport"]
+                  }
+                  """));
+
+      assertEquals(false, map.get("verified_claims_supported"));
+      assertFalse(map.containsKey("documents_supported"));
+      assertFalse(map.containsKey("trust_frameworks_supported"));
+    }
+
+    @Test
+    void legacyConfigKeyNoLongerMapsToField() {
+      // Hard rename without @JsonAlias: a stored config using the old key is silently ignored
+      // on read (Jackson ignores unknown properties), so the renamed field stays empty.
+      AuthorizationServerConfiguration legacy =
+          config(
+              """
+              {
+                "verified_claims_supported": true,
+                "id_documents_supported": ["passport"]
+              }
+              """);
+
+      assertFalse(legacy.hasDocumentsSupported());
+      assertTrue(legacy.documentsSupported().isEmpty());
+    }
+  }
+}


### PR DESCRIPTION
## Summary

OIDC4IDA 1.0 §8（OpenID Provider Metadata）の verified_claims 関連フィールドを仕様準拠に修正する。Discovery メタデータのフィールド名が旧 Implementer's Draft（ID2/2020）世代のままだった問題を是正し、不足していた条件付き REQUIRED フィールドを追加する。

Closes #1513

## 変更内容

### フィールド名リネーム（⚠️ 破壊的変更）
| 旧（ID2世代） | 新（1.0） |
|---|---|
| `id_documents_supported` | `documents_supported` |
| `id_documents_verification_methods_supported` | `documents_methods_supported` |

### 新規フィールド追加
| フィールド | 要件 |
|---|---|
| `electronic_records_supported` | `evidence_supported` に `electronic_record` を含む時 REQUIRED |
| `documents_check_methods_supported` | OPTIONAL |

### 出力挙動
- 各フィールドは**非空時のみ** emit（空配列を広告しない）
- 後方互換 alias は**設けない**（core を jackson-free に保つため）。旧キーを持つ保存済み設定は読み込み時に黙殺され、再保存で新名へ移行する

## 後方互換の判断

- 旧名 `id_documents_*` は OIDC4IDA **ID2（2020-05）世代の名残**で、仕様上は ID3（2021-09）で既にリネーム済み。本実装（2025-06）時点で既に廃止予定名だった。
- 旧キーを持つテナント設定は限定的（自環境では不在を確認済み）。`@JsonAlias` 互換は core への jackson 依存導入を伴うため見送り、ハードリネームを採用。

## テスト

### 単体（`ServerConfigurationResponseCreatorTest` 新規・5件）
- 新名で emit される
- 非空時のみ emit（未設定の optional は出ない）
- 旧名は emit されない
- verified_claims 無効時は IDA フィールド全省略
- 旧キー `id_documents_supported` は読み込みで黙殺され field に入らない

### E2E（`spec/oidc_for_identity_assurance.test.js`）
OIDC4IDA §8 の describe を**仕様文言そのまま**で追加。test-tenant 再登録後に実機確認済み（5/5 pass）。

```
✅ verified_claims_supported: true
✅ documents_supported に passport
✅ documents_methods_supported に pipp
✅ 旧名 id_documents_* は出ない
```

## 設定・ドキュメント追従
- ekyc テンプレート: `evidence_supported` を 1.0 値（`document`）に正規化し、`documents_supported` / `documents_methods_supported` / `electronic_records_supported` を追加。VERIFY.md に §8 確認手順を追記
- config 例（test-tenant / admin-tenant）・開発者ガイド（discovery-metadata.md）・gap 分析を新名へ追従

## スコープ外
- `evidence_supported` の旧ドラフト値（`id_document` / `utility_bill` / `qes`）の全テナント横展開は範囲外（本 PR は ekyc テンプレートのみ正規化）。evidence 値は Discovery 広告専用で検証ロジックは非参照。

🤖 Generated with [Claude Code](https://claude.com/claude-code)