### PR TITLE
fix(security-event-hook): フック実行の想定外例外を分離し同期実行時の500を解消 (#1619)

### DIFF
--- a/libs/idp-server-platform/src/main/java/org/idp/server/platform/security/handler/SecurityEventHandler.java
+++ b/libs/idp-server-platform/src/main/java/org/idp/server/platform/security/handler/SecurityEventHandler.java
@@ -20,22 +20,14 @@ import java.time.LocalDate;
 import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 import org.idp.server.platform.log.LoggerWrapper;
 import org.idp.server.platform.multi_tenancy.tenant.Tenant;
 import org.idp.server.platform.security.SecurityEvent;
 import org.idp.server.platform.security.event.DefaultSecurityEventType;
 import org.idp.server.platform.security.event.SecurityEventUser;
 import org.idp.server.platform.security.event.SecurityEventUserIdentifier;
-import org.idp.server.platform.security.hook.*;
-import org.idp.server.platform.security.hook.SecurityEventHook;
-import org.idp.server.platform.security.hook.SecurityEventHooks;
-import org.idp.server.platform.security.hook.configuration.SecurityEventHookConfiguration;
-import org.idp.server.platform.security.hook.configuration.SecurityEventHookConfigurations;
 import org.idp.server.platform.security.log.SecurityEventLogConfiguration;
 import org.idp.server.platform.security.log.SecurityEventLogService;
-import org.idp.server.platform.security.repository.SecurityEventHookConfigurationQueryRepository;
-import org.idp.server.platform.security.repository.SecurityEventHookResultCommandRepository;
 import org.idp.server.platform.statistics.FiscalYearCalculator;
 import org.idp.server.platform.statistics.StatisticsEventRecord;
 import org.idp.server.platform.statistics.repository.DailyActiveUserCommandRepository;
@@ -45,9 +37,7 @@ import org.idp.server.platform.statistics.repository.YearlyActiveUserCommandRepo
 
 public class SecurityEventHandler {
 
-  SecurityEventHookResultCommandRepository resultsCommandRepository;
-  SecurityEventHooks securityEventHooks;
-  SecurityEventHookConfigurationQueryRepository securityEventHookConfigurationQueryRepository;
+  SecurityEventHookDispatcher hookDispatcher;
   SecurityEventLogService logService;
   StatisticsEventsCommandRepository statisticsEventsRepository;
   DailyActiveUserCommandRepository dailyActiveUserRepository;
@@ -57,18 +47,13 @@ public class SecurityEventHandler {
   LoggerWrapper log = LoggerWrapper.getLogger(SecurityEventHandler.class);
 
   public SecurityEventHandler(
-      SecurityEventHooks securityEventHooks,
-      SecurityEventHookResultCommandRepository resultsCommandRepository,
-      SecurityEventHookConfigurationQueryRepository securityEventHookConfigurationQueryRepository,
+      SecurityEventHookDispatcher hookDispatcher,
       SecurityEventLogService logService,
       StatisticsEventsCommandRepository statisticsEventsRepository,
       DailyActiveUserCommandRepository dailyActiveUserRepository,
       MonthlyActiveUserCommandRepository monthlyActiveUserRepository,
       YearlyActiveUserCommandRepository yearlyActiveUserRepository) {
-    this.securityEventHooks = securityEventHooks;
-    this.resultsCommandRepository = resultsCommandRepository;
-    this.securityEventHookConfigurationQueryRepository =
-        securityEventHookConfigurationQueryRepository;
+    this.hookDispatcher = hookDispatcher;
     this.logService = logService;
     this.statisticsEventsRepository = statisticsEventsRepository;
     this.dailyActiveUserRepository = dailyActiveUserRepository;
@@ -83,45 +68,8 @@ public class SecurityEventHandler {
     // Execute hooks first (before statistics) to minimize lock hold time.
     // Hook execution involves blocking I/O (email, Slack, webhook: 450-500ms).
     // If statistics rows are locked before hooks, the lock is held during I/O,
-    // causing cascading lock contention on statistics_events under high load.
-    SecurityEventHookConfigurations securityEventHookConfigurations =
-        securityEventHookConfigurationQueryRepository.find(tenant);
-
-    List<SecurityEventHookResult> results = new ArrayList<>();
-    for (SecurityEventHookConfiguration hookConfiguration : securityEventHookConfigurations) {
-
-      Optional<SecurityEventHook> optionalExecutor =
-          securityEventHooks.find(hookConfiguration.hookType());
-
-      if (optionalExecutor.isEmpty()) {
-        log.warn(
-            "Skipping unsupported security event hook type: {} for tenant: {}",
-            hookConfiguration.hookType().name(),
-            tenant.identifierValue());
-        continue;
-      }
-
-      SecurityEventHook securityEventHookExecutor = optionalExecutor.get();
-
-      if (securityEventHookExecutor.shouldExecute(tenant, securityEvent, hookConfiguration)) {
-        log.info(
-            String.format(
-                "security event hook execution trigger: %s, type: %s tenant: %s client: %s user: %s, ",
-                securityEvent.type().value(),
-                hookConfiguration.hookType().name(),
-                securityEvent.tenantIdentifierValue(),
-                securityEvent.clientIdentifierValue(),
-                securityEvent.userSub()));
-
-        SecurityEventHookResult hookResult =
-            securityEventHookExecutor.execute(tenant, securityEvent, hookConfiguration);
-        results.add(hookResult);
-      }
-    }
-
-    if (!results.isEmpty()) {
-      resultsCommandRepository.bulkRegister(tenant, results);
-    }
+    // causing cascading lock contention on statistics_events under high load (#1442).
+    hookDispatcher.dispatch(tenant, securityEvent);
 
     // Update statistics after hooks to keep lock hold time minimal (few ms).
     SecurityEventLogConfiguration config = tenant.securityEventLogConfiguration();

--- a/libs/idp-server-platform/src/main/java/org/idp/server/platform/security/handler/SecurityEventHookDispatcher.java
+++ b/libs/idp-server-platform/src/main/java/org/idp/server/platform/security/handler/SecurityEventHookDispatcher.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright 2025 Hirokazu Kobayashi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.idp.server.platform.security.handler;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import org.idp.server.platform.log.LoggerWrapper;
+import org.idp.server.platform.multi_tenancy.tenant.Tenant;
+import org.idp.server.platform.security.SecurityEvent;
+import org.idp.server.platform.security.hook.SecurityEventHook;
+import org.idp.server.platform.security.hook.SecurityEventHookResult;
+import org.idp.server.platform.security.hook.SecurityEventHooks;
+import org.idp.server.platform.security.hook.configuration.SecurityEventHookConfiguration;
+import org.idp.server.platform.security.hook.configuration.SecurityEventHookConfigurations;
+import org.idp.server.platform.security.repository.SecurityEventHookConfigurationQueryRepository;
+import org.idp.server.platform.security.repository.SecurityEventHookResultCommandRepository;
+
+/**
+ * Dispatches a {@link SecurityEvent} to every configured hook for the tenant.
+ *
+ * <p>Owns the hook-execution concern that used to live inline in {@link SecurityEventHandler}:
+ * loading the hook configurations, resolving each executor, running it, and persisting the results.
+ * Keeping it separate from the statistics concern lets this be unit-tested without the statistics
+ * repositories.
+ *
+ * <p>Failures are isolated per hook (see {@link #executeHook}). Callers should invoke {@link
+ * #dispatch} <em>before</em> taking the statistics row lock so that blocking hook I/O is not held
+ * inside the lock window (#1442).
+ */
+public class SecurityEventHookDispatcher {
+
+  SecurityEventHooks securityEventHooks;
+  SecurityEventHookConfigurationQueryRepository securityEventHookConfigurationQueryRepository;
+  SecurityEventHookResultCommandRepository resultsCommandRepository;
+
+  LoggerWrapper log = LoggerWrapper.getLogger(SecurityEventHookDispatcher.class);
+
+  public SecurityEventHookDispatcher(
+      SecurityEventHooks securityEventHooks,
+      SecurityEventHookConfigurationQueryRepository securityEventHookConfigurationQueryRepository,
+      SecurityEventHookResultCommandRepository resultsCommandRepository) {
+    this.securityEventHooks = securityEventHooks;
+    this.securityEventHookConfigurationQueryRepository =
+        securityEventHookConfigurationQueryRepository;
+    this.resultsCommandRepository = resultsCommandRepository;
+  }
+
+  /**
+   * Runs every configured hook for the event and persists the collected results.
+   *
+   * <p>Hook execution involves blocking I/O (email, Slack, webhook: 450-500ms), so this is intended
+   * to run before the statistics update to minimize the statistics row lock hold time (#1442).
+   */
+  public void dispatch(Tenant tenant, SecurityEvent securityEvent) {
+
+    SecurityEventHookConfigurations securityEventHookConfigurations =
+        securityEventHookConfigurationQueryRepository.find(tenant);
+
+    List<SecurityEventHookResult> results = new ArrayList<>();
+    for (SecurityEventHookConfiguration hookConfiguration : securityEventHookConfigurations) {
+
+      Optional<SecurityEventHook> optionalExecutor =
+          securityEventHooks.find(hookConfiguration.hookType());
+
+      if (optionalExecutor.isEmpty()) {
+        log.warn(
+            "Skipping unsupported security event hook type: {} for tenant: {}",
+            hookConfiguration.hookType().name(),
+            tenant.identifierValue());
+        continue;
+      }
+
+      SecurityEventHook securityEventHookExecutor = optionalExecutor.get();
+
+      if (securityEventHookExecutor.shouldExecute(tenant, securityEvent, hookConfiguration)) {
+        log.info(
+            String.format(
+                "security event hook execution trigger: %s, type: %s tenant: %s client: %s user: %s, ",
+                securityEvent.type().value(),
+                hookConfiguration.hookType().name(),
+                securityEvent.tenantIdentifierValue(),
+                securityEvent.clientIdentifierValue(),
+                securityEvent.userSub()));
+
+        results.add(
+            executeHook(tenant, securityEvent, hookConfiguration, securityEventHookExecutor));
+      }
+    }
+
+    if (!results.isEmpty()) {
+      resultsCommandRepository.bulkRegister(tenant, results);
+    }
+  }
+
+  /**
+   * Executes a single hook, isolating unexpected failures as a FAILURE result.
+   *
+   * <p>Each executor already converts the failures it can anticipate into a {@link
+   * SecurityEventHookResult}, but exceptions thrown outside its own try/catch (configuration
+   * parsing, template interpolation, NPE on a missing field — see #1447) would otherwise propagate
+   * out of {@link #dispatch}, aborting the remaining hooks and the subsequent statistics update. In
+   * the synchronous ({@code publishSync}) path that turns the whole authentication request into a
+   * 500. Converting the failure here keeps it scoped to a single hook.
+   *
+   * <p>A {@code null} return is treated the same way: an executor is contractually required to
+   * return a result, and a null would otherwise propagate into {@code bulkRegister} and abort the
+   * rest of the processing with the very NPE this method exists to prevent.
+   */
+  private SecurityEventHookResult executeHook(
+      Tenant tenant,
+      SecurityEvent securityEvent,
+      SecurityEventHookConfiguration hookConfiguration,
+      SecurityEventHook securityEventHookExecutor) {
+
+    long hookStartTime = System.currentTimeMillis();
+    try {
+      SecurityEventHookResult hookResult =
+          securityEventHookExecutor.execute(tenant, securityEvent, hookConfiguration);
+      if (hookResult != null) {
+        return hookResult;
+      }
+      log.error(
+          "Security event hook execution returned null: type={} tenant={} event={}",
+          hookConfiguration.hookType().name(),
+          tenant.identifierValue(),
+          securityEvent.type().value());
+      return failureResult(
+          securityEvent,
+          hookConfiguration,
+          hookStartTime,
+          "NullHookResult",
+          "Security event hook execution returned null");
+    } catch (Exception e) {
+      log.error(
+          "Security event hook execution threw an unexpected exception: type={} tenant={} event={}",
+          hookConfiguration.hookType().name(),
+          tenant.identifierValue(),
+          securityEvent.type().value(),
+          e);
+      return failureResult(
+          securityEvent,
+          hookConfiguration,
+          hookStartTime,
+          e.getClass().getSimpleName(),
+          "Security event hook execution failed: " + e.getMessage());
+    }
+  }
+
+  private SecurityEventHookResult failureResult(
+      SecurityEvent securityEvent,
+      SecurityEventHookConfiguration hookConfiguration,
+      long hookStartTime,
+      String errorType,
+      String errorMessage) {
+    long executionDurationMs = System.currentTimeMillis() - hookStartTime;
+    return SecurityEventHookResult.failureWithContext(
+        hookConfiguration, securityEvent, null, executionDurationMs, errorType, errorMessage);
+  }
+}

--- a/libs/idp-server-platform/src/test/java/org/idp/server/platform/security/handler/SecurityEventHookDispatcherTest.java
+++ b/libs/idp-server-platform/src/test/java/org/idp/server/platform/security/handler/SecurityEventHookDispatcherTest.java
@@ -1,0 +1,188 @@
+/*
+ * Copyright 2025 Hirokazu Kobayashi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.idp.server.platform.security.handler;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+import java.util.List;
+import java.util.Map;
+import org.idp.server.platform.multi_tenancy.tenant.Tenant;
+import org.idp.server.platform.security.SecurityEvent;
+import org.idp.server.platform.security.event.SecurityEventType;
+import org.idp.server.platform.security.hook.SecurityEventHook;
+import org.idp.server.platform.security.hook.SecurityEventHookResult;
+import org.idp.server.platform.security.hook.SecurityEventHookType;
+import org.idp.server.platform.security.hook.SecurityEventHooks;
+import org.idp.server.platform.security.hook.configuration.SecurityEventHookConfiguration;
+import org.idp.server.platform.security.hook.configuration.SecurityEventHookConfigurationIdentifier;
+import org.idp.server.platform.security.hook.configuration.SecurityEventHookConfigurations;
+import org.idp.server.platform.security.repository.SecurityEventHookConfigurationQueryRepository;
+import org.idp.server.platform.security.repository.SecurityEventHookResultCommandRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * #1619: an executor that throws an unexpected exception (outside its own try/catch) must not
+ * propagate out of {@link SecurityEventHookDispatcher#dispatch}. The exception is converted to a
+ * FAILURE result and the remaining hooks still run, so one misconfigured/buggy hook cannot abort
+ * the rest of the event processing — and, on the synchronous path, cannot turn the authentication
+ * request into a 500.
+ */
+@ExtendWith(MockitoExtension.class)
+class SecurityEventHookDispatcherTest {
+
+  @Mock Tenant tenant;
+  @Mock SecurityEvent securityEvent;
+  @Mock SecurityEventHookConfigurationQueryRepository queryRepository;
+  @Mock SecurityEventHookResultCommandRepository resultsCommandRepository;
+
+  @Captor ArgumentCaptor<List<SecurityEventHookResult>> resultsCaptor;
+
+  private void stubEventLogging() {
+    lenient().when(tenant.identifierValue()).thenReturn("tenant-1");
+    lenient().when(securityEvent.type()).thenReturn(new SecurityEventType("login_success"));
+    lenient().when(securityEvent.tenantIdentifierValue()).thenReturn("tenant-1");
+    lenient().when(securityEvent.clientIdentifierValue()).thenReturn("client-1");
+    lenient().when(securityEvent.userSub()).thenReturn("user-1");
+  }
+
+  private SecurityEventHookConfiguration mockConfiguration(SecurityEventHookType type, String id) {
+    SecurityEventHookConfiguration configuration = mock(SecurityEventHookConfiguration.class);
+    lenient().when(configuration.hookType()).thenReturn(type);
+    lenient()
+        .when(configuration.identifier())
+        .thenReturn(new SecurityEventHookConfigurationIdentifier(id));
+    return configuration;
+  }
+
+  private SecurityEventHook mockExecutor() {
+    SecurityEventHook executor = mock(SecurityEventHook.class);
+    when(executor.shouldExecute(any(), any(), any())).thenReturn(true);
+    return executor;
+  }
+
+  @Test
+  void unexpectedException_isIsolated_andSubsequentHooksStillRun() {
+    stubEventLogging();
+
+    SecurityEventHookType webhookType = new SecurityEventHookType("WEBHOOK");
+    SecurityEventHookType slackType = new SecurityEventHookType("SLACK");
+    SecurityEventHookConfiguration webhookConfig = mockConfiguration(webhookType, "hook-webhook");
+    SecurityEventHookConfiguration slackConfig = mockConfiguration(slackType, "hook-slack");
+    when(queryRepository.find(tenant))
+        .thenReturn(new SecurityEventHookConfigurations(List.of(webhookConfig, slackConfig)));
+
+    SecurityEventHook throwingExecutor = mockExecutor();
+    when(throwingExecutor.execute(any(), any(), any()))
+        .thenThrow(new IllegalStateException("boom"));
+
+    SecurityEventHook succeedingExecutor = mockExecutor();
+    SecurityEventHookResult successResult =
+        SecurityEventHookResult.successWithContext(slackConfig, securityEvent, Map.of(), 1L);
+    when(succeedingExecutor.execute(any(), any(), any())).thenReturn(successResult);
+
+    SecurityEventHooks hooks =
+        new SecurityEventHooks(
+            Map.of(webhookType, throwingExecutor, slackType, succeedingExecutor));
+    SecurityEventHookDispatcher dispatcher =
+        new SecurityEventHookDispatcher(hooks, queryRepository, resultsCommandRepository);
+
+    assertDoesNotThrow(() -> dispatcher.dispatch(tenant, securityEvent));
+
+    // The second hook ran despite the first one throwing.
+    verify(succeedingExecutor).execute(any(), any(), any());
+
+    verify(resultsCommandRepository).bulkRegister(eq(tenant), resultsCaptor.capture());
+    List<SecurityEventHookResult> persisted = resultsCaptor.getValue();
+    assertEquals(2, persisted.size());
+    assertTrue(persisted.get(0).isFailure(), "throwing hook recorded as FAILURE");
+    assertTrue(persisted.get(1).isSuccess(), "subsequent hook recorded as SUCCESS");
+  }
+
+  @Test
+  void unexpectedException_isConvertedToFailureResult_withExceptionType() {
+    stubEventLogging();
+
+    SecurityEventHookType webhookType = new SecurityEventHookType("WEBHOOK");
+    SecurityEventHookConfiguration webhookConfig = mockConfiguration(webhookType, "hook-webhook");
+    when(queryRepository.find(tenant))
+        .thenReturn(new SecurityEventHookConfigurations(List.of(webhookConfig)));
+
+    SecurityEventHook throwingExecutor = mockExecutor();
+    when(throwingExecutor.execute(any(), any(), any()))
+        .thenThrow(new NullPointerException("overlays is null"));
+
+    SecurityEventHooks hooks = new SecurityEventHooks(Map.of(webhookType, throwingExecutor));
+    SecurityEventHookDispatcher dispatcher =
+        new SecurityEventHookDispatcher(hooks, queryRepository, resultsCommandRepository);
+
+    dispatcher.dispatch(tenant, securityEvent);
+
+    verify(resultsCommandRepository).bulkRegister(eq(tenant), resultsCaptor.capture());
+    SecurityEventHookResult result = resultsCaptor.getValue().get(0);
+    assertTrue(result.isFailure());
+    assertEquals("WEBHOOK", result.type().name());
+  }
+
+  @Test
+  void nullHookResult_isConvertedToFailure() {
+    stubEventLogging();
+
+    SecurityEventHookType webhookType = new SecurityEventHookType("WEBHOOK");
+    SecurityEventHookConfiguration webhookConfig = mockConfiguration(webhookType, "hook-webhook");
+    when(queryRepository.find(tenant))
+        .thenReturn(new SecurityEventHookConfigurations(List.of(webhookConfig)));
+
+    // A misbehaving executor that returns null instead of a result must not NPE bulkRegister.
+    SecurityEventHook nullReturningExecutor = mockExecutor();
+    when(nullReturningExecutor.execute(any(), any(), any())).thenReturn(null);
+
+    SecurityEventHooks hooks = new SecurityEventHooks(Map.of(webhookType, nullReturningExecutor));
+    SecurityEventHookDispatcher dispatcher =
+        new SecurityEventHookDispatcher(hooks, queryRepository, resultsCommandRepository);
+
+    assertDoesNotThrow(() -> dispatcher.dispatch(tenant, securityEvent));
+
+    verify(resultsCommandRepository).bulkRegister(eq(tenant), resultsCaptor.capture());
+    SecurityEventHookResult result = resultsCaptor.getValue().get(0);
+    assertTrue(result.isFailure());
+    assertEquals("WEBHOOK", result.type().name());
+  }
+
+  @Test
+  void unsupportedHookType_isSkipped_withoutPersistingResults() {
+    SecurityEventHookType unknownType = new SecurityEventHookType("UNKNOWN");
+    SecurityEventHookConfiguration unknownConfig = mockConfiguration(unknownType, "hook-unknown");
+    when(queryRepository.find(tenant))
+        .thenReturn(new SecurityEventHookConfigurations(List.of(unknownConfig)));
+
+    // No executor registered for the configured type.
+    SecurityEventHooks hooks = new SecurityEventHooks(Map.of());
+    SecurityEventHookDispatcher dispatcher =
+        new SecurityEventHookDispatcher(hooks, queryRepository, resultsCommandRepository);
+
+    assertDoesNotThrow(() -> dispatcher.dispatch(tenant, securityEvent));
+
+    verify(resultsCommandRepository, never()).bulkRegister(any(), any());
+  }
+}

--- a/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/application/system/SecurityEventEntryService.java
+++ b/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/application/system/SecurityEventEntryService.java
@@ -23,6 +23,7 @@ import org.idp.server.platform.multi_tenancy.tenant.TenantQueryRepository;
 import org.idp.server.platform.security.SecurityEvent;
 import org.idp.server.platform.security.SecurityEventApi;
 import org.idp.server.platform.security.handler.SecurityEventHandler;
+import org.idp.server.platform.security.handler.SecurityEventHookDispatcher;
 import org.idp.server.platform.security.hook.SecurityEventHooks;
 import org.idp.server.platform.security.log.SecurityEventLogService;
 import org.idp.server.platform.security.repository.SecurityEventCommandRepository;
@@ -49,11 +50,12 @@ public class SecurityEventEntryService implements SecurityEventApi {
       DailyActiveUserCommandRepository dailyActiveUserRepository,
       MonthlyActiveUserCommandRepository monthlyActiveUserRepository,
       YearlyActiveUserCommandRepository yearlyActiveUserRepository) {
+    SecurityEventHookDispatcher hookDispatcher =
+        new SecurityEventHookDispatcher(
+            securityEventHooks, hookQueryRepository, securityEventHookResultCommandRepository);
     this.securityEventHandler =
         new SecurityEventHandler(
-            securityEventHooks,
-            securityEventHookResultCommandRepository,
-            hookQueryRepository,
+            hookDispatcher,
             new SecurityEventLogService(securityEventCommandRepository),
             statisticsEventsRepository,
             dailyActiveUserRepository,


### PR DESCRIPTION
## 概要
`SecurityEventHandler` のフック実行ループで `execute()` が想定外例外を投げると `handle()` まで伝播し、後続フック・統計更新がスキップされていた。特に**同期実行（`publishSync`）経路**では認証リクエスト全体が **500 Internal Server Error** になり、1つの誤設定・不具合フックが無関係な認証処理まで巻き込む構造だった。

Closes #1619

## 原因
各 executor（Email/Webhook 等）は内部で try/catch して失敗を `SecurityEventHookResult.failureWithContext()` に変換するが、これは executor が想定内で握りつぶせた例外に限られる。設定パース・テンプレート補間・フィールドアクセス（NPE）など **executor の try/catch 外**で例外が出ると保護されず、`handle()` を貫通していた（#1447 の SLACK NPE が発見契機）。

## 修正
- フックのディスパッチ責務を **`SecurityEventHookDispatcher`** に切り出し（設定ロード → executor 探索 → 実行 → 結果 `bulkRegister`）。`SecurityEventHandler` は `logEvent → dispatch → 統計更新` に整理し、統計責務のみ残す。
- `executeHook` で `execute()` の **想定外例外・null 返却** を FAILURE の `SecurityEventHookResult` に変換し、次フックへ継続（フック単位で失敗を分離）。
- これにより同期経路の 500 を解消し、非同期経路でも後続フック・統計更新が走る。
- **#1442 の順序制約を維持**：フック実行（外部I/O）は統計更新（`statistics_events` の行ロック取得）の前のまま。`bulkRegister` は `security_event_hook_results` への単純 INSERT でロックに影響しない。

## テスト
`SecurityEventHookDispatcherTest`（新規, 4ケース・全緑）：
- 1つ目フックが例外でも2つ目が実行され、FAILURE + SUCCESS が記録される
- 例外が FAILURE 結果（exception type 保持）に変換される
- executor が null を返しても NPE にならず FAILURE 化
- 未サポートのフックタイプはスキップし永続化しない

統計4リポジトリをモックせずフック実行だけ単体検証できるのが切り出しの利点。

## 補足
- `catch (Exception)` は意図通り（`Error` は回復不能で捕捉しない）。既存 executor（Webhook/SSF）と方針一貫。
- 関連: #1447（SLACK NPE / 発見契機）, #1442（統計書き込みのロック順序）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
