### PR TITLE
feat(identity-verification): claims パラメータ経由の verified_claims を UserInfo で返却 (#1628)

### DIFF
--- a/documentation/docs/content_03_concepts/05-advanced-id/concept-01-id-verified.md
+++ b/documentation/docs/content_03_concepts/05-advanced-id/concept-01-id-verified.md
@@ -295,6 +295,12 @@ payload
 }
 ```
 
+### 2方式が競合した場合の優先順位
+
+`claims` パラメータ（OIDC4IDA 標準）と `verified_claims:*` スコープ（idp-server 独自仕様）の両方で `verified_claims` を要求し、**同一の配信先（UserInfo レスポンス）に出力される**場合は、**`claims` パラメータ（標準）を優先**する。両者は同じトップレベル `verified_claims` キーを生成するため、独自仕様のスコープ側は出力しない。`claims` パラメータはリクエスト単位で明示的かつ粒度の細かい標準の要求方式であり、これを正とする（両方を同時指定するクライアントは実運用では想定していない）。
+
+> UserInfo での要求方式・優先順位の詳細は [UserInfo エンドポイント](../../content_06_developer-guide/03-application-plane/05-userinfo.md#verified_claims身元確認済みクレーム) を参照。
+
 ## 身元確認チェック：`required_identity_verification_scopes`
 
 `required_identity_verification_scopes` は、**身元確認（verified_claims）を済ませたユーザーだけが取得できるスコープ**を定義する設定です。  

--- a/documentation/docs/content_06_developer-guide/03-application-plane/05-userinfo.md
+++ b/documentation/docs/content_06_developer-guide/03-application-plane/05-userinfo.md
@@ -301,6 +301,17 @@ UserInfoレスポンス:
 
 > 上の例では `verified_claims:verification:trust_framework` を要求していないが、`trust_framework` は必須要素なので返る。`evidence` は要求していないので返らない。
 
+#### 要求方式と優先順位
+
+`verified_claims` の要求方式は2つある。
+
+| 方式 | 要求方法 | 位置づけ |
+|------|---------|---------|
+| `claims` パラメータ | `claims` の `userinfo.verified_claims` メンバ | OIDC4IDA 標準。`value`/`values` 制約や §5.7 の選択的省略が適用される |
+| `verified_claims:*` スコープ | `verified_claims:<claim>` 等のスコープ | idp-server 独自拡張。`extension.access_token_selective_verified_claims: true` が必要 |
+
+両経路はどちらもトップレベルの `verified_claims` キーを生成するため、1リクエストで両方が指定された場合は **`claims` パラメータ（標準）を優先**し、`verified_claims:*` スコープ（独自拡張）側は出力しない。`claims` パラメータはリクエスト単位で明示的かつ粒度の細かい要求方式であり、こちらを正とする（両方を同時指定する RP は実運用では想定していない）。
+
 構造仕様・設定追従・過去構造からの移行は [verified_claims 出力構造の変更（利用者対応）](../../content_09_project/verified-claims-structure-change.md) を参照。
 
 ---

--- a/documentation/docs/content_06_developer-guide/03-application-plane/05-userinfo.md
+++ b/documentation/docs/content_06_developer-guide/03-application-plane/05-userinfo.md
@@ -312,7 +312,7 @@ UserInfoレスポンス:
 
 両経路はどちらもトップレベルの `verified_claims` キーを生成するため、1リクエストで両方が指定された場合は **`claims` パラメータ（標準）を優先**し、`verified_claims:*` スコープ（独自拡張）側は出力しない。`claims` パラメータはリクエスト単位で明示的かつ粒度の細かい要求方式であり、こちらを正とする（両方を同時指定する RP は実運用では想定していない）。
 
-構造仕様・設定追従・過去構造からの移行は [verified_claims 出力構造の変更（利用者対応）](../../content_09_project/verified-claims-structure-change.md) を参照。
+構造仕様・設定追従・過去構造からの移行は [verified_claims 出力構造の変更（利用者対応）](../../content_09_project/v0.11.0-verified-claims-impact.md) を参照。
 
 ---
 

--- a/documentation/docs/content_06_developer-guide/04-implementation-guides/oauth-oidc/scope-claims-management.md
+++ b/documentation/docs/content_06_developer-guide/04-implementation-guides/oauth-oidc/scope-claims-management.md
@@ -263,7 +263,7 @@ public class AccessTokenCustomClaimsCreators {
 - **JWT形式の場合**: カスタムクレームを追加可能
 - **Opaque形式の場合**: クレームは含まれず、Introspectionで取得
 
-> **`verified_claims` の出力構造**: 身元確認済みクレームは OIDC4IDA 準拠のネスト構造（`verification` + `claims`）で出力される。Access Token / UserInfo の構造仕様と、過去のフラット構造からの移行手順は [verified_claims 出力構造の変更（利用者対応）](../../../content_09_project/verified-claims-structure-change.md) を参照。
+> **`verified_claims` の出力構造**: 身元確認済みクレームは OIDC4IDA 準拠のネスト構造（`verification` + `claims`）で出力される。Access Token / UserInfo の構造仕様と、過去のフラット構造からの移行手順は [verified_claims 出力構造の変更（利用者対応）](../../../content_09_project/v0.11.0-verified-claims-impact.md) を参照。
 
 ### 3. Userinfo エンドポイント
 

--- a/documentation/docs/content_09_project/v0.11.0-verified-claims-impact.md
+++ b/documentation/docs/content_09_project/v0.11.0-verified-claims-impact.md
@@ -1,16 +1,21 @@
-# verified_claims 出力構造の OIDC4IDA 準拠化と UserInfo 対応
+# v0.11.0 影響確認 — verified_claims の OIDC4IDA 準拠化・配信・移行
+
+本ドキュメントは **v0.11.0** に含まれる `verified_claims`（身元確認済みクレーム）関連の変更と、その**利用者側（RP / テナント運用者）への影響**をまとめる。
 
 **Issue #1435 / PR #1514 対応**: 身元確認済みクレーム（`verified_claims`）の Access Token 出力構造を OIDC4IDA 準拠のネスト構造に修正し、UserInfo エンドポイントでの返却に対応した。
 
-本ドキュメントは、この変更に対する**利用者側（RP / テナント運用者）の対応**をまとめる。
+**Issue #1628 追加対応**: UserInfo を `claims` パラメータ（OIDC4IDA 標準の要求方式）経由でも返せるようにし、`verified_claims` の §5.7「要求より少なく返す」挙動を仕様精査に基づいて見直した（claims が空でも `verification` は返す）。あわせて「何のクレームに同意したか」の記録を grant に自己完結保存する内部変更を行った。
 
 ## 影響まとめ
 
 | 変更 | 種別 | 対象 |
 |------|------|------|
 | Access Token の `verified_claims` がフラット → ネスト構造（`verification` + `claims`）になる | 🔴 破壊的 | `access_token_selective_verified_claims` を有効にしているテナントと、その Access Token を消費する RP / リソースサーバー |
-| UserInfo が `verified_claims` を返すようになる | 🟢 追加 | `access_token_selective_verified_claims` + `verified_claims:*` スコープを使うテナント |
+| UserInfo が `verified_claims` を返すようになる（スコープ経由） | 🟢 追加 | `access_token_selective_verified_claims` + `verified_claims:*` スコープを使うテナント |
+| UserInfo が **`claims` パラメータ（OIDC4IDA 標準）経由**でも `verified_claims` を返す（フラグ不要） | 🟢 追加 | `claims` パラメータで `userinfo.verified_claims` を要求する RP（#1628） |
+| 要求クレームが全て利用不可/不一致でも **`verification` + 空 `claims` を返す**（従来の「全体省略」を見直し） | 🟡 挙動変更 | `verified_claims` を消費する RP（§5.7 / #1512 の挙動見直し） |
 | `verified_claims:*` スコープ・`access_token_selective_verified_claims` フラグの設定追従 | 🟡 設定 | eKYC / 身元確認を提供するテナント |
+| `verified_claims` 要求（同意内容）を grant に sentinel 形式で自己完結保存（ID Token 側も対象） | ⚙️ 内部/運用 | テナント運用者（ローリングデプロイ / 同意レコード） |
 
 ---
 
@@ -81,7 +86,7 @@
 
 ## 2. UserInfo での verified_claims 返却（追加）
 
-これまで UserInfo は `verified_claims` を返さなかったが、本変更で **Access Token のスコープに基づいて選択的に返却**するようになった。Access Token と同じネスト構造（`verification` + `claims`）で返る。
+これまで UserInfo は `verified_claims` を返さなかったが、本変更で返却するようになった。Access Token / ID Token と同じネスト構造（`verification` + `claims`）で返る。
 
 ```json
 // GET /v1/userinfo の応答（抜粋）
