### PR TITLE
fix(springboot): 空 UserDetailsService Bean で起動時の既定ユーザー警告を抑止 (#1348)

### DIFF
--- a/app/src/main/java/org/idp/server/IdPApplication.java
+++ b/app/src/main/java/org/idp/server/IdPApplication.java
@@ -19,7 +19,13 @@ package org.idp.server;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
-@SpringBootApplication
+// idp-server has its own authentication; exclude Spring Security's default in-memory
+// UserDetailsService so it does not auto-generate a dev user / random password at startup (#1348).
+// excludeName (by FQCN) is used because the auto-configuration class lives in the runtime-only
+// spring-boot-security module (Spring Boot 4.x) and is not on the compile classpath.
+@SpringBootApplication(
+    excludeName =
+        "org.springframework.boot.security.autoconfigure.UserDetailsServiceAutoConfiguration")
 public class IdPApplication {
 
   public static void main(String[] args) {

--- a/app/src/main/java/org/idp/server/IdPApplication.java
+++ b/app/src/main/java/org/idp/server/IdPApplication.java
@@ -19,13 +19,7 @@ package org.idp.server;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
-// idp-server has its own authentication; exclude Spring Security's default in-memory
-// UserDetailsService so it does not auto-generate a dev user / random password at startup (#1348).
-// excludeName (by FQCN) is used because the auto-configuration class lives in the runtime-only
-// spring-boot-security module (Spring Boot 4.x) and is not on the compile classpath.
-@SpringBootApplication(
-    excludeName =
-        "org.springframework.boot.security.autoconfigure.UserDetailsServiceAutoConfiguration")
+@SpringBootApplication
 public class IdPApplication {
 
   public static void main(String[] args) {

--- a/libs/idp-server-springboot-adapter/src/main/java/org/idp/server/adapters/springboot/SecurityConfig.java
+++ b/libs/idp-server-springboot-adapter/src/main/java/org/idp/server/adapters/springboot/SecurityConfig.java
@@ -25,6 +25,8 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
 
@@ -84,5 +86,22 @@ public class SecurityConfig {
     http.addFilterBefore(dynamicCorsFilter, ProtectedResourceApiFilter.class);
 
     return http.build();
+  }
+
+  /**
+   * idp-server authenticates through the custom filters above (token / scope based), not through
+   * Spring Security's {@code UserDetailsService}. Declaring an empty one makes {@code
+   * UserDetailsServiceAutoConfiguration} back off ({@code @ConditionalOnMissingBean
+   * UserDetailsService}), so Spring Boot does not auto-generate a default in-memory user / random
+   * password — nor its {@code "Using generated security password"} startup warning. (#1348)
+   *
+   * <p><b>Load-bearing</b>: do not remove. Without this bean the auto-configuration re-activates
+   * and the default user and startup warning come back.
+   */
+  @Bean
+  public UserDetailsService userDetailsService() {
+    return username -> {
+      throw new UsernameNotFoundException("idp-server does not use UserDetailsService-based login");
+    };
   }
 }


### PR DESCRIPTION
## Summary

起動時に Spring Security が出力する以下の WARN を抑止する。

```
Using generated security password: <uuid>
This generated password is for development use only. ...
```

## 原因

`UserDetailsServiceAutoConfiguration` は `UserDetailsService` / `AuthenticationManager` / `AuthenticationProvider` 等の Bean が無いと既定の in-memory ユーザー（ランダムパスワード）を自動生成する。idp-server の認証は `SecurityConfig` の独自フィルタ（`STATELESS` / `httpBasic` 無効 / `anyRequest().permitAll()`、トークン・スコープ検証）で完結し、これらの Bean を持たないため autoconfig が back off せず既定ユーザーが生成されていた。既定ユーザーは httpBasic 無効で使い道もなく死蔵。

## 修正

`SecurityConfig` に**空の `UserDetailsService` Bean** を定義し、`UserDetailsServiceAutoConfiguration` を `@ConditionalOnMissingBean` で back off させる。

### なぜ `exclude` ではなく Bean か

初回コミットは `@SpringBootApplication(excludeName = "…UserDetailsServiceAutoConfiguration")` だったが、以下の理由で Bean 方式へ変更:

- **堅牢性**: `excludeName` は FQCN のマジック文字列で、クラスのパッケージ移動時に**サイレントに失効**する（`AutoConfigurationImportSelector` は未解決名を黙ってスキップ）。実際 Boot 3.x→4.x で当該クラスが `autoconfigure.security.servlet` → `security.autoconfigure` に移動済みで、この脆さは現実的。Bean は安定型 `org.springframework.security.core.userdetails.UserDetailsService` のみ参照で**型安全・移動に強い**。
- **凝集**: 「なぜ既定ユーザーが出ないか」を追う人はまず `SecurityConfig` を見る。Bean + Javadoc がそこにある。
- Spring 公認の「自前 Bean で上書き」機構。
- Javadoc に警告文と **"Load-bearing: do not remove"** を明記し誤削除を防止。

## 動作確認（docker idp-server-1, idp-server-2）

| | 修正前 | 修正後 |
|---|---|---|
| `generated security password` WARN | ⚠️ 両ノードで発生 | ✅ 0 件 |
| 起動 | - | ✅ `Started IdPApplication ~3s` |

機能的影響なし（独自フィルタ認証は不変、既定ユーザーは元々未使用）。

Closes #1348

🤖 Generated with [Claude Code](https://claude.com/claude-code)
