### PR TITLE
fix(verified-claims): verification 要件未達/クレーム不在時に verified_claims 全体を省略 (OIDC4IDA 5.7.4/5.7.5) (#1512)

### DIFF
--- a/e2e/src/tests/spec/oidc_for_identity_assurance.test.js
+++ b/e2e/src/tests/spec/oidc_for_identity_assurance.test.js
@@ -127,6 +127,81 @@ describe("OpenID Connect for Identity Assurance 1.0 ", () => {
 
   });
 
+  // OpenID Connect for Identity Assurance 1.0, Section 5.7 (Returning less data than requested).
+  // Test names quote the spec verbatim, as in the Section 8 block. verified_claims is requested via
+  // the `claims` parameter and returned in the ID Token (handled by VerifiedClaimsCreator).
+  //
+  // Regression for #1512. §5.7.4 (Data not matching requirements) states:
+  //   "If the respective requirement was expressed for a claim within verified_claims/verification,
+  //    the OP shall omit the whole verified_claims element."
+  //   "Otherwise, the OP shall omit the respective claim from the response."
+  //   "In both cases, the OP shall not return an error to the RP."
+  describe("Section 5.7 Returning less data than requested", () => {
+    // The default end-user (ito.ichiro@gmail.com) has stored verified_claims with
+    // verification.trust_framework = "eidas" and claims given_name/family_name/birthdate/address.
+    // middle_name and gender are intentionally NOT stored, so requests for them are "unavailable".
+    const idTokenVerifiedClaims = async (verifiedClaimsRequest) => {
+      const { authorizationResponse } = await requestAuthorizations({
+        endpoint: serverConfig.authorizationEndpoint,
+        clientId: clientSecretPostClient.clientId,
+        responseType: "code",
+        state: "verified_claims_5_7",
+        scope: "openid " + clientSecretPostClient.scope,
+        redirectUri: clientSecretPostClient.redirectUri,
+        claims: JSON.stringify({ id_token: { verified_claims: verifiedClaimsRequest } }),
+      });
+      expect(authorizationResponse.code).not.toBeNull();
+
+      const tokenResponse = await requestToken({
+        endpoint: serverConfig.tokenEndpoint,
+        code: authorizationResponse.code,
+        grantType: "authorization_code",
+        redirectUri: clientSecretPostClient.redirectUri,
+        clientId: clientSecretPostClient.clientId,
+        clientSecret: clientSecretPostClient.clientSecret,
+      });
+      // §5.7.4: "In both cases, the OP shall not return an error to the RP."
+      expect(tokenResponse.status).toBe(200);
+      expect(tokenResponse.data).toHaveProperty("id_token");
+
+      const jwksResponse = await getJwks({ endpoint: serverConfig.jwksEndpoint });
+      const decodedIdToken = verifyAndDecodeJwt({
+        jwt: tokenResponse.data.id_token,
+        jwks: jwksResponse.data,
+      });
+      expect(decodedIdToken.verifyResult).toBe(true);
+      return decodedIdToken.payload;
+    };
+
+    it("If the OP does not have data about a certain claim, does not understand/support the respective claim, OPs shall omit the respective claim from any corresponding ID Token or UserInfo response.", async () => {
+      // given_name is available; middle_name is not. The unavailable claim is dropped, but
+      // verified_claims is still returned because at least one requested claim is available.
+      const payload = await idTokenVerifiedClaims({
+        verification: { trust_framework: null },
+        claims: { given_name: null, middle_name: null },
+      });
+      console.log(JSON.stringify(payload.verified_claims, null, 2));
+
+      expect(payload.verified_claims).toBeDefined();
+      expect(payload.verified_claims.verification.trust_framework).toEqual("eidas");
+      expect(payload.verified_claims.claims.given_name).toEqual("Sarah");
+      expect(payload.verified_claims.claims).not.toHaveProperty("middle_name");
+    });
+
+    it("If an element is to be omitted according to the rules above, but is a requirement for a valid response, the OP shall omit its parent element as well.", async () => {
+      // #1512: every requested verified claim is unavailable, so the claims element would be empty.
+      // claims is a requirement for a valid verified_claims, so the whole verified_claims element is
+      // omitted — it must NOT be returned as {"verification": {...}, "claims": {}}.
+      const payload = await idTokenVerifiedClaims({
+        verification: { trust_framework: null },
+        claims: { middle_name: null, gender: null },
+      });
+      console.log(JSON.stringify(payload, null, 2));
+
+      expect(payload.verified_claims).toBeUndefined();
+    });
+  });
+
   // OpenID Connect for Identity Assurance 1.0, Section 8 (OpenID Provider Metadata).
   // Test names quote the spec verbatim. See issue #1513.
   describe("Section 8 OpenID Provider Metadata", () => {

--- a/libs/idp-server-core-extension-ida/src/main/java/org/idp/server/core/extension/identity/verified/VerifiedClaimsCreator.java
+++ b/libs/idp-server-core-extension-ida/src/main/java/org/idp/server/core/extension/identity/verified/VerifiedClaimsCreator.java
@@ -30,8 +30,47 @@ import org.idp.server.core.openid.identity.id_token.plugin.CustomIndividualClaim
 import org.idp.server.core.openid.oauth.configuration.AuthorizationServerConfiguration;
 import org.idp.server.core.openid.oauth.configuration.client.ClientConfiguration;
 import org.idp.server.platform.json.JsonNodeWrapper;
+import org.idp.server.platform.log.LoggerWrapper;
 
+/**
+ * Builds the OIDC4IDA {@code verified_claims} element returned in the ID Token, from the {@code
+ * claims} request parameter (its {@code id_token.verified_claims} member).
+ *
+ * <p>The output follows the OpenID Connect for Identity Assurance 1.0 structure (§5.1): a {@code
+ * verification} object — whose {@code trust_framework} is REQUIRED — plus a {@code claims} object
+ * carrying the verified end-user claims.
+ *
+ * <h3>Returning less data than requested (§5.7)</h3>
+ *
+ * <p>Only data the user actually has is returned, and the element is omitted entirely when it
+ * cannot be formed validly — never returned as a partial/empty shell such as {@code
+ * {"verification": {}, "claims": {...}}} or {@code {"verification": {...}, "claims": {}}}:
+ *
+ * <ul>
+ *   <li><b>§5.7.2 Unavailable data</b>: "If the OP does not have data about a certain claim, does
+ *       not understand/support the respective claim, OPs shall omit the respective claim from any
+ *       corresponding ID Token or UserInfo response." Each requested claim is included only when
+ *       present on the user.
+ *   <li><b>§5.7.4 Data not matching requirements</b>: "the OP shall omit the whole verified_claims
+ *       element" / "the OP shall not return an error to the RP." When the verification requirement
+ *       cannot be met (no {@code trust_framework}), the whole element is omitted rather than
+ *       emitting a schema-invalid {@code verification}.
+ *   <li><b>§5.7.5 Omitting elements</b>: "If an element is to be omitted according to the rules
+ *       above, but is a requirement for a valid response, the OP shall omit its parent element as
+ *       well." When no requested claim is available the {@code claims} object would be empty; since
+ *       {@code claims} is required for a valid {@code verified_claims}, the whole element is
+ *       omitted.
+ * </ul>
+ *
+ * <p>The scope-based selective path (access token / UserInfo) is handled by {@link
+ * SelectiveVerifiedClaims}, which applies the same §5.7 omission rules.
+ *
+ * @see <a href="https://openid.net/specs/openid-connect-4-identity-assurance-1_0.html">OpenID
+ *     Connect for Identity Assurance 1.0</a>
+ */
 public class VerifiedClaimsCreator implements CustomIndividualClaimsCreator {
+
+  private static final LoggerWrapper log = LoggerWrapper.getLogger(VerifiedClaimsCreator.class);
 
   @Override
   public boolean shouldCreate(
@@ -118,6 +157,22 @@ public class VerifiedClaimsCreator implements CustomIndividualClaimsCreator {
     if (claimsNodeWrapper.contains("email_verified") && userClaims.contains("email_verified")) {
       verifiedClaims.put("email_verified", userVerifiedClaims.getValueAsBoolean("email_verified"));
     }
+    // OIDC4IDA §5.7.4 / §5.7.5: when no requested claim matched a user claim, omit verified_claims
+    // entirely rather than emit an empty claims object (and leak verification metadata).
+    if (verifiedClaims.isEmpty()) {
+      return claims;
+    }
+
+    // IDA schema §5.1 / OIDC4IDA §5.7.4: verification.trust_framework is REQUIRED. Without it the
+    // verification requirement cannot be met, so omit verified_claims entirely rather than emit a
+    // schema-invalid verification block (e.g. an empty {} or one carrying only evidence).
+    if (!verification.containsKey("trust_framework")) {
+      log.warn(
+          "verified_claims omitted: stored verification has no required trust_framework"
+              + " (check the tenant's verified_claims mapping configuration)");
+      return claims;
+    }
+
     verified.put("verification", verification);
     verified.put("claims", verifiedClaims);
     claims.put("verified_claims", verified);

--- a/libs/idp-server-core-extension-ida/src/test/java/org/idp/server/core/extension/identity/verified/VerifiedClaimsCreatorTest.java
+++ b/libs/idp-server-core-extension-ida/src/test/java/org/idp/server/core/extension/identity/verified/VerifiedClaimsCreatorTest.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2025 Hirokazu Kobayashi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.idp.server.core.extension.identity.verified;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.idp.server.core.openid.identity.User;
+import org.idp.server.core.openid.identity.id_token.RequestedClaimsPayload;
+import org.idp.server.platform.json.JsonConverter;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Regression for the OIDC4IDA verified_claims output in the ID Token ({@code claims} parameter)
+ * path.
+ *
+ * <p>OIDC4IDA §5.7.4 / §5.7.5: when the {@code verification} requirement cannot be met (no required
+ * {@code trust_framework}) or no requested claim matches a user claim, the OP SHALL omit the whole
+ * {@code verified_claims} element rather than emit a schema-invalid {@code verification: {}} or an
+ * empty {@code claims} object. This mirrors {@link SelectiveVerifiedClaims} (scope-based path).
+ */
+class VerifiedClaimsCreatorTest {
+
+  private final VerifiedClaimsCreator creator = new VerifiedClaimsCreator();
+
+  /** Builds the RP request payload from the {@code verified_claims} request object (snake_case). */
+  private static RequestedClaimsPayload request(String verifiedClaimsRequestJson) {
+    String json = "{\"id_token\":{\"verified_claims\":" + verifiedClaimsRequestJson + "}}";
+    return JsonConverter.snakeCaseInstance().read(json, RequestedClaimsPayload.class);
+  }
+
+  private static User userWith(Map<String, Object> verification, Map<String, Object> claims) {
+    Map<String, Object> verifiedClaims = new HashMap<>();
+    verifiedClaims.put("verification", verification);
+    verifiedClaims.put("claims", claims);
+    return new User().setVerifiedClaims(verifiedClaims);
+  }
+
+  private Map<String, Object> create(User user, RequestedClaimsPayload payload) {
+    return creator.create(user, null, null, null, payload, null, null);
+  }
+
+  @SuppressWarnings("unchecked")
+  private static Map<String, Object> structure(Map<String, Object> result) {
+    return (Map<String, Object>) result.get("verified_claims");
+  }
+
+  @SuppressWarnings("unchecked")
+  private static Map<String, Object> verificationOf(Map<String, Object> result) {
+    return (Map<String, Object>) structure(result).get("verification");
+  }
+
+  @SuppressWarnings("unchecked")
+  private static Map<String, Object> claimsOf(Map<String, Object> result) {
+    return (Map<String, Object>) structure(result).get("claims");
+  }
+
+  @Test
+  void omitsVerifiedClaimsWhenUserHasNoTrustFramework() {
+    // #1512 repro: RP requests verification.trust_framework + a claim, but the user's stored
+    // verification has no trust_framework. §5.7.4: omit verified_claims entirely (must NOT return
+    // {"verified_claims": {"verification": {}, "claims": {...}}}).
+    User user = userWith(new HashMap<>(), Map.of("given_name", "Taro"));
+    RequestedClaimsPayload payload =
+        request("{\"verification\":{\"trust_framework\":null},\"claims\":{\"given_name\":null}}");
+
+    Map<String, Object> result = create(user, payload);
+
+    assertFalse(
+        result.containsKey("verified_claims"),
+        "verification requirement unmet (no trust_framework) must emit no verified_claims");
+  }
+
+  @Test
+  void emitsVerifiedClaimsWhenVerificationAndClaimsPresent() {
+    User user =
+        userWith(
+            Map.of("trust_framework", "eidas"),
+            Map.of("given_name", "Taro", "family_name", "Yamada"));
+    RequestedClaimsPayload payload =
+        request(
+            "{\"verification\":{\"trust_framework\":null},"
+                + "\"claims\":{\"given_name\":null,\"family_name\":null}}");
+
+    Map<String, Object> result = create(user, payload);
+
+    assertTrue(result.containsKey("verified_claims"));
+    assertEquals("eidas", verificationOf(result).get("trust_framework"));
+    assertEquals("Taro", claimsOf(result).get("given_name"));
+    assertEquals("Yamada", claimsOf(result).get("family_name"));
+  }
+
+  @Test
+  void omitsVerifiedClaimsWhenNoRequestedClaimMatches() {
+    // §5.7.5: parent (verified_claims) requires claims; with no matching claim, omit the parent
+    // rather than emit verification with an empty claims object.
+    User user = userWith(Map.of("trust_framework", "eidas"), Map.of("family_name", "Yamada"));
+    RequestedClaimsPayload payload =
+        request("{\"verification\":{\"trust_framework\":null},\"claims\":{\"given_name\":null}}");
+
+    Map<String, Object> result = create(user, payload);
+
+    assertFalse(
+        result.containsKey("verified_claims"),
+        "no matching claim must emit no verified_claims at all");
+  }
+
+  @Test
+  void omitsVerifiedClaimsWhenVerificationHasOnlyEvidenceWithoutTrustFramework() {
+    // Guards the trust_framework check (vs. a plain verification.isEmpty() check): the user's
+    // verification carries evidence but no trust_framework, so verification is non-empty yet
+    // schema-invalid. §5.7.4: still omit verified_claims.
+    Map<String, Object> verification = new HashMap<>();
+    verification.put("evidence", List.of(Map.of("type", "electronic_record")));
+    User user = userWith(verification, Map.of("given_name", "Taro"));
+    RequestedClaimsPayload payload =
+        request(
+            "{\"verification\":{\"trust_framework\":null,\"evidence\":null},"
+                + "\"claims\":{\"given_name\":null}}");
+
+    Map<String, Object> result = create(user, payload);
+
+    assertFalse(
+        result.containsKey("verified_claims"),
+        "verification without the required trust_framework must emit no verified_claims");
+  }
+}


### PR DESCRIPTION
## 概要

Closes #1512

`VerifiedClaimsCreator`（ID Token の `claims` パラメータ経路）が `verification` が空でも `verified_claims` を返してしまい、OIDC4IDA §5.7.4 / §5.7.5 に違反していた。`{"verified_claims": {"verification": {}, "claims": {...}}}` のような不正/空シェルを返さないよう、リファレンス実装 `SelectiveVerifiedClaims`（scope 経路）と挙動を揃えた。

## 仕様要件（OIDC4IDA 1.0, §5.7）

> **§5.7.4 Data not matching requirements** — "the OP shall omit the whole verified_claims element" / "the OP shall not return an error to the RP."
>
> **§5.7.5 Omitting elements** — "If an element is to be omitted according to the rules above, but is a requirement for a valid response, the OP shall omit its parent element as well."

## 変更内容

- **claims が空**（要求クレームがどれもユーザーに無い）→ `verified_claims` 全体を省略（§5.7.5）
- **`verification.trust_framework` 欠如** → warn ログ＋ `verified_claims` 全体を省略（§5.7.4）
  - Issue 案の `verification.isEmpty()` ではなく **`trust_framework` 有無**で判定。`evidence` のみで `trust_framework` 欠如の schema 不正ケースも正しく弾くため
- 兄弟2クラス（AT / UserInfo）は `SelectiveVerifiedClaims` 委譲済みでバグ無し。修正対象はこの1ファイルのみ
- クラス Javadoc に §5.7.2 / §5.7.4 / §5.7.5 を**原文引用**＋ spec リンクを追加

## テスト

- **unit**: `VerifiedClaimsCreatorTest`（4ケース）— trust_framework 欠如→省略 / 正常 emit / クレーム不一致→省略 / evidence のみ trust_framework 欠如→省略
- **E2E**: `oidc_for_identity_assurance.test.js` の `Section 5.7`（2ケース、テスト名は spec 原文 verbatim）
  - デプロイ前の実サーバで §5.7.5 ケースが `{"claims": {}, "verification": {"trust_framework": "eidas"}}` を返す**バグを実再現（赤）→ fix 反映後に緑**を確認済み
- モジュールテスト全緑・spotless 適用済み

## フォローアップ

- §5.7.4 のもう一方のトリガー（`value`/`values` 制約と不一致 → 省略）は未対応。別Issue #1624 で対応予定

🤖 Generated with [Claude Code](https://claude.com/claude-code)
