### PR TITLE
fix(identity-verification): process() の hard error で failure_count を記録 (#1608)

### DIFF
--- a/e2e/src/tests/integration/ida/integration-15-identity-verification-process-failure-count.test.js
+++ b/e2e/src/tests/integration/ida/integration-15-identity-verification-process-failure-count.test.js
@@ -1,0 +1,216 @@
+import { describe, expect, it, beforeAll, afterAll } from "@jest/globals";
+import { get, postWithJson, deletion } from "../../../lib/http";
+import { requestToken } from "../../../api/oauthClient";
+import {
+  backendUrl,
+  clientSecretPostClient,
+  serverConfig,
+  federationServerConfig,
+  mockApiBaseUrl
+} from "../../testConfig";
+import { createFederatedUser, registerFidoUaf } from "../../../user";
+import { v4 as uuidv4 } from "uuid";
+
+/**
+ * Regression test for Issue #1608
+ *
+ * Bug: IdentityVerificationApplicationEntryService.process() early-returned on
+ * applyingResult.isError() WITHOUT calling updateProcessWith / applicationCommandRepository.update,
+ * so a hard error (HTTP 4xx/5xx, timeout, connection failure) during a process execution was never
+ * recorded against the application. failure_count stayed 0, breaking failure_count-based
+ * conditions (lock_conditions / retry limits) and leaving no audit trail of the failed attempt.
+ *
+ * This test:
+ *   1. apply() succeeds (no_action) → an application exists.
+ *   2. A second process ("verify") whose execution calls the mock eKYC endpoint with status=500
+ *      hard-errors. The API returns 500 either way (the bug is about persistence, not the response).
+ *   3. The application is fetched back and the failed attempt MUST be recorded:
+ *      processes.verify = { call_count: 1, success_count: 0, failure_count: 1 }.
+ *   4. The original "apply" process counters MUST be preserved (the failed verify attempt only
+ *      touches its own process result; the empty error context makes the detail merge a no-op).
+ *   5. A second hard error increments the counters again (call_count: 2, failure_count: 2).
+ *
+ * Before the fix, step 3 fails because processes.verify is never persisted (undefined).
+ *
+ * Note: Requires the mock server at http://host.docker.internal:4000 (/e2e/error-responses).
+ */
+describe("Identity Verification: process() records failure_count on hard error (Issue #1608)", () => {
+  const orgId = serverConfig.organizationId;
+  const tenantId = serverConfig.tenantId;
+
+  let orgAccessToken;
+  const createdConfigIds = [];
+
+  beforeAll(async () => {
+    const orgAuthResponse = await requestToken({
+      endpoint: `${backendUrl}/${tenantId}/v1/tokens`,
+      grantType: "password",
+      username: "ito.ichiro@gmail.com",
+      password: "successUserCode001",
+      clientId: clientSecretPostClient.clientId,
+      clientSecret: clientSecretPostClient.clientSecret,
+      scope: "org-management account management"
+    });
+    expect(orgAuthResponse.status).toBe(200);
+    orgAccessToken = orgAuthResponse.data.access_token;
+  });
+
+  afterAll(async () => {
+    for (const configId of createdConfigIds) {
+      await deletion({
+        url: `${backendUrl}/v1/management/organizations/${orgId}/tenants/${tenantId}/identity-verification-configurations/${configId}`,
+        headers: { Authorization: `Bearer ${orgAccessToken}` }
+      }).catch(() => {});
+    }
+  });
+
+  const registerConfiguration = async (configurationData) => {
+    const response = await postWithJson({
+      url: `${backendUrl}/v1/management/organizations/${orgId}/tenants/${tenantId}/identity-verification-configurations`,
+      headers: {
+        "Authorization": `Bearer ${orgAccessToken}`,
+        "Content-Type": "application/json"
+      },
+      body: configurationData
+    });
+    expect(response.status).toBe(201);
+    createdConfigIds.push(configurationData.id);
+  };
+
+  const createTestUser = async () => {
+    const { user, accessToken } = await createFederatedUser({
+      serverConfig: serverConfig,
+      federationServerConfig: federationServerConfig,
+      client: clientSecretPostClient,
+      adminClient: clientSecretPostClient,
+      scope: "openid profile phone email identity_verification_application " + clientSecretPostClient.identityVerificationScope
+    });
+    await registerFidoUaf({ accessToken: accessToken });
+    return { user, accessToken };
+  };
+
+  const getApplication = async (accessToken, applicationId) => {
+    const response = await get({
+      url: `${serverConfig.identityVerificationApplicationsEndpoint}?id=${applicationId}`,
+      headers: { Authorization: `Bearer ${accessToken}` }
+    });
+    expect(response.status).toBe(200);
+    const application = response.data.list.find((a) => a.id === applicationId);
+    expect(application).toBeDefined();
+    return application;
+  };
+
+  it("records failure_count on the application when a process execution hard-errors", async () => {
+    const { accessToken } = await createTestUser();
+
+    const configId = uuidv4();
+    const type = uuidv4();
+
+    // apply: succeeds (no_action). verify: execution calls the mock eKYC endpoint which returns the
+    // HTTP status carried in the request body (status=500 / 503) → hard error.
+    await registerConfiguration({
+      "id": configId,
+      "type": type,
+      "attributes": { "enabled": true },
+      "common": { "auth_type": "none" },
+      "processes": {
+        "apply": {
+          "request": {
+            "schema": {
+              "type": "object",
+              "required": ["name"],
+              "properties": { "name": { "type": "string" } }
+            }
+          },
+          "execution": { "type": "no_action" },
+          "store": {
+            "application_details_mapping_rules": [{ "from": "$.request_body", "to": "*" }]
+          },
+          "transition": { "applying": { "any_of": [[]] } }
+        },
+        "verify": {
+          "request": {
+            "schema": {
+              "type": "object",
+              "properties": { "status": { "type": "string" } }
+            }
+          },
+          "execution": {
+            "type": "http_request",
+            "http_request": {
+              "url": `${mockApiBaseUrl}/e2e/error-responses`,
+              "method": "POST",
+              "auth_type": "none",
+              "body_mapping_rules": [{ "from": "$.request_body", "to": "*" }]
+            }
+          }
+        }
+      }
+    });
+
+    // Step 1: apply → an application is created
+    const applyUrl = serverConfig.identityVerificationApplyEndpoint
+      .replace("{type}", type)
+      .replace("{process}", "apply");
+    const applyResponse = await postWithJson({
+      url: applyUrl,
+      headers: { "Content-Type": "application/json", Authorization: `Bearer ${accessToken}` },
+      body: { name: "Test User" }
+    });
+    expect(applyResponse.status).toBe(200);
+    const applicationId = applyResponse.data.id;
+    expect(applicationId).toBeDefined();
+
+    // Baseline: apply recorded as one successful attempt.
+    const appBefore = await getApplication(accessToken, applicationId);
+    expect(appBefore.processes.apply).toEqual({
+      call_count: 1,
+      success_count: 1,
+      failure_count: 0
+    });
+
+    const verifyUrl = serverConfig.identityVerificationProcessEndpoint
+      .replace("{type}", type)
+      .replace("{id}", applicationId)
+      .replace("{process}", "verify");
+
+    // Step 2: first hard error (500)
+    const firstError = await postWithJson({
+      url: verifyUrl,
+      headers: { "Content-Type": "application/json", Authorization: `Bearer ${accessToken}` },
+      body: { status: "500" }
+    });
+    expect(firstError.status).toBe(500);
+
+    // Step 3: the failed attempt MUST be recorded against the application (the bug)
+    const appAfterFirst = await getApplication(accessToken, applicationId);
+    expect(appAfterFirst.processes.verify).toBeDefined();
+    expect(appAfterFirst.processes.verify).toEqual({
+      call_count: 1,
+      success_count: 0,
+      failure_count: 1
+    });
+
+    // Step 4: the apply counters MUST be untouched by the failed verify attempt
+    expect(appAfterFirst.processes.apply).toEqual({
+      call_count: 1,
+      success_count: 1,
+      failure_count: 0
+    });
+
+    // Step 5: a second hard error (503) increments the counters again
+    const secondError = await postWithJson({
+      url: verifyUrl,
+      headers: { "Content-Type": "application/json", Authorization: `Bearer ${accessToken}` },
+      body: { status: "503" }
+    });
+    expect(secondError.status).toBe(503);
+
+    const appAfterSecond = await getApplication(accessToken, applicationId);
+    expect(appAfterSecond.processes.verify).toEqual({
+      call_count: 2,
+      success_count: 0,
+      failure_count: 2
+    });
+  });
+});

--- a/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/application/enduser/IdentityVerificationApplicationEntryService.java
+++ b/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/application/enduser/IdentityVerificationApplicationEntryService.java
@@ -275,8 +275,16 @@ public class IdentityVerificationApplicationEntryService
             request,
             requestAttributes,
             verificationConfiguration);
