### PR TITLE
refactor(identity-verification): IDA の暫定実装(TODO)を解消 (#1268)

### DIFF
--- a/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/identity/verification/application/query/IdentityVerificationApplicationQueryDataSource.java
+++ b/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/identity/verification/application/query/IdentityVerificationApplicationQueryDataSource.java
@@ -68,7 +68,6 @@ public class IdentityVerificationApplicationQueryDataSource
     return ModelConverter.convert(result);
   }
 
-  // TODO improve query implementation (#1268)
   @Override
   public IdentityVerificationApplication get(Tenant tenant, String key, String identifier) {
     try {

--- a/libs/idp-server-core-extension-ida/src/main/java/org/idp/server/core/extension/identity/verification/application/model/IdentityVerificationApplication.java
+++ b/libs/idp-server-core-extension-ida/src/main/java/org/idp/server/core/extension/identity/verification/application/model/IdentityVerificationApplication.java
@@ -154,13 +154,15 @@ public class IdentityVerificationApplication {
             applyingResult.applicationContext(),
             processConfig.store().applicationDetailsMappingRules());
 
-    Map<String, IdentityVerificationApplicationProcessResult> resultMap = processes.toMap();
+    // Defensive copy: processes.toMap() exposes the internal map, so mutate a copy rather than this
+    // application's state. A put on an existing key replaces the value, so no remove is needed.
+    Map<String, IdentityVerificationApplicationProcessResult> resultMap =
+        new HashMap<>(processes.toMap());
     if (processes.contains(process.name())) {
 
       IdentityVerificationApplicationProcessResult foundResult = processes.get(process.name());
       IdentityVerificationApplicationProcessResult updatedResult =
           foundResult.updateWith(applyingResult);
-      resultMap.remove(process.name());
       resultMap.put(process.name(), updatedResult);
 
     } else {
@@ -204,13 +206,14 @@ public class IdentityVerificationApplication {
     IdentityVerificationApplicationDetails mergedApplicationDetails =
         applicationDetails.merge(context, processConfig.store().applicationDetailsMappingRules());
 
-    // TODO improve process result merge strategy (#1268)
-    Map<String, IdentityVerificationApplicationProcessResult> resultMap = processes.toMap();
+    // Defensive copy: processes.toMap() exposes the internal map, so mutate a copy rather than this
+    // application's state. A put on an existing key replaces the value, so no remove is needed.
+    Map<String, IdentityVerificationApplicationProcessResult> resultMap =
+        new HashMap<>(processes.toMap());
     if (processes.contains(process.name())) {
 
       IdentityVerificationApplicationProcessResult foundResult = processes.get(process.name());
       IdentityVerificationApplicationProcessResult updatedResult = foundResult.updateSuccess();
-      resultMap.remove(process.name());
       resultMap.put(process.name(), updatedResult);
 
     } else {

--- a/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/application/identity_verification_service/IdentityVerificationEntryService.java
+++ b/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/application/identity_verification_service/IdentityVerificationEntryService.java
@@ -106,7 +106,8 @@ public class IdentityVerificationEntryService implements IdentityVerificationApi
       return validationResult.errorResponse();
     }
 
-    // TODO improve type-safe request parameter access (#1268)
+    // user_id is a body field of the direct-registration request (already schema-validated above),
+    // resolved into the typed UserIdentifier here.
     UserIdentifier userIdentifier = new UserIdentifier(request.getValueAsString("user_id"));
     User user = userQueryRepository.get(tenant, userIdentifier);
 


### PR DESCRIPTION
## 概要
IDA モジュールの暫定実装(TODO)を解消する (#1268)。CDD 関連は #1592（ParameterResolver）/ #1636（Verifier）で対応済みのため、本 PR は残りの暫定実装を扱う。

## 変更
- **IdentityVerificationApplication**: プロセス結果マージを防御コピー化し冗長な `remove` を削除。`processes.toMap()` は内部マップ参照を返すため `remove`/`put` が `this` の状態を破壊していたのを修正（`HashMap` で `put` は上書き＝`remove` 不要）。apply / callback 両経路に適用。
- **IdentityVerificationEntryService**: `user_id` から `UserIdentifier` を構築する TODO を解消（直接登録リクエストのボディフィールドからの解決は妥当なため意図をコメント化）。
- **IdentityVerificationApplicationQueryDataSource**: `get()` は専用 `external_application_id` カラム + JSONB フォールバックで実装済みのため stale な TODO を削除。

## 検証
IDA integration E2E 全 **22 suites / 108 tests green**（apply/callback のマージ経路を通る integration-03/11/14/15 含む）。

Closes #1268

🤖 Generated with [Claude Code](https://claude.com/claude-code)
