### PR TITLE
fix(verified-claims): value/values 制約を enforce し VerifiedClaimsCreator を統一 (OIDC4IDA 5.5.1/5.7.4) (#1624)

### DIFF
--- a/e2e/src/tests/spec/oidc_for_identity_assurance.test.js
+++ b/e2e/src/tests/spec/oidc_for_identity_assurance.test.js
@@ -200,6 +200,46 @@ describe("OpenID Connect for Identity Assurance 1.0 ", () => {
 
       expect(payload.verified_claims).toBeUndefined();
     });
+
+    // §5.7.4 value/values constraint enforcement (#1624). The user holds trust_framework "eidas"
+    // and given_name "Sarah" / family_name "Meredyth".
+    it("If the respective requirement was expressed for a claim within verified_claims/verification, the OP shall omit the whole verified_claims element.", async () => {
+      // RP constrains verification.trust_framework to "gold", but the user has "eidas" → the
+      // verification requirement is unmet, so the whole verified_claims is omitted.
+      const payload = await idTokenVerifiedClaims({
+        verification: { trust_framework: { value: "gold" } },
+        claims: { given_name: null },
+      });
+      console.log(JSON.stringify(payload, null, 2));
+
+      expect(payload.verified_claims).toBeUndefined();
+    });
+
+    it("Otherwise, the OP shall omit the respective claim from the response.", async () => {
+      // RP constrains given_name to "Bob" (mismatch → dropped), family_name is unconstrained (kept).
+      // The mismatch is on a claims element, so only that claim is omitted; verified_claims remains.
+      const payload = await idTokenVerifiedClaims({
+        verification: { trust_framework: null },
+        claims: { given_name: { value: "Bob" }, family_name: null },
+      });
+      console.log(JSON.stringify(payload.verified_claims, null, 2));
+
+      expect(payload.verified_claims).toBeDefined();
+      expect(payload.verified_claims.claims.family_name).toEqual("Meredyth");
+      expect(payload.verified_claims.claims).not.toHaveProperty("given_name");
+    });
+
+    it("returns the claim when its value/values constraint is satisfied", async () => {
+      const payload = await idTokenVerifiedClaims({
+        verification: { trust_framework: { value: "eidas" } },
+        claims: { given_name: { values: ["Hanako", "Sarah"] } },
+      });
+      console.log(JSON.stringify(payload.verified_claims, null, 2));
+
+      expect(payload.verified_claims).toBeDefined();
+      expect(payload.verified_claims.verification.trust_framework).toEqual("eidas");
+      expect(payload.verified_claims.claims.given_name).toEqual("Sarah");
+    });
   });
 
   // OpenID Connect for Identity Assurance 1.0, Section 8 (OpenID Provider Metadata).

--- a/libs/idp-server-core-extension-ida/src/main/java/org/idp/server/core/extension/identity/verified/VerifiedClaimsCreator.java
+++ b/libs/idp-server-core-extension-ida/src/main/java/org/idp/server/core/extension/identity/verified/VerifiedClaimsCreator.java
@@ -52,15 +52,21 @@ import org.idp.server.platform.log.LoggerWrapper;
  *       corresponding ID Token or UserInfo response." Each requested claim is included only when
  *       present on the user.
  *   <li><b>§5.7.4 Data not matching requirements</b>: "the OP shall omit the whole verified_claims
- *       element" / "the OP shall not return an error to the RP." When the verification requirement
- *       cannot be met (no {@code trust_framework}), the whole element is omitted rather than
- *       emitting a schema-invalid {@code verification}.
+ *       element" / "the OP shall not return an error to the RP." A requested {@code value} / {@code
+ *       values} constraint (OpenID Connect §5.5.1) is enforced: a mismatch on a {@code
+ *       verification} element (or a missing required {@code trust_framework}) omits the whole
+ *       {@code verified_claims}; a mismatch on a {@code claims} element omits just that claim.
  *   <li><b>§5.7.5 Omitting elements</b>: "If an element is to be omitted according to the rules
  *       above, but is a requirement for a valid response, the OP shall omit its parent element as
  *       well." When no requested claim is available the {@code claims} object would be empty; since
  *       {@code claims} is required for a valid {@code verified_claims}, the whole element is
  *       omitted.
  * </ul>
+ *
+ * <p>{@code trust_framework} is the REQUIRED floor of {@code verification}: it is returned whenever
+ * the user holds it, never gated behind an explicit request. Verified claims are resolved
+ * dynamically against the user's stored claims (no fixed claim list); other {@code verification}
+ * elements (e.g. {@code evidence}, which can carry PII) are opt-in via explicit request.
  *
  * <p>The scope-based selective path (access token / UserInfo) is handled by {@link
  * SelectiveVerifiedClaims}, which applies the same §5.7 omission rules.
