### PR TITLE
fix(identity-verification): callback の execution エラーを実 statusCode で返す (#1613)

### DIFF
--- a/e2e/src/tests/integration/ida/integration-14-callback-pre-hook-verification.test.js
+++ b/e2e/src/tests/integration/ida/integration-14-callback-pre-hook-verification.test.js
@@ -300,6 +300,77 @@ describe("Identity Verification - callback pre_hook verification (#1522)", () =>
     expect(status).toBe("approved");
   });
 
+  // #1613: when a callback `execution` (http_request) hits a downstream failure, the callback must
+  // report that real status (e.g. 502) instead of collapsing every error to 400. Before the fix the
+  // status code was discarded and CLIENT_ERROR (400) was returned unconditionally, masking IdP-side
+  // downstream outages as "your request is invalid" to the calling eKYC service.
+  it("returns the downstream status (502) when the callback execution fails, not a blanket 400", async () => {
+    const { accessToken } = await createTestUser();
+    const type = uuidv4();
+    const basicAuth = { username: "cb_5xx_user", password: "cb_5xx_password001" };
+    await registerConfiguration({
+      "id": uuidv4(),
+      "type": type,
+      "attributes": { "enabled": true },
+      "common": { "auth_type": "none", "callback_application_id_param": "application_id" },
+      "processes": {
+        "apply": {
+          "request": {
+            "schema": {
+              "type": "object",
+              "required": ["external_ref"],
+              "properties": { "external_ref": { "type": "string" } }
+            }
+          },
+          "execution": { "type": "no_action" },
+          "store": {
+            "application_details_mapping_rules": [
+              { "from": "$.request_body", "to": "*" },
+              { "from": "$.request_body.external_ref", "to": "application_id" }
+            ]
+          }
+        },
+        "callback-result": {
+          "request": {
+            "basic_auth": basicAuth,
+            "schema": {
+              "type": "object",
+              "required": ["application_id"],
+              "properties": { "application_id": { "type": "string" } }
+            }
+          },
+          // execution targets the mock's error endpoint, which returns 502 for body.status="502"
+          "execution": {
+            "type": "http_request",
+            "http_request": {
+              "url": `${mockApiBaseUrl}/e2e/error-responses`,
+              "method": "POST",
+              "auth_type": "none",
+              "header_mapping_rules": [{ "static_value": "application/json", "to": "Content-Type" }],
+              "body_mapping_rules": [{ "static_value": "502", "to": "status" }]
+            }
+          }
+        }
+      }
+    });
+
+    const externalRef = uuidv4();
+    await apply({ type, accessToken, externalRef });
+
+    const callbackUrl = serverConfig.identityVerificationApplicationsPublicCallbackEndpoint
+      .replace("{type}", type)
+      .replace("{callbackName}", "callback-result");
+    const response = await callProcess({
+      url: callbackUrl,
+      headers: { "Content-Type": "application/json", ...createBasicAuthHeader(basicAuth) },
+      body: { application_id: externalRef }
+    });
+
+    // the callback surfaces the downstream 502, not a flattened 400 (#1613)
+    expect(response.status).toBe(502);
+    expect(response.status).not.toBe(400);
+  });
+
   // The callback endpoint is public; its only gate is the configured Basic auth. A callback with
   // wrong credentials must be rejected (not silently processed). (#1186)
   it("rejects a callback presenting invalid Basic credentials", async () => {

--- a/e2e/src/tests/integration/ida/integration-14-callback-pre-hook-verification.test.js
+++ b/e2e/src/tests/integration/ida/integration-14-callback-pre-hook-verification.test.js
@@ -366,9 +366,8 @@ describe("Identity Verification - callback pre_hook verification (#1522)", () =>
       body: { application_id: externalRef }
     });
 
-    // the callback surfaces the downstream 502, not a flattened 400 (#1613)
+    // the callback surfaces the downstream 502 instead of a flattened 400 (#1613)
     expect(response.status).toBe(502);
-    expect(response.status).not.toBe(400);
   });
 
   // The callback endpoint is public; its only gate is the configured Basic auth. A callback with

--- a/libs/idp-server-core-extension-ida/src/main/java/org/idp/server/core/extension/identity/verification/io/IdentityVerificationCallbackResponse.java
+++ b/libs/idp-server-core-extension-ida/src/main/java/org/idp/server/core/extension/identity/verification/io/IdentityVerificationCallbackResponse.java
@@ -38,6 +38,19 @@ public class IdentityVerificationCallbackResponse {
         IdentityVerificationCallbackStatus.SERVER_ERROR, response);
   }
 
