### PR TITLE
fix(notification-apns): 一過性エラー(too many concurrent streams 等)に送信リトライを追加 (#1539)

### DIFF
--- a/libs/idp-server-notification-apns-adapter/src/main/java/org/idp/server/notification/push/apns/ApnsConfiguration.java
+++ b/libs/idp-server-notification-apns-adapter/src/main/java/org/idp/server/notification/push/apns/ApnsConfiguration.java
@@ -16,7 +16,10 @@
 
 package org.idp.server.notification.push.apns;
 
+import java.time.Duration;
 import java.util.Map;
+import java.util.Set;
+import org.idp.server.platform.http.HttpRetryConfiguration;
 import org.idp.server.platform.json.JsonReadable;
 import org.idp.server.platform.notification.NotificationTemplate;
 
@@ -28,6 +31,15 @@ public class ApnsConfiguration implements JsonReadable {
   String keyContent;
   boolean production;
   Map<String, NotificationTemplate> templates;
+  // Optional send-retry tuning (#1539). When absent, defaults to a single 100ms retry.
+  Integer retryMaxRetries;
+  Long retryBackoffMillis;
+
+  private static final int DEFAULT_RETRY_MAX_RETRIES = 1;
+  private static final long DEFAULT_RETRY_BACKOFF_MILLIS = 100;
+  // 502 covers the IOException ("too many concurrent streams") mapped in ApnsNotifier#send.
+  // 4xx (BadDeviceToken / ExpiredProviderToken / Unregistered) are intentionally excluded.
+  private static final Set<Integer> RETRYABLE_STATUS_CODES = Set.of(429, 500, 502, 503, 504);
 
   public ApnsConfiguration() {}
 
@@ -68,5 +80,39 @@ public class ApnsConfiguration implements JsonReadable {
 
   public NotificationTemplate findTemplate(String key) {
     return templates.getOrDefault(key, new NotificationTemplate());
+  }
+
+  /**
+   * Send-retry policy for APNs, reusing the platform {@code HttpRetryStrategy}.
+   *
+   * <p>With no configuration present, this defaults to a <b>single retry with a 100ms backoff</b> —
+   * enough to absorb the transient HTTP/2 "too many concurrent streams" race that occurs when a
+   * burst oversubscribes the shared connection, while keeping the added latency bounded (CIBA
+   * backchannel requests wait on the send synchronously). Retryable responses are {@code
+   * 429/500/502/503/504}; the {@code IOException} raised by the stream race is mapped to 502 in
+   * {@code ApnsNotifier#send} so it is covered too. Permanent 4xx (BadDeviceToken /
+   * ExpiredProviderToken / Unregistered) are never retried.
+   *
+   * <p>Overridable per tenant via the APNs config JSON:
+   *
+   * <ul>
+   *   <li>{@code retry_max_retries} — number of retries (default 1; {@code <= 0} disables retry)
+   *   <li>{@code retry_backoff_millis} — fixed backoff in ms before each retry (default 100)
+   * </ul>
+   *
+   * @return retry configuration applied to every APNs send (#1539)
+   */
+  public HttpRetryConfiguration retryConfiguration() {
+    int maxRetries = retryMaxRetries != null ? retryMaxRetries : DEFAULT_RETRY_MAX_RETRIES;
+    if (maxRetries <= 0) {
+      return HttpRetryConfiguration.noRetry();
+    }
+    long backoffMillis =
+        retryBackoffMillis != null ? retryBackoffMillis : DEFAULT_RETRY_BACKOFF_MILLIS;
+    return HttpRetryConfiguration.builder()
+        .maxRetries(maxRetries)
+        .backoffDelays(Duration.ofMillis(backoffMillis))
+        .retryableStatusCodes(RETRYABLE_STATUS_CODES)
+        .build();
   }
 }

--- a/libs/idp-server-notification-apns-adapter/src/main/java/org/idp/server/notification/push/apns/ApnsNotifier.java
+++ b/libs/idp-server-notification-apns-adapter/src/main/java/org/idp/server/notification/push/apns/ApnsNotifier.java
@@ -16,19 +16,23 @@
 
 package org.idp.server.notification.push.apns;
 
+import java.io.IOException;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.time.LocalDateTime;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import org.idp.server.authentication.interactors.device.AuthenticationDeviceNotifier;
 import org.idp.server.core.openid.authentication.config.AuthenticationExecutionConfig;
 import org.idp.server.core.openid.identity.device.AuthenticationDevice;
 import org.idp.server.platform.date.SystemDateTime;
+import org.idp.server.platform.http.HttpRequestResult;
+import org.idp.server.platform.http.HttpRetryConfiguration;
+import org.idp.server.platform.http.HttpRetryStrategy;
 import org.idp.server.platform.jose.JsonWebSignature;
 import org.idp.server.platform.jose.JsonWebSignatureFactory;
 import org.idp.server.platform.json.JsonConverter;
@@ -39,6 +43,37 @@ import org.idp.server.platform.notification.NotificationChannel;
 import org.idp.server.platform.notification.NotificationResult;
 import org.idp.server.platform.notification.NotificationTemplate;
 
+/**
+ * {@link AuthenticationDeviceNotifier} implementation for Apple Push Notification service (APNs).
+ *
+ * <p>Pushes authentication challenges (CIBA / FIDO-UAF device notifications) to iOS devices over
+ * the APNs HTTP/2 API ({@code POST /3/device/{token}}).
+ *
+ * <h3>Connection &amp; authentication</h3>
+ *
+ * <ul>
+ *   <li><b>HTTP/2 only</b>: APNs requires HTTP/2, so a dedicated {@link HttpClient} pinned to
+ *       {@code HTTP_2} is used (the shared platform client is HTTP/1.1 and cannot be reused here).
+ *   <li><b>Provider token</b>: requests are authenticated with a JWT (ES256) bearer "provider
+ *       token" built from the tenant's APNs key, cached per tenant and refreshed on expiry (see
+ *       {@link #getOrCreateJwtToken}).
+ * </ul>
+ *
+ * <h3>Concurrency &amp; retry (#1539)</h3>
+ *
+ * <p>This notifier is a shared instance, so all tenants and concurrent CIBA requests multiplex over
+ * the same APNs HTTP/2 connection pool. Under a burst that oversubscribes a reused connection's
+ * {@code MAX_CONCURRENT_STREAMS}, {@code HttpClient#send} can throw the transient {@code
+ * IOException("too many concurrent streams")}. To avoid dropping notifications, {@link #send} maps
+ * that (and other transient failures) to a retryable status and retry/backoff is delegated to the
+ * platform {@link HttpRetryStrategy} — by default a single 100ms retry, tunable via {@link
+ * ApnsConfiguration#retryConfiguration()}.
+ *
+ * <h3>Security</h3>
+ *
+ * <p>The device {@code credential_payload} / provider key are never logged; only non-sensitive
+ * metadata (status, APNs reason, apns-id) is emitted on failures.
+ */
 public class ApnsNotifier implements AuthenticationDeviceNotifier {
 
   LoggerWrapper log = LoggerWrapper.getLogger(ApnsNotifier.class);
@@ -50,6 +85,8 @@ public class ApnsNotifier implements AuthenticationDeviceNotifier {
           .followRedirects(HttpClient.Redirect.NEVER)
           .build();
   JsonWebSignatureFactory jwsFactory = new JsonWebSignatureFactory();
+  // Retry/backoff is delegated to the shared platform strategy. Package-private for tests. (#1539)
+  HttpRetryStrategy retryStrategy = new HttpRetryStrategy();
 
   private static final String PRODUCTION_URL = "https://api.push.apple.com";
   private static final String DEVELOPMENT_URL = "https://api.sandbox.push.apple.com";
@@ -102,18 +139,7 @@ public class ApnsNotifier implements AuthenticationDeviceNotifier {
               .POST(HttpRequest.BodyPublishers.ofString(payload))
               .build();
 
-      HttpResponse<String> response =
-          httpClient.send(request, HttpResponse.BodyHandlers.ofString());
-
-      String apnsId = response.headers().firstValue("apns-id").orElse("unknown");
-
-      if (response.statusCode() == 200) {
-        log.info("APNs notification sent successfully, apns-id: {}", apnsId);
-        return NotificationResult.success("apns", Map.of("apns-id", apnsId));
-      } else {
-        String errorMessage = handleApnsError(response, apnsId, tenant);
-        return NotificationResult.failure("apns", errorMessage);
-      }
+      return sendWithRetry(tenant, request, apnsConfiguration.retryConfiguration());
 
     } catch (Exception e) {
       log.error("APNs notification failed: {}", e.getMessage());
@@ -121,44 +147,108 @@ public class ApnsNotifier implements AuthenticationDeviceNotifier {
     }
   }
 
-  String handleApnsError(HttpResponse<String> response, String apnsId, Tenant tenant) {
-    try {
-      int statusCode = response.statusCode();
-      String responseBody = response.body();
+  /**
+   * Sends the request, delegating retry/backoff to the shared {@link HttpRetryStrategy}. Transient
+   * failures — an {@link IOException} (e.g. the HTTP/2 "too many concurrent streams" thrown when a
+   * burst oversubscribes the shared connection, mapped to 502 in {@link #send}) and APNs 429 / 5xx
+   * — are retried per {@code retryConfig}; permanent 4xx (BadDeviceToken, etc.) are returned
+   * without retry. The retry budget is bounded ({@link ApnsConfiguration#retryConfiguration()}
+   * defaults to a single 100ms retry) because CIBA backchannel requests wait on this send
+   * synchronously. (#1539)
+   */
+  NotificationResult sendWithRetry(
+      Tenant tenant, HttpRequest request, HttpRetryConfiguration retryConfig) {
+    HttpRequestResult result = retryStrategy.executeWithRetry(request, retryConfig, this::send);
 
-      // Parse APNs error response
-      if (Objects.nonNull(responseBody) && !responseBody.isEmpty()) {
-        JsonNodeWrapper errorJson = JsonNodeWrapper.fromString(responseBody);
-        String reason = errorJson.getValueOrEmptyAsString("reason");
-        if (reason.isEmpty()) {
-          reason = "unknown";
-        }
-
-        log.warn(
-            "APNs notification failed - Status: {}, Reason: {}, APNs-ID: {}, Body: {}",
-            statusCode,
-            reason,
-            apnsId,
-            responseBody);
-
-        // Handle specific error cases
-        switch (reason) {
-          case "BadDeviceToken" -> log.warn("Invalid device token");
-          case "TopicDisallowed" -> log.warn("Topic not allowed");
-          case "ExpiredProviderToken" -> {
-            log.warn("JWT token expired, clearing cache");
-            jwtTokenCache.remove(createCacheKey(tenant));
-          }
-        }
-        return "Status: " + statusCode + ", Reason: " + reason;
-      } else {
-        log.warn("APNs notification failed - Status: {}, APNs-ID: {}", statusCode, apnsId);
-        return "Status: " + statusCode + ", APNs-ID: " + apnsId;
-      }
-    } catch (Exception e) {
-      log.error("Error parsing APNs error response: {}", e.getMessage());
-      return "Error parsing APNs response: " + e.getMessage();
+    String apnsId = firstHeader(result.headers(), "apns-id");
+    if (result.statusCode() == 200) {
+      log.info("APNs notification sent successfully, apns-id: {}", apnsId);
+      return NotificationResult.success("apns", Map.of("apns-id", apnsId));
     }
+
+    return NotificationResult.failure("apns", handleApnsError(result, apnsId, tenant));
+  }
+
+  /**
+   * Performs a single send. Checked exceptions are mapped to retryable status results (502/503) so
+   * the status-code-based {@link HttpRetryStrategy} can retry them — notably the HTTP/2 "too many
+   * concurrent streams" {@link IOException}. (#1539)
+   */
+  HttpRequestResult send(HttpRequest request) {
+    try {
+      HttpResponse<String> response =
+          httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+      return new HttpRequestResult(
+          response.statusCode(), response.headers().map(), parseBody(response.body()));
+    } catch (IOException e) {
+      log.warn("APNs send I/O error (mapped to 502 for retry): {}", e.getMessage());
+      return new HttpRequestResult(502, Map.of(), reasonBody(e.getMessage()));
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      return new HttpRequestResult(503, Map.of(), reasonBody("interrupted: " + e.getMessage()));
+    }
+  }
+
+  private JsonNodeWrapper parseBody(String body) {
+    if (body == null || body.isEmpty()) {
+      return JsonNodeWrapper.fromMap(Map.of());
+    }
+    try {
+      return JsonNodeWrapper.fromString(body);
+    } catch (Exception e) {
+      log.warn("Failed to parse APNs response body as JSON: {}", e.getMessage());
+      return JsonNodeWrapper.fromMap(Map.of());
+    }
+  }
+
+  private JsonNodeWrapper reasonBody(String reason) {
+    return JsonNodeWrapper.fromMap(Map.of("reason", reason == null ? "unknown" : reason));
+  }
+
+  private String firstHeader(Map<String, List<String>> headers, String name) {
+    if (headers != null) {
+      for (Map.Entry<String, List<String>> entry : headers.entrySet()) {
+        if (name.equalsIgnoreCase(entry.getKey())
+            && entry.getValue() != null
+            && !entry.getValue().isEmpty()) {
+          return entry.getValue().get(0);
+        }
+      }
+    }
+    return "unknown";
+  }
+
+  String handleApnsError(HttpRequestResult result, String apnsId, Tenant tenant) {
+    int statusCode = result.statusCode();
+    JsonNodeWrapper body = result.body();
+
+    if (body != null && body.exists() && body.contains("reason")) {
+      String reason = body.getValueOrEmptyAsString("reason");
+      if (reason.isEmpty()) {
+        reason = "unknown";
+      }
+
+      log.warn(
+          "APNs notification failed - Status: {}, Reason: {}, APNs-ID: {}",
+          statusCode,
+          reason,
+          apnsId);
+
+      // Handle specific error cases
+      switch (reason) {
+        case "BadDeviceToken" -> log.warn("Invalid device token");
+        case "TopicDisallowed" -> log.warn("Topic not allowed");
+        case "ExpiredProviderToken" -> {
+          log.warn("JWT token expired, clearing cache");
+          jwtTokenCache.remove(createCacheKey(tenant));
+        }
+        default -> {}
+      }
+      return "Status: " + statusCode + ", Reason: " + reason;
+    }
+
+    log.warn("APNs notification failed - Status: {}, APNs-ID: {}", statusCode, apnsId);
+    return "Status: " + statusCode + ", APNs-ID: " + apnsId;
   }
 
   String createApnsPayload(NotificationTemplate template, Tenant tenant) {

--- a/libs/idp-server-notification-apns-adapter/src/test/java/org/idp/server/notification/push/apns/ApnsConfigurationTest.java
+++ b/libs/idp-server-notification-apns-adapter/src/test/java/org/idp/server/notification/push/apns/ApnsConfigurationTest.java
@@ -20,6 +20,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.HashMap;
 import java.util.Map;
+import org.idp.server.platform.http.HttpRetryConfiguration;
 import org.idp.server.platform.notification.NotificationTemplate;
 import org.junit.jupiter.api.Test;
 
@@ -55,5 +56,32 @@ class ApnsConfigurationTest {
     NotificationTemplate template = config.findTemplate("nonexistent");
 
     assertNotNull(template);
+  }
+
+  @Test
+  void retryConfiguration_defaultsToSingleRetry() {
+    // No retry config in JSON → default: 1 retry, transient codes (incl. 502 for the IOException).
+    // (#1539)
+    HttpRetryConfiguration retry = new ApnsConfiguration().retryConfiguration();
+
+    assertEquals(1, retry.maxRetries());
+    assertTrue(retry.retryableStatusCodes().contains(502));
+    assertFalse(retry.retryableStatusCodes().contains(400));
+  }
+
+  @Test
+  void retryConfiguration_disabledWhenMaxRetriesNotPositive() {
+    ApnsConfiguration config = new ApnsConfiguration();
+    config.retryMaxRetries = 0;
+
+    assertEquals(0, config.retryConfiguration().maxRetries());
+  }
+
+  @Test
+  void retryConfiguration_honorsOverride() {
+    ApnsConfiguration config = new ApnsConfiguration();
+    config.retryMaxRetries = 3;
+
+    assertEquals(3, config.retryConfiguration().maxRetries());
   }
 }

--- a/libs/idp-server-notification-apns-adapter/src/test/java/org/idp/server/notification/push/apns/ApnsNotifierTest.java
+++ b/libs/idp-server-notification-apns-adapter/src/test/java/org/idp/server/notification/push/apns/ApnsNotifierTest.java
@@ -19,8 +19,19 @@ package org.idp.server.notification.push.apns;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpHeaders;
+import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import org.idp.server.platform.dependency.protocol.AuthorizationProvider;
+import org.idp.server.platform.http.HttpRequestResult;
+import org.idp.server.platform.http.HttpRetryConfiguration;
 import org.idp.server.platform.json.JsonNodeWrapper;
 import org.idp.server.platform.multi_tenancy.organization.OrganizationIdentifier;
 import org.idp.server.platform.multi_tenancy.tenant.*;
@@ -29,11 +40,14 @@ import org.idp.server.platform.multi_tenancy.tenant.config.SessionConfiguration;
 import org.idp.server.platform.multi_tenancy.tenant.config.UIConfiguration;
 import org.idp.server.platform.multi_tenancy.tenant.policy.TenantIdentityPolicy;
 import org.idp.server.platform.notification.NotificationChannel;
+import org.idp.server.platform.notification.NotificationResult;
 import org.idp.server.platform.notification.NotificationTemplate;
 import org.idp.server.platform.security.event.SecurityEventUserAttributeConfiguration;
 import org.idp.server.platform.security.log.SecurityEventLogConfiguration;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentMatchers;
+import org.mockito.stubbing.OngoingStubbing;
 
 class ApnsNotifierTest {
 
@@ -155,54 +169,127 @@ class ApnsNotifierTest {
 
   @Test
   void testHandleApnsErrorWithBadDeviceToken() {
-    Tenant tenant =
-        new Tenant(
-            new TenantIdentifier("test-tenant"),
-            new TenantName("Test Tenant"),
-            TenantType.PUBLIC,
-            new TenantDomain("test.example.com"),
-            new AuthorizationProvider("idp-server"),
-            new TenantAttributes(),
-            new UIConfiguration(),
-            new CorsConfiguration(),
-            new SessionConfiguration(),
-            new SecurityEventLogConfiguration(),
-            new SecurityEventUserAttributeConfiguration(),
-            TenantIdentityPolicy.defaultPolicy(),
-            new OrganizationIdentifier("test-org"),
-            true);
-
-    HttpResponse<String> response = mock(HttpResponse.class);
-    when(response.statusCode()).thenReturn(400);
-    when(response.body()).thenReturn("{\"reason\": \"BadDeviceToken\"}");
+    HttpRequestResult result =
+        new HttpRequestResult(
+            400, Map.of(), JsonNodeWrapper.fromString("{\"reason\": \"BadDeviceToken\"}"));
 
     // Should not throw exception
-    assertDoesNotThrow(() -> apnsNotifier.handleApnsError(response, "test-apns-id", tenant));
+    assertDoesNotThrow(() -> apnsNotifier.handleApnsError(result, "test-apns-id", tenant()));
   }
 
   @Test
   void testHandleApnsErrorWithExpiredToken() {
-    Tenant tenant =
-        new Tenant(
-            new TenantIdentifier("test-tenant"),
-            new TenantName("Test Tenant"),
-            TenantType.PUBLIC,
-            new TenantDomain("test.example.com"),
-            new AuthorizationProvider("idp-server"),
-            new TenantAttributes(),
-            new UIConfiguration(),
-            new CorsConfiguration(),
-            new SessionConfiguration(),
-            new SecurityEventLogConfiguration(),
-            new SecurityEventUserAttributeConfiguration(),
-            TenantIdentityPolicy.defaultPolicy(),
-            new OrganizationIdentifier("test-org"),
-            true);
+    HttpRequestResult result =
+        new HttpRequestResult(
+            403, Map.of(), JsonNodeWrapper.fromString("{\"reason\": \"ExpiredProviderToken\"}"));
 
-    HttpResponse<String> response = mock(HttpResponse.class);
-    when(response.statusCode()).thenReturn(403);
-    when(response.body()).thenReturn("{\"reason\": \"ExpiredProviderToken\"}");
+    assertDoesNotThrow(() -> apnsNotifier.handleApnsError(result, "test-apns-id", tenant()));
+  }
 
-    assertDoesNotThrow(() -> apnsNotifier.handleApnsError(response, "test-apns-id", tenant));
+  // ----- retry (#1539): delegated to HttpRetryStrategy -----
+
+  @Test
+  void sendWithRetry_retriesOnTransientIOException_thenSucceeds() throws Exception {
+    HttpClient mockClient = mock(HttpClient.class);
+    HttpResponse<String> ok = httpResponse(200, "", "apns-1");
+    whenSend(mockClient).thenThrow(new IOException("too many concurrent streams")).thenReturn(ok);
+    apnsNotifier.httpClient = mockClient;
+
+    NotificationResult result = apnsNotifier.sendWithRetry(tenant(), dummyRequest(), oneRetry());
+
+    assertTrue(result.isSuccess());
+    verify(mockClient, times(2)).send(any(), any());
+  }
+
+  @Test
+  void sendWithRetry_retriesOnTransient503_thenSucceeds() throws Exception {
+    HttpClient mockClient = mock(HttpClient.class);
+    HttpResponse<String> r503 = httpResponse(503, "{\"reason\":\"ServiceUnavailable\"}", "apns-1");
+    HttpResponse<String> ok = httpResponse(200, "", "apns-2");
+    whenSend(mockClient).thenReturn(r503, ok);
+    apnsNotifier.httpClient = mockClient;
+
+    NotificationResult result = apnsNotifier.sendWithRetry(tenant(), dummyRequest(), oneRetry());
+
+    assertTrue(result.isSuccess());
+    verify(mockClient, times(2)).send(any(), any());
+  }
+
+  @Test
+  void sendWithRetry_fails_whenRetryExhausted() throws Exception {
+    HttpClient mockClient = mock(HttpClient.class);
+    whenSend(mockClient).thenThrow(new IOException("too many concurrent streams"));
+    apnsNotifier.httpClient = mockClient;
+
+    NotificationResult result = apnsNotifier.sendWithRetry(tenant(), dummyRequest(), oneRetry());
+
+    assertTrue(result.isFailure());
+    verify(mockClient, times(2)).send(any(), any());
+  }
+
+  @Test
+  void sendWithRetry_doesNotRetry_onPermanent4xx() throws Exception {
+    HttpClient mockClient = mock(HttpClient.class);
+    HttpResponse<String> r400 = httpResponse(400, "{\"reason\":\"BadDeviceToken\"}", "apns-1");
+    HttpResponse<String> ok = httpResponse(200, "", "apns-2");
+    whenSend(mockClient).thenReturn(r400, ok);
+    apnsNotifier.httpClient = mockClient;
+
+    NotificationResult result = apnsNotifier.sendWithRetry(tenant(), dummyRequest(), oneRetry());
+
+    assertTrue(result.isFailure());
+    verify(mockClient, times(1)).send(any(), any());
+  }
+
+  // ----- helpers -----
+
+  private static OngoingStubbing<HttpResponse<String>> whenSend(HttpClient client)
+      throws Exception {
+    return when(
+        client.send(
+            ArgumentMatchers.any(HttpRequest.class),
+            ArgumentMatchers.<HttpResponse.BodyHandler<String>>any()));
+  }
+
+  @SuppressWarnings("unchecked")
+  private static HttpResponse<String> httpResponse(int status, String body, String apnsId) {
+    HttpResponse<String> resp = mock(HttpResponse.class);
+    when(resp.statusCode()).thenReturn(status);
+    when(resp.body()).thenReturn(body);
+    when(resp.headers())
+        .thenReturn(HttpHeaders.of(Map.of("apns-id", List.of(apnsId)), (a, b) -> true));
+    return resp;
+  }
+
+  private static HttpRequest dummyRequest() {
+    return HttpRequest.newBuilder(URI.create("https://api.push.apple.com/3/device/x"))
+        .POST(HttpRequest.BodyPublishers.ofString("{}"))
+        .build();
+  }
+
+  private static HttpRetryConfiguration oneRetry() {
+    return HttpRetryConfiguration.builder()
+        .maxRetries(1)
+        .backoffDelays(Duration.ofMillis(0))
+        .retryableStatusCodes(Set.of(429, 500, 502, 503, 504))
+        .build();
+  }
+
+  private static Tenant tenant() {
+    return new Tenant(
+        new TenantIdentifier("test-tenant"),
+        new TenantName("Test Tenant"),
+        TenantType.PUBLIC,
+        new TenantDomain("test.example.com"),
+        new AuthorizationProvider("idp-server"),
+        new TenantAttributes(),
+        new UIConfiguration(),
+        new CorsConfiguration(),
+        new SessionConfiguration(),
+        new SecurityEventLogConfiguration(),
+        new SecurityEventUserAttributeConfiguration(),
+        TenantIdentityPolicy.defaultPolicy(),
+        new OrganizationIdentifier("test-org"),
+        true);
   }
 }


### PR DESCRIPTION
## 概要

Closes #1539

CIBA / FIDO-UAF のバーストで多数の APNs 通知が **1個の共有 HttpClient** に集約され、APNs 接続の `MAX_CONCURRENT_STREAMS` を超えると HTTP/2 の `too many concurrent streams` (IOException) が発生。`ApnsNotifier#notify` はこれを即 `failure` にしリトライしないため、一過性の衝突で**プッシュが欠損**していた。

> 発生機序・ローカル再現・対策の実測は #1539 のコメント（[調査メモ](https://github.com/hirokazu-kobayashi-koba-hiro/idp-server/issues/1539#issuecomment-4718078458)）参照。1回リトライで中度超過 90% / 軽度超過 95% のエラー削減を確認済み。

## 変更内容

- **自前リトライではなく platform の `HttpRetryStrategy` / `HttpRetryConfiguration` を再利用**（APNs は HTTP/2 必須・汎用クライアントは HTTP/1.1 のため専用 HttpClient は維持し、retry/backoff のみ委譲）
- `ApnsNotifier#send`: 単発送信。`IOException`→502 / `InterruptedException`→503 に寄せ、status ベースの strategy がリトライできるようにする（対象 `429/500/502/503/504`）
- **4xx（BadDeviceToken / ExpiredProviderToken / Unregistered 等）は対象外＝即 failure**（Issue 仕様どおり）
- リトライ回数・バックオフは `ApnsConfiguration` で設定可能（`retry_max_retries` / `retry_backoff_millis`）。**デフォルトは 1 回・100ms**（同期 CIBA のレイテンシ配慮）
- `handleApnsError` を `HttpRequestResult` ベースに変更、クラス Javadoc を追加

## テスト

- `ApnsNotifierTest`: リトライ4ケース（IOException→成功 / 503→成功 / 枯渇→失敗 / 4xx→即失敗、送信回数を `verify`）
- `ApnsConfigurationTest`: デフォルト挙動ガード3ケース（既定1回 / `<=0` で無効化 / 上書き）
- モジュールテスト全緑・spotless 適用済み

## スコープ外

- Semaphore による並行制御（過剰並列の入口制御）は別Issueで検討（リトライは「まれな一過性」向け、恒常的過負荷には admission control が必要）

🤖 Generated with [Claude Code](https://claude.com/claude-code)