@@ -97,86 +103,140 @@ public class VerifiedClaimsCreator implements CustomIndividualClaimsCreator {
       ClientConfiguration clientConfiguration) {
 
     RequestedIdTokenClaims requestedIdTokenClaims = requestedClaimsPayload.idToken();
-
-    HashMap<String, Object> claims = new HashMap<>();
-
-    VerifiedClaimsObject verifiedClaimsObject = requestedIdTokenClaims.verifiedClaims();
+    VerifiedClaimsObject requested = requestedIdTokenClaims.verifiedClaims();
     JsonNodeWrapper userVerifiedClaims = user.verifiedClaimsNodeWrapper();
-    Map<String, Object> verified = new HashMap<>();
 
-    JsonNodeWrapper verificationNodeWrapper = verifiedClaimsObject.verificationNodeWrapper();
-    Map<String, Object> verification = new HashMap<>();
-    JsonNodeWrapper verificationClaim = userVerifiedClaims.getValueAsJsonNode("verification");
-    if (verificationNodeWrapper.contains("trust_framework")
-        && verificationClaim.contains("trust_framework")) {
-      verification.put(
-          "trust_framework", verificationClaim.getValueOrEmptyAsString("trust_framework"));
-    }
-    if (verificationNodeWrapper.contains("evidence") && verificationClaim.contains("evidence")) {
-      verification.put("evidence", verificationClaim.getValueAsJsonNodeListAsMap("evidence"));
-    }
+    HashMap<String, Object> result = new HashMap<>();
 
-    JsonNodeWrapper claimsNodeWrapper = verifiedClaimsObject.claimsNodeWrapper();
-    JsonNodeWrapper userClaims = userVerifiedClaims.getValueAsJsonNode("claims");
-    Map<String, Object> verifiedClaims = new HashMap<>();
-    if (claimsNodeWrapper.contains("name") && userClaims.contains("name")) {
-      verifiedClaims.put("name", userClaims.getValueOrEmptyAsString("name"));
-    }
-    if (claimsNodeWrapper.contains("given_name") && userClaims.contains("given_name")) {
-      verifiedClaims.put("given_name", userClaims.getValueOrEmptyAsString("given_name"));
-    }
-    if (claimsNodeWrapper.contains("family_name") && userClaims.contains("family_name")) {
-      verifiedClaims.put("family_name", userClaims.getValueOrEmptyAsString("family_name"));
-    }
-    if (claimsNodeWrapper.contains("middle_name") && userClaims.contains("middle_name")) {
-      verifiedClaims.put("middle_name", userClaims.getValueOrEmptyAsString("middle_name"));
-    }
-    if (claimsNodeWrapper.contains("gender") && userClaims.contains("gender")) {
-      verifiedClaims.put("gender", userClaims.getValueOrEmptyAsString("gender"));
-    }
-    if (claimsNodeWrapper.contains("birthdate") && userClaims.contains("birthdate")) {
-      verifiedClaims.put("birthdate", userClaims.getValueOrEmptyAsString("birthdate"));
-    }
-    if (claimsNodeWrapper.contains("locale") && userClaims.contains("locale")) {
-      verifiedClaims.put("locale", userClaims.getValueOrEmptyAsString("locale"));
-    }
-    if (claimsNodeWrapper.contains("address") && userClaims.contains("address")) {
-      verifiedClaims.put("address", userClaims.getValueAsJsonNode("address").toMap());
-    }
-    if (claimsNodeWrapper.contains("phone_number") && userClaims.contains("phone_number")) {
-      verifiedClaims.put("phone_number", userClaims.getValueOrEmptyAsString("phone_number"));
-    }
-    if (claimsNodeWrapper.contains("phone_number_verified")
-        && userClaims.contains("phone_number_verified")) {
-      verifiedClaims.put(
-          "phone_number_verified", userClaims.getValueAsBoolean("phone_number_verified"));
-    }
-    if (claimsNodeWrapper.contains("email") && userClaims.contains("email")) {
-      verifiedClaims.put("email", userClaims.getValueOrEmptyAsString("email"));
-    }
-    if (claimsNodeWrapper.contains("email_verified") && userClaims.contains("email_verified")) {
-      verifiedClaims.put("email_verified", userVerifiedClaims.getValueAsBoolean("email_verified"));
-    }
-    // OIDC4IDA §5.7.4 / §5.7.5: when no requested claim matched a user claim, omit verified_claims
-    // entirely rather than emit an empty claims object (and leak verification metadata).
-    if (verifiedClaims.isEmpty()) {
-      return claims;
+    // claims: resolve the requested claim names dynamically against the user's stored claims,
+    // honoring any value/values constraint. A claim that is unavailable (§5.7.2) or fails its
+    // constraint (§5.7.4, claims branch) is dropped individually.
+    Map<String, Object> claims =
+        selectClaims(requested.claimsNodeWrapper(), userBlock(userVerifiedClaims, "claims"));
+
+    // OIDC4IDA §5.7.4 / §5.7.5: when no requested claim is available, omit the whole
+    // verified_claims rather than emit an empty claims object (and leak verification metadata).
+    if (claims.isEmpty()) {
+      return result;
     }
 
-    // IDA schema §5.1 / OIDC4IDA §5.7.4: verification.trust_framework is REQUIRED. Without it the
+    Map<String, Object> verification =
+        selectVerification(
+            requested.verificationNodeWrapper(), userBlock(userVerifiedClaims, "verification"));
+
+    // §5.7.4 (verification branch): a requested verification element failed its value/values
+    // constraint, so the verification requirement is unmet — omit the whole verified_claims.
+    if (verification == null) {
+      log.warn(
+          "verified_claims omitted: a requested verification element did not match its"
+              + " value/values constraint");
+      return result;
+    }
+
+    // IDA schema §5.1 / §5.7.4: verification.trust_framework is REQUIRED. Without it the
     // verification requirement cannot be met, so omit verified_claims entirely rather than emit a
-    // schema-invalid verification block (e.g. an empty {} or one carrying only evidence).
+    // schema-invalid verification block.
     if (!verification.containsKey("trust_framework")) {
       log.warn(
           "verified_claims omitted: stored verification has no required trust_framework"
               + " (check the tenant's verified_claims mapping configuration)");
-      return claims;
+      return result;
     }
 
+    Map<String, Object> verified = new HashMap<>();
     verified.put("verification", verification);
-    verified.put("claims", verifiedClaims);
-    claims.put("verified_claims", verified);
+    verified.put("claims", claims);
+    result.put("verified_claims", verified);
 
-    return claims;
+    return result;
+  }
+
+  /** Returns the user's stored {@code verification} / {@code claims} block as a Java map. */
+  private Map<String, Object> userBlock(JsonNodeWrapper userVerifiedClaims, String key) {
+    if (!userVerifiedClaims.contains(key)) {
+      return Map.of();
+    }
+    return userVerifiedClaims.getValueAsJsonNode(key).toMap();
+  }
+
+  /**
+   * Selects each requested claim that the user holds and whose stored value satisfies the requested
+   * {@code value} / {@code values} constraint. Unavailable or non-matching claims are dropped
+   * individually (§5.7.2 / §5.7.4 claims branch).
+   */
+  private Map<String, Object> selectClaims(
+      JsonNodeWrapper requestedClaims, Map<String, Object> userClaims) {
+    Map<String, Object> selected = new HashMap<>();
+    for (String name : requestedClaims.fieldNamesAsList()) {
+      if (!userClaims.containsKey(name)) {
+        continue;
+      }
+      Object userValue = userClaims.get(name);
+      if (matchesConstraint(requestedClaims.getValueAsJsonNode(name), userValue)) {
+        selected.put(name, userValue);
+      }
+    }
+    return selected;
+  }
+
+  /**
+   * Builds the {@code verification} block. {@code trust_framework} is the REQUIRED floor: always
+   * included when the user holds it (never gated behind an explicit request), mirroring {@link
+   * SelectiveVerifiedClaims}. Other elements (e.g. {@code evidence}) are opt-in via explicit
+   * request. Returns {@code null} when a requested verification element fails its {@code value} /
+   * {@code values} constraint, signaling the whole verified_claims must be omitted (§5.7.4).
+   */
+  private Map<String, Object> selectVerification(
+      JsonNodeWrapper requestedVerification, Map<String, Object> userVerification) {
+    Map<String, Object> selected = new HashMap<>();
+
+    if (userVerification.containsKey("trust_framework")) {
+      Object userValue = userVerification.get("trust_framework");
+      if (!matchesConstraint(
+          requestedVerification.getValueAsJsonNode("trust_framework"), userValue)) {
+        return null;
+      }
+      selected.put("trust_framework", userValue);
+    }
+
+    for (String element : requestedVerification.fieldNamesAsList()) {
+      if (element.equals("trust_framework") || !userVerification.containsKey(element)) {
+        continue;
+      }
+      Object userValue = userVerification.get(element);
+      if (!matchesConstraint(requestedVerification.getValueAsJsonNode(element), userValue)) {
+        return null;
+      }
+      selected.put(element, userValue);
+    }
+    return selected;
+  }
+
+  /**
+   * Matches a stored value against a requested claim's {@code value} / {@code values} constraint
+   * (OpenID Connect §5.5.1). A {@code null} request (no constraint object) or one carrying neither
+   * {@code value} nor {@code values} always matches — the claim was requested, not constrained.
+   * {@code max_age} is out of scope.
+   */
+  private boolean matchesConstraint(JsonNodeWrapper constraint, Object userValue) {
+    if (constraint == null || !constraint.exists() || !constraint.isObject()) {
+      return true;
+    }
+    if (constraint.contains("value")) {
+      return stringEquals(constraint.getValueOrEmptyAsString("value"), userValue);
+    }
+    if (constraint.contains("values")) {
+      for (JsonNodeWrapper candidate : constraint.getValueAsJsonNodeList("values")) {
+        if (stringEquals(candidate.asText(), userValue)) {
+          return true;
+        }
+      }
+      return false;
+    }
+    return true;
+  }
+
+  private boolean stringEquals(String requested, Object userValue) {
+    return userValue != null && requested.equals(String.valueOf(userValue));
   }
 }

