### PR TITLE
feat(identity-verification): application_details の store に deep_merge オプションを追加 (#1637)

### DIFF
--- a/e2e/src/tests/integration/ida/integration-21-application-details-deep-merge.test.js
+++ b/e2e/src/tests/integration/ida/integration-21-application-details-deep-merge.test.js
@@ -1,0 +1,185 @@
+import { describe, expect, it, beforeAll, afterAll } from "@jest/globals";
+import { get, postWithJson, deletion } from "../../../lib/http";
+import { requestToken } from "../../../api/oauthClient";
+import {
+  backendUrl,
+  clientSecretPostClient,
+  serverConfig,
+  federationServerConfig,
+} from "../../testConfig";
+import { createFederatedUser } from "../../../user";
+import { v4 as uuidv4 } from "uuid";
+
+/**
+ * #1637: store の `application_details_update_policy` を検証する。
+ *
+ * 複数 process が同じ親キー（`progress`）配下の別サブキーを書くとき、
+ *  - 既定（`merge` = トップレベル putAll）: 後続 process が親キーごと置換し、先行サブキーが消える
+ *  - `deep_merge`: Map を再帰マージし、サブキーが共存する
+ *
+ * apply（progress.opening を作成）→ review-investment（progress.investment を追記）の 2 process で、
+ * policy 別に application_details.progress の中身がどうなるかを確認する。
+ */
+describe("Identity Verification - application_details deep_merge (#1637)", () => {
+  const orgId = serverConfig.organizationId;
+  const tenantId = serverConfig.tenantId;
+
+  let orgAccessToken;
+  let userAccessToken;
+  const createdConfigIds = [];
+
+  beforeAll(async () => {
+    const orgAuthResponse = await requestToken({
+      endpoint: `${backendUrl}/${tenantId}/v1/tokens`,
+      grantType: "password",
+      username: "ito.ichiro@gmail.com",
+      password: "successUserCode001",
+      clientId: clientSecretPostClient.clientId,
+      clientSecret: clientSecretPostClient.clientSecret,
+      scope: "org-management account management",
+    });
+    expect(orgAuthResponse.status).toBe(200);
+    orgAccessToken = orgAuthResponse.data.access_token;
+
+    const { accessToken } = await createFederatedUser({
+      serverConfig: serverConfig,
+      federationServerConfig: federationServerConfig,
+      client: clientSecretPostClient,
+      adminClient: clientSecretPostClient,
+      scope:
+        "openid profile phone email identity_verification_application " +
+        clientSecretPostClient.identityVerificationScope,
+    });
+    userAccessToken = accessToken;
+  });
+
+  afterAll(async () => {
+    for (const configId of createdConfigIds) {
+      await deletion({
+        url: `${backendUrl}/v1/management/organizations/${orgId}/tenants/${tenantId}/identity-verification-configurations/${configId}`,
+        headers: { Authorization: `Bearer ${orgAccessToken}` },
+      });
+    }
+  });
+
+  // apply writes progress.opening; review-investment writes progress.investment under the given
+  // update policy. No carry-forward ($.application.application_details) mapping is used, so the
+  // sibling subkey survives only when the policy preserves it.
+  const registerConfiguration = async (type, investmentUpdatePolicy) => {
+    const configId = uuidv4();
+    const investmentStore = {
+      application_details_mapping_rules: [
+        { from: "$.request_body.investment_status", to: "progress.investment" },
+      ],
+    };
+    if (investmentUpdatePolicy) {
+      investmentStore.application_details_update_policy = investmentUpdatePolicy;
+    }
+    const response = await postWithJson({
+      url: `${backendUrl}/v1/management/organizations/${orgId}/tenants/${tenantId}/identity-verification-configurations`,
+      headers: {
+        Authorization: `Bearer ${orgAccessToken}`,
+        "Content-Type": "application/json",
+      },
+      body: {
+        id: configId,
+        type,
+        attributes: { enabled: true },
+        common: { auth_type: "none" },
+        processes: {
+          apply: {
+            request: {
+              schema: {
+                type: "object",
+                required: ["opening_status"],
+                properties: { opening_status: { type: "string" } },
+              },
+            },
+            execution: { type: "no_action" },
+            store: {
+              application_details_mapping_rules: [
+                { from: "$.request_body.opening_status", to: "progress.opening" },
+              ],
+            },
+          },
+          "review-investment": {
+            request: {
+              schema: {
+                type: "object",
+                required: ["investment_status"],
+                properties: { investment_status: { type: "string" } },
+              },
+            },
+            execution: { type: "no_action" },
+            store: investmentStore,
+          },
+        },
+      },
+    });
+    expect(response.status).toBe(201);
+    createdConfigIds.push(configId);
+    return type;
+  };
+
+  const apply = async (type, body) => {
+    const url = serverConfig.identityVerificationApplyEndpoint
+      .replace("{type}", type)
+      .replace("{process}", "apply");
+    const response = await postWithJson({
+      url,
+      headers: { "Content-Type": "application/json", Authorization: `Bearer ${userAccessToken}` },
+      body,
+    });
+    expect(response.status).toBe(200);
+    return response.data.id;
+  };
+
+  const runProcess = async (type, applicationId, process, body) => {
+    const url = serverConfig.identityVerificationProcessEndpoint
+      .replace("{type}", type)
+      .replace("{id}", applicationId)
+      .replace("{process}", process);
+    const response = await postWithJson({
+      url,
+      headers: { "Content-Type": "application/json", Authorization: `Bearer ${userAccessToken}` },
+      body,
+    });
+    expect(response.status).toBe(200);
+    return response;
+  };
+
+  const getApplicationDetails = async (type, applicationId) => {
+    const response = await get({
+      url: serverConfig.identityVerificationApplicationsEndpoint + `?id=${applicationId}&type=${type}`,
+      headers: { Authorization: `Bearer ${userAccessToken}` },
+    });
+    expect(response.status).toBe(200);
+    expect(response.data.list.length).toBe(1);
+    console.log("application_details:", JSON.stringify(response.data.list[0].application_details, null, 2));
+    return response.data.list[0].application_details;
+  };
+
+  it("deep_merge: sibling subkeys under a shared parent are preserved across processes", async () => {
+    const type = await registerConfiguration(uuidv4(), "deep_merge");
+
+    const applicationId = await apply(type, { opening_status: "approved" });
+    await runProcess(type, applicationId, "review-investment", { investment_status: "approved" });
+
+    const details = await getApplicationDetails(type, applicationId);
+    expect(details.progress.opening).toEqual("approved");
+    expect(details.progress.investment).toEqual("approved");
+  });
+
+  it("default (merge): the shared parent is replaced, dropping the earlier sibling subkey", async () => {
+    // Documents the pre-#1637 behavior and guards the default path: without deep_merge the second
+    // process's putAll replaces `progress` wholesale, so progress.opening is lost.
+    const type = await registerConfiguration(uuidv4(), undefined);
+
+    const applicationId = await apply(type, { opening_status: "approved" });
+    await runProcess(type, applicationId, "review-investment", { investment_status: "approved" });
+
+    const details = await getApplicationDetails(type, applicationId);
+    expect(details.progress.investment).toEqual("approved");
+    expect(details.progress.opening).toBeUndefined();
+  });
+});

--- a/libs/idp-server-core-extension-ida/src/main/java/org/idp/server/core/extension/identity/verification/application/model/IdentityVerificationApplication.java
+++ b/libs/idp-server-core-extension-ida/src/main/java/org/idp/server/core/extension/identity/verification/application/model/IdentityVerificationApplication.java
@@ -152,7 +152,8 @@ public class IdentityVerificationApplication {
     IdentityVerificationApplicationDetails mergedApplicationDetails =
         applicationDetails.merge(
             applyingResult.applicationContext(),
-            processConfig.store().applicationDetailsMappingRules());
+            processConfig.store().applicationDetailsMappingRules(),
+            processConfig.store().isApplicationDetailsDeepMerge());
 
     // Defensive copy: processes.toMap() exposes the internal map, so mutate a copy rather than this
     // application's state. A put on an existing key replaces the value, so no remove is needed.
@@ -204,7 +205,10 @@ public class IdentityVerificationApplication {
         verificationConfiguration.getProcessConfig(process);
 
     IdentityVerificationApplicationDetails mergedApplicationDetails =
-        applicationDetails.merge(context, processConfig.store().applicationDetailsMappingRules());
+        applicationDetails.merge(
+            context,
+            processConfig.store().applicationDetailsMappingRules(),
+            processConfig.store().isApplicationDetailsDeepMerge());
 
     // Defensive copy: processes.toMap() exposes the internal map, so mutate a copy rather than this
     // application's state. A put on an existing key replaces the value, so no remove is needed.

--- a/libs/idp-server-core-extension-ida/src/main/java/org/idp/server/core/extension/identity/verification/application/model/IdentityVerificationApplicationDetails.java
+++ b/libs/idp-server-core-extension-ida/src/main/java/org/idp/server/core/extension/identity/verification/application/model/IdentityVerificationApplicationDetails.java
@@ -64,8 +64,8 @@ public class IdentityVerificationApplicationDetails {
    * putAll}: a colliding parent key is replaced wholesale, so two processes writing different
    * subkeys under the same parent lose each other's data. With {@code deepMerge=true} (policy
    * {@code "deep_merge"}) nested {@link Map} values are merged recursively (scalars and arrays
-   * still overwrite), so sibling subkeys under a shared parent are preserved — e.g. accumulating
-   * {@code progress.<sub>} across processes. (#1637)
+   * still overwrite, null source values are skipped), so sibling subkeys under a shared parent are
+   * preserved — e.g. accumulating {@code progress.<sub>} across processes. (#1637)
    */
   public IdentityVerificationApplicationDetails merge(
       IdentityVerificationContext applicationContext,
@@ -88,12 +88,18 @@ public class IdentityVerificationApplicationDetails {
   /**
    * Recursively merges {@code source} into {@code target}: when both sides hold a {@link Map} for
    * the same key the children are merged recursively; otherwise (scalar, array, or type change) the
-   * source value overwrites. Package-private for direct unit testing. (#1637)
+   * source value overwrites. A null source value is skipped so it never clobbers existing data — an
+   * unmatched {@code from} JSONPath maps to null, and the intent of deep_merge is to accumulate.
+   * Mirrors the null-skip semantics of {@code verified_claims} deep_merge. Package-private for
+   * direct unit testing. (#1637)
    */
   @SuppressWarnings("unchecked")
   static void deepMerge(Map<String, Object> target, Map<String, Object> source) {
     source.forEach(
         (key, newValue) -> {
+          if (newValue == null) {
+            return;
+          }
           Object existingValue = target.get(key);
           if (existingValue instanceof Map && newValue instanceof Map) {
             Map<String, Object> mergedChild = new HashMap<>((Map<String, Object>) existingValue);

--- a/libs/idp-server-core-extension-ida/src/main/java/org/idp/server/core/extension/identity/verification/application/model/IdentityVerificationApplicationDetails.java
+++ b/libs/idp-server-core-extension-ida/src/main/java/org/idp/server/core/extension/identity/verification/application/model/IdentityVerificationApplicationDetails.java
@@ -54,15 +54,55 @@ public class IdentityVerificationApplicationDetails {
 
   public IdentityVerificationApplicationDetails merge(
       IdentityVerificationContext applicationContext, List<MappingRule> mappingRules) {
+    return merge(applicationContext, mappingRules, false);
+  }
+
+  /**
+   * Merges this process's mapping result into the current {@code application_details}.
+   *
+   * <p>With {@code deepMerge=false} (default policy {@code "merge"}) this is a top-level {@code
+   * putAll}: a colliding parent key is replaced wholesale, so two processes writing different
+   * subkeys under the same parent lose each other's data. With {@code deepMerge=true} (policy
+   * {@code "deep_merge"}) nested {@link Map} values are merged recursively (scalars and arrays
+   * still overwrite), so sibling subkeys under a shared parent are preserved — e.g. accumulating
+   * {@code progress.<sub>} across processes. (#1637)
+   */
+  public IdentityVerificationApplicationDetails merge(
+      IdentityVerificationContext applicationContext,
+      List<MappingRule> mappingRules,
+      boolean deepMerge) {
     JsonNodeWrapper jsonNodeWrapper = JsonNodeWrapper.fromMap(applicationContext.toMap());
     JsonPathWrapper jsonPathWrapper = new JsonPathWrapper(jsonNodeWrapper.toJson());
     Map<String, Object> mappingResult =
         MappingRuleObjectMapper.execute(mappingRules, jsonPathWrapper);
     Map<String, Object> mergedResult = new HashMap<>(json.toMap());
-    ;
-    mergedResult.putAll(mappingResult);
+    if (deepMerge) {
+      deepMerge(mergedResult, mappingResult);
+    } else {
+      mergedResult.putAll(mappingResult);
+    }
 
     return new IdentityVerificationApplicationDetails(JsonNodeWrapper.fromMap(mergedResult));
+  }
+
+  /**
+   * Recursively merges {@code source} into {@code target}: when both sides hold a {@link Map} for
+   * the same key the children are merged recursively; otherwise (scalar, array, or type change) the
+   * source value overwrites. Package-private for direct unit testing. (#1637)
+   */
+  @SuppressWarnings("unchecked")
+  static void deepMerge(Map<String, Object> target, Map<String, Object> source) {
+    source.forEach(
+        (key, newValue) -> {
+          Object existingValue = target.get(key);
+          if (existingValue instanceof Map && newValue instanceof Map) {
+            Map<String, Object> mergedChild = new HashMap<>((Map<String, Object>) existingValue);
+            deepMerge(mergedChild, (Map<String, Object>) newValue);
+            target.put(key, mergedChild);
+          } else {
+            target.put(key, newValue);
+          }
+        });
   }
 
   public String getValueOrEmptyAsString(String fieldName) {

--- a/libs/idp-server-core-extension-ida/src/main/java/org/idp/server/core/extension/identity/verification/configuration/process/IdentityVerificationStoreConfig.java
+++ b/libs/idp-server-core-extension-ida/src/main/java/org/idp/server/core/extension/identity/verification/configuration/process/IdentityVerificationStoreConfig.java
@@ -46,6 +46,10 @@ public class IdentityVerificationStoreConfig implements JsonReadable {
         : applicationDetailsUpdatePolicy;
   }
 
+  public boolean hasApplicationDetailsUpdatePolicy() {
+    return applicationDetailsUpdatePolicy != null && !applicationDetailsUpdatePolicy.isEmpty();
+  }
+
   public boolean isApplicationDetailsDeepMerge() {
     return "deep_merge".equals(applicationDetailsUpdatePolicy());
   }
@@ -65,7 +69,8 @@ public class IdentityVerificationStoreConfig implements JsonReadable {
     Map<String, Object> map = new HashMap<>();
     if (hasApplicationDetailsMappingRules())
       map.put("application_details_mapping_rules", applicationDetailsMappingRulesMap());
-    map.put("application_details_update_policy", applicationDetailsUpdatePolicy());
+    if (hasApplicationDetailsUpdatePolicy())
+      map.put("application_details_update_policy", applicationDetailsUpdatePolicy);
     return map;
   }
 }

--- a/libs/idp-server-core-extension-ida/src/main/java/org/idp/server/core/extension/identity/verification/configuration/process/IdentityVerificationStoreConfig.java
+++ b/libs/idp-server-core-extension-ida/src/main/java/org/idp/server/core/extension/identity/verification/configuration/process/IdentityVerificationStoreConfig.java
@@ -26,6 +26,10 @@ import org.idp.server.platform.mapper.MappingRule;
 public class IdentityVerificationStoreConfig implements JsonReadable {
 
   List<MappingRule> applicationDetailsMappingRules = new ArrayList<>();
+  // How this process's mapping result is merged into application_details. Mirrors
+  // result.verified_claims_update_policy: "merge" (default, top-level putAll) or "deep_merge"
+  // (recursive merge so sibling subkeys under a shared parent are preserved). (#1637)
+  String applicationDetailsUpdatePolicy;
 
   public IdentityVerificationStoreConfig() {}
 
@@ -34,6 +38,16 @@ public class IdentityVerificationStoreConfig implements JsonReadable {
       return new ArrayList<>();
     }
     return applicationDetailsMappingRules;
+  }
+
+  public String applicationDetailsUpdatePolicy() {
+    return applicationDetailsUpdatePolicy == null || applicationDetailsUpdatePolicy.isEmpty()
+        ? "merge"
+        : applicationDetailsUpdatePolicy;
+  }
+
+  public boolean isApplicationDetailsDeepMerge() {
+    return "deep_merge".equals(applicationDetailsUpdatePolicy());
   }
 
   public List<Map<String, Object>> applicationDetailsMappingRulesMap() {
@@ -51,6 +65,7 @@ public class IdentityVerificationStoreConfig implements JsonReadable {
     Map<String, Object> map = new HashMap<>();
     if (hasApplicationDetailsMappingRules())
       map.put("application_details_mapping_rules", applicationDetailsMappingRulesMap());
+    map.put("application_details_update_policy", applicationDetailsUpdatePolicy());
     return map;
   }
 }

--- a/libs/idp-server-core-extension-ida/src/test/java/org/idp/server/core/extension/identity/verification/application/model/IdentityVerificationApplicationDetailsTest.java
+++ b/libs/idp-server-core-extension-ida/src/test/java/org/idp/server/core/extension/identity/verification/application/model/IdentityVerificationApplicationDetailsTest.java
@@ -92,4 +92,34 @@ class IdentityVerificationApplicationDetailsTest {
     assertEquals(1, merged.get("a"));
     assertEquals(2, merged.get("b"));
   }
+
+  @Test
+  void skipsNullSourceValuesPreservingExisting() {
+    // An unmatched `from` JSONPath maps to null; deep_merge must not clobber existing data with it.
+    Map<String, Object> target = new HashMap<>(Map.of("progress", new HashMap<>(Map.of("a", 1))));
+    Map<String, Object> source = new HashMap<>();
+    source.put("progress", null);
+
+    Map<String, Object> merged = deepMerge(target, source);
+
+    @SuppressWarnings("unchecked")
+    Map<String, Object> progress = (Map<String, Object>) merged.get("progress");
+    assertEquals(1, progress.get("a"));
+  }
+
+  @Test
+  void skipsNullSubkeyValuesPreservingExistingSibling() {
+    Map<String, Object> target =
+        new HashMap<>(Map.of("progress", new HashMap<>(Map.of("opening", "approved"))));
+    Map<String, Object> investment = new HashMap<>();
+    investment.put("investment", null);
+    Map<String, Object> source = Map.of("progress", investment);
+
+    Map<String, Object> merged = deepMerge(target, source);
+
+    @SuppressWarnings("unchecked")
+    Map<String, Object> progress = (Map<String, Object>) merged.get("progress");
+    assertEquals("approved", progress.get("opening"));
+    assertFalse(progress.containsKey("investment"));
+  }
 }

--- a/libs/idp-server-core-extension-ida/src/test/java/org/idp/server/core/extension/identity/verification/application/model/IdentityVerificationApplicationDetailsTest.java
+++ b/libs/idp-server-core-extension-ida/src/test/java/org/idp/server/core/extension/identity/verification/application/model/IdentityVerificationApplicationDetailsTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2025 Hirokazu Kobayashi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.idp.server.core.extension.identity.verification.application.model;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for the {@code deep_merge} application_details policy (#1637): {@code Map} values
+ * merge recursively so sibling subkeys under a shared parent are preserved, while scalars and
+ * arrays overwrite.
+ */
+class IdentityVerificationApplicationDetailsTest {
+
+  @SuppressWarnings("unchecked")
+  private static Map<String, Object> deepMerge(
+      Map<String, Object> target, Map<String, Object> source) {
+    Map<String, Object> copy = new HashMap<>(target);
+    IdentityVerificationApplicationDetails.deepMerge(copy, source);
+    return copy;
+  }
+
+  @Test
+  void preservesSiblingSubkeysUnderSharedParent() {
+    // The core #1637 case: process B writing progress.b must not drop process A's progress.a.
+    Map<String, Object> target = new HashMap<>(Map.of("progress", new HashMap<>(Map.of("a", 1))));
+    Map<String, Object> source = Map.of("progress", Map.of("b", 2));
+
+    Map<String, Object> merged = deepMerge(target, source);
+
+    @SuppressWarnings("unchecked")
+    Map<String, Object> progress = (Map<String, Object>) merged.get("progress");
+    assertEquals(1, progress.get("a"));
+    assertEquals(2, progress.get("b"));
+  }
+
+  @Test
+  void overwritesScalarValues() {
+    Map<String, Object> merged = deepMerge(new HashMap<>(Map.of("x", 1)), Map.of("x", 2));
+    assertEquals(2, merged.get("x"));
+  }
+
+  @Test
+  void mergesRecursivelyAtDeeperLevels() {
+    Map<String, Object> target = new HashMap<>(Map.of("a", Map.of("b", Map.of("c", 1))));
+    Map<String, Object> source = Map.of("a", Map.of("b", Map.of("d", 2)));
+
+    Map<String, Object> merged = deepMerge(target, source);
+
+    @SuppressWarnings("unchecked")
+    Map<String, Object> b = (Map<String, Object>) ((Map<String, Object>) merged.get("a")).get("b");
+    assertEquals(1, b.get("c"));
+    assertEquals(2, b.get("d"));
+  }
+
+  @Test
+  void overwritesArraysRatherThanMerging() {
+    Map<String, Object> merged =
+        deepMerge(new HashMap<>(Map.of("a", List.of(1, 2))), Map.of("a", List.of(3)));
+    assertEquals(List.of(3), merged.get("a"));
+  }
+
+  @Test
+  void overwritesWhenTypeChangesBetweenMapAndScalar() {
+    // existing Map, incoming scalar -> overwrite (no merge across incompatible types)
+    Map<String, Object> merged =
+        deepMerge(new HashMap<>(Map.of("a", new HashMap<>(Map.of("b", 1)))), Map.of("a", "scalar"));
+    assertEquals("scalar", merged.get("a"));
+  }
+
+  @Test
+  void addsNewTopLevelKeys() {
+    Map<String, Object> merged = deepMerge(new HashMap<>(Map.of("a", 1)), Map.of("b", 2));
+    assertEquals(1, merged.get("a"));
+    assertEquals(2, merged.get("b"));
+  }
+}


### PR DESCRIPTION
## 概要

Closes #1637

Identity Verification の store フェーズで `application_details` を更新する `IdentityVerificationApplicationDetails.merge()` は `putAll` による**浅いトップレベルマージ**で、複数 process が同じ親キー配下の別サブキーを書くと後続 process が親キーごと置換し、先行サブキーが失われていた。

store に **`application_details_update_policy`** を追加し、`deep_merge` を opt-in で選べるようにする。

## 変更内容

- `IdentityVerificationStoreConfig`: `application_details_update_policy` フィールド追加（`merge`（既定）/ `deep_merge`）＋ `isApplicationDetailsDeepMerge()`
- `IdentityVerificationApplicationDetails`: `merge(ctx, rules, deepMerge)` オーバーロード＋**再帰 deep-merge** ヘルパ（Map は再帰マージ、スカラー・配列は上書き）。既存 `merge(ctx, rules)` は `merge(…, false)` に委譲
- `IdentityVerificationApplication`（`updateProcessWith` / `updateCallbackWith`）: store の policy を merge に伝播
- 命名は既存 `verified_claims_update_policy` の語彙（`merge` / `deep_merge`）に統一（Issue 本文の「replace=putAll」は putAll が実際はトップレベル merge のため `merge` に補正）

## 後方互換

既定は `merge`（= 現状の putAll）。`deep_merge` は opt-in で既存設定に影響なし。

## テスト

- **unit** `IdentityVerificationApplicationDetailsTest`（6ケース）: 兄弟サブキー保持 / スカラー上書き / 深い再帰 / 配列上書き / 型変化で上書き / 新規キー追加
- **E2E** `integration-21-application-details-deep-merge`（2ケース）: 複合申請（apply→review-investment）で
  - `deep_merge`: `progress.opening` と `progress.investment` が**共存**
  - 既定 `merge`: 後続 putAll で `progress` ごと置換し `opening` が**消失**
  - デプロイ前は deep_merge ケースが `opening: undefined` の**赤を確認 → デプロイ後に緑**（赤→緑実証）

## 補足

`$.application.application_details` を全コピーして次プロセスに引き継ぐ既存の回避策（例: integration-11）が、`deep_merge` なら不要になり、ドメイン上 1 つのネストオブジェクトを平坦化せず自然に表現できる。

> 別スコープ: ドキュメント（config スキーマ）への `application_details_update_policy` 追記は別途。result 側の `verified_claims_update_policy` deep_merge は現状1階層のままで、将来 harmonization 候補。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
