### PR TITLE
fix(identity-verification): callback 経路を application パイプラインに統一し pre_hook を honor する (#1522)

### DIFF
--- a/.claude/skills/spec-identity-verification/skill.md
+++ b/.claude/skills/spec-identity-verification/skill.md
@@ -228,13 +228,15 @@ e2e/src/tests/
 
 ```
 Phase 1: Request  → JSON Schema バリデーション
-Phase 2: Pre Hook → AdditionalRequestParameterResolvers（外部パラメータ解決）
-Phase 3: Execute  → IdentityVerificationApplicationExecutors（外部 eKYC API 呼び出し）
-Phase 4: Post Hook → 後処理
+Phase 2: Pre Hook → verifications（process_sequence 等）＋ AdditionalRequestParameterResolvers（外部パラメータ解決）
+Phase 3: Execute  → IdentityVerificationApplicationExecutors（外部 eKYC API 呼び出し）。execution 省略時は no_action
+Phase 4: Post Hook → 後処理（未実装 / #1611）
 Phase 5: Transition → ステータス遷移（12 種の条件演算子で判定）
 Phase 6: Store    → IdentityVerificationApplicationRepository に永続化
 Phase 7: Response → IdentityVerificationApplyingResult を返却
 ```
+
+> **callback 経路も同一パイプライン (#1522)**: `IdentityVerificationCallbackEntryService` も `executeRequest` を通るため、callback プロセスでも Phase 2（pre_hook: verifications / additional_parameters）が honor される。execution 無しは `no_action`（結果は inbound）。merge のみ `updateCallbackWith`（fallback が `EXAMINATION_PROCESSING`、application 経路は `APPLYING`）。
 
 ### Conditional Execution（Phase 5）
 

--- a/documentation/docs/content_05_how-to/phase-4-extensions/identity-verification/02-application.md
+++ b/documentation/docs/content_05_how-to/phase-4-extensions/identity-verification/02-application.md
@@ -233,6 +233,13 @@ POST /{tenant-id}/internal/v1/identity-verification/callback/{verification-type}
 
 これらのフェーズにより、柔軟で拡張可能な申込み処理を実現しています。
 
+:::info コールバック経路も同一フェーズで処理されます
+`callback` プロセスも application 経路（apply/process）と**同じパイプライン**を通ります。そのため `pre_hook`（`verifications` の `process_sequence`・`additional_parameters`）はコールバックでも同じように適用され、`dependencies` / `allow_retry` による順序・再実行制御が効きます。
+
+- コールバックは結果が外部から push されるため `execution` を省略でき、その場合は `no_action`（受信したリクエストボディがそのまま結果として取り込まれる）。
+- `execution` を設定すれば、コールバック受信時に外部API実行を行い、その応答 `$.response_body` で `transition` を駆動することもできます。
+:::
+
 ### フェーズ一覧
 
 | フェーズ名             | 役割・目的                      | 主な設定項目                                                    | 必須 |
@@ -240,7 +247,7 @@ POST /{tenant-id}/internal/v1/identity-verification/callback/{verification-type}
 | **1. request**    | リクエストの構造・形式を検証             | `schema`（JSON Schema）                                     | -  |
 | **history**       | pre_hook に渡す過去申込み read model の取得条件（[詳細](../../../content_06_developer-guide/05-configuration/identity-verification.md#history過去申込みの取得条件)） | `filters`                                                 | -  |
 | **2. pre_hook**   | 実行前の事前検証・外部パラメータ取得・外部API実行 | `verifications`, `additional_parameters`                  | -  |
-| **3. execution**  | メイン業務処理（外部連携 or 内部処理）      | `type`, `http_request`, `mock`, `no_action` など（処理タイプに応じて） | ✅  |
+| **3. execution**  | メイン業務処理（外部連携 or 内部処理）。**省略時は `no_action`** | `type`, `http_request`, `mock`, `no_action` など（処理タイプに応じて） | -  |
 | **4. post_hook**  | 実行後の検証・外部API実行             | `verifications` `additional_parameters`                   | -  |
 | **5. transition** | ステータス遷移                    | `approved` `rejected` `canceled`                          | -  |
 | **6. store**      | 処理結果や申請内容の永続化              | `application_details_mapping_rules`                       | -  |

--- a/documentation/docs/content_06_developer-guide/05-configuration/identity-verification.md
+++ b/documentation/docs/content_06_developer-guide/05-configuration/identity-verification.md
@@ -151,8 +151,8 @@ POST /{tenant-id}/v1/me/identity-verification/applications/{type}/cancel
 |---------|------|------|
 | `request` | リクエストスキーマ定義 | ❌ |
 | `history` | pre_hook フェーズ（verifications / additional_parameters）に渡す過去申込み read model の取得条件（[詳細](#history過去申込みの取得条件)） | ❌ |
-| `pre_hook` | 実行前処理 | ❌ |
-| `execution` | メイン処理（外部API呼び出し等） | ✅ |
+| `pre_hook` | 実行前処理（`verifications` / `additional_parameters`）。**application 経路（apply/process）・callback 経路の両方で実行される** | ❌ |
+| `execution` | メイン処理（外部API呼び出し等）。**省略時は `no_action`**（サーバ側で実行する処理なし）。結果が外部から push されるコールバックプロセス等は省略可 | ❌ |
 | `post_hook` | 実行後処理 | ❌ |
 | `transition` | ステータス遷移条件 | ❌ |
 | `store` | 結果保存 | ❌ |

--- a/e2e/src/tests/integration/ida/integration-14-callback-pre-hook-verification.test.js
+++ b/e2e/src/tests/integration/ida/integration-14-callback-pre-hook-verification.test.js
@@ -1,0 +1,302 @@
+import { describe, expect, it, beforeAll, afterAll } from "@jest/globals";
+import { get, postWithJson, deletion } from "../../../lib/http";
+import { requestToken } from "../../../api/oauthClient";
+import {
+  backendUrl,
+  clientSecretPostClient,
+  serverConfig,
+  federationServerConfig
+} from "../../testConfig";
+import { createFederatedUser, registerFidoUaf } from "../../../user";
+import { createBasicAuthHeader } from "../../../lib/util";
+import { mockApiBaseUrl } from "../../testConfig";
+import { v4 as uuidv4 } from "uuid";
+
+/**
+ * #1522: callback API 経路でも pre_hook (process_sequence) が honor されることを検証する。
+ *
+ * 修正前は callback 経路が pre_hook 検証を実行せず、callback プロセスに設定した
+ * dependencies / allow_retry が事実上無視されてバイパス可能だった。
+ *
+ * 1. 依存プロセス未完で callback-result を送ると 400 pre_hook_validation_failed
+ * 2. allow_retry: false の callback-result を二重送信すると 2 回目が 400
+ */
+describe("Identity Verification - callback pre_hook verification (#1522)", () => {
+  const orgId = serverConfig.organizationId;
+  const tenantId = serverConfig.tenantId;
+
+  let orgAccessToken;
+  const createdConfigIds = [];
+
+  beforeAll(async () => {
+    const orgAuthResponse = await requestToken({
+      endpoint: `${backendUrl}/${tenantId}/v1/tokens`,
+      grantType: "password",
+      username: "ito.ichiro@gmail.com",
+      password: "successUserCode001",
+      clientId: clientSecretPostClient.clientId,
+      clientSecret: clientSecretPostClient.clientSecret,
+      scope: "org-management account management"
+    });
+    expect(orgAuthResponse.status).toBe(200);
+    orgAccessToken = orgAuthResponse.data.access_token;
+  });
+
+  afterAll(async () => {
+    for (const configId of createdConfigIds) {
+      await deletion({
+        url: `${backendUrl}/v1/management/organizations/${orgId}/tenants/${tenantId}/identity-verification-configurations/${configId}`,
+        headers: { Authorization: `Bearer ${orgAccessToken}` }
+      });
+    }
+  });
+
+  const registerConfiguration = async (configurationData) => {
+    const response = await postWithJson({
+      url: `${backendUrl}/v1/management/organizations/${orgId}/tenants/${tenantId}/identity-verification-configurations`,
+      headers: {
+        "Authorization": `Bearer ${orgAccessToken}`,
+        "Content-Type": "application/json"
+      },
+      body: configurationData
+    });
+    expect(response.status).toBe(201);
+    createdConfigIds.push(configurationData.id);
+  };
+
+  const createTestUser = async () => {
+    const { user, accessToken } = await createFederatedUser({
+      serverConfig: serverConfig,
+      federationServerConfig: federationServerConfig,
+      client: clientSecretPostClient,
+      adminClient: clientSecretPostClient,
+      scope: "openid profile phone email identity_verification_application " + clientSecretPostClient.identityVerificationScope
+    });
+    await registerFidoUaf({ accessToken: accessToken });
+    return { user, accessToken };
+  };
+
+  const callProcess = async ({ url, accessToken, body, headers }) => {
+    const response = await postWithJson({
+      url,
+      headers: headers || {
+        "Content-Type": "application/json",
+        "Authorization": `Bearer ${accessToken}`
+      },
+      body
+    });
+    console.log("Process response:", url, response.status, JSON.stringify(response.data, null, 2));
+    return response;
+  };
+
+  // apply (store application_id) + a callback "callback-result" guarded by process_sequence.
+  const buildConfig = ({ configId, type, basicAuth, dependencies }) => ({
+    "id": configId,
+    "type": type,
+    "attributes": { "enabled": true },
+    "common": { "auth_type": "none", "callback_application_id_param": "application_id" },
+    "processes": {
+      "apply": {
+        "request": {
+          "schema": {
+            "type": "object",
+            "required": ["external_ref"],
+            "properties": { "external_ref": { "type": "string" } }
+          }
+        },
+        "execution": { "type": "no_action" },
+        "store": {
+          "application_details_mapping_rules": [
+            { "from": "$.request_body", "to": "*" },
+            { "from": "$.request_body.external_ref", "to": "application_id" }
+          ]
+        }
+      },
+      "callback-result": {
+        "request": {
+          "basic_auth": basicAuth,
+          "schema": {
+            "type": "object",
+            "required": ["application_id", "result"],
+            "properties": {
+              "application_id": { "type": "string" },
+              "result": { "type": "string" }
+            }
+          }
+        },
+        "dependencies": dependencies,
+        "pre_hook": { "verifications": [{ "type": "process_sequence" }] },
+        "transition": {
+          "approved": {
+            "any_of": [
+              [{ "path": "$.request_body.result", "type": "string", "operation": "eq", "value": "ok" }]
+            ]
+          }
+        }
+      }
+    }
+  });
+
+  const apply = async ({ type, accessToken, externalRef }) => {
+    const applyUrl = serverConfig.identityVerificationApplyEndpoint
+      .replace("{type}", type)
+      .replace("{process}", "apply");
+    const res = await callProcess({ url: applyUrl, accessToken, body: { external_ref: externalRef } });
+    expect(res.status).toBe(200);
+    return res.data.id;
+  };
+
+  const getApplicationStatus = async ({ type, accessToken, applicationId }) => {
+    const res = await get({
+      url: serverConfig.identityVerificationApplicationsEndpoint + `?id=${applicationId}&type=${type}`,
+      headers: { Authorization: `Bearer ${accessToken}` }
+    });
+    expect(res.status).toBe(200);
+    expect(res.data.list.length).toBe(1);
+    return res.data.list[0].status;
+  };
+
+  const sendCallbackResult = async ({ type, basicAuth, externalRef }) => {
+    const callbackUrl = serverConfig.identityVerificationApplicationsPublicCallbackEndpoint
+      .replace("{type}", type)
+      .replace("{callbackName}", "callback-result");
+    return callProcess({
+      url: callbackUrl,
+      headers: { "Content-Type": "application/json", ...createBasicAuthHeader(basicAuth) },
+      body: { application_id: externalRef, result: "ok" }
+    });
+  };
+
+  it("rejects callback when a required process is not completed (process_sequence honored on callback)", async () => {
+    const { accessToken } = await createTestUser();
+    const type = uuidv4();
+    const basicAuth = { username: "cb_dep_user", password: "cb_dep_password001" };
+    // callback-result requires "callback-examination", which is never executed.
+    await registerConfiguration(
+      buildConfig({
+        configId: uuidv4(),
+        type,
+        basicAuth,
+        dependencies: { required_processes: ["callback-examination"], allow_retry: false }
+      })
+    );
+
+    const externalRef = uuidv4();
+    await apply({ type, accessToken, externalRef });
+
+    const response = await sendCallbackResult({ type, basicAuth, externalRef });
+
+    expect(response.status).toBe(400);
+    expect(response.data).toHaveProperty("error", "pre_hook_validation_failed");
+    expect(JSON.stringify(response.data)).toContain("callback-examination");
+  });
+
+  it("rejects a duplicate callback when allow_retry is false (retry control honored on callback)", async () => {
+    const { accessToken } = await createTestUser();
+    const type = uuidv4();
+    const basicAuth = { username: "cb_retry_user", password: "cb_retry_password001" };
+    await registerConfiguration(
+      buildConfig({
+        configId: uuidv4(),
+        type,
+        basicAuth,
+        dependencies: { required_processes: [], allow_retry: false }
+      })
+    );
+
+    const externalRef = uuidv4();
+    await apply({ type, accessToken, externalRef });
+
+    const first = await sendCallbackResult({ type, basicAuth, externalRef });
+    expect(first.status).toBe(200);
+
+    const second = await sendCallbackResult({ type, basicAuth, externalRef });
+    expect(second.status).toBe(400);
+    expect(second.data).toHaveProperty("error", "pre_hook_validation_failed");
+    expect(JSON.stringify(second.data)).toContain("does not allow retry");
+  });
+
+  // New capability unlocked by the unification: a callback process can now run an `execution`
+  // (e.g. http_request) on receipt AND drive its transition from the executed `$.response_body`.
+  // Before the unification the callback never executed, so `$.response_body` did not exist and the
+  // transition could only see the inbound `$.request_body`. (#1522)
+  it("drives the callback transition from the executed $.response_body (→ approved)", async () => {
+    const { accessToken } = await createTestUser();
+    const type = uuidv4();
+    const basicAuth = { username: "cb_exec_user", password: "cb_exec_password001" };
+    await registerConfiguration({
+      "id": uuidv4(),
+      "type": type,
+      "attributes": { "enabled": true },
+      "common": { "auth_type": "none", "callback_application_id_param": "application_id" },
+      "processes": {
+        "apply": {
+          "request": {
+            "schema": {
+              "type": "object",
+              "required": ["external_ref"],
+              "properties": { "external_ref": { "type": "string" } }
+            }
+          },
+          "execution": { "type": "no_action" },
+          "store": {
+            "application_details_mapping_rules": [
+              { "from": "$.request_body", "to": "*" },
+              { "from": "$.request_body.external_ref", "to": "application_id" }
+            ]
+          }
+        },
+        "callback-result": {
+          "request": {
+            "basic_auth": basicAuth,
+            "schema": {
+              "type": "object",
+              "required": ["application_id"],
+              "properties": { "application_id": { "type": "string" } }
+            }
+          },
+          // execution runs against the mock on callback receipt; the mock returns {status:"ok"}
+          "execution": {
+            "type": "http_request",
+            "http_request": {
+              "url": `${mockApiBaseUrl}/crm-registration`,
+              "method": "POST",
+              "auth_type": "none",
+              "header_mapping_rules": [{ "static_value": "application/json", "to": "Content-Type" }],
+              "body_mapping_rules": [{ "from": "$.request_body", "to": "*" }]
+            }
+          },
+          // transition reads the EXECUTED response, not the inbound request body
+          "transition": {
+            "approved": {
+              "any_of": [
+                [{ "path": "$.response_body.status", "type": "string", "operation": "eq", "value": "ok" }]
+              ]
+            }
+          },
+          "response": { "body_mapping_rules": [{ "from": "$.response_body", "to": "*" }] }
+        }
+      }
+    });
+
+    const externalRef = uuidv4();
+    const applicationId = await apply({ type, accessToken, externalRef });
+
+    const callbackUrl = serverConfig.identityVerificationApplicationsPublicCallbackEndpoint
+      .replace("{type}", type)
+      .replace("{callbackName}", "callback-result");
+    const response = await callProcess({
+      url: callbackUrl,
+      headers: { "Content-Type": "application/json", ...createBasicAuthHeader(basicAuth) },
+      body: { application_id: externalRef }
+    });
+
+    // execution ran on the callback path → the executed response was echoed back
+    expect(response.status).toBe(200);
+    expect(response.data).toHaveProperty("status", "ok");
+
+    // and the transition was driven by that executed $.response_body → application is approved
+    const status = await getApplicationStatus({ type, accessToken, applicationId });
+    expect(status).toBe("approved");
+  });
+});

--- a/libs/idp-server-core-extension-ida/src/main/java/org/idp/server/core/extension/identity/verification/application/IdentityVerificationApplicationHandler.java
+++ b/libs/idp-server-core-extension-ida/src/main/java/org/idp/server/core/extension/identity/verification/application/IdentityVerificationApplicationHandler.java
@@ -128,7 +128,8 @@ public class IdentityVerificationApplicationHandler {
     IdentityVerificationProcessConfiguration processConfig =
         verificationConfiguration.getProcessConfig(processes);
     IdentityVerificationExecutionConfig executionConfig = processConfig.execution();
-    IdentityVerificationApplicationExecutor executor = executors.get(executionConfig.type());
+    IdentityVerificationApplicationExecutor executor =
+        executors.get(executionConfig.executorType());
 
     IdentityVerificationContext context = contextBuilder.build();
     IdentityVerificationExecutionResult executionResult =

--- a/libs/idp-server-core-extension-ida/src/main/java/org/idp/server/core/extension/identity/verification/configuration/process/IdentityVerificationExecutionConfig.java
+++ b/libs/idp-server-core-extension-ida/src/main/java/org/idp/server/core/extension/identity/verification/configuration/process/IdentityVerificationExecutionConfig.java
@@ -22,6 +22,8 @@ import org.idp.server.platform.http.*;
 import org.idp.server.platform.json.JsonReadable;
 
 public class IdentityVerificationExecutionConfig implements JsonReadable {
+  static final String DEFAULT_EXECUTOR_TYPE = "no_action";
+
   String type;
   IdentityVerificationHttpRequestConfig httpRequest = new IdentityVerificationHttpRequestConfig();
   IdentityVerificationMockConfig mock = new IdentityVerificationMockConfig();
@@ -30,6 +32,16 @@ public class IdentityVerificationExecutionConfig implements JsonReadable {
 
   public String type() {
     return type;
+  }
+
+  /**
+   * Executor type to dispatch to. When no execution is configured ({@link #exists()} is false),
+   * defaults to {@code no_action} — "nothing to execute server-side" — so processes whose result is
+   * produced externally and pushed in (e.g. callbacks) share the same execution pipeline. A
+   * non-empty but unknown type is returned as-is and fails loud at the executor registry. (#1522)
+   */
+  public String executorType() {
+    return exists() ? type : DEFAULT_EXECUTOR_TYPE;
   }
 
   public IdentityVerificationHttpRequestConfig httpRequest() {

--- a/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/application/identity_verification_service/IdentityVerificationCallbackEntryService.java
+++ b/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/application/identity_verification_service/IdentityVerificationCallbackEntryService.java
@@ -19,8 +19,10 @@ package org.idp.server.usecases.application.identity_verification_service;
 import java.util.Map;
 import org.idp.server.core.extension.identity.verification.*;
 import org.idp.server.core.extension.identity.verification.application.IdentityVerificationApplicationHandler;
+import org.idp.server.core.extension.identity.verification.application.IdentityVerificationApplyingResult;
 import org.idp.server.core.extension.identity.verification.application.model.IdentityVerificationApplication;
 import org.idp.server.core.extension.identity.verification.application.model.IdentityVerificationApplicationIdentifier;
+import org.idp.server.core.extension.identity.verification.application.model.IdentityVerificationApplications;
 import org.idp.server.core.extension.identity.verification.application.pre_hook.additional_parameter.AdditionalRequestParameterResolver;
 import org.idp.server.core.extension.identity.verification.callback.validation.IdentityVerificationCallbackRequestValidator;
 import org.idp.server.core.extension.identity.verification.callback.validation.IdentityVerificationCallbackValidationResult;
@@ -116,18 +118,15 @@ public class IdentityVerificationCallbackEntryService implements IdentityVerific
     IdentityVerificationApplication application =
         applicationQueryRepository.get(tenant, applicationIdParams, applicationId);
 
-    Map<String, Object> response =
-        updateApplicationAndCreateResponse(
-            type,
-            process,
-            request,
-            requestAttributes,
-            application,
-            verificationConfiguration,
-            tenant,
-            processConfiguration);
-
-    return IdentityVerificationCallbackResponse.OK(response);
+    return updateApplicationAndCreateResponse(
+        type,
+        process,
+        request,
+        requestAttributes,
+        application,
+        verificationConfiguration,
+        tenant,
+        processConfiguration);
   }
 
   @Override
@@ -160,21 +159,18 @@ public class IdentityVerificationCallbackEntryService implements IdentityVerific
     IdentityVerificationApplication application =
         applicationQueryRepository.get(tenant, identifier);
 
-    Map<String, Object> response =
-        updateApplicationAndCreateResponse(
-            type,
-            process,
-            request,
-            requestAttributes,
-            application,
-            verificationConfiguration,
-            tenant,
-            processConfiguration);
-
-    return IdentityVerificationCallbackResponse.OK(response);
+    return updateApplicationAndCreateResponse(
+        type,
+        process,
+        request,
+        requestAttributes,
+        application,
+        verificationConfiguration,
+        tenant,
+        processConfiguration);
   }
 
-  private Map<String, Object> updateApplicationAndCreateResponse(
+  private IdentityVerificationCallbackResponse updateApplicationAndCreateResponse(
       IdentityVerificationType type,
       IdentityVerificationProcess process,
       IdentityVerificationRequest request,
@@ -185,14 +181,35 @@ public class IdentityVerificationCallbackEntryService implements IdentityVerific
       IdentityVerificationProcessConfiguration processConfiguration) {
     User user = userQueryRepository.get(tenant, application.userIdentifier());
 
-    IdentityVerificationContext context =
-        new IdentityVerificationContextBuilder()
-            .request(request)
-            .requestAttributes(requestAttributes)
-            .application(application)
-            .user(user)
-            .build();
+    // Run the same pipeline as the application path: pre_hook (verifications +
+    // additional_parameters) → execute. For callback processes (no execution block) execute is
+    // no_action, so the inbound result carried in the request is incorporated by updateProcessWith.
+    // This makes callback processes honor the same config as the application path. (#1522)
+    IdentityVerificationApplications previousApplications =
+        applicationQueryRepository.findHistory(
+            tenant, user, processConfiguration.historyPlan(type));
+    IdentityVerificationApplyingResult applyingResult =
+        identityVerificationApplicationHandler.executeRequest(
+            tenant,
+            user,
+            application,
+            previousApplications,
+            type,
+            process,
+            request,
+            requestAttributes,
+            verificationConfiguration);
+    if (applyingResult.isError()) {
+      return IdentityVerificationCallbackResponse.CLIENT_ERROR(
+          applyingResult.errorResponse().response());
+    }
 
+    IdentityVerificationContext context = applyingResult.applicationContext();
+
+    // Merge uses updateCallbackWith (not updateProcessWith): the two are identical except the
+    // fallback status when no transition condition matches — callback → EXAMINATION_PROCESSING
+    // (awaiting async review), process → APPLYING. That difference is intentional, so the callback
+    // keeps its own merge. The shared part (pre_hook + execute) is unified above. (#1522)
     IdentityVerificationApplication updatedApplication =
         application.updateCallbackWith(process, context, verificationConfiguration);
     applicationCommandRepository.update(tenant, updatedApplication);
@@ -263,7 +280,9 @@ public class IdentityVerificationCallbackEntryService implements IdentityVerific
           requestAttributes);
     }
 
-    return IdentityVerificationDynamicResponseMapper.buildDynamicResponse(
-        context, processConfiguration.response());
+    Map<String, Object> response =
+        IdentityVerificationDynamicResponseMapper.buildDynamicResponse(
+            context, processConfiguration.response());
+    return IdentityVerificationCallbackResponse.OK(response);
   }
 }

--- a/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/application/identity_verification_service/IdentityVerificationCallbackEntryService.java
+++ b/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/application/identity_verification_service/IdentityVerificationCallbackEntryService.java
@@ -183,7 +183,8 @@ public class IdentityVerificationCallbackEntryService implements IdentityVerific
 
     // Run the same pipeline as the application path: pre_hook (verifications +
     // additional_parameters) → execute. For callback processes (no execution block) execute is
-    // no_action, so the inbound result carried in the request is incorporated by updateCallbackWith.
+    // no_action, so the inbound result carried in the request is incorporated by
+    // updateCallbackWith.
     // This makes callback processes honor the same config as the application path. (#1522)
     IdentityVerificationApplications previousApplications =
         applicationQueryRepository.findHistory(

--- a/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/application/identity_verification_service/IdentityVerificationCallbackEntryService.java
+++ b/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/application/identity_verification_service/IdentityVerificationCallbackEntryService.java
@@ -183,7 +183,7 @@ public class IdentityVerificationCallbackEntryService implements IdentityVerific
 
     // Run the same pipeline as the application path: pre_hook (verifications +
     // additional_parameters) → execute. For callback processes (no execution block) execute is
-    // no_action, so the inbound result carried in the request is incorporated by updateProcessWith.
+    // no_action, so the inbound result carried in the request is incorporated by updateCallbackWith.
     // This makes callback processes honor the same config as the application path. (#1522)
     IdentityVerificationApplications previousApplications =
         applicationQueryRepository.findHistory(


### PR DESCRIPTION
## Summary

callback API 経路が `pre_hook` 検証（`process_sequence` 等）を実行しておらず、callback プロセスに設定した `dependencies` / `allow_retry` が**事実上無視されてバイパス可能**だった（設定と実装の矛盾）。callback 経路を application 経路と同じ `executeRequest` パイプラインに統一して解消する。

Closes #1522

## 原因

`IdentityVerificationCallbackEntryService` は callback リクエスト形式の validation のみで `application.updateCallbackWith(...)` を直接呼び、`IdentityVerificationApplicationRequestVerifiers`（pre_hook）を通っていなかった。pre_hook は application 経路（`executeRequest`）でのみ実行されていた。

## 変更内容

### callback を executeRequest に統一
- `IdentityVerificationCallbackEntryService`: `validate → updateCallbackWith` を、**`executeRequest`（pre_hook: verifications + additional_parameters → execute）→ updateCallbackWith** に統一。pre_hook エラーは `400 pre_hook_validation_failed` を返す。

### execution 未設定時の no_action デフォルト
- `IdentityVerificationExecutionConfig.executorType()` を追加。`execution` 省略時は `no_action`（サーバ側で実行する処理なし＝結果が外部から push される callback 等）。**非空の未知 type は従来どおり fail-loud**（typo を握りつぶさない）。

### merge は updateCallbackWith を維持（重要）
`updateProcessWith` との差は **fallback ステータスのみ**（callback → `EXAMINATION_PROCESSING` / process → `APPLYING`）。これは「審査待ち」を表す**正当な意味差**のため、callback の merge は据え置き。pipeline（pre_hook + execute）だけ統一。

## callback で新たに可能になること

- `pre_hook` の `process_sequence`（依存・再実行制御）/ `additional_parameters`
- `execution`（http_request 等）の実行と、その応答 **`$.response_body` による `transition` 駆動**（統一前は callback で response_body が存在せず不可能だった）

## テスト（実機 docker 確認済み）

### E2E（新規 `integration-14-callback-pre-hook-verification.test.js` / 3件）
| シナリオ | 期待 |
|---|---|
| 依存プロセス未完で callback 送信 | `400 pre_hook_validation_failed`（missing 依存）|
| `allow_retry: false` の callback 二重送信 | 2回目 `400`（does not allow retry）|
| callback で execution(http_request) 実行 → `$.response_body.status` で transition | application が `approved` |

### 回帰
- IDA integration **16 suites / 91 tests 全緑**、application 経路（`integration-03` process_sequence）維持、callback 承認（`integration-11`）維持。

## ドキュメント
- callback も同一フェーズで処理される旨、`execution` の `no_action` デフォルトを反映（config reference / how-to / spec skill）。

## スコープ外
- `post_hook`（Phase 4）は config 可能だが全経路で未実装の dead config。本PRとは独立した新機能として **#1611** に分離。

🤖 Generated with [Claude Code](https://claude.com/claude-code)