--- a/libs/idp-server-core-extension-ida/src/test/java/org/idp/server/core/extension/identity/verified/VerifiedClaimsCreatorTest.java
+++ b/libs/idp-server-core-extension-ida/src/test/java/org/idp/server/core/extension/identity/verified/VerifiedClaimsCreatorTest.java
@@ -140,4 +140,93 @@ class VerifiedClaimsCreatorTest {
         result.containsKey("verified_claims"),
         "verification without the required trust_framework must emit no verified_claims");
   }
+
+  // ----- value/values constraint enforcement, dynamic claims, trust_framework user-gate (#1624) --
+
+  @Test
+  void emitsWhenValueAndValuesConstraintsMatch() {
+    User user = userWith(Map.of("trust_framework", "eidas"), Map.of("given_name", "Taro"));
+    // verification value + claims values both satisfied by the stored data.
+    RequestedClaimsPayload payload =
+        request(
+            "{\"verification\":{\"trust_framework\":{\"value\":\"eidas\"}},"
+                + "\"claims\":{\"given_name\":{\"values\":[\"Hanako\",\"Taro\"]}}}");
+
+    Map<String, Object> result = create(user, payload);
+
+    assertTrue(result.containsKey("verified_claims"));
+    assertEquals("eidas", verificationOf(result).get("trust_framework"));
+    assertEquals("Taro", claimsOf(result).get("given_name"));
+  }
+
+  @Test
+  void omitsVerifiedClaimsWhenVerificationValueDoesNotMatch() {
+    // §5.7.4 (verification branch): requested trust_framework value "gold" but the user has "eidas"
+    // → the verification requirement is unmet, so the whole verified_claims is omitted.
+    User user = userWith(Map.of("trust_framework", "eidas"), Map.of("given_name", "Taro"));
+    RequestedClaimsPayload payload =
+        request(
+            "{\"verification\":{\"trust_framework\":{\"value\":\"gold\"}},"
+                + "\"claims\":{\"given_name\":null}}");
+
+    Map<String, Object> result = create(user, payload);
+
+    assertFalse(
+        result.containsKey("verified_claims"),
+        "verification value mismatch must omit the whole verified_claims");
+  }
+
+  @Test
+  void dropsOnlyTheClaimWhoseValueDoesNotMatch() {
+    // §5.7.4 (claims branch): given_name value mismatch drops just given_name; family_name (no
+    // constraint) is still returned, so verified_claims itself is kept.
+    User user =
+        userWith(
+            Map.of("trust_framework", "eidas"),
+            Map.of("given_name", "Sarah", "family_name", "Yamada"));
+    RequestedClaimsPayload payload =
+        request(
+            "{\"verification\":{\"trust_framework\":null},"
+                + "\"claims\":{\"given_name\":{\"value\":\"Bob\"},\"family_name\":null}}");
+
+    Map<String, Object> result = create(user, payload);
+
+    assertTrue(result.containsKey("verified_claims"));
+    assertEquals("Yamada", claimsOf(result).get("family_name"));
+    assertFalse(
+        claimsOf(result).containsKey("given_name"),
+        "claim failing its value constraint must be dropped individually");
+  }
+
+  @Test
+  void returnsDynamicallyResolvedClaimBeyondLegacyFixedList() {
+    // place_of_birth is not in the old hard-coded list; the dynamic resolver returns it when the
+    // user holds it.
+    User user =
+        userWith(
+            Map.of("trust_framework", "eidas"), Map.of("place_of_birth", Map.of("country", "UK")));
+    RequestedClaimsPayload payload =
+        request(
+            "{\"verification\":{\"trust_framework\":null},\"claims\":{\"place_of_birth\":null}}");
+
+    Map<String, Object> result = create(user, payload);
+
+    assertTrue(result.containsKey("verified_claims"));
+    assertEquals(Map.of("country", "UK"), claimsOf(result).get("place_of_birth"));
+  }
+
+  @Test
+  void alwaysReturnsTrustFrameworkEvenWhenRequestOmitsIt() {
+    // trust_framework is the REQUIRED floor: returned whenever the user holds it, even if the RP
+    // did
+    // not list it (no verification block in the request).
+    User user = userWith(Map.of("trust_framework", "eidas"), Map.of("given_name", "Taro"));
+    RequestedClaimsPayload payload = request("{\"claims\":{\"given_name\":null}}");
+
+    Map<String, Object> result = create(user, payload);
+
+    assertTrue(result.containsKey("verified_claims"));
+    assertEquals("eidas", verificationOf(result).get("trust_framework"));
+    assertEquals("Taro", claimsOf(result).get("given_name"));
+  }
 }


