### PR TITLE
fix(oauth): 外部サービストークン取得失敗を 502 external_service_error にし 500 を解消 (#1384)

### DIFF
--- a/e2e/src/tests/integration/ida/integration-17-oauth-external-service-error.test.js
+++ b/e2e/src/tests/integration/ida/integration-17-oauth-external-service-error.test.js
@@ -1,0 +1,120 @@
+import { describe, expect, it, beforeAll, afterAll } from "@jest/globals";
+import { postWithJson, deletion } from "../../../lib/http";
+import { requestToken } from "../../../api/oauthClient";
+import {
+  backendUrl,
+  clientSecretPostClient,
+  serverConfig,
+  federationServerConfig,
+  mockApiBaseUrl,
+} from "../../testConfig";
+import { createFederatedUser } from "../../../user";
+import { v4 as uuidv4 } from "uuid";
+
+/**
+ * #1384: when the external eKYC execution fails to obtain an OAuth token (misconfigured
+ * oauth_authorization, e.g. invalid client_id → token endpoint returns 401), the API must respond
+ * with a meaningful 502 external_service_error — NOT a generic 500 server_error.
+ *
+ * The token endpoint is pointed at the mock `e2e/oauth-retry/401-always` route (POST → 401), so the
+ * OAuth resolver fails while building the request, before the main eKYC call. Before the fix this
+ * surfaced as 500 server_error ("unexpected error is occurred"); after the fix it is 502
+ * external_service_error.
+ */
+describe("Identity Verification - external OAuth failure returns 502 (#1384)", () => {
+  const orgId = serverConfig.organizationId;
+  const tenantId = serverConfig.tenantId;
+
+  let orgAccessToken;
+  let userAccessToken;
+  const type = uuidv4();
+  const configId = uuidv4();
+
+  beforeAll(async () => {
+    const orgAuthResponse = await requestToken({
+      endpoint: `${backendUrl}/${tenantId}/v1/tokens`,
+      grantType: "password",
+      username: "ito.ichiro@gmail.com",
+      password: "successUserCode001",
+      clientId: clientSecretPostClient.clientId,
+      clientSecret: clientSecretPostClient.clientSecret,
+      scope: "org-management account management",
+    });
+    expect(orgAuthResponse.status).toBe(200);
+    orgAccessToken = orgAuthResponse.data.access_token;
+
+    const { accessToken } = await createFederatedUser({
+      serverConfig: serverConfig,
+      federationServerConfig: federationServerConfig,
+      client: clientSecretPostClient,
+      adminClient: clientSecretPostClient,
+      scope:
+        "openid profile email identity_verification_application " +
+        clientSecretPostClient.identityVerificationScope,
+    });
+    userAccessToken = accessToken;
+
+    // apply process whose execution authenticates with oauth2; the token endpoint always returns 401.
+    const create = await postWithJson({
+      url: `${backendUrl}/v1/management/organizations/${orgId}/tenants/${tenantId}/identity-verification-configurations`,
+      headers: {
+        Authorization: `Bearer ${orgAccessToken}`,
+        "Content-Type": "application/json",
+      },
+      body: {
+        id: configId,
+        type,
+        attributes: { enabled: true },
+        common: { auth_type: "none" },
+        processes: {
+          apply: {
+            request: { schema: { type: "object", properties: {} } },
+            execution: {
+              type: "http_request",
+              http_request: {
+                url: `${mockApiBaseUrl}/e2e/oauth-retry/401-always`,
+                method: "POST",
+                auth_type: "oauth2",
+                oauth_authorization: {
+                  type: "client_credentials",
+                  token_endpoint: `${mockApiBaseUrl}/e2e/oauth-retry/401-always`,
+                  client_authentication_type: "client_secret_post",
+                  client_id: "invalid-client",
+                  client_secret: "invalid-secret",
+                  scope: "api:access",
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+    expect(create.status).toBe(201);
+  });
+
+  afterAll(async () => {
+    await deletion({
+      url: `${backendUrl}/v1/management/organizations/${orgId}/tenants/${tenantId}/identity-verification-configurations/${configId}`,
+      headers: { Authorization: `Bearer ${orgAccessToken}` },
+    });
+  });
+
+  it("returns 502 external_service_error when the external token endpoint rejects the OAuth request", async () => {
+    const applyUrl = serverConfig.identityVerificationApplyEndpoint
+      .replace("{type}", type)
+      .replace("{process}", "apply");
+
+    const response = await postWithJson({
+      url: applyUrl,
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${userAccessToken}`,
+      },
+      body: {},
+    });
+    console.log("apply response:", response.status, JSON.stringify(response.data, null, 2));
+
+    expect(response.status).toBe(502);
+    expect(response.data).toHaveProperty("error", "external_service_error");
+  });
+});

--- a/libs/idp-server-platform/src/main/java/org/idp/server/platform/oauth/ClientCredentialsAuthorizationResolver.java
+++ b/libs/idp-server-platform/src/main/java/org/idp/server/platform/oauth/ClientCredentialsAuthorizationResolver.java
@@ -19,7 +19,6 @@ package org.idp.server.platform.oauth;
 import java.net.URI;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
-import org.idp.server.platform.http.HttpNetworkErrorException;
 import org.idp.server.platform.http.HttpQueryParams;
 import org.idp.server.platform.http.SsrfProtectedHttpClient;
 import org.idp.server.platform.json.JsonConverter;
@@ -66,14 +65,11 @@ public class ClientCredentialsAuthorizationResolver implements OAuthAuthorizatio
     log.debug("Response status: {}", response.statusCode());
     log.debug("Response body: {}", response.body());
 
-    if (response.statusCode() >= 400 && response.statusCode() < 500) {
-      throw new HttpNetworkErrorException(
-          "Token request failed: " + response.statusCode(), new RuntimeException(response.body()));
-    }
-
-    if (response.statusCode() >= 500) {
-      throw new HttpNetworkErrorException(
-          "Token request failed: " + response.statusCode(), new RuntimeException(response.body()));
+    // The token endpoint responded but rejected the request (e.g. invalid client_id) or failed
+    // upstream. Surface a dedicated exception so the boundary returns a meaningful external-service
+    // error instead of a generic 500. See #1384.
+    if (response.statusCode() >= 400) {
+      throw new OAuthAuthorizationException(response.statusCode(), response.body());
     }
 
     JsonNodeWrapper jsonNodeWrapper = jsonConverter.readTree(response.body());

--- a/libs/idp-server-platform/src/main/java/org/idp/server/platform/oauth/OAuthAuthorizationException.java
+++ b/libs/idp-server-platform/src/main/java/org/idp/server/platform/oauth/OAuthAuthorizationException.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2025 Hirokazu Kobayashi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.idp.server.platform.oauth;
+
+/**
+ * Thrown when acquiring an OAuth 2.0 access token from an external service's token endpoint fails
+ * (non-2xx response). This is distinct from a network/transport failure ({@code
+ * HttpNetworkErrorException}): the token endpoint <em>responded</em>, but rejected the request —
+ * typically a misconfigured {@code oauth_authorization} (e.g. an invalid {@code client_id}).
+ *
+ * <p>Carrying the upstream {@code statusCode}/{@code responseBody} lets the boundary handler log
+ * the cause for diagnosis while returning a meaningful, non-500 error to the caller. The response
+ * body is for server-side logging only and must not be echoed to the API client (it is the external
+ * service's internal error representation).
+ */
+public class OAuthAuthorizationException extends RuntimeException {
+
+  int statusCode;
+  String responseBody;
+
+  public OAuthAuthorizationException(int statusCode, String responseBody) {
+    super("OAuth token request failed: " + statusCode);
+    this.statusCode = statusCode;
+    this.responseBody = responseBody;
+  }
+
+  public int statusCode() {
+    return statusCode;
+  }
+
+  public String responseBody() {
+    return responseBody;
+  }
+}

--- a/libs/idp-server-platform/src/main/java/org/idp/server/platform/oauth/ResourceOwnerPasswordCredentialsAuthorizationResolver.java
+++ b/libs/idp-server-platform/src/main/java/org/idp/server/platform/oauth/ResourceOwnerPasswordCredentialsAuthorizationResolver.java
@@ -19,7 +19,6 @@ package org.idp.server.platform.oauth;
 import java.net.URI;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
-import org.idp.server.platform.http.HttpNetworkErrorException;
 import org.idp.server.platform.http.HttpQueryParams;
 import org.idp.server.platform.http.SsrfProtectedHttpClient;
 import org.idp.server.platform.json.JsonConverter;
@@ -65,14 +64,11 @@ public class ResourceOwnerPasswordCredentialsAuthorizationResolver
     log.debug("Response status: {}", response.statusCode());
     log.debug("Response body: {}", response.body());
 
-    if (response.statusCode() >= 400 && response.statusCode() < 500) {
-      throw new HttpNetworkErrorException(
-          "Token request failed: " + response.statusCode(), new RuntimeException(response.body()));
-    }
-
-    if (response.statusCode() >= 500) {
-      throw new HttpNetworkErrorException(
-          "Token request failed: " + response.statusCode(), new RuntimeException(response.body()));
+    // The token endpoint responded but rejected the request (e.g. invalid client_id) or failed
+    // upstream. Surface a dedicated exception so the boundary returns a meaningful external-service
+    // error instead of a generic 500. See #1384.
+    if (response.statusCode() >= 400) {
+      throw new OAuthAuthorizationException(response.statusCode(), response.body());
     }
 
     JsonNodeWrapper jsonNodeWrapper = jsonConverter.readTree(response.body());

--- a/libs/idp-server-platform/src/main/java/org/idp/server/platform/oauth/cache/SmartCachedOAuthAuthorizationResolver.java
+++ b/libs/idp-server-platform/src/main/java/org/idp/server/platform/oauth/cache/SmartCachedOAuthAuthorizationResolver.java
@@ -21,13 +21,13 @@ import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.util.Optional;
 import org.idp.server.platform.datasource.cache.CacheStore;
-import org.idp.server.platform.http.HttpNetworkErrorException;
 import org.idp.server.platform.http.HttpQueryParams;
 import org.idp.server.platform.http.SsrfProtectedHttpClient;
 import org.idp.server.platform.json.JsonConverter;
 import org.idp.server.platform.json.JsonNodeWrapper;
 import org.idp.server.platform.log.LoggerWrapper;
 import org.idp.server.platform.oauth.OAuthAuthorizationConfiguration;
+import org.idp.server.platform.oauth.OAuthAuthorizationException;
 import org.idp.server.platform.oauth.OAuthAuthorizationResolver;
 
 public class SmartCachedOAuthAuthorizationResolver implements OAuthAuthorizationResolver {
@@ -137,9 +137,7 @@ public class SmartCachedOAuthAuthorizationResolver implements OAuthAuthorization
     log.debug("Token response status: {}", response.statusCode());
 
     if (response.statusCode() >= 400) {
-      throw new HttpNetworkErrorException(
-          "Token endpoint returned non-200 status: " + response.statusCode(),
-          new RuntimeException("HTTP status: " + response.statusCode()));
+      throw new OAuthAuthorizationException(response.statusCode(), response.body());
     }
 
     JsonNodeWrapper jsonNodeWrapper = jsonConverter.readTree(response.body());

--- a/libs/idp-server-platform/src/test/java/org/idp/server/platform/oauth/OAuthAuthorizationResolverErrorTest.java
+++ b/libs/idp-server-platform/src/test/java/org/idp/server/platform/oauth/OAuthAuthorizationResolverErrorTest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2025 Hirokazu Kobayashi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.idp.server.platform.oauth;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.Map;
+import org.idp.server.platform.http.SsrfProtectedHttpClient;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * #1384: when the external token endpoint rejects the request (non-2xx), the OAuth resolvers must
+ * raise a dedicated {@link OAuthAuthorizationException} carrying the upstream status/body — not a
+ * generic network error — so the boundary can return a meaningful error instead of a 500.
+ */
+@ExtendWith(MockitoExtension.class)
+class OAuthAuthorizationResolverErrorTest {
+
+  @Mock SsrfProtectedHttpClient httpClient;
+  @Mock OAuthAuthorizationConfiguration config;
+
+  @SuppressWarnings("unchecked")
+  private void stubResponse(int status, String body) {
+    HttpResponse<String> response = mock(HttpResponse.class);
+    when(response.statusCode()).thenReturn(status);
+    lenient().when(response.body()).thenReturn(body);
+    when(httpClient.send(any(HttpRequest.class))).thenReturn(response);
+  }
+
+  private void stubConfig() {
+    when(config.toRequestValues()).thenReturn(Map.of("grant_type", "password"));
+    when(config.tokenEndpoint()).thenReturn("https://idp.example.com/token");
+  }
+
+  @Test
+  void passwordResolver_throwsOAuthAuthorizationExceptionOn401() {
+    stubConfig();
+    stubResponse(401, "{\"error\":\"invalid_client\"}");
+    var resolver = new ResourceOwnerPasswordCredentialsAuthorizationResolver(httpClient);
+
+    OAuthAuthorizationException ex =
+        assertThrows(OAuthAuthorizationException.class, () -> resolver.resolve(config));
+    assertEquals(401, ex.statusCode());
+    assertEquals("{\"error\":\"invalid_client\"}", ex.responseBody());
+  }
+
+  @Test
+  void passwordResolver_throwsOAuthAuthorizationExceptionOn500() {
+    stubConfig();
+    stubResponse(500, "boom");
+    var resolver = new ResourceOwnerPasswordCredentialsAuthorizationResolver(httpClient);
+
+    OAuthAuthorizationException ex =
+        assertThrows(OAuthAuthorizationException.class, () -> resolver.resolve(config));
+    assertEquals(500, ex.statusCode());
+  }
+
+  @Test
+  void passwordResolver_returnsAccessTokenOn200() {
+    stubConfig();
+    stubResponse(200, "{\"access_token\":\"tok-123\"}");
+    var resolver = new ResourceOwnerPasswordCredentialsAuthorizationResolver(httpClient);
+
+    assertEquals("tok-123", resolver.resolve(config));
+  }
+
+  @Test
+  void clientCredentialsResolver_throwsOAuthAuthorizationExceptionOn401() {
+    stubConfig();
+    when(config.isClientSecretBasic()).thenReturn(false);
+    stubResponse(401, "{\"error\":\"invalid_client\"}");
+    var resolver = new ClientCredentialsAuthorizationResolver(httpClient);
+
+    OAuthAuthorizationException ex =
+        assertThrows(OAuthAuthorizationException.class, () -> resolver.resolve(config));
+    assertEquals(401, ex.statusCode());
+    assertEquals("{\"error\":\"invalid_client\"}", ex.responseBody());
+  }
+
+  @Test
+  void clientCredentialsResolver_returnsAccessTokenOn200() {
+    stubConfig();
+    when(config.isClientSecretBasic()).thenReturn(false);
+    stubResponse(200, "{\"access_token\":\"tok-456\"}");
+    var resolver = new ClientCredentialsAuthorizationResolver(httpClient);
+
+    assertEquals("tok-456", resolver.resolve(config));
+  }
+}

--- a/libs/idp-server-springboot-adapter/src/main/java/org/idp/server/adapters/springboot/ApiExceptionHandler.java
+++ b/libs/idp-server-springboot-adapter/src/main/java/org/idp/server/adapters/springboot/ApiExceptionHandler.java
@@ -24,6 +24,7 @@ import org.idp.server.platform.datasource.SqlForeignKeyViolationException;
 import org.idp.server.platform.datasource.SqlTransactionConflictException;
 import org.idp.server.platform.exception.*;
 import org.idp.server.platform.log.LoggerWrapper;
+import org.idp.server.platform.oauth.OAuthAuthorizationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageConversionException;
@@ -219,6 +220,27 @@ public class ApiExceptionHandler {
             "error_description",
             "The server has a configuration error. Please contact the administrator.");
     return new ResponseEntity<>(response, HttpStatus.INTERNAL_SERVER_ERROR);
+  }
+
+  @ExceptionHandler(OAuthAuthorizationException.class)
+  public ResponseEntity<?> handleException(OAuthAuthorizationException exception) {
+    // Failure to obtain an OAuth token from an external service's token endpoint is an upstream /
+    // configuration problem, not an internal server error. Log the upstream status and body for
+    // diagnosis, but return only a generic message — the upstream body is the external service's
+    // internal error representation and must not be echoed to the client. See #1384.
+    log.error(
+        "External service OAuth authorization failed: status={}, body={}",
+        exception.statusCode(),
+        exception.responseBody(),
+        exception);
+    return new ResponseEntity<>(
+        Map.of(
+            "error",
+            "external_service_error",
+            "error_description",
+            "Failed to authenticate with the external service."
+                + " Please check the oauth_authorization settings."),
+        HttpStatus.BAD_GATEWAY);
   }
 
   @ExceptionHandler

--- a/libs/idp-server-springboot-adapter/src/test/java/org/idp/server/adapters/springboot/ApiExceptionHandlerTest.java
+++ b/libs/idp-server-springboot-adapter/src/test/java/org/idp/server/adapters/springboot/ApiExceptionHandlerTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2025 Hirokazu Kobayashi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.idp.server.adapters.springboot;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.Map;
+import org.idp.server.platform.oauth.OAuthAuthorizationException;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+class ApiExceptionHandlerTest {
+
+  /**
+   * #1384: an external-service OAuth token failure must map to a meaningful 502
+   * external_service_error (not a generic 500 server_error), and must not echo the upstream
+   * token-endpoint body to the client.
+   */
+  @Test
+  void oauthAuthorizationExceptionMapsTo502WithoutLeakingUpstreamBody() {
+    ApiExceptionHandler handler = new ApiExceptionHandler();
+    String upstreamBody = "{\"error\":\"invalid_client\",\"internal\":\"do-not-leak\"}";
+
+    ResponseEntity<?> response =
+        handler.handleException(new OAuthAuthorizationException(401, upstreamBody));
+
+    assertEquals(HttpStatus.BAD_GATEWAY, response.getStatusCode());
+
+    @SuppressWarnings("unchecked")
+    Map<String, String> body = (Map<String, String>) response.getBody();
+    assertEquals("external_service_error", body.get("error"));
+    assertFalse(
+        body.get("error_description").contains("do-not-leak"),
+        "upstream token-endpoint body must not be echoed to the client");
+  }
+}


### PR DESCRIPTION
## 概要

Closes #1384

外部サービス連携（eKYC 等）の `execution` で **OAuth トークン取得が非2xxで失敗**すると、resolver が `HttpNetworkErrorException` を投げ、`ApiExceptionHandler` に専用ハンドラが無いため汎用 **`500 server_error`（`unexpected error is occurred`）** になっていた。実態は「外部サービスへの OAuth 認証失敗（`oauth_authorization` 設定ミス等）」で、ステータス・メッセージともに原因が特定できない。

## 変更内容

- **`OAuthAuthorizationException`（新設）**: 上流の `statusCode` / `responseBody` を保持。`HttpNetworkErrorException`（ネットワーク/トランスポート障害）と区別。
- **resolver 3箇所でこの例外を throw**（トークンend が非2xx 時）:
  - `ResourceOwnerPasswordCredentialsAuthorizationResolver`
  - `ClientCredentialsAuthorizationResolver`
  - `SmartCachedOAuthAuthorizationResolver.executeTokenRequest`（issue 未記載だった3つ目の取得箇所も統一）
- **`ApiExceptionHandler` に専用ハンドラ追加** → **`502 external_service_error`**。upstream の status/body は**サーバーログのみ**に記録し、クライアントには汎用メッセージ（外部サービスの内部情報を漏らさない）。

## 設計判断

- **502 Bad Gateway**（issue 準拠）。401（client_id 設定ミス）も「外部サービス認証失敗」として 502 に集約。
- 例外は `extends RuntimeException`（OAuth パスで `HttpNetworkErrorException` を catch している本番コードが無いことを確認済み → 型変更は安全）。
- パイプラインは例外を素直に伝播（HttpRequestBuilder→Executor→IDA executor→handler→EntryService→proxy はいずれも握りつぶさず、proxy も `InvocationTargetException` を unwrap して原例外を再throw）。

## テスト

- **unit**
  - `OAuthAuthorizationResolverErrorTest`（5ケース）: 401/500 → `OAuthAuthorizationException`（status/body 保持）、200 → access_token
  - `ApiExceptionHandlerTest`: `OAuthAuthorizationException` → 502 `external_service_error`、upstream body を client に出さない
- **E2E** `integration-17-oauth-external-service-error`: IDA 申込みの execution が `auth_type: oauth2` でトークンend（mock の 401-always）から 401 を受ける構成。**再ビルド前=`500 server_error`（赤）→ 本修正デプロイ後=`502 external_service_error`（緑）** を実機で確認。
- platform / springboot-adapter モジュール全テスト緑・spotless 適用済み。

### ログ（観測性）

502 時はサーバーログに upstream の status/body を記録（client には出さない）:

```
[ERROR] External service OAuth authorization failed: status=401, body={"error":"invalid_token","error_description":"..."}
```

## スコープ外（別Issue）

- **#1630**: `oauth_authorization` の任意フィールド（`scope` 等）欠落時に、トークン**組み立て前**に `URLEncoder.encode(null)` で NPE→500 になる別の失敗モード。本PRの「token end が非2xx を返す」経路とは発生箇所が異なるため別対応。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