+  /**
+   * Builds a callback response whose status is resolved from a downstream/error status code, so a
+   * failed callback execution reports the real cause (e.g. an external API 502) instead of a
+   * blanket 400. pre_hook validation errors carry 400 and stay {@code CLIENT_ERROR}; execution
+   * failures carry their own 4xx/5xx. Mirrors {@link
+   * IdentityVerificationApplicationResponse#ERROR(int, Map)}. (#1613)
+   */
+  public static IdentityVerificationCallbackResponse fromStatusCode(
+      int statusCode, Map<String, Object> response) {
+    return new IdentityVerificationCallbackResponse(
+        IdentityVerificationCallbackStatus.fromStatusCode(statusCode), response);
+  }
+
   private IdentityVerificationCallbackResponse(
       IdentityVerificationCallbackStatus status, Map<String, Object> response) {
     this.status = status;

--- a/libs/idp-server-core-extension-ida/src/main/java/org/idp/server/core/extension/identity/verification/io/IdentityVerificationCallbackStatus.java
+++ b/libs/idp-server-core-extension-ida/src/main/java/org/idp/server/core/extension/identity/verification/io/IdentityVerificationCallbackStatus.java
@@ -22,7 +22,16 @@ public enum IdentityVerificationCallbackStatus {
   UNAUTHORIZED(401),
   FORBIDDEN(403),
   NOT_FOUND(404),
-  SERVER_ERROR(500);
+  REQUEST_TIMEOUT(408),
+  CONFLICT(409),
+  PAYLOAD_TOO_LARGE(413),
+  UNSUPPORTED_MEDIA_TYPE(415),
+  UNPROCESSABLE_ENTITY(422),
+  TOO_MANY_REQUESTS(429),
+  SERVER_ERROR(500),
+  BAD_GATEWAY(502),
+  SERVICE_UNAVAILABLE(503),
+  GATEWAY_TIMEOUT(504);
 
   int statusCode;
 
@@ -36,5 +45,18 @@ public enum IdentityVerificationCallbackStatus {
 
   public boolean isOK() {
     return this == OK;
+  }
+
+  public static IdentityVerificationCallbackStatus fromStatusCode(int statusCode) {
+    for (IdentityVerificationCallbackStatus status : values()) {
+      if (status.statusCode == statusCode) {
+        return status;
+      }
+    }
+    if (statusCode >= 400 && statusCode < 500) {
+      return CLIENT_ERROR;
+    }
+
+    return SERVER_ERROR;
   }
 }

--- a/libs/idp-server-core-extension-ida/src/test/java/org/idp/server/core/extension/identity/verification/io/IdentityVerificationCallbackStatusTest.java
+++ b/libs/idp-server-core-extension-ida/src/test/java/org/idp/server/core/extension/identity/verification/io/IdentityVerificationCallbackStatusTest.java
@@ -17,6 +17,7 @@
 package org.idp.server.core.extension.identity.verification.io;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 import org.junit.jupiter.api.Test;
 
@@ -67,7 +68,6 @@ class IdentityVerificationCallbackStatusTest {
     IdentityVerificationCallbackStatus resolved =
         IdentityVerificationCallbackStatus.fromStatusCode(502);
     assertEquals(502, resolved.statusCode());
-    org.junit.jupiter.api.Assertions.assertNotEquals(
-        IdentityVerificationCallbackStatus.CLIENT_ERROR, resolved);
+    assertNotEquals(IdentityVerificationCallbackStatus.CLIENT_ERROR, resolved);
   }
 }

--- a/libs/idp-server-core-extension-ida/src/test/java/org/idp/server/core/extension/identity/verification/io/IdentityVerificationCallbackStatusTest.java
+++ b/libs/idp-server-core-extension-ida/src/test/java/org/idp/server/core/extension/identity/verification/io/IdentityVerificationCallbackStatusTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2025 Hirokazu Kobayashi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.idp.server.core.extension.identity.verification.io;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * #1613: a failed callback execution must report the real downstream status rather than a blanket
+ * 400. {@link IdentityVerificationCallbackStatus#fromStatusCode(int)} resolves the carried status
+ * code, distinguishing client (4xx) from server (5xx) failures.
+ */
+class IdentityVerificationCallbackStatusTest {
+
+  @Test
+  void resolvesExactlyMappedCodes() {
+    assertEquals(
+        IdentityVerificationCallbackStatus.CLIENT_ERROR,
+        IdentityVerificationCallbackStatus.fromStatusCode(400));
+    assertEquals(
+        IdentityVerificationCallbackStatus.UNAUTHORIZED,
+        IdentityVerificationCallbackStatus.fromStatusCode(401));
+    assertEquals(
+        IdentityVerificationCallbackStatus.BAD_GATEWAY,
+        IdentityVerificationCallbackStatus.fromStatusCode(502));
+    assertEquals(
+        IdentityVerificationCallbackStatus.SERVICE_UNAVAILABLE,
+        IdentityVerificationCallbackStatus.fromStatusCode(503));
+    assertEquals(
+        IdentityVerificationCallbackStatus.GATEWAY_TIMEOUT,
+        IdentityVerificationCallbackStatus.fromStatusCode(504));
+  }
+
+  @Test
+  void fallsBackUnmappedClientCodesToClientError() {
+    // 418 is not enumerated; any other 4xx collapses to CLIENT_ERROR (still client, not server).
+    assertEquals(
+        IdentityVerificationCallbackStatus.CLIENT_ERROR,
+        IdentityVerificationCallbackStatus.fromStatusCode(418));
+  }
+
+  @Test
+  void fallsBackUnmappedServerCodesToServerError() {
+    assertEquals(
+        IdentityVerificationCallbackStatus.SERVER_ERROR,
+        IdentityVerificationCallbackStatus.fromStatusCode(599));
+  }
+
+  @Test
+  void theCoreBugCaseExecutionFailureIsNotFlattenedTo400() {
+    // The #1613 regression guard: a downstream 5xx must NOT be reported as CLIENT_ERROR (400).
+    IdentityVerificationCallbackStatus resolved =
+        IdentityVerificationCallbackStatus.fromStatusCode(502);
+    assertEquals(502, resolved.statusCode());
+    org.junit.jupiter.api.Assertions.assertNotEquals(
+        IdentityVerificationCallbackStatus.CLIENT_ERROR, resolved);
+  }
+}

--- a/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/application/identity_verification_service/IdentityVerificationCallbackEntryService.java
+++ b/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/application/identity_verification_service/IdentityVerificationCallbackEntryService.java
@@ -201,8 +201,12 @@ public class IdentityVerificationCallbackEntryService implements IdentityVerific
             requestAttributes,
             verificationConfiguration);
     if (applyingResult.isError()) {
-      return IdentityVerificationCallbackResponse.CLIENT_ERROR(
-          applyingResult.errorResponse().response());
+      // Preserve the real failure status instead of collapsing every error to 400: errorResponse()
+      // already branches pre_hook validation failures to 400 and execution failures (e.g. an
+      // external API 502) to their own status code. (#1613)
+      IdentityVerificationApplicationResponse errorResponse = applyingResult.errorResponse();
+      return IdentityVerificationCallbackResponse.fromStatusCode(
+          errorResponse.statusCode(), errorResponse.response());
     }
 
     IdentityVerificationContext context = applyingResult.applicationContext();


### PR DESCRIPTION
## 概要

Closes #1613

callback 経路でプロセスの `execution`（`http_request` 等）が失敗した際、ダウンストリームの実ステータス（502 等）が捨てられ、**一律 HTTP 400 (`CLIENT_ERROR`)** が callback 呼び出し元に返っていた。pre_hook 検証エラー（正当に 400）と execution 障害（本来 5xx 相当）が区別されず、呼び出し元（外部 eKYC サービス等）のリトライ判断やアラートを誤らせていた。

#1522 / #1612 で callback を application パイプライン（`executeRequest`）に統一し、callback でも `execution` が走るようになって顕在化した。

## 原因

`IdentityVerificationCallbackEntryService` が `applyingResult.errorResponse()` から**ボディだけ取り出し、ステータスを `CLIENT_ERROR` 固定**にしていた。
`errorResponse()` 自体は既に「pre_hook 検証エラー → 400 / execution エラー → `executionResult.statusCode()`」を分岐済みだったため、**捨てていた statusCode を使うだけ**で済む。

## 変更内容

- **`IdentityVerificationCallbackStatus`**: `IdentityVerificationApplicationStatus` と同じ値セットへ拡張（`408/409/413/415/422/429/502/503/504`）＋ `fromStatusCode(int)` を追加（4xx→`CLIENT_ERROR`、5xx/その他→`SERVER_ERROR` フォールバック）
- **`IdentityVerificationCallbackResponse`**: `fromStatusCode(int, Map)` ファクトリを追加（`IdentityVerificationApplicationResponse.ERROR(int, Map)` のミラー）
- **`IdentityVerificationCallbackEntryService`**: `errorResponse().statusCode()` を反映。コントローラは既に `HttpStatus.valueOf(response.statusCode())` で直結済みのため、これで実ステータスがそのまま callback 呼び出し元へ届く

## 後方互換

- pre_hook 検証エラー（schema / assert）→ **400 を維持**（`verifyResult.errorResponse()` が `CLIENT_ERROR`）
- execution エラー → ダウンストリームの実コード（502/503/504 等）を**忠実に反映**

## テスト

- **unit** `IdentityVerificationCallbackStatusTest`: enum マッピング（厳密一致 / 未定義 4xx→`CLIENT_ERROR` / 未定義 5xx→`SERVER_ERROR` / 502 が 400 に潰れない回帰ガード）
- **E2E** `integration-14`（新規ケース）: callback の `execution`（mock `/e2e/error-responses` が 502）→ callback も **HTTP 502** を返す
  - **デプロイ前 赤**（`Expected: 502, Received: 400`、ただし error_details.status_code は 502 を保持）→ **デプロイ後 緑** を実証

## 補足

`execution` の `executionResult.statusCode()` は既に正しく 502 を保持していた（application 経路は元々 502 を返せていた）。本 PR は callback 経路をそれに揃えるもの。

🤖 Generated with [Claude Code](https://claude.com/claude-code)