### PR DESCRIPTION
## 概要

Closes #1624

`VerifiedClaimsCreator`（ID Token の `claims` パラメータ経路）が RP の `value`/`values` 制約を無視し、ユーザー保持値を制約一致の有無に関わらずそのまま返していた（OpenID Connect §5.5.1 / OIDC4IDA §5.7.4 違反）。#1512 で対応した「未保持・構造不成立 → 省略」に続き、§5.7.4 のもう一方のトリガー（**要求値と不一致 → 省略**）を実装。あわせて PR #1625 レビューで顕在化した 2 つの先在の非対称を解消し、`SelectiveVerifiedClaims`（scope 経路）と挙動を統一する。

## 仕様要件（OIDC4IDA 1.0, §5.7.4）

> When the available data does not fulfill the requirements of the RP expressed through `value`, `values`, or `max_age`:
> - If the respective requirement was expressed for a claim within `verified_claims/verification`, the OP shall omit the whole `verified_claims` element.
> - Otherwise, the OP shall omit the respective claim from the response.
> In both cases, the OP shall not return an error to the RP.

## 変更内容

- **value/values 照合（§5.7.4）**: `verification` 要素の不一致 → `verified_claims` 全体を省略 / `claims` 要素の不一致 → その claim のみ省略
- **trust_framework を user-gate に統一（①）**: RP のリクエスト列挙に依存せず、ユーザーが保持していれば常に出力（§5.1 の REQUIRED floor）。`SelectiveVerifiedClaims` と同じ
- **claims を動的解決に変更（②）**: ハードコード 13 個の列挙を廃止し、要求名をユーザーの保持クレームに動的に突き合わせ（`place_of_birth` 等も返せる）。型は `toMap` で保持（address=Map / evidence=List / `*_verified`=Boolean）。`email_verified` を top-level から誤読していた既存バグも解消
- Javadoc を value/values・user-gate・動的解決に合わせて更新

> ①② は PR #1625 のレビューで指摘された先在の非対称（[#1624 コメント](https://github.com/hirokazu-kobayashi-koba-hiro/idp-server/issues/1624#issuecomment-4725078699)）。3 つとも同じ「`SelectiveVerifiedClaims` 方式へ寄せる」リファクタで一括解消。

## スコープ外

- **`max_age` 鮮度（§5.5.2, SHOULD）** — verified_claims の鮮度判定そのものが未実装。別途
- **scope 経路（`SelectiveVerifiedClaims`）** — scope は値制約を表現できないため対象外

## テスト

- **unit**: `VerifiedClaimsCreatorTest`（計 9 ケース）— value/values 一致・不一致（verification/claims 別の省略粒度）・動的クレーム（place_of_birth）・trust_framework user-gate を追加
- **E2E**: `oidc_for_identity_assurance.test.js` の `Section 5.7` に §5.7.4 verbatim で 3 ケース追加
  - 未デプロイの実サーバで value 不一致が `{"claims":{"given_name":"Sarah"},"verification":{"trust_framework":"eidas"}}`（制約無視で返却）の**赤を確認 → デプロイ後に緑**（ファイル全体 10/10）
- モジュールテスト全緑・spotless 適用済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)