@@ -94,7 +99,26 @@
 }
 ```
 
-返却される `claims` は、Access Token が持つ `verified_claims:<claim>` スコープに対応するものに限られる（例: `verified_claims:given_name` があれば `given_name` のみ）。`verification` は必須要素 `trust_framework` が常に含まれ、`evidence` 等の任意要素は `verified_claims:verification:<element>` スコープで選択する（[3.1](#31-スコープの列挙)）。
+### 2.1 2つの要求方式
+
+| 方式 | 要求方法 | フラグ | 位置づけ |
+|------|---------|--------|---------|
+| `verified_claims:*` スコープ | Access Token のスコープ | `access_token_selective_verified_claims: true` が**必要** | idp-server 独自拡張。要素単位の選択は [3.1](#31-スコープの列挙) |
+| `claims` パラメータ（#1628） | 認可リクエストの `claims` の `userinfo.verified_claims` メンバ | **不要** | OIDC4IDA 標準。`value` / `values` 制約や §5.7 の選択的省略が適用される |
+
+> スコープ経由は `access_token_selective_verified_claims` フラグに依存するが、**`claims` パラメータ経由はフラグ非依存**で動作する（標準の要求メカニズムのため）。スコープ経由で返る `claims` は Access Token が持つ `verified_claims:<claim>` スコープに対応するものに限られ、`verification` の任意要素は `verified_claims:verification:<element>` スコープで選択する（[3.1](#31-スコープの列挙)）。
+
+### 2.2 競合時の優先順位
+
+両経路はどちらもトップレベルの `verified_claims` キーを生成するため、1リクエストで両方が指定された場合は **`claims` パラメータ（標準）を優先**し、`verified_claims:*` スコープ（独自拡張）側は出力しない（両方を同時指定する RP は実運用では想定していない）。
+
+### 2.3 返却ルール（§5.7「要求より少なく返す」）
+
+要求したクレームのうち、ユーザーが保持しない／`value`・`values` 制約に一致しないものは個別に省かれる。その結果 `claims` が空になっても、**`verification` が有効なら `verified_claims` は `verification` + 空 `claims`（`claims: {}`）で返す**。IDA スキーマが「`claims` は空でよい」と定める（[IDA-verified-claims §5.3](https://openid.net/specs/openid-ida-verified-claims-1_0.html)）ため、§5.7.5 の親要素省略は空 `claims` では発火しない、という仕様精査の結論による（#1512 の「全体省略」を見直し）。
+
+`verified_claims` を**丸ごと省略**するのは **`verification` 要件が満たせない場合のみ**（`verification` 要素の `value`/`values` 不一致、または必須の `trust_framework` をユーザーが持たない＝§5.7.4）。この挙動は ID Token / UserInfo で共通（OIDC4IDA は配信先を区別しない §5.2）。
+
+> **RP への影響**: 「`verified_claims` が無い＝ユーザーは検証済み属性を持たない」と決め打ちしないこと。要求クレームが揃わなくても `{"verification": {...}, "claims": {}}` が返り得る。
 
 ---
 
@@ -153,19 +177,32 @@
 |--------|--------|-------------|------|
 | `access_token_selective_verified_claims: true` | Access Token **および** UserInfo | `verified_claims:*` スコープに対応するクレームのみ | `verification` + `claims` |
 
-> `access_token_selective_verified_claims` は Access Token と UserInfo の**両方**の選択的返却を制御する。UserInfo に `verified_claims` を返したい場合はこのフラグを有効にする。
+> `access_token_selective_verified_claims` は Access Token と UserInfo の**両方**の選択的返却を制御する。UserInfo に `verified_claims` を返したい場合はこのフラグを有効にする（**スコープ経由のみ**。`claims` パラメータ経由はフラグ不要 = [2.1](#21-2つの要求方式)）。
 > 旧 `access_token_verified_claims`（スコープ不問で全量を Access Token に焼き込むモード）は #1603 で廃止し、選択モードに一本化した。データ最小化（§3.1）の観点でも全量配信は非推奨だったため。
+
+### 3.4 同意記録の永続化（運用者向け）
+
+`claims` パラメータで要求された `verified_claims`（＝ユーザーが何に同意したか）は、grant の `userinfo_claims`（#1628）に **sentinel トークン `vc:<base64url(JSON)>`** として永続化される（DB スキーマ変更なし）。grant を「同意内容の権威ある記録」とし、トークン発行時に元の認可リクエストが無くても `verified_claims` を組み立てられるようにするため。同じ方式を ID Token 側（`id_token_claims`）にも展開中（#1628 フォローアップ）。
+
+- **ローリングデプロイ / ロールバック安全**: 旧バージョンは未知の `vc:` トークンを単に無視する（クレーム出力は `values.contains("name")` 等の**既知名チェック**で、トークン集合を列挙しない）。新旧混在・巻き戻しでもクラッシュや誤クレーム混入は起きない。
+- **同意内容の確認**: 現状この sentinel は Grant 管理 API のレスポンスには出していない（`scopes` のみ）。同意した `verified_claims` を API から観測可能にする対応は #1644 で追跡。
 
 ---
 
 ## 4. 動作確認
 
-`verified_claims:given_name verified_claims:family_name` スコープで Access Token を取得し、AT のデコードと UserInfo の双方でネスト構造を確認する。`verification.trust_framework` が（スコープ未要求でも）常に含まれ、未要求の `evidence` が含まれないこと（オプトイン）、ユーザーが保持するが未要求の `birthdate` 等が含まれないこと（データ最小化）もあわせて確認する。回帰確認は E2E テスト `e2e/src/tests/usecase/ekyc/ekyc-01-verified-claims-at-userinfo-structure.test.js` を参照。
+`verified_claims:given_name verified_claims:family_name` スコープで Access Token を取得し、AT のデコードと UserInfo の双方でネスト構造を確認する。`verification.trust_framework` が（スコープ未要求でも）常に含まれ、未要求の `evidence` が含まれないこと（オプトイン）、ユーザーが保持するが未要求の `birthdate` 等が含まれないこと（データ最小化）もあわせて確認する。
+
+| 経路 | E2E テスト |
+|------|-----------|
+| スコープ経由（AT / UserInfo 構造）| `e2e/src/tests/usecase/ekyc/ekyc-01-verified-claims-at-userinfo-structure.test.js` |
+| `claims` パラメータ経由・§5.7 返却ルール（ID Token / UserInfo）| `e2e/src/tests/spec/oidc_for_identity_assurance.test.js` |
 
 ---
 
 ## 関連ドキュメント
 
 - [スコープ・クレーム管理](../content_06_developer-guide/04-implementation-guides/oauth-oidc/scope-claims-management.md) — `claims:` / `verified_claims:` プレフィックスの仕組み
-- [UserInfo エンドポイント](../content_06_developer-guide/03-application-plane/05-userinfo.md)
+- [UserInfo エンドポイント](../content_06_developer-guide/03-application-plane/05-userinfo.md) — 2つの要求方式と優先順位
+- [身元確認済みID（概念）](../content_03_concepts/05-advanced-id/concept-01-id-verified.md) — 標準（`claims` パラメータ）と独自仕様（`verified_claims:*` スコープ）の対比・優先順位
 - [身元確認申込み実装ガイド](../content_06_developer-guide/03-application-plane/07-identity-verification.md)

--- a/documentation/gap-analysis/oidc4ida-verified-claims-gap-analysis.md
+++ b/documentation/gap-analysis/oidc4ida-verified-claims-gap-analysis.md
@@ -1,7 +1,7 @@
 # OIDC4IDA verified_claims Gap分析
 
 > **ステータス: 本分析は #1514 以前のスナップショット（解消済み）。**
-> - Gap 1（AT のフラット構造）・UserInfo 未実装 → #1514 で `verification` + `claims` ネスト構造化 + UserInfo 対応（利用者向けは [verified-claims-structure-change](../docs/content_09_project/verified-claims-structure-change.md) を参照）。
+> - Gap 1（AT のフラット構造）・UserInfo 未実装 → #1514 で `verification` + `claims` ネスト構造化 + UserInfo 対応（利用者向けは [v0.11.0-verified-claims-impact](../docs/content_09_project/v0.11.0-verified-claims-impact.md) を参照）。
 > - 全件版 `AccessTokenVerifiedClaimsCreator` 自体は #1603 で廃止し、`AccessTokenSelectiveVerifiedClaimsCreator`（selective）へ一本化。以降、本文中の同クラスへの言及は歴史的記録。
 
 ## 仕様要件

--- a/documentation/openapi/swagger-cp-user-ja.yaml
+++ b/documentation/openapi/swagger-cp-user-ja.yaml
@@ -1046,6 +1046,10 @@ components:
           minLength: 8
           maxLength: 255
           description: Plain text password (will be hashed on server)
+        verified_claims:
+          type: object
+          additionalProperties: true
+          description: Verified identity claims (OpenID for Identity Assurance)
         custom_properties:
           type: object
           additionalProperties: true
@@ -1198,6 +1202,10 @@ components:
               maxLength: 255
               description: Country
           description: Physical address of the user
+        verified_claims:
+          type: object
+          additionalProperties: true
+          description: Verified identity claims (OpenID for Identity Assurance)
         custom_properties:
           type: object
           additionalProperties: true

--- a/documentation/openapi/swagger-rp-ja.yaml
+++ b/documentation/openapi/swagger-rp-ja.yaml
@@ -1670,6 +1670,31 @@ components:
 
         仕様：OpenID Connect Core 1.0 Section 5.5 を参照。
 
+        ## verified_claims（身元確認済みクレーム / OIDC4IDA）
+
+        `userinfo` / `id_token` 配下に `verified_claims` を指定すると、OpenID Connect for
+        Identity Assurance 1.0 に従って身元確認済みクレームを要求できる。`verification`
+        （必須要素 `trust_framework`）と `claims` のネスト構造で指定し、`value` / `values`
+        制約や §5.7 の選択的省略（不一致・未保持クレームの省略）が適用される。
+
+        例:
+        {
+          "userinfo": {
+            "verified_claims": {
+              "verification": { "trust_framework": { "value": "eidas" } },
+              "claims": { "given_name": null, "family_name": null }
+            }
+          }
+        }
+
+        ◆優先順位
+        idp-server には `verified_claims:<claim>` プレフィックスのスコープによる独自拡張もあり、
+        UserInfo ではどちらも同一のトップレベル `verified_claims` キーを生成する。1リクエストで
+        両方を指定した場合は **`claims` パラメータ（標準）を優先**し、`verified_claims:*` スコープ
+        （独自拡張）側は出力しない。
+
+        仕様：OpenID Connect for Identity Assurance 1.0 を参照。
+
       schema:
         type: string
 

--- a/e2e/src/tests/spec/oidc_for_identity_assurance.test.js
+++ b/e2e/src/tests/spec/oidc_for_identity_assurance.test.js
@@ -188,15 +188,19 @@ describe("OpenID Connect for Identity Assurance 1.0 ", () => {
       expect(idTokenPayload.verified_claims).toBeUndefined();
     });
 
-    it("applies the §5.7 value constraint on the UserInfo path (claim dropped → whole element omitted)", async () => {
-      // given_name is "Sarah"; a value:"Bob" constraint fails, and with no other matching claim the
-      // whole verified_claims is omitted (§5.7.4/§5.7.5) — same engine as the ID Token path.
+    it("returns verified_claims with an empty claims object when the only requested claim fails its value constraint (UserInfo)", async () => {
+      // given_name is "Sarah"; a value:"Bob" constraint fails (§5.7.4 claims branch → the claim is
+      // dropped). The IDA verified_claims schema permits an empty claims object ([IDA-verified-claims]
+      // §5.3), so verification is still returned with an empty claims — NOT a whole omission. Same
+      // engine as the ID Token path.
       const { userinfo } = await userinfoVerifiedClaims({
         verification: { trust_framework: null },
         claims: { given_name: { value: "Bob" } },
       });
 
-      expect(userinfo.verified_claims).toBeUndefined();
+      expect(userinfo.verified_claims).toBeDefined();
+      expect(userinfo.verified_claims.verification.trust_framework).toEqual("eidas");
+      expect(userinfo.verified_claims.claims).toEqual({});
     });
   });
 
@@ -261,17 +265,21 @@ describe("OpenID Connect for Identity Assurance 1.0 ", () => {
       expect(payload.verified_claims.claims).not.toHaveProperty("middle_name");
     });
 
-    it("If an element is to be omitted according to the rules above, but is a requirement for a valid response, the OP shall omit its parent element as well.", async () => {
-      // #1512: every requested verified claim is unavailable, so the claims element would be empty.
-      // claims is a requirement for a valid verified_claims, so the whole verified_claims element is
-      // omitted — it must NOT be returned as {"verification": {...}, "claims": {}}.
+    it("returns verified_claims with an empty claims object when all requested claims are unavailable ([IDA-verified-claims] §5.3: the claims element may be empty)", async () => {
+      // middle_name and gender are not stored, so both are dropped individually (§5.7.2). The claims
+      // object is then empty, which the IDA verified_claims schema explicitly permits (§5.3: "the
+      // claims element may be empty"), so verified_claims is still returned with verification — NOT
+      // omitted as a whole. §5.7.5 cascades omission to the parent only when the omitted element is
+      // required for a valid response, which an empty claims object is not.
       const payload = await idTokenVerifiedClaims({
         verification: { trust_framework: null },
         claims: { middle_name: null, gender: null },
       });
       console.log(JSON.stringify(payload, null, 2));
 
-      expect(payload.verified_claims).toBeUndefined();
+      expect(payload.verified_claims).toBeDefined();
+      expect(payload.verified_claims.verification.trust_framework).toEqual("eidas");
+      expect(payload.verified_claims.claims).toEqual({});
     });
 
     // §5.7.4 value/values constraint enforcement (#1624). The user holds trust_framework "eidas"

--- a/e2e/src/tests/spec/oidc_for_identity_assurance.test.js
+++ b/e2e/src/tests/spec/oidc_for_identity_assurance.test.js
@@ -127,6 +127,79 @@ describe("OpenID Connect for Identity Assurance 1.0 ", () => {
 
   });
 
+  // OpenID Connect for Identity Assurance 1.0 §5.3 / §5.7, eKYC conformance module #9
+  // (ekyc-server-request-only-in-userinfo). verified_claims requested via the `claims` parameter's
+  // `userinfo` member must be returned in the UserInfo response and NOT in the ID Token. Before
+  // #1628 the claims-parameter request was dropped at the grant boundary, so UserInfo only honored
+  // the verified_claims:* scope. (#1628)
+  describe("verified_claims via the claims parameter (UserInfo)", () => {
+    const userinfoVerifiedClaims = async (verifiedClaimsRequest) => {
+      const { authorizationResponse } = await requestAuthorizations({
+        endpoint: serverConfig.authorizationEndpoint,
+        clientId: clientSecretPostClient.clientId,
+        responseType: "code",
+        state: "userinfo_verified_claims_1628",
+        // no verified_claims:* scope: this exercises the claims-parameter path, not the scope path.
+        scope: "openid " + clientSecretPostClient.scope,
+        redirectUri: clientSecretPostClient.redirectUri,
+        claims: JSON.stringify({ userinfo: { verified_claims: verifiedClaimsRequest } }),
+      });
+      expect(authorizationResponse.code).not.toBeNull();
+
+      const tokenResponse = await requestToken({
+        endpoint: serverConfig.tokenEndpoint,
+        code: authorizationResponse.code,
+        grantType: "authorization_code",
+        redirectUri: clientSecretPostClient.redirectUri,
+        clientId: clientSecretPostClient.clientId,
+        clientSecret: clientSecretPostClient.clientSecret,
+      });
+      expect(tokenResponse.status).toBe(200);
+
+      const jwksResponse = await getJwks({ endpoint: serverConfig.jwksEndpoint });
+      const decodedIdToken = verifyAndDecodeJwt({
+        jwt: tokenResponse.data.id_token,
+        jwks: jwksResponse.data,
+      });
+      expect(decodedIdToken.verifyResult).toBe(true);
+
+      const userinfoResponse = await get({
+        url: `${backendUrl}/${serverConfig.tenantId}/v1/userinfo`,
+        headers: { Authorization: `Bearer ${tokenResponse.data.access_token}` },
+      });
+      expect(userinfoResponse.status).toBe(200);
+      console.log(JSON.stringify(userinfoResponse.data, null, 2));
+      return { userinfo: userinfoResponse.data, idTokenPayload: decodedIdToken.payload };
+    };
+
+    it("returns verified_claims in the UserInfo response and omits it from the ID Token (module #9)", async () => {
+      const { userinfo, idTokenPayload } = await userinfoVerifiedClaims({
+        verification: { trust_framework: null },
+        claims: { given_name: null, family_name: null },
+      });
+
+      // §5.3: the UserInfo response carries the requested verified_claims.
+      expect(userinfo.verified_claims).toBeDefined();
+      expect(userinfo.verified_claims.verification.trust_framework).toEqual("eidas");
+      expect(userinfo.verified_claims.claims.given_name).toEqual("Sarah");
+
+      // EnsureIdTokenDoesNotContainVerifiedClaims: requested userinfo-only, so the ID Token must not
+      // carry verified_claims.
+      expect(idTokenPayload.verified_claims).toBeUndefined();
+    });
+
+    it("applies the §5.7 value constraint on the UserInfo path (claim dropped → whole element omitted)", async () => {
+      // given_name is "Sarah"; a value:"Bob" constraint fails, and with no other matching claim the
+      // whole verified_claims is omitted (§5.7.4/§5.7.5) — same engine as the ID Token path.
+      const { userinfo } = await userinfoVerifiedClaims({
+        verification: { trust_framework: null },
+        claims: { given_name: { value: "Bob" } },
+      });
+
+      expect(userinfo.verified_claims).toBeUndefined();
+    });
+  });
+
   // OpenID Connect for Identity Assurance 1.0, Section 5.7 (Returning less data than requested).
   // Test names quote the spec verbatim, as in the Section 8 block. verified_claims is requested via
   // the `claims` parameter and returned in the ID Token (handled by VerifiedClaimsCreator).

--- a/libs/idp-server-core-extension-ida/src/main/java/org/idp/server/core/extension/identity/verified/UserinfoSelectiveVerifiedClaimsCreator.java
+++ b/libs/idp-server-core-extension-ida/src/main/java/org/idp/server/core/extension/identity/verified/UserinfoSelectiveVerifiedClaimsCreator.java
@@ -48,6 +48,17 @@ public class UserinfoSelectiveVerifiedClaimsCreator
       return false;
     }
 
+    // The scope path and the claims-parameter path (UserinfoVerifiedClaimsCreator) both emit the
+    // same top-level verified_claims key, and the invoker composes creators via putAll — running
+    // both would let SPI/ServiceLoader order decide the winner non-deterministically. The claims
+    // parameter is the more explicit, per-request mechanism, so it takes precedence: when an RP
+    // requested verified_claims via the claims parameter, defer to that path and skip scope-based
+    // selection here. (An RP mixing both in one request is not an expected real-world case.)
+    // (#1628)
+    if (authorizationGrant.userinfoClaims().hasVerifiedClaims()) {
+      return false;
+    }
+
     Scopes scopes = authorizationGrant.scopes();
     if (!scopes.hasScopeMatchedPrefix(SelectiveVerifiedClaims.PREFIX)) {
       return false;

--- a/libs/idp-server-core-extension-ida/src/main/java/org/idp/server/core/extension/identity/verified/UserinfoVerifiedClaimsCreator.java
+++ b/libs/idp-server-core-extension-ida/src/main/java/org/idp/server/core/extension/identity/verified/UserinfoVerifiedClaimsCreator.java
@@ -17,59 +17,46 @@
 package org.idp.server.core.extension.identity.verified;
 
 import java.util.Map;
-import org.idp.server.core.openid.authentication.Authentication;
 import org.idp.server.core.openid.grant_management.grant.AuthorizationGrant;
-import org.idp.server.core.openid.grant_management.grant.GrantIdTokenClaims;
 import org.idp.server.core.openid.identity.User;
-import org.idp.server.core.openid.identity.id_token.IdTokenCustomClaims;
-import org.idp.server.core.openid.identity.id_token.RequestedClaimsPayload;
-import org.idp.server.core.openid.identity.id_token.RequestedIdTokenClaims;
 import org.idp.server.core.openid.identity.id_token.VerifiedClaimsObject;
-import org.idp.server.core.openid.identity.id_token.plugin.CustomIndividualClaimsCreator;
 import org.idp.server.core.openid.oauth.configuration.AuthorizationServerConfiguration;
 import org.idp.server.core.openid.oauth.configuration.client.ClientConfiguration;
+import org.idp.server.core.openid.userinfo.plugin.UserinfoCustomIndividualClaimsCreator;
 import org.idp.server.platform.json.JsonNodeWrapper;
 
 /**
- * Builds the ID Token {@code verified_claims} element from the {@code claims} request parameter's
- * {@code id_token.verified_claims} member. The OIDC4IDA §5.1 / §5.7 assembly (including the
- * value/values constraint and omission rules) lives in {@link VerifiedClaimsAssembler}, shared with
- * the UserInfo path; this creator just supplies the requested structure and the user's stored
- * verified claims. (#1628)
+ * Adds the OIDC4IDA {@code verified_claims} element to the UserInfo response when it was requested
+ * via the {@code claims} parameter's {@code userinfo.verified_claims} member (OIDC4IDA §5.3 / §5.7,
+ * eKYC conformance module #9).
  *
- * @see <a href="https://openid.net/specs/openid-connect-4-identity-assurance-1_0.html">OpenID
- *     Connect for Identity Assurance 1.0</a>
+ * <p>UserInfo runs from an access token with no live request, so the requested structure is read
+ * from the grant — where it was persisted as the consent record at authorization time ({@link
+ * org.idp.server.core.openid.grant_management.grant.GrantUserinfoClaims}). The assembly
+ * (value/values constraints, §5.7 omission, required trust_framework) is shared with the ID Token
+ * path via {@link VerifiedClaimsAssembler}. The scope-driven counterpart ({@code
+ * verified_claims:*}) is {@link UserinfoSelectiveVerifiedClaimsCreator}; the two are independent
+ * and may both contribute. (#1628)
  */
-public class VerifiedClaimsCreator implements CustomIndividualClaimsCreator {
+public class UserinfoVerifiedClaimsCreator implements UserinfoCustomIndividualClaimsCreator {
 
   @Override
   public boolean shouldCreate(
       User user,
-      Authentication authentication,
       AuthorizationGrant authorizationGrant,
-      IdTokenCustomClaims customClaims,
-      RequestedClaimsPayload requestedClaimsPayload,
       AuthorizationServerConfiguration authorizationServerConfiguration,
       ClientConfiguration clientConfiguration) {
-
-    GrantIdTokenClaims idTokenClaims = authorizationGrant.idTokenClaims();
-    return idTokenClaims.hasVerifiedClaims() && user.hasVerifiedClaims();
+    return authorizationGrant.userinfoClaims().hasVerifiedClaims() && user.hasVerifiedClaims();
   }
 
   @Override
   public Map<String, Object> create(
       User user,
-      Authentication authentication,
       AuthorizationGrant authorizationGrant,
-      IdTokenCustomClaims customClaims,
-      RequestedClaimsPayload requestedClaimsPayload,
       AuthorizationServerConfiguration authorizationServerConfiguration,
       ClientConfiguration clientConfiguration) {
-
-    RequestedIdTokenClaims requestedIdTokenClaims = requestedClaimsPayload.idToken();
-    VerifiedClaimsObject requested = requestedIdTokenClaims.verifiedClaims();
+    VerifiedClaimsObject requested = authorizationGrant.userinfoClaims().verifiedClaims();
     JsonNodeWrapper userVerifiedClaims = user.verifiedClaimsNodeWrapper();
-
     return VerifiedClaimsAssembler.assemble(requested, userVerifiedClaims);
   }
 }

--- a/libs/idp-server-core-extension-ida/src/main/java/org/idp/server/core/extension/identity/verified/UserinfoVerifiedClaimsCreator.java
+++ b/libs/idp-server-core-extension-ida/src/main/java/org/idp/server/core/extension/identity/verified/UserinfoVerifiedClaimsCreator.java
@@ -35,8 +35,9 @@ import org.idp.server.platform.json.JsonNodeWrapper;
  * org.idp.server.core.openid.grant_management.grant.GrantUserinfoClaims}). The assembly
  * (value/values constraints, §5.7 omission, required trust_framework) is shared with the ID Token
  * path via {@link VerifiedClaimsAssembler}. The scope-driven counterpart ({@code
- * verified_claims:*}) is {@link UserinfoSelectiveVerifiedClaimsCreator}; the two are independent
- * and may both contribute. (#1628)
+ * verified_claims:*}) is {@link UserinfoSelectiveVerifiedClaimsCreator}; since both emit the same
+ * top-level {@code verified_claims} key, this claims-parameter path takes precedence and the
+ * scope-driven creator stands down when a claims-parameter request is present. (#1628)
  */
 public class UserinfoVerifiedClaimsCreator implements UserinfoCustomIndividualClaimsCreator {
 

--- a/libs/idp-server-core-extension-ida/src/main/java/org/idp/server/core/extension/identity/verified/VerifiedClaimsAssembler.java
+++ b/libs/idp-server-core-extension-ida/src/main/java/org/idp/server/core/extension/identity/verified/VerifiedClaimsAssembler.java
@@ -1,0 +1,206 @@
+/*
+ * Copyright 2025 Hirokazu Kobayashi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.idp.server.core.extension.identity.verified;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.idp.server.core.openid.identity.id_token.VerifiedClaimsObject;
+import org.idp.server.platform.json.JsonNodeWrapper;
+import org.idp.server.platform.log.LoggerWrapper;
+
+/**
+ * Builds the OIDC4IDA {@code verified_claims} element from a requested {@code verified_claims}
+ * structure and the user's stored verified claims, independent of whether it targets the ID Token
+ * or the UserInfo response (#1628).
+ *
+ * <p>The output follows OpenID Connect for Identity Assurance 1.0 §5.1: a {@code verification}
+ * object — whose {@code trust_framework} is REQUIRED — plus a {@code claims} object carrying the
+ * verified end-user claims.
+ *
+ * <h3>Returning less data than requested (§5.7)</h3>
+ *
+ * <p>Only data the user actually has is returned, and the element is omitted entirely when it
+ * cannot be formed validly — never returned as a partial/empty shell:
+ *
+ * <ul>
+ *   <li><b>§5.7.2 Unavailable data</b>: each requested claim is included only when present on the
+ *       user.
+ *   <li><b>§5.7.4 Data not matching requirements</b>: a requested {@code value} / {@code values}
+ *       constraint (OpenID Connect §5.5.1) is enforced; a mismatch on a {@code verification}
+ *       element (or a missing required {@code trust_framework}) omits the whole {@code
+ *       verified_claims}; a mismatch on a {@code claims} element omits just that claim. The OP does
+ *       not return an error.
+ *   <li><b>§5.7.5 Omitting elements</b>: when no requested claim is available the {@code claims}
+ *       object would be empty; since {@code claims} is required, the whole element is omitted.
+ * </ul>
+ *
+ * <p>{@code trust_framework} is the REQUIRED floor of {@code verification}: returned whenever the
+ * user holds it, never gated behind an explicit request. Other {@code verification} elements (e.g.
+ * {@code evidence}, which can carry PII) are opt-in via explicit request.
+ *
+ * @see <a href="https://openid.net/specs/openid-connect-4-identity-assurance-1_0.html">OpenID
+ *     Connect for Identity Assurance 1.0</a>
+ */
+public class VerifiedClaimsAssembler {
+
+  private static final LoggerWrapper log = LoggerWrapper.getLogger(VerifiedClaimsAssembler.class);
+
+  private VerifiedClaimsAssembler() {}
+
+  /**
+   * Assembles the {@code verified_claims} element, or an empty map when it must be omitted. Returns
+   * a map with at most one entry, {@code "verified_claims"}.
+   */
+  public static Map<String, Object> assemble(
+      VerifiedClaimsObject requested, JsonNodeWrapper userVerifiedClaims) {
+    HashMap<String, Object> result = new HashMap<>();
+    if (requested == null) {
+      return result;
+    }
+
+    // claims: resolve the requested claim names dynamically against the user's stored claims,
+    // honoring any value/values constraint. A claim that is unavailable (§5.7.2) or fails its
+    // constraint (§5.7.4, claims branch) is dropped individually.
+    Map<String, Object> claims =
+        selectClaims(requested.claimsNodeWrapper(), userBlock(userVerifiedClaims, "claims"));
+
+    // §5.7.4 / §5.7.5: when no requested claim is available, omit the whole verified_claims rather
+    // than emit an empty claims object (and leak verification metadata).
+    if (claims.isEmpty()) {
+      return result;
+    }
+
+    Map<String, Object> verification =
+        selectVerification(
+            requested.verificationNodeWrapper(), userBlock(userVerifiedClaims, "verification"));
+
+    // §5.7.4 (verification branch): a requested verification element failed its value/values
+    // constraint, so the verification requirement is unmet — omit the whole verified_claims.
+    if (verification == null) {
+      log.warn(
+          "verified_claims omitted: a requested verification element did not match its"
+              + " value/values constraint");
+      return result;
+    }
+
+    // IDA schema §5.1 / §5.7.4: verification.trust_framework is REQUIRED. Without it the
+    // verification requirement cannot be met, so omit verified_claims entirely rather than emit a
+    // schema-invalid verification block.
+    if (!verification.containsKey("trust_framework")) {
+      log.warn(
+          "verified_claims omitted: stored verification has no required trust_framework"
+              + " (check the tenant's verified_claims mapping configuration)");
+      return result;
+    }
+
+    Map<String, Object> verified = new HashMap<>();
+    verified.put("verification", verification);
+    verified.put("claims", claims);
+    result.put("verified_claims", verified);
+
+    return result;
+  }
+
+  /** Returns the user's stored {@code verification} / {@code claims} block as a Java map. */
+  private static Map<String, Object> userBlock(JsonNodeWrapper userVerifiedClaims, String key) {
+    if (!userVerifiedClaims.contains(key)) {
+      return Map.of();
+    }
+    return userVerifiedClaims.getValueAsJsonNode(key).toMap();
+  }
+
+  /**
+   * Selects each requested claim that the user holds and whose stored value satisfies the requested
+   * {@code value} / {@code values} constraint. Unavailable or non-matching claims are dropped
+   * individually (§5.7.2 / §5.7.4 claims branch).
+   */
+  private static Map<String, Object> selectClaims(
+      JsonNodeWrapper requestedClaims, Map<String, Object> userClaims) {
+    Map<String, Object> selected = new HashMap<>();
+    for (String name : requestedClaims.fieldNamesAsList()) {
+      if (!userClaims.containsKey(name)) {
+        continue;
+      }
+      Object userValue = userClaims.get(name);
+      if (matchesConstraint(requestedClaims.getValueAsJsonNode(name), userValue)) {
+        selected.put(name, userValue);
+      }
+    }
+    return selected;
+  }
+
+  /**
+   * Builds the {@code verification} block. {@code trust_framework} is the REQUIRED floor: always
+   * included when the user holds it (never gated behind an explicit request). Other elements (e.g.
+   * {@code evidence}) are opt-in via explicit request. Returns {@code null} when a requested
+   * verification element fails its {@code value} / {@code values} constraint, signaling the whole
+   * verified_claims must be omitted (§5.7.4).
+   */
+  private static Map<String, Object> selectVerification(
+      JsonNodeWrapper requestedVerification, Map<String, Object> userVerification) {
+    Map<String, Object> selected = new HashMap<>();
+
+    if (userVerification.containsKey("trust_framework")) {
+      Object userValue = userVerification.get("trust_framework");
+      if (!matchesConstraint(
+          requestedVerification.getValueAsJsonNode("trust_framework"), userValue)) {
+        return null;
+      }
+      selected.put("trust_framework", userValue);
+    }
+
+    for (String element : requestedVerification.fieldNamesAsList()) {
+      if (element.equals("trust_framework") || !userVerification.containsKey(element)) {
+        continue;
+      }
+      Object userValue = userVerification.get(element);
+      if (!matchesConstraint(requestedVerification.getValueAsJsonNode(element), userValue)) {
+        return null;
+      }
+      selected.put(element, userValue);
+    }
+    return selected;
+  }
+
+  /**
+   * Matches a stored value against a requested claim's {@code value} / {@code values} constraint
+   * (OpenID Connect §5.5.1). A {@code null} request (no constraint object) or one carrying neither
+   * {@code value} nor {@code values} always matches — the claim was requested, not constrained.
+   * {@code max_age} is out of scope.
+   */
+  private static boolean matchesConstraint(JsonNodeWrapper constraint, Object userValue) {
+    if (constraint == null || !constraint.exists() || !constraint.isObject()) {
+      return true;
+    }
+    if (constraint.contains("value")) {
+      return stringEquals(constraint.getValueOrEmptyAsString("value"), userValue);
+    }
+    if (constraint.contains("values")) {
+      for (JsonNodeWrapper candidate : constraint.getValueAsJsonNodeList("values")) {
+        if (stringEquals(candidate.asText(), userValue)) {
+          return true;
+        }
+      }
+      return false;
+    }
+    return true;
+  }
+
+  private static boolean stringEquals(String requested, Object userValue) {
+    return userValue != null && requested.equals(String.valueOf(userValue));
+  }
+}

--- a/libs/idp-server-core-extension-ida/src/main/java/org/idp/server/core/extension/identity/verified/VerifiedClaimsAssembler.java
+++ b/libs/idp-server-core-extension-ida/src/main/java/org/idp/server/core/extension/identity/verified/VerifiedClaimsAssembler.java
@@ -33,8 +33,9 @@ import org.idp.server.platform.log.LoggerWrapper;
  *
  * <h3>Returning less data than requested (§5.7)</h3>
  *
- * <p>Only data the user actually has is returned, and the element is omitted entirely when it
- * cannot be formed validly — never returned as a partial/empty shell:
+ * <p>Only data the user actually has is returned. The whole element is omitted only when {@code
+ * verification} cannot be formed validly; a missing/empty {@code claims} object is a valid
+ * response:
  *
  * <ul>
  *   <li><b>§5.7.2 Unavailable data</b>: each requested claim is included only when present on the
@@ -44,8 +45,12 @@ import org.idp.server.platform.log.LoggerWrapper;
  *       element (or a missing required {@code trust_framework}) omits the whole {@code
  *       verified_claims}; a mismatch on a {@code claims} element omits just that claim. The OP does
  *       not return an error.
- *   <li><b>§5.7.5 Omitting elements</b>: when no requested claim is available the {@code claims}
- *       object would be empty; since {@code claims} is required, the whole element is omitted.
+ *   <li><b>§5.7.5 Omitting elements</b>: omission cascades to the parent only when the omitted
+ *       element is required for a <i>valid</i> response. An empty {@code claims} object is valid
+ *       per the IDA schema ([IDA-verified-claims] §5.3, "the claims element may be empty"), so
+ *       dropping all requested claims yields {@code verification} + an empty {@code claims} object
+ *       — NOT a whole omission. Both delivery channels (ID Token and UserInfo) are treated
+ *       identically; the spec draws no distinction (§5.2).
  * </ul>
  *
  * <p>{@code trust_framework} is the REQUIRED floor of {@code verification}: returned whenever the
@@ -78,11 +83,15 @@ public class VerifiedClaimsAssembler {
     Map<String, Object> claims =
         selectClaims(requested.claimsNodeWrapper(), userBlock(userVerifiedClaims, "claims"));
 
-    // §5.7.4 / §5.7.5: when no requested claim is available, omit the whole verified_claims rather
-    // than emit an empty claims object (and leak verification metadata).
-    if (claims.isEmpty()) {
-      return result;
-    }
+    // An empty claims object is NOT a reason to omit verified_claims. The IDA schema
+    // ([IDA-verified-claims] §5.3 "Claims element") states the claims element may be empty, so when
+    // every requested claim is dropped (§5.7.2 unavailable / §5.7.4 claims-branch mismatch) the
+    // valid response is verification + an empty claims object. §5.7.5 cascades omission to the
+    // parent only when the omitted element is *required* for a valid response, which an empty
+    // claims
+    // object is not. Whole-omission therefore happens only below, when verification itself cannot
+    // be
+    // formed validly. (#1628)
 
     Map<String, Object> verification =
         selectVerification(

--- a/libs/idp-server-core-extension-ida/src/main/java/org/idp/server/core/extension/identity/verified/VerifiedClaimsCreator.java
+++ b/libs/idp-server-core-extension-ida/src/main/java/org/idp/server/core/extension/identity/verified/VerifiedClaimsCreator.java
@@ -23,7 +23,6 @@ import org.idp.server.core.openid.grant_management.grant.GrantIdTokenClaims;
 import org.idp.server.core.openid.identity.User;
 import org.idp.server.core.openid.identity.id_token.IdTokenCustomClaims;
 import org.idp.server.core.openid.identity.id_token.RequestedClaimsPayload;
-import org.idp.server.core.openid.identity.id_token.RequestedIdTokenClaims;
 import org.idp.server.core.openid.identity.id_token.VerifiedClaimsObject;
 import org.idp.server.core.openid.identity.id_token.plugin.CustomIndividualClaimsCreator;
 import org.idp.server.core.openid.oauth.configuration.AuthorizationServerConfiguration;
@@ -31,11 +30,12 @@ import org.idp.server.core.openid.oauth.configuration.client.ClientConfiguration
 import org.idp.server.platform.json.JsonNodeWrapper;
 
 /**
- * Builds the ID Token {@code verified_claims} element from the {@code claims} request parameter's
- * {@code id_token.verified_claims} member. The OIDC4IDA §5.1 / §5.7 assembly (including the
- * value/values constraint and omission rules) lives in {@link VerifiedClaimsAssembler}, shared with
- * the UserInfo path; this creator just supplies the requested structure and the user's stored
- * verified claims. (#1628)
+ * Builds the ID Token {@code verified_claims} element from the {@code id_token.verified_claims}
+ * request that was persisted with the grant (the consent record), falling back to the live {@code
+ * claims} parameter for legacy grants. Reading from the grant lets the ID Token be built without
+ * the original request. The OIDC4IDA §5.1 / §5.7 assembly (including the value/values constraint
+ * and omission rules) lives in {@link VerifiedClaimsAssembler}, shared with the UserInfo path; this
+ * creator just supplies the requested structure and the user's stored verified claims. (#1628)
  *
  * @see <a href="https://openid.net/specs/openid-connect-4-identity-assurance-1_0.html">OpenID
  *     Connect for Identity Assurance 1.0</a>
@@ -66,8 +66,14 @@ public class VerifiedClaimsCreator implements CustomIndividualClaimsCreator {
       AuthorizationServerConfiguration authorizationServerConfiguration,
       ClientConfiguration clientConfiguration) {
 
-    RequestedIdTokenClaims requestedIdTokenClaims = requestedClaimsPayload.idToken();
-    VerifiedClaimsObject requested = requestedIdTokenClaims.verifiedClaims();
+    // Prefer the grant's persisted request (the consent record) so the ID Token can be built from
+    // the grant alone — without the original claims parameter, which is gone by the time a token is
+    // re-issued. Fall back to the live request for legacy grants that recorded only the bare name
+    // token (pre-sentinel). (#1628 follow-up)
+    VerifiedClaimsObject requested = authorizationGrant.idTokenClaims().verifiedClaims();
+    if (requested == null) {
+      requested = requestedClaimsPayload.idToken().verifiedClaims();
+    }
     JsonNodeWrapper userVerifiedClaims = user.verifiedClaimsNodeWrapper();
 
     return VerifiedClaimsAssembler.assemble(requested, userVerifiedClaims);

--- a/libs/idp-server-core-extension-ida/src/main/resources/META-INF/services/org.idp.server.core.openid.userinfo.plugin.UserinfoCustomIndividualClaimsCreator
+++ b/libs/idp-server-core-extension-ida/src/main/resources/META-INF/services/org.idp.server.core.openid.userinfo.plugin.UserinfoCustomIndividualClaimsCreator
@@ -1,1 +1,2 @@
 org.idp.server.core.extension.identity.verified.UserinfoSelectiveVerifiedClaimsCreator
+org.idp.server.core.extension.identity.verified.UserinfoVerifiedClaimsCreator

--- a/libs/idp-server-core-extension-ida/src/test/java/org/idp/server/core/extension/identity/verified/UserinfoSelectiveVerifiedClaimsCreatorTest.java
+++ b/libs/idp-server-core-extension-ida/src/test/java/org/idp/server/core/extension/identity/verified/UserinfoSelectiveVerifiedClaimsCreatorTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2025 Hirokazu Kobayashi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.idp.server.core.extension.identity.verified;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import org.idp.server.core.openid.grant_management.grant.AuthorizationGrant;
+import org.idp.server.core.openid.grant_management.grant.AuthorizationGrantBuilder;
+import org.idp.server.core.openid.grant_management.grant.GrantUserinfoClaims;
+import org.idp.server.core.openid.grant_management.grant.RequestedVerifiedClaims;
+import org.idp.server.core.openid.identity.User;
+import org.idp.server.core.openid.identity.id_token.RequestedClaimsPayload;
+import org.idp.server.core.openid.identity.id_token.VerifiedClaimsObject;
+import org.idp.server.core.openid.oauth.configuration.AuthorizationServerConfiguration;
+import org.idp.server.core.openid.oauth.type.oauth.GrantType;
+import org.idp.server.core.openid.oauth.type.oauth.RequestedClientId;
+import org.idp.server.core.openid.oauth.type.oauth.Scopes;
+import org.idp.server.platform.json.JsonConverter;
+import org.idp.server.platform.multi_tenancy.tenant.TenantIdentifier;
+import org.junit.jupiter.api.Test;
+
+/**
+ * #1628: the scope path ({@code verified_claims:*}) and the claims-parameter path ({@link
+ * UserinfoVerifiedClaimsCreator}) both emit the same top-level {@code verified_claims} key and the
+ * invoker composes creators via {@code putAll}. These tests pin the precedence rule that keeps the
+ * result deterministic: the claims-parameter path is authoritative, so this scope-based creator
+ * stands down whenever a claims-parameter verified_claims request is present on the grant.
+ */
+class UserinfoSelectiveVerifiedClaimsCreatorTest {
+
+  private final UserinfoSelectiveVerifiedClaimsCreator creator =
+      new UserinfoSelectiveVerifiedClaimsCreator();
+
+  private static AuthorizationServerConfiguration serverConfigWithSelectiveEnabled() {
+    Map<String, Object> extension = new HashMap<>();
+    extension.put("accessTokenSelectiveVerifiedClaims", true);
+    Map<String, Object> config = new HashMap<>();
+    config.put("extension", extension);
+    return JsonConverter.defaultInstance().read(config, AuthorizationServerConfiguration.class);
+  }
+
+  /** Builds a GrantUserinfoClaims carrying the userinfo.verified_claims request (via sentinel). */
+  private static GrantUserinfoClaims grantUserinfoClaimsRequesting(String verifiedClaimsJson) {
+    String json = "{\"userinfo\":{\"verified_claims\":" + verifiedClaimsJson + "}}";
+    RequestedClaimsPayload payload =
+        JsonConverter.snakeCaseInstance().read(json, RequestedClaimsPayload.class);
+    VerifiedClaimsObject requested = payload.userinfo().verifiedClaims();
+    return new GrantUserinfoClaims(Set.of(), RequestedVerifiedClaims.of(requested));
+  }
+
+  private static AuthorizationGrant grantWith(
+      Scopes scopes, GrantUserinfoClaims userinfoClaims, User user) {
+    return new AuthorizationGrantBuilder(
+            new TenantIdentifier("11111111-1111-1111-1111-111111111111"),
+            new RequestedClientId("client"),
+            GrantType.authorization_code,
+            scopes)
+        .add(user)
+        .add(userinfoClaims)
+        .build();
+  }
+
+  private static User userWith(Map<String, Object> verification, Map<String, Object> claims) {
+    Map<String, Object> verifiedClaims = new HashMap<>();
+    verifiedClaims.put("verification", verification);
+    verifiedClaims.put("claims", claims);
+    return new User().setVerifiedClaims(verifiedClaims);
+  }
+
+  @Test
+  void createsForScopeOnlyRequest() {
+    User user = userWith(Map.of("trust_framework", "eidas"), Map.of("given_name", "Taro"));
+    Scopes scopes = new Scopes(Set.of("openid", "verified_claims:given_name"));
+    AuthorizationGrant grant = grantWith(scopes, new GrantUserinfoClaims(Set.of()), user);
+
+    assertTrue(creator.shouldCreate(user, grant, serverConfigWithSelectiveEnabled(), null));
+  }
+
+  @Test
+  void standsDownWhenClaimsParameterRequestIsPresent() {
+    User user = userWith(Map.of("trust_framework", "eidas"), Map.of("given_name", "Taro"));
+    Scopes scopes = new Scopes(Set.of("openid", "verified_claims:given_name"));
+    GrantUserinfoClaims userinfoClaims =
+        grantUserinfoClaimsRequesting(
+            "{\"verification\":{\"trust_framework\":null},\"claims\":{\"given_name\":null}}");
+    AuthorizationGrant grant = grantWith(scopes, userinfoClaims, user);
+
+    assertFalse(creator.shouldCreate(user, grant, serverConfigWithSelectiveEnabled(), null));
+  }
+}

--- a/libs/idp-server-core-extension-ida/src/test/java/org/idp/server/core/extension/identity/verified/UserinfoVerifiedClaimsCreatorTest.java
+++ b/libs/idp-server-core-extension-ida/src/test/java/org/idp/server/core/extension/identity/verified/UserinfoVerifiedClaimsCreatorTest.java
@@ -79,6 +79,12 @@ class UserinfoVerifiedClaimsCreatorTest {
     return (Map<String, Object>) structure.get("claims");
   }
 
+  @SuppressWarnings("unchecked")
+  private static Map<String, Object> verificationOf(Map<String, Object> result) {
+    Map<String, Object> structure = (Map<String, Object>) result.get("verified_claims");
+    return (Map<String, Object>) structure.get("verification");
+  }
+
   @Test
   void emitsVerifiedClaimsReadFromTheGrant() {
     User user = userWith(Map.of("trust_framework", "eidas"), Map.of("given_name", "Taro"));
@@ -96,8 +102,9 @@ class UserinfoVerifiedClaimsCreatorTest {
 
   @Test
   void enforcesValueConstraintThroughTheSharedAssembler() {
-    // Proves the assembler is wired: a values constraint not satisfied by the user drops the claim,
-    // and with no other claim the whole verified_claims is omitted (§5.7.4/§5.7.5).
+    // Proves the assembler is wired: a value constraint not satisfied by the user drops the claim
+    // (§5.7.4 claims branch). The IDA schema permits an empty claims object ([IDA-verified-claims]
+    // §5.3), so verification + an empty claims object is returned — not a whole omission.
     User user = userWith(Map.of("trust_framework", "eidas"), Map.of("given_name", "Taro"));
     GrantUserinfoClaims userinfoClaims =
         grantUserinfoClaimsRequesting(
@@ -107,7 +114,10 @@ class UserinfoVerifiedClaimsCreatorTest {
 
     Map<String, Object> result = creator.create(user, grant, null, null);
 
-    assertFalse(result.containsKey("verified_claims"));
+    assertTrue(result.containsKey("verified_claims"));
+    assertEquals("eidas", verificationOf(result).get("trust_framework"));
+    assertTrue(
+        claimsOf(result).isEmpty(), "claim failing its value constraint dropped; claims empty");
   }
 
   @Test

--- a/libs/idp-server-core-extension-ida/src/test/java/org/idp/server/core/extension/identity/verified/UserinfoVerifiedClaimsCreatorTest.java
+++ b/libs/idp-server-core-extension-ida/src/test/java/org/idp/server/core/extension/identity/verified/UserinfoVerifiedClaimsCreatorTest.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2025 Hirokazu Kobayashi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.idp.server.core.extension.identity.verified;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import org.idp.server.core.openid.grant_management.grant.AuthorizationGrant;
+import org.idp.server.core.openid.grant_management.grant.AuthorizationGrantBuilder;
+import org.idp.server.core.openid.grant_management.grant.GrantUserinfoClaims;
+import org.idp.server.core.openid.grant_management.grant.RequestedVerifiedClaims;
+import org.idp.server.core.openid.identity.User;
+import org.idp.server.core.openid.identity.id_token.RequestedClaimsPayload;
+import org.idp.server.core.openid.identity.id_token.VerifiedClaimsObject;
+import org.idp.server.core.openid.oauth.type.oauth.GrantType;
+import org.idp.server.core.openid.oauth.type.oauth.RequestedClientId;
+import org.idp.server.core.openid.oauth.type.oauth.Scopes;
+import org.idp.server.platform.json.JsonConverter;
+import org.idp.server.platform.multi_tenancy.tenant.TenantIdentifier;
+import org.junit.jupiter.api.Test;
+
+/**
+ * #1628: the UserInfo verified_claims creator reads the request from the grant (the consent record
+ * persisted at authorization time), not a live request, then defers assembly to {@link
+ * VerifiedClaimsAssembler} — the same engine as the ID Token path. These tests pin the grant-read
+ * wiring and the shouldCreate gating; the §5.7 / value-values rules are covered by {@code
+ * VerifiedClaimsCreatorTest}.
+ */
+class UserinfoVerifiedClaimsCreatorTest {
+
+  private final UserinfoVerifiedClaimsCreator creator = new UserinfoVerifiedClaimsCreator();
+
+  /** Builds a GrantUserinfoClaims carrying the userinfo.verified_claims request (via sentinel). */
+  private static GrantUserinfoClaims grantUserinfoClaimsRequesting(String verifiedClaimsJson) {
+    String json = "{\"userinfo\":{\"verified_claims\":" + verifiedClaimsJson + "}}";
+    RequestedClaimsPayload payload =
+        JsonConverter.snakeCaseInstance().read(json, RequestedClaimsPayload.class);
+    VerifiedClaimsObject requested = payload.userinfo().verifiedClaims();
+    return new GrantUserinfoClaims(Set.of(), RequestedVerifiedClaims.of(requested));
+  }
+
+  private static AuthorizationGrant grantWith(GrantUserinfoClaims userinfoClaims, User user) {
+    return new AuthorizationGrantBuilder(
+            new TenantIdentifier("11111111-1111-1111-1111-111111111111"),
+            new RequestedClientId("client"),
+            GrantType.authorization_code,
+            new Scopes(Set.of("openid")))
+        .add(user)
+        .add(userinfoClaims)
+        .build();
+  }
+
+  private static User userWith(Map<String, Object> verification, Map<String, Object> claims) {
+    Map<String, Object> verifiedClaims = new HashMap<>();
+    verifiedClaims.put("verification", verification);
+    verifiedClaims.put("claims", claims);
+    return new User().setVerifiedClaims(verifiedClaims);
+  }
+
+  @SuppressWarnings("unchecked")
+  private static Map<String, Object> claimsOf(Map<String, Object> result) {
+    Map<String, Object> structure = (Map<String, Object>) result.get("verified_claims");
+    return (Map<String, Object>) structure.get("claims");
+  }
+
+  @Test
+  void emitsVerifiedClaimsReadFromTheGrant() {
+    User user = userWith(Map.of("trust_framework", "eidas"), Map.of("given_name", "Taro"));
+    GrantUserinfoClaims userinfoClaims =
+        grantUserinfoClaimsRequesting(
+            "{\"verification\":{\"trust_framework\":null},\"claims\":{\"given_name\":null}}");
+    AuthorizationGrant grant = grantWith(userinfoClaims, user);
+
+    assertTrue(creator.shouldCreate(user, grant, null, null));
+    Map<String, Object> result = creator.create(user, grant, null, null);
+
+    assertTrue(result.containsKey("verified_claims"));
+    assertEquals("Taro", claimsOf(result).get("given_name"));
+  }
+
+  @Test
+  void enforcesValueConstraintThroughTheSharedAssembler() {
+    // Proves the assembler is wired: a values constraint not satisfied by the user drops the claim,
+    // and with no other claim the whole verified_claims is omitted (§5.7.4/§5.7.5).
+    User user = userWith(Map.of("trust_framework", "eidas"), Map.of("given_name", "Taro"));
+    GrantUserinfoClaims userinfoClaims =
+        grantUserinfoClaimsRequesting(
+            "{\"verification\":{\"trust_framework\":null},"
+                + "\"claims\":{\"given_name\":{\"value\":\"Hanako\"}}}");
+    AuthorizationGrant grant = grantWith(userinfoClaims, user);
+
+    Map<String, Object> result = creator.create(user, grant, null, null);
+
+    assertFalse(result.containsKey("verified_claims"));
+  }
+
+  @Test
+  void doesNotCreateWhenGrantHasNoVerifiedClaimsRequest() {
+    User user = userWith(Map.of("trust_framework", "eidas"), Map.of("given_name", "Taro"));
+    AuthorizationGrant grant = grantWith(new GrantUserinfoClaims(Set.of("email")), user);
+
+    assertFalse(creator.shouldCreate(user, grant, null, null));
+  }
+
+  @Test
+  void doesNotCreateWhenUserHasNoVerifiedClaims() {
+    User user = new User();
+    GrantUserinfoClaims userinfoClaims =
+        grantUserinfoClaimsRequesting(
+            "{\"verification\":{\"trust_framework\":null},\"claims\":{\"given_name\":null}}");
+    AuthorizationGrant grant = grantWith(userinfoClaims, user);
+
+    assertFalse(creator.shouldCreate(user, grant, null, null));
+  }
+}

--- a/libs/idp-server-core-extension-ida/src/test/java/org/idp/server/core/extension/identity/verified/VerifiedClaimsCreatorTest.java
+++ b/libs/idp-server-core-extension-ida/src/test/java/org/idp/server/core/extension/identity/verified/VerifiedClaimsCreatorTest.java
@@ -21,9 +21,18 @@ import static org.junit.jupiter.api.Assertions.*;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import org.idp.server.core.openid.grant_management.grant.AuthorizationGrant;
+import org.idp.server.core.openid.grant_management.grant.AuthorizationGrantBuilder;
+import org.idp.server.core.openid.grant_management.grant.GrantIdTokenClaims;
+import org.idp.server.core.openid.grant_management.grant.RequestedVerifiedClaims;
 import org.idp.server.core.openid.identity.User;
 import org.idp.server.core.openid.identity.id_token.RequestedClaimsPayload;
+import org.idp.server.core.openid.oauth.type.oauth.GrantType;
+import org.idp.server.core.openid.oauth.type.oauth.RequestedClientId;
+import org.idp.server.core.openid.oauth.type.oauth.Scopes;
 import org.idp.server.platform.json.JsonConverter;
+import org.idp.server.platform.multi_tenancy.tenant.TenantIdentifier;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -55,7 +64,21 @@ class VerifiedClaimsCreatorTest {
   }
 
   private Map<String, Object> create(User user, RequestedClaimsPayload payload) {
-    return creator.create(user, null, null, null, payload, null, null);
+    // Production persists the id_token.verified_claims request in the grant (the consent record),
+    // and the creator reads it from there. Build a grant carrying that request.
+    GrantIdTokenClaims idTokenClaims =
+        new GrantIdTokenClaims(
+            Set.of(), RequestedVerifiedClaims.of(payload.idToken().verifiedClaims()));
+    AuthorizationGrant grant =
+        new AuthorizationGrantBuilder(
+                new TenantIdentifier("11111111-1111-1111-1111-111111111111"),
+                new RequestedClientId("client"),
+                GrantType.authorization_code,
+                new Scopes(Set.of("openid")))
+            .add(user)
+            .add(idTokenClaims)
+            .build();
+    return creator.create(user, null, grant, null, payload, null, null);
   }
 
   @SuppressWarnings("unchecked")

--- a/libs/idp-server-core-extension-ida/src/test/java/org/idp/server/core/extension/identity/verified/VerifiedClaimsCreatorTest.java
+++ b/libs/idp-server-core-extension-ida/src/test/java/org/idp/server/core/extension/identity/verified/VerifiedClaimsCreatorTest.java
@@ -30,10 +30,12 @@ import org.junit.jupiter.api.Test;
  * Regression for the OIDC4IDA verified_claims output in the ID Token ({@code claims} parameter)
  * path.
  *
- * <p>OIDC4IDA §5.7.4 / §5.7.5: when the {@code verification} requirement cannot be met (no required
- * {@code trust_framework}) or no requested claim matches a user claim, the OP SHALL omit the whole
- * {@code verified_claims} element rather than emit a schema-invalid {@code verification: {}} or an
- * empty {@code claims} object. This mirrors {@link SelectiveVerifiedClaims} (scope-based path).
+ * <p>OIDC4IDA §5.7.4 / §5.7.5: the whole {@code verified_claims} element is omitted only when the
+ * {@code verification} requirement cannot be met — a failed {@code verification} {@code value} /
+ * {@code values} constraint, or a missing required {@code trust_framework} — never emitting a
+ * schema-invalid {@code verification: {}}. When every requested claim drops but {@code
+ * verification} is valid, the element is kept with an empty {@code claims} object, which the IDA
+ * schema permits ([IDA-verified-claims] §5.3, "the claims element may be empty").
  */
 class VerifiedClaimsCreatorTest {
 
@@ -107,18 +109,23 @@ class VerifiedClaimsCreatorTest {
   }
 
   @Test
-  void omitsVerifiedClaimsWhenNoRequestedClaimMatches() {
-    // §5.7.5: parent (verified_claims) requires claims; with no matching claim, omit the parent
-    // rather than emit verification with an empty claims object.
+  void keepsVerifiedClaimsWithEmptyClaimsWhenNoRequestedClaimMatches() {
+    // §5.7.2 drops the unavailable claim individually. The IDA schema ([IDA-verified-claims] §5.3)
+    // permits an empty claims object, so verification + an empty claims object is a valid response
+    // —
+    // NOT a whole omission. §5.7.5 cascades only when the omitted element is required for validity,
+    // which an empty claims object is not.
     User user = userWith(Map.of("trust_framework", "eidas"), Map.of("family_name", "Yamada"));
     RequestedClaimsPayload payload =
         request("{\"verification\":{\"trust_framework\":null},\"claims\":{\"given_name\":null}}");
 
     Map<String, Object> result = create(user, payload);
 
-    assertFalse(
-        result.containsKey("verified_claims"),
-        "no matching claim must emit no verified_claims at all");
+    assertTrue(result.containsKey("verified_claims"));
+    assertEquals("eidas", verificationOf(result).get("trust_framework"));
+    assertTrue(
+        claimsOf(result).isEmpty(),
+        "unavailable claim dropped; claims object left empty, not omitted");
   }
 
   @Test

--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/grant_management/grant/AuthorizationGrant.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/grant_management/grant/AuthorizationGrant.java
@@ -215,13 +215,11 @@ public class AuthorizationGrant {
     newAuthorizationGrant.scopes().forEach(newScopeValues::add);
     Scopes newScopes = new Scopes(newScopeValues);
 
-    Set<String> newIdTokenClaims = new HashSet<>(idTokenClaims.toStringSet());
-    newAuthorizationGrant.idTokenClaims().forEach(newIdTokenClaims::add);
-    GrantIdTokenClaims newGrantIdToken = new GrantIdTokenClaims(newIdTokenClaims);
-
-    Set<String> newClaims = new HashSet<>(userinfoClaims.toStringSet());
-    newAuthorizationGrant.userinfoClaims().forEach(newClaims::add);
-    GrantUserinfoClaims newGrantUserinfo = new GrantUserinfoClaims(newClaims);
+    // Route through the typed merge so the persisted verified_claims request (carried as a separate
+    // field, not a plain claim-name token) survives an incremental-consent merge. (#1628)
+    GrantIdTokenClaims newGrantIdToken = idTokenClaims.merge(newAuthorizationGrant.idTokenClaims());
+    GrantUserinfoClaims newGrantUserinfo =
+        userinfoClaims.merge(newAuthorizationGrant.userinfoClaims());
 
     CustomProperties newCustomProperties = newAuthorizationGrant.customProperties();
     AuthorizationDetails newAuthorizationDetails = newAuthorizationGrant.authorizationDetails();

--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/grant_management/grant/GrantIdTokenClaims.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/grant_management/grant/GrantIdTokenClaims.java
@@ -17,18 +17,23 @@
 package org.idp.server.core.openid.grant_management.grant;
 
 import java.util.*;
-import java.util.stream.Collectors;
 import org.idp.server.core.openid.identity.id_token.RequestedIdTokenClaims;
+import org.idp.server.core.openid.identity.id_token.VerifiedClaimsObject;
 import org.idp.server.core.openid.oauth.type.oauth.ResponseType;
 import org.idp.server.core.openid.oauth.type.oauth.Scopes;
 
 public class GrantIdTokenClaims implements Iterable<String> {
 
   Set<String> values;
+  // The OIDC4IDA verified_claims request persisted with the grant, so the ID Token can be built
+  // from the consent record at issuance time without the original claims parameter. Mirrors
+  // GrantUserinfoClaims. (#1628 follow-up)
+  RequestedVerifiedClaims requestedVerifiedClaims;
   private static final String delimiter = " ";
 
   public GrantIdTokenClaims() {
     this.values = new HashSet<>();
+    this.requestedVerifiedClaims = RequestedVerifiedClaims.empty();
   }
 
   public static GrantIdTokenClaims create(
@@ -83,27 +88,51 @@ public class GrantIdTokenClaims implements Iterable<String> {
     if (shouldAddUpdatedAt(scopes, responseType, supportedClaims, idTokenClaims, idTokenStrictMode))
       claims.add("updated_at");
 
-    if (shouldAddVerifiedClaims(idTokenClaims)) claims.add("verified_claims");
-
-    return new GrantIdTokenClaims(claims);
+    // verified_claims is carried as a sentinel (vc:<base64url(JSON)>) holding the full requested
+    // structure, not as a bare "verified_claims" name token — so the consent record is
+    // self-contained and the ID Token can be rebuilt from the grant alone. (#1628 follow-up)
+    return new GrantIdTokenClaims(
+        claims, RequestedVerifiedClaims.of(idTokenClaims.verifiedClaims()));
   }
 
   public GrantIdTokenClaims(String value) {
     if (Objects.isNull(value) || value.isEmpty()) {
       this.values = new HashSet<>();
+      this.requestedVerifiedClaims = RequestedVerifiedClaims.empty();
       return;
     }
-    this.values = Arrays.stream(value.split(delimiter)).collect(Collectors.toSet());
+    Set<String> names = new HashSet<>();
+    RequestedVerifiedClaims parsed = RequestedVerifiedClaims.empty();
+    for (String token : value.split(delimiter)) {
+      if (RequestedVerifiedClaims.isSentinel(token)) {
+        parsed = RequestedVerifiedClaims.fromSentinel(token);
+      } else {
+        names.add(token);
+      }
+    }
+    this.values = names;
+    this.requestedVerifiedClaims = parsed;
   }
 
   public GrantIdTokenClaims(Set<String> values) {
     this.values = values;
+    this.requestedVerifiedClaims = RequestedVerifiedClaims.empty();
+  }
+
+  public GrantIdTokenClaims(Set<String> values, RequestedVerifiedClaims requestedVerifiedClaims) {
+    this.values = values;
+    this.requestedVerifiedClaims = requestedVerifiedClaims;
   }
 
   public GrantIdTokenClaims merge(GrantIdTokenClaims other) {
     Set<String> newValues = new HashSet<>(this.values);
     newValues.addAll(other.values);
-    return new GrantIdTokenClaims(newValues);
+    // The latest request's verified_claims supersedes; fall back to the existing one.
+    RequestedVerifiedClaims mergedVerifiedClaims =
+        other.requestedVerifiedClaims.exists()
+            ? other.requestedVerifiedClaims
+            : this.requestedVerifiedClaims;
+    return new GrantIdTokenClaims(newValues, mergedVerifiedClaims);
   }
 
   @Override
@@ -112,7 +141,7 @@ public class GrantIdTokenClaims implements Iterable<String> {
   }
 
   public boolean exists() {
-    return values != null && !values.isEmpty();
+    return (values != null && !values.isEmpty()) || requestedVerifiedClaims.exists();
   }
 
   public Set<String> toStringSet() {
@@ -120,7 +149,12 @@ public class GrantIdTokenClaims implements Iterable<String> {
   }
 
   public String toStringValues() {
-    return String.join(delimiter, values);
+    String names = String.join(delimiter, values);
+    if (!requestedVerifiedClaims.exists()) {
+      return names;
+    }
+    String sentinel = requestedVerifiedClaims.toSentinelToken();
+    return names.isEmpty() ? sentinel : names + delimiter + sentinel;
   }
 
   public boolean hasName() {
@@ -200,7 +234,19 @@ public class GrantIdTokenClaims implements Iterable<String> {
   }
 
   public boolean hasVerifiedClaims() {
-    return Objects.nonNull(values) && values.contains("verified_claims");
+    // New rows carry the request as a sentinel; legacy rows carry the bare "verified_claims" name
+    // token (pre-sentinel). Recognize both so existing grants keep working.
+    return requestedVerifiedClaims.exists()
+        || (Objects.nonNull(values) && values.contains("verified_claims"));
+  }
+
+  /**
+   * The requested verified_claims structure persisted with the grant, or {@code null} for legacy
+   * grants that recorded only the bare name token — in which case the caller falls back to the live
+   * request. (#1628 follow-up)
+   */
+  public VerifiedClaimsObject verifiedClaims() {
+    return requestedVerifiedClaims.exists() ? requestedVerifiedClaims.toObject() : null;
   }
 
   private static boolean shouldAddName(
@@ -543,10 +589,6 @@ public class GrantIdTokenClaims implements Iterable<String> {
       return idTokenClaims.hasUpdatedAt();
     }
     return scopes.contains("profile");
-  }
-
-  public static boolean shouldAddVerifiedClaims(RequestedIdTokenClaims idTokenClaims) {
-    return idTokenClaims.hasVerifiedClaims();
   }
 
   public boolean contains(String claims) {

--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/grant_management/grant/GrantUserinfoClaims.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/grant_management/grant/GrantUserinfoClaims.java
@@ -17,17 +17,21 @@
 package org.idp.server.core.openid.grant_management.grant;
 
 import java.util.*;
-import java.util.stream.Collectors;
 import org.idp.server.core.openid.identity.id_token.RequestedUserinfoClaims;
+import org.idp.server.core.openid.identity.id_token.VerifiedClaimsObject;
 import org.idp.server.core.openid.oauth.type.oauth.Scopes;
 
 public class GrantUserinfoClaims implements Iterable<String> {
 
   Set<String> values;
+  // The OIDC4IDA verified_claims request persisted with the grant, so UserInfo can honor the
+  // claims parameter at issuance time (when the original request is gone). (#1628)
+  RequestedVerifiedClaims requestedVerifiedClaims;
   private static final String delimiter = " ";
 
   public GrantUserinfoClaims() {
     this.values = new HashSet<>();
+    this.requestedVerifiedClaims = RequestedVerifiedClaims.empty();
   }
 
   public static GrantUserinfoClaims create(
@@ -56,25 +60,48 @@ public class GrantUserinfoClaims implements Iterable<String> {
     if (shouldAddAddress(scopes, supportedClaims, userinfoClaims)) claims.add("address");
     if (shouldAddUpdatedAt(scopes, supportedClaims, userinfoClaims)) claims.add("updated_at");
 
-    return new GrantUserinfoClaims(claims);
+    return new GrantUserinfoClaims(
+        claims, RequestedVerifiedClaims.of(userinfoClaims.verifiedClaims()));
   }
 
   public GrantUserinfoClaims(String value) {
     if (Objects.isNull(value) || value.isEmpty()) {
       this.values = new HashSet<>();
+      this.requestedVerifiedClaims = RequestedVerifiedClaims.empty();
       return;
     }
-    this.values = Arrays.stream(value.split(delimiter)).collect(Collectors.toSet());
+    Set<String> names = new HashSet<>();
+    RequestedVerifiedClaims parsed = RequestedVerifiedClaims.empty();
+    for (String token : value.split(delimiter)) {
+      if (RequestedVerifiedClaims.isSentinel(token)) {
+        parsed = RequestedVerifiedClaims.fromSentinel(token);
+      } else {
+        names.add(token);
+      }
+    }
+    this.values = names;
+    this.requestedVerifiedClaims = parsed;
   }
 
   public GrantUserinfoClaims(Set<String> values) {
     this.values = values;
+    this.requestedVerifiedClaims = RequestedVerifiedClaims.empty();
+  }
+
+  public GrantUserinfoClaims(Set<String> values, RequestedVerifiedClaims requestedVerifiedClaims) {
+    this.values = values;
+    this.requestedVerifiedClaims = requestedVerifiedClaims;
   }
 
   public GrantUserinfoClaims merge(GrantUserinfoClaims other) {
     Set<String> newValues = new HashSet<>(this.values);
     newValues.addAll(other.values);
-    return new GrantUserinfoClaims(newValues);
+    // The latest request's verified_claims supersedes; fall back to the existing one.
+    RequestedVerifiedClaims mergedVerifiedClaims =
+        other.requestedVerifiedClaims.exists()
+            ? other.requestedVerifiedClaims
+            : this.requestedVerifiedClaims;
+    return new GrantUserinfoClaims(newValues, mergedVerifiedClaims);
   }
 
   @Override
@@ -83,7 +110,10 @@ public class GrantUserinfoClaims implements Iterable<String> {
   }
 
   public boolean exists() {
-    return values != null && !values.isEmpty();
+    // Also true when only a verified_claims request is present (no plain claim names): otherwise
+    // the
+    // persistence write path skips userinfo_claims and the sentinel is lost. (#1628)
+    return (values != null && !values.isEmpty()) || requestedVerifiedClaims.exists();
   }
 
   public Set<String> toStringSet() {
@@ -91,7 +121,20 @@ public class GrantUserinfoClaims implements Iterable<String> {
   }
 
   public String toStringValues() {
-    return String.join(delimiter, values);
+    String names = String.join(delimiter, values);
+    if (!requestedVerifiedClaims.exists()) {
+      return names;
+    }
+    String sentinel = requestedVerifiedClaims.toSentinelToken();
+    return names.isEmpty() ? sentinel : names + delimiter + sentinel;
+  }
+
+  public boolean hasVerifiedClaims() {
+    return requestedVerifiedClaims.exists();
+  }
+
+  public VerifiedClaimsObject verifiedClaims() {
+    return requestedVerifiedClaims.toObject();
   }
 
   public boolean hasName() {

--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/grant_management/grant/RequestedVerifiedClaims.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/grant_management/grant/RequestedVerifiedClaims.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2025 Hirokazu Kobayashi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.idp.server.core.openid.grant_management.grant;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import org.idp.server.core.openid.identity.id_token.VerifiedClaimsObject;
+import org.idp.server.platform.json.JsonConverter;
+
+/**
+ * The OIDC4IDA {@code verified_claims} request (from the {@code claims} parameter) persisted
+ * alongside a grant's requested claim names, so it survives to ID Token / UserInfo issuance as part
+ * of the consent record — the grant, not the transient request, is the authority for what was
+ * granted. (#1628)
+ *
+ * <p>It is carried inside the existing space-delimited claim-name TEXT column as a single sentinel
+ * token {@code vc:<base64url(JSON)>}, so no schema change is needed. Because claim emission matches
+ * fixed known claim names (e.g. {@code values.contains("name")}) rather than enumerating the token
+ * set, an unrecognized {@code vc:} token is simply ignored by code that predates this change —
+ * keeping rolling deploys safe. The token is held verbatim and decoded lazily, so token reads that
+ * never touch verified_claims (introspection, resource access) pay no parse cost.
+ */
+public class RequestedVerifiedClaims {
+
+  static final String SENTINEL_PREFIX = "vc:";
+  private static final JsonConverter jsonConverter = JsonConverter.defaultInstance();
+
+  // "vc:<base64url(json)>" when a verified_claims request is present, otherwise null.
+  private final String sentinelToken;
+  private VerifiedClaimsObject cached;
+
+  private RequestedVerifiedClaims(String sentinelToken) {
+    this.sentinelToken = sentinelToken;
+  }
+
+  public static RequestedVerifiedClaims empty() {
+    return new RequestedVerifiedClaims(null);
+  }
+
+  /** Builds from a parsed request; empty when there is no verified_claims to persist. */
+  public static RequestedVerifiedClaims of(VerifiedClaimsObject verifiedClaims) {
+    if (verifiedClaims == null) {
+      return empty();
+    }
+    String json = jsonConverter.write(verifiedClaims);
+    String base64 =
+        Base64.getUrlEncoder()
+            .withoutPadding()
+            .encodeToString(json.getBytes(StandardCharsets.UTF_8));
+    return new RequestedVerifiedClaims(SENTINEL_PREFIX + base64);
+  }
+
+  /** True when {@code token} is the verified_claims sentinel rather than a plain claim name. */
+  static boolean isSentinel(String token) {
+    return token != null && token.startsWith(SENTINEL_PREFIX);
+  }
+
+  /** Restores from a serialized sentinel token; decoding is deferred to {@link #toObject()}. */
+  static RequestedVerifiedClaims fromSentinel(String sentinelToken) {
+    return new RequestedVerifiedClaims(sentinelToken);
+  }
+
+  public boolean exists() {
+    return sentinelToken != null && !sentinelToken.isEmpty();
+  }
+
+  /** Decodes the persisted request lazily; an empty object when none was requested. */
+  public VerifiedClaimsObject toObject() {
+    if (!exists()) {
+      return new VerifiedClaimsObject();
+    }
+    if (cached == null) {
+      String base64 = sentinelToken.substring(SENTINEL_PREFIX.length());
+      String json = new String(Base64.getUrlDecoder().decode(base64), StandardCharsets.UTF_8);
+      cached = jsonConverter.read(json, VerifiedClaimsObject.class);
+    }
+    return cached;
+  }
+
+  /** The serialized sentinel token, or an empty string when absent (callers skip it). */
+  public String toSentinelToken() {
+    return exists() ? sentinelToken : "";
+  }
+}

--- a/libs/idp-server-core/src/test/java/org/idp/server/core/openid/grant_management/grant/GrantIdTokenClaimsTest.java
+++ b/libs/idp-server-core/src/test/java/org/idp/server/core/openid/grant_management/grant/GrantIdTokenClaimsTest.java
@@ -19,9 +19,12 @@ package org.idp.server.core.openid.grant_management.grant;
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Stream;
+import org.idp.server.core.openid.identity.id_token.RequestedClaimsPayload;
 import org.idp.server.core.openid.identity.id_token.RequestedIdTokenClaims;
+import org.idp.server.core.openid.identity.id_token.VerifiedClaimsObject;
 import org.idp.server.core.openid.oauth.type.oauth.ResponseType;
 import org.idp.server.core.openid.oauth.type.oauth.Scopes;
 import org.idp.server.platform.json.JsonConverter;
@@ -130,5 +133,112 @@ class GrantIdTokenClaimsTest {
             true);
 
     assertFalse(result.contains("family_name"));
+  }
+
+  // ---- #1628 follow-up: verified_claims request persisted with the grant (sentinel round-trip) --
+
+  private static VerifiedClaimsObject sampleVerifiedClaimsRequest() {
+    return new VerifiedClaimsObject(
+        Map.of("trust_framework", Map.of("value", "eidas")), Map.of("given_name", Map.of()));
+  }
+
+  @Test
+  void roundTripsVerifiedClaimsThroughStringForm() {
+    GrantIdTokenClaims original =
+        new GrantIdTokenClaims(
+            Set.of("name"), RequestedVerifiedClaims.of(sampleVerifiedClaimsRequest()));
+
+    GrantIdTokenClaims restored = new GrantIdTokenClaims(original.toStringValues());
+
+    assertTrue(restored.hasVerifiedClaims());
+    assertTrue(restored.hasName());
+    assertTrue(restored.verifiedClaims().verificationNodeWrapper().contains("trust_framework"));
+    assertTrue(restored.verifiedClaims().claimsNodeWrapper().contains("given_name"));
+  }
+
+  @Test
+  void recognizesLegacyVerifiedClaimsNameToken() {
+    // A row written before this change carries the bare "verified_claims" name token, not a
+    // sentinel. hasVerifiedClaims() must still return true; verifiedClaims() returns null so the
+    // creator falls back to the live request.
+    GrantIdTokenClaims legacy = new GrantIdTokenClaims("given_name verified_claims");
+
+    assertTrue(legacy.hasVerifiedClaims());
+    assertNull(legacy.verifiedClaims());
+    assertTrue(legacy.hasGivenName());
+  }
+
+  @Test
+  void backwardCompatibleWithLegacyNameOnlyString() {
+    GrantIdTokenClaims legacy = new GrantIdTokenClaims("name email");
+
+    assertFalse(legacy.hasVerifiedClaims());
+    assertTrue(legacy.hasName());
+    assertTrue(legacy.hasEmail());
+  }
+
+  @Test
+  void sentinelDoesNotLeakIntoPlainClaimNameView() {
+    GrantIdTokenClaims claims =
+        new GrantIdTokenClaims(
+            Set.of("name"), RequestedVerifiedClaims.of(sampleVerifiedClaimsRequest()));
+
+    // toStringSet()/iterator() expose claim names only — never the vc: sentinel.
+    assertEquals(Set.of("name"), claims.toStringSet());
+    for (String name : claims) {
+      assertFalse(name.startsWith(RequestedVerifiedClaims.SENTINEL_PREFIX));
+    }
+  }
+
+  @Test
+  void existsWhenOnlyVerifiedClaimsRequested() {
+    GrantIdTokenClaims claims =
+        new GrantIdTokenClaims(Set.of(), RequestedVerifiedClaims.of(sampleVerifiedClaimsRequest()));
+
+    assertTrue(claims.exists());
+    assertTrue(claims.toStringValues().startsWith(RequestedVerifiedClaims.SENTINEL_PREFIX));
+  }
+
+  @Test
+  void absentVerifiedClaimsSerializesNamesOnly() {
+    GrantIdTokenClaims claims = new GrantIdTokenClaims(Set.of("name"));
+
+    assertEquals("name", claims.toStringValues());
+    assertFalse(claims.hasVerifiedClaims());
+  }
+
+  @Test
+  void createPersistsVerifiedClaimsAsSentinelNotNameToken() {
+    String claimsValue =
+        "{\"id_token\":{\"verified_claims\":{\"verification\":{\"trust_framework\":null},"
+            + "\"claims\":{\"given_name\":null}}}}";
+    RequestedIdTokenClaims idToken = JSON.read(claimsValue, RequestedClaimsPayload.class).idToken();
+
+    GrantIdTokenClaims result =
+        GrantIdTokenClaims.create(
+            new Scopes(Set.of("openid")), ResponseType.code, List.of(), idToken, false);
+
+    assertTrue(result.hasVerifiedClaims(), "create() must persist the requested verified_claims");
+    assertTrue(
+        result.toStringValues().contains(RequestedVerifiedClaims.SENTINEL_PREFIX),
+        "verified_claims must be persisted as a sentinel");
+    assertFalse(
+        result.toStringSet().contains("verified_claims"),
+        "the bare verified_claims name token must no longer be written");
+  }
+
+  @Test
+  void mergeCarriesVerifiedClaimsFromEitherSide() {
+    GrantIdTokenClaims withVc =
+        new GrantIdTokenClaims(
+            Set.of("email"), RequestedVerifiedClaims.of(sampleVerifiedClaimsRequest()));
+    GrantIdTokenClaims namesOnly = new GrantIdTokenClaims(Set.of("name"));
+
+    // existing has it, incoming does not -> preserved
+    assertTrue(namesOnly.merge(withVc).hasVerifiedClaims());
+    // incoming has it, existing does not -> preserved
+    assertTrue(withVc.merge(namesOnly).hasVerifiedClaims());
+    // names are unioned regardless
+    assertEquals(Set.of("email", "name"), withVc.merge(namesOnly).toStringSet());
   }
 }

--- a/libs/idp-server-core/src/test/java/org/idp/server/core/openid/grant_management/grant/GrantUserinfoClaimsTest.java
+++ b/libs/idp-server-core/src/test/java/org/idp/server/core/openid/grant_management/grant/GrantUserinfoClaimsTest.java
@@ -19,9 +19,12 @@ package org.idp.server.core.openid.grant_management.grant;
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Stream;
+import org.idp.server.core.openid.identity.id_token.RequestedClaimsPayload;
 import org.idp.server.core.openid.identity.id_token.RequestedUserinfoClaims;
+import org.idp.server.core.openid.identity.id_token.VerifiedClaimsObject;
 import org.idp.server.core.openid.oauth.type.oauth.Scopes;
 import org.idp.server.platform.json.JsonConverter;
 import org.junit.jupiter.api.Test;
@@ -119,5 +122,126 @@ class GrantUserinfoClaimsTest {
             new Scopes(), supportedWithoutFamilyName, requestOnly("family_name"));
 
     assertFalse(result.contains("family_name"));
+  }
+
+  // ---- #1628: verified_claims request persisted with the grant (sentinel round-trip) ----
+
+  private static VerifiedClaimsObject sampleVerifiedClaimsRequest() {
+    return new VerifiedClaimsObject(
+        Map.of("trust_framework", Map.of("value", "de_aml")), Map.of("given_name", Map.of()));
+  }
+
+  @Test
+  void roundTripsVerifiedClaimsThroughStringForm() {
+    GrantUserinfoClaims original =
+        new GrantUserinfoClaims(
+            Set.of("email"), RequestedVerifiedClaims.of(sampleVerifiedClaimsRequest()));
+
+    GrantUserinfoClaims restored = new GrantUserinfoClaims(original.toStringValues());
+
+    assertTrue(restored.hasVerifiedClaims());
+    assertTrue(restored.hasEmail());
+    assertTrue(restored.verifiedClaims().verificationNodeWrapper().contains("trust_framework"));
+    assertTrue(restored.verifiedClaims().claimsNodeWrapper().contains("given_name"));
+  }
+
+  @Test
+  void backwardCompatibleWithLegacyNameOnlyString() {
+    // A row written before #1628 carries only space-delimited names and no sentinel.
+    GrantUserinfoClaims legacy = new GrantUserinfoClaims("name email phone_number");
+
+    assertFalse(legacy.hasVerifiedClaims());
+    assertTrue(legacy.hasName());
+    assertTrue(legacy.hasEmail());
+    assertTrue(legacy.hasPhoneNumber());
+  }
+
+  @Test
+  void sentinelDoesNotLeakIntoPlainClaimNameView() {
+    GrantUserinfoClaims claims =
+        new GrantUserinfoClaims(
+            Set.of("email"), RequestedVerifiedClaims.of(sampleVerifiedClaimsRequest()));
+
+    // toStringSet()/iterator() expose claim names only — never the vc: sentinel.
+    assertEquals(Set.of("email"), claims.toStringSet());
+    for (String name : claims) {
+      assertFalse(name.startsWith(RequestedVerifiedClaims.SENTINEL_PREFIX));
+    }
+  }
+
+  @Test
+  void existsWhenOnlyVerifiedClaimsRequested() {
+    // The persistence write guard is AuthorizationGrant.hasUserinfoClaim() -> exists(); a
+    // verified_claims-only grant (no plain claim names) must still report exists() so the sentinel
+    // is written. Regression for the conformance ekyc-server-testuserprovidedrequest failure
+    // (#1628).
+    GrantUserinfoClaims claims =
+        new GrantUserinfoClaims(
+            Set.of(), RequestedVerifiedClaims.of(sampleVerifiedClaimsRequest()));
+
+    assertTrue(claims.exists());
+    assertTrue(claims.toStringValues().startsWith(RequestedVerifiedClaims.SENTINEL_PREFIX));
+  }
+
+  @Test
+  void absentVerifiedClaimsSerializesNamesOnly() {
+    GrantUserinfoClaims claims = new GrantUserinfoClaims(Set.of("email"));
+
+    assertEquals("email", claims.toStringValues());
+    assertFalse(claims.hasVerifiedClaims());
+  }
+
+  @Test
+  void createPersistsVerifiedClaimsFromParsedClaimsParameter() {
+    // The exact claims_value persisted by an authorization request requesting
+    // userinfo.verified_claims.
+    String claimsValue =
+        "{\"userinfo\":{\"verified_claims\":{\"verification\":{\"trust_framework\":null},"
+            + "\"claims\":{\"given_name\":null,\"family_name\":null}}}}";
+    RequestedUserinfoClaims userinfo =
+        JSON.read(claimsValue, RequestedClaimsPayload.class).userinfo();
+
+    GrantUserinfoClaims result =
+        GrantUserinfoClaims.create(new Scopes(Set.of("openid")), STANDARD_CLAIMS, userinfo);
+
+    assertTrue(
+        result.hasVerifiedClaims(),
+        "create() must persist the requested userinfo.verified_claims as a sentinel");
+  }
+
+  @Test
+  void roundTripPreservesNullValuedClaimRequests() {
+    // OIDC §5.5: a claim requested with a null value ({"given_name": null}) is the common "just
+    // give me this claim" form. The sentinel round-trip must preserve these keys, or UserInfo drops
+    // them and omits verified_claims entirely (conformance ekyc-server-testuserprovidedrequest).
+    java.util.Map<String, Object> claims = new java.util.HashMap<>();
+    claims.put("given_name", null);
+    claims.put("family_name", null);
+    VerifiedClaimsObject requested =
+        new VerifiedClaimsObject(Map.of("trust_framework", Map.of("value", "eidas")), claims);
+
+    GrantUserinfoClaims grant =
+        new GrantUserinfoClaims(Set.of(), RequestedVerifiedClaims.of(requested));
+    GrantUserinfoClaims restored = new GrantUserinfoClaims(grant.toStringValues());
+
+    assertTrue(
+        restored.verifiedClaims().claimsNodeWrapper().contains("given_name"),
+        "null-valued requested claim must survive the sentinel round-trip");
+    assertTrue(restored.verifiedClaims().claimsNodeWrapper().contains("family_name"));
+  }
+
+  @Test
+  void mergeCarriesVerifiedClaimsFromEitherSide() {
+    GrantUserinfoClaims withVc =
+        new GrantUserinfoClaims(
+            Set.of("email"), RequestedVerifiedClaims.of(sampleVerifiedClaimsRequest()));
+    GrantUserinfoClaims namesOnly = new GrantUserinfoClaims(Set.of("name"));
+
+    // existing has it, incoming does not -> preserved
+    assertTrue(namesOnly.merge(withVc).hasVerifiedClaims());
+    // incoming has it, existing does not -> preserved
+    assertTrue(withVc.merge(namesOnly).hasVerifiedClaims());
+    // names are unioned regardless
+    assertEquals(Set.of("email", "name"), withVc.merge(namesOnly).toStringSet());
   }
 }


### PR DESCRIPTION
## 概要

OIDC4IDA の `verified_claims` を `claims` パラメータの `userinfo` メンバで要求したとき、UserInfo レスポンスで返却できるようにする。

## 背景

従来は claims パラメータの verified_claims 要求が grant 境界で破棄され、UserInfo は `verified_claims:*` スコープ経路しか尊重できなかった（eKYC conformance module #9 = `ekyc-server-request-only-in-userinfo` を満たせない）。UserInfo はアクセストークンから動作しライブな認可リクエストが存在しないため、要求構造を grant（同意レコード）に永続化して発行時に参照する必要がある。

## 変更点

- **`RequestedVerifiedClaims`（新規）**: 要求された verified_claims を grant に保持。`userinfo_claims` 文字列に sentinel トークンとして直列化し、永続化往復でも消えないようにする
- **`GrantUserinfoClaims`**: `RequestedVerifiedClaims` を保持。VC のみ要求時も `exists()=true`、`merge` は最新要求を優先
- **`AuthorizationGrant#merge`**: 型付き merge を経由し、incremental consent でも永続化済みの VC 要求が残るように
- **`VerifiedClaimsAssembler`（新規）**: §5.1 構造 / §5.5.1 value・values / §5.7 省略 / `trust_framework` 必須 の組み立てを ID Token 経路（`VerifiedClaimsCreator`）から抽出し共有化
- **`UserinfoVerifiedClaimsCreator`（新規）**: UserInfo 用 creator を新設し SPI 登録。scope 駆動の `UserinfoSelectiveVerifiedClaimsCreator` とは独立に動作
- **swagger**: ユーザースキーマに `verified_claims` を記載