-    if (applyingResult.isError()) {
+    // Record the process attempt for both success and hard error. updateProcessWith advances
+    // success_count or failure_count from applyingResult; on a hard error the merge is a no-op on
+    // the empty error context and the status falls back to APPLYING (same as a non-transitioning
+    // success), so failure_count-based conditions (lock_conditions / retry limits) work for hard
+    // errors too. (#1608)
+    IdentityVerificationApplication updated =
+        application.updateProcessWith(process, applyingResult, verificationConfiguration);
+    applicationCommandRepository.update(tenant, updated);
 
+    if (applyingResult.isError()) {
       SecurityEventType securityEventType =
           new SecurityEventType(type.name() + "_" + process.name() + "_" + "failure");
       eventPublisher.publish(
@@ -289,12 +297,8 @@ public class IdentityVerificationApplicationEntryService
       return applyingResult.errorResponse();
     }
 
-    IdentityVerificationApplication updated =
-        application.updateProcessWith(process, applyingResult, verificationConfiguration);
-    applicationCommandRepository.update(tenant, updated);
     SecurityEventType securityEventType =
         new SecurityEventType(type.name() + "_" + process.name() + "_" + "success");
-
     eventPublisher.publish(tenant, oAuthToken, securityEventType, requestAttributes);
 
     handleTerminalTransition(


### PR DESCRIPTION
## 概要

Closes #1608

`IdentityVerificationApplicationEntryService.process()` がプロセス実行の **hard error**（HTTP 4xx/5xx・timeout・接続失敗）時に `updateProcessWith` / `applicationCommandRepository.update` を呼ばず early return していたため、**失敗試行が application に記録されず `failure_count` が増えない**バグを修正。

## 影響

- `failure_count` ベースの条件（`lock_conditions` / リトライ上限）が hard error で機能しない
- プロセス履歴・監査に hard error の失敗試行が残らない
- soft な経路との不整合

## 原因と方針

`updateProcessWith` は元々 success/failure 両対応（`isSuccess() ? 0 : 1`）で設計されており、**早期 return がその failure 分岐をデッドコード化していた**のが根因。

→ error 経路も成功経路と同じく `updateProcessWith` + `update` を通すだけの**最小差分**（モデル無改造）。

設計を読み解いた上での判断:
- 空の error context でも **detail merge は no-op**（既存保持）、**status は APPLYING fallback**（= 非遷移の成功 process と同じ既存挙動）なので副作用なし
- `apply()` の error 経路は **application 作成前**のため対象外（Issue 記載どおり）
- callback 経路は `updateCallbackWith` が `failure_count` を持たない設計のため対象外

> 補足: 「status の非遷移 fallback を APPLYING にしている」こと自体の是非（前進 `REQUESTED→APPLYING` / 後退 `EXAMINATION_PROCESSING→APPLYING` の整理）は本 PR のスコープ外。別途検討。

## テスト

E2E `integration-15-identity-verification-process-failure-count.test.js` を追加:

1. `apply` 成功 → application 生成
2. `verify` プロセスの execution が mock eKYC で 500/503 → hard error
3. GET で `processes.verify.failure_count` が **1 → 2** とインクリメントされることを検証
4. `processes.apply` のカウンタが据え置きであることを検証

| | 修正前 | 修正後 |
|---|---|---|
| integration-15 | ❌ `processes.verify` 不在で fail | ✅ pass |
| IDA 統合 100 テスト | — | ✅ 回帰なし |

🤖 Generated with [Claude Code](https://claude.com/claude-code)