## 仕様対応（OIDC for Identity Assurance 1.0）

| § | 内容 |
|---|---|
| 5.2 / 5.3 | claims パラメータの `userinfo` メンバ要求 → UserInfo で返却（ID Token とは独立） |
| 5.7 | UserInfo 経路でも selective 省略エンジン（`VerifiedClaimsAssembler`）を適用 |

## テスト

- e2e spec `oidc_for_identity_assurance.test.js`: UserInfo 経路 / §5.7 値制約
- `GrantUserinfoClaimsTest`: sentinel 直列化・merge・exists 挙動
- `UserinfoVerifiedClaimsCreatorTest`: shouldCreate / assemble 委譲

---

## 追補（その後の変更 — レビュー対応・仕様精査・ID Token 対応）

当初の「UserInfo claims-param verified_claims」から、レビュー対応と OIDC4IDA / IDA スキーマの仕様精査を経て以下を追加。

| commit | 内容 |
|---|---|
| `d3d1c6a9e` | **scope × claims-param 競合の決定化**: 両経路が同じ `verified_claims` キーを生成し `putAll` で SPI 順依存だった問題を、claims-param 優先で明示化（`UserinfoSelectiveVerifiedClaimsCreator` が claims-param 在時 stand down）。doc 3箇所に優先順位明記 |
| `41778d651` | **§5.7 空 claims の扱いを修正**: 要求クレームが全て不可/不一致でも `verification` が有効なら丸ごと省略せず `claims: {}` で返す（[IDA-verified-claims] §5.3「claims は空でよい」+ §5.7.1「valid=スキーマ準拠」）。丸ごと省略は verification 要件不充足時のみ。#1512 の挙動を見直し |
| `76b56a367` | **ID Token も grant 自己完結化**: `GrantIdTokenClaims` に sentinel 永続化を横展開し `VerifiedClaimsCreator` を grant 読みへ。「何に同意したか」を grant に正確記録（ID Token / UserInfo 対称）。旧コードは未知 `vc:` を無視するためローリングデプロイ/ロールバック安全。変更管理 doc を `v0.11.0-verified-claims-impact.md` に統合 |

### 検証（当初の「test 未実行」を更新）

- unit: `idp-server-core` / `idp-server-core-extension-ida` 全テスト green
- e2e: `oidc_for_identity_assurance.test.js` **12/12 green**（デプロイ実機で確認）
- OIDF conformance: `ekyc-server-one-claim-with-random-value-omitted` **PASSED**（SUCCESS 54 / FAILURE 0）。module #9 も green

## スコープ外（フォローアップ）

- #1644: Grant 管理 API のレスポンスに付与クレーム（`id_token_claims` / `userinfo_claims`）を出し、同意内容を観測可能にする
- spec テストの describe/it を仕様文言 verbatim へ再構成（§5.7.x 入れ子化、§8 `trust_frameworks_supported` / `claims_in_verified_claims_supported` の Required 検証、§7 未要求データ非返却の負テスト 等）
- eKYC conformance ハーネス（setup/conformance 設定）は別ブランチで管理

関連: #1628 / #1644

🤖 Generated with [Claude Code](https://claude.com/claude-code)
