### PR TITLE
feat(identity-verification): eKYC OIDCCore conformance テスト環境のセットアップを自動化 (#1643)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,16 +53,21 @@ cd e2e && npm test
    - 管理API → `content_06_developer-guide/02-control-plane/`
    - OAuth/OIDC → `content_06_developer-guide/03-application-plane/`
 
-2. **既存コードを探す**
+2. **API仕様を先に確認**（ソース深掘りの前に）
+   - 管理API/エンドポイントの入出力スキーマは `documentation/openapi/*.yaml` を最初に参照する
+   - 仕様で足りる場合はソースの深掘り不要。仕様に無い／実装と食い違う場合のみコード確認に進む
+   - 仕様と実装が食い違ったら、それ自体を記載漏れ等として別途修正する
+
+3. **既存コードを探す**
    ```
    Grep "関連キーワード" libs/idp-server-core/
    ```
 
-3. **関連ファイルを読む**
+4. **関連ファイルを読む**
    - Handler → Service → Repository の処理フロー確認
    - 既存の類似実装をパターン参考
 
-4. **変更箇所を特定**
+5. **変更箇所を特定**
    - 新規作成: 値オブジェクト、Gateway、Validator等
    - 修正: Handler、Verifier、設定クラス等
 

--- a/config/templates/use-cases/ekyc/conformance-config-oidccore.json
+++ b/config/templates/use-cases/ekyc/conformance-config-oidccore.json
@@ -1,0 +1,81 @@
+{
+  "alias": "${CONFORMANCE_ALIAS}",
+  "description": "OpenID for Identity Assurance (eKYC) certification config for the local idp-server eKYC use-case tenant. Use with the 'OpenID for IDA using OpenID Connect Core' test plan (ekyc-test-plan-oidccore) and ClientAuthType=client_secret_post. The client matches the use-case client registered by setup.sh. Generated from config/templates/use-cases/ekyc/conformance-config-oidccore.json by setup.sh.",
+  "server": {
+    "discoveryUrl": "${BASE_URL}/${PUBLIC_TENANT_ID}/.well-known/openid-configuration"
+  },
+  "client": {
+    "client_id": "${CLIENT_ID}",
+    "client_secret": "${CLIENT_SECRET}",
+    "scope": "openid"
+  },
+  "ekyc": {
+    "verified_claims_request_list": {
+      "id_token": {
+        "verified_claims": {
+          "verification": {
+            "trust_framework": {
+              "value": "eidas"
+            }
+          },
+          "claims": {
+            "given_name": null,
+            "family_name": null
+          }
+        }
+      },
+      "userinfo": {
+        "verified_claims": {
+          "verification": {
+            "trust_framework": {
+              "value": "eidas"
+            }
+          },
+          "claims": {
+            "given_name": null,
+            "family_name": null,
+            "birthdate": null
+          }
+        }
+      }
+    },
+    "userinfo": {
+      "sub": "f647f683-e46d-43bd-bc76-526d93429b86",
+      "verified_claims": {
+        "verification": {
+          "trust_framework": "eidas",
+          "evidence": [
+            {
+              "type": "document",
+              "check_details": [
+                {
+                  "check_method": "vpip"
+                }
+              ],
+              "document_details": {
+                "type": "idcard"
+              }
+            }
+          ]
+        },
+        "claims": {
+          "given_name": "Given001",
+          "family_name": "Family001",
+          "birthdate": "1950-01-01"
+        }
+      }
+    },
+    "expected_verified_claims": {
+      "f647f683-e46d-43bd-bc76-526d93429b86": {
+        "verification": {
+          "trust_framework": "eidas"
+        },
+        "claims": {
+          "given_name": "Given001",
+          "family_name": "Family001",
+          "birthdate": "1950-01-01"
+        }
+      }
+    }
+  }
+}

--- a/config/templates/use-cases/ekyc/conformance-test-user-template.json
+++ b/config/templates/use-cases/ekyc/conformance-test-user-template.json
@@ -1,0 +1,34 @@
+{
+  "sub": "${CONFORMANCE_TEST_SUB}",
+  "provider_id": "idp-server",
+  "name": "Given001 Family001",
+  "given_name": "Given001",
+  "family_name": "Family001",
+  "birthdate": "1950-01-01",
+  "email": "${CONFORMANCE_TEST_EMAIL}",
+  "email_verified": true,
+  "raw_password": "${CONFORMANCE_TEST_PASSWORD}",
+  "verified_claims": {
+    "verification": {
+      "trust_framework": "eidas",
+      "evidence": [
+        {
+          "type": "document",
+          "check_details": [
+            {
+              "check_method": "vpip"
+            }
+          ],
+          "document_details": {
+            "type": "idcard"
+          }
+        }
+      ]
+    },
+    "claims": {
+      "given_name": "Given001",
+      "family_name": "Family001",
+      "birthdate": "1950-01-01"
+    }
+  }
+}

--- a/config/templates/use-cases/ekyc/delete.sh
+++ b/config/templates/use-cases/ekyc/delete.sh
@@ -98,6 +98,27 @@ else
 fi
 echo ""
 
+# Step 2.5: Delete conformance test user (must run before public tenant deletion,
+# otherwise the user is orphaned in idp_user and re-runs hit a duplicate-key conflict)
+if [ -f "${OUTPUT_DIR}/conformance-test-user.json" ]; then
+  CONFORMANCE_TEST_SUB=$(jq -r '.sub' "${OUTPUT_DIR}/conformance-test-user.json")
+  echo "Step 2.5: Deleting conformance test user (${CONFORMANCE_TEST_SUB})..."
+  CONFORMANCE_USER_DELETE_RESPONSE=$(curl -s -w "\n%{http_code}" -X DELETE \
+    "${AUTHORIZATION_SERVER_URL}/v1/management/tenants/${PUBLIC_TENANT_ID}/users/${CONFORMANCE_TEST_SUB}" \
+    -H "Authorization: Bearer ${SYSTEM_ACCESS_TOKEN}")
+
+  CONFORMANCE_USER_DELETE_HTTP_CODE=$(echo "${CONFORMANCE_USER_DELETE_RESPONSE}" | tail -n1)
+
+  if [ "${CONFORMANCE_USER_DELETE_HTTP_CODE}" = "204" ]; then
+    echo "Conformance test user deleted successfully"
+  elif [ "${CONFORMANCE_USER_DELETE_HTTP_CODE}" = "404" ]; then
+    echo "Warning: Conformance test user not found (may already be deleted)"
+  else
+    echo "Warning: Conformance test user deletion failed (HTTP ${CONFORMANCE_USER_DELETE_HTTP_CODE})"
+  fi
+  echo ""
+fi
+
 # Step 3: Delete public tenant
 echo "Step 3: Deleting public tenant..."
 PUBLIC_TENANT_DELETE_RESPONSE=$(curl -s -w "\n%{http_code}" -X DELETE \

--- a/config/templates/use-cases/ekyc/public-client-template.json
+++ b/config/templates/use-cases/ekyc/public-client-template.json
@@ -3,7 +3,8 @@
   "client_id_alias": "${CLIENT_ALIAS}",
   "client_secret": "${CLIENT_SECRET}",
   "redirect_uris": [
-    "${REDIRECT_URI}"
+    "${REDIRECT_URI}",
+    "${CONFORMANCE_REDIRECT_URI}"
   ],
   "response_types": [
     "code"

--- a/config/templates/use-cases/ekyc/public-tenant-template.json
+++ b/config/templates/use-cases/ekyc/public-tenant-template.json
@@ -140,6 +140,9 @@
       "sripp",
       "eid"
     ],
+    "documents_check_methods_supported": [
+      "vpip"
+    ],
     "electronic_records_supported": [
       "bank_account",
       "utility_statement"

--- a/config/templates/use-cases/ekyc/setup.sh
+++ b/config/templates/use-cases/ekyc/setup.sh
@@ -128,6 +128,12 @@ ID_TOKEN_DURATION="${ID_TOKEN_DURATION:-3600}"
 REFRESH_TOKEN_DURATION="${REFRESH_TOKEN_DURATION:-86400}"
 REGISTRATION_REQUIRED_FIELDS="${REGISTRATION_REQUIRED_FIELDS:-email,password,name}"
 
+# OIDF conformance test settings
+# CONFORMANCE_ALIAS must match the "alias" used by the generated conformance config,
+# because the OpenID conformance suite callback URL is /test/a/<alias>/callback.
+CONFORMANCE_ALIAS="${CONFORMANCE_ALIAS:-idp-server-ekyc-usecase-oidccore-local}"
+CONFORMANCE_REDIRECT_URI="${CONFORMANCE_REDIRECT_URI:-https://localhost.emobix.co.uk:8443/test/a/${CONFORMANCE_ALIAS}/callback}"
+
 # Create output directory for generated JSON files
 OUTPUT_DIR="${PROJECT_ROOT}/config/generated/${ORGANIZATION_NAME}"
 mkdir -p "${OUTPUT_DIR}"
@@ -351,7 +357,8 @@ CLIENT_JSON=$(substitute_template "${SCRIPT_DIR}/public-client-template.json" \
   "CLIENT_ALIAS" "${CLIENT_ALIAS}" \
   "CLIENT_SECRET" "${CLIENT_SECRET}" \
   "CLIENT_NAME" "${CLIENT_NAME}" \
-  "REDIRECT_URI" "${REDIRECT_URI}")
+  "REDIRECT_URI" "${REDIRECT_URI}" \
+  "CONFORMANCE_REDIRECT_URI" "${CONFORMANCE_REDIRECT_URI}")
 
 echo "${CLIENT_JSON}" | jq '.' > "${OUTPUT_DIR}/public-client.json"
 echo "  Saved: ${OUTPUT_DIR}/public-client.json"
@@ -432,6 +439,71 @@ else
 fi
 echo ""
 
+# --- Step 10: Register conformance test user (verified_claims seed) ---
+echo "Step 10: Registering conformance test user (verified_claims seed)..."
+
+CONFORMANCE_TEST_SUB="${CONFORMANCE_TEST_SUB:-$(uuidgen | tr '[:upper:]' '[:lower:]')}"
+CONFORMANCE_TEST_EMAIL="${CONFORMANCE_TEST_EMAIL:-oidcc-ekyc-test@example.com}"
+CONFORMANCE_TEST_PASSWORD="${CONFORMANCE_TEST_PASSWORD:-OidccTestPassword123!}"
+
+USER_TEMPLATE="${SCRIPT_DIR}/conformance-test-user-template.json"
+if [ -f "${USER_TEMPLATE}" ]; then
+  TEST_USER_JSON=$(substitute_template "${USER_TEMPLATE}" \
+    "CONFORMANCE_TEST_SUB" "${CONFORMANCE_TEST_SUB}" \
+    "CONFORMANCE_TEST_EMAIL" "${CONFORMANCE_TEST_EMAIL}" \
+    "CONFORMANCE_TEST_PASSWORD" "${CONFORMANCE_TEST_PASSWORD}")
+
+  echo "${TEST_USER_JSON}" | jq '.' > "${OUTPUT_DIR}/conformance-test-user.json"
+  echo "  Saved: ${OUTPUT_DIR}/conformance-test-user.json"
+
+  USER_RESPONSE=$(curl -s -w "\n%{http_code}" -X POST \
+    "${ORG_BASE_URL}/${PUBLIC_TENANT_ID}/users" \
+    -H "Authorization: Bearer ${ORG_ACCESS_TOKEN}" \
+    -H "Content-Type: application/json" \
+    -d @"${OUTPUT_DIR}/conformance-test-user.json")
+
+  HTTP_CODE=$(echo "${USER_RESPONSE}" | tail -n1)
+  RESPONSE_BODY=$(echo "${USER_RESPONSE}" | sed '$d')
+
+  if [ "${HTTP_CODE}" = "200" ] || [ "${HTTP_CODE}" = "201" ]; then
+    echo "  Conformance test user registered: sub=${CONFORMANCE_TEST_SUB}"
+  else
+    echo "  Failed (HTTP ${HTTP_CODE})"
+    echo "  ${RESPONSE_BODY}" | jq '.' 2>/dev/null || echo "  ${RESPONSE_BODY}"
+    exit 1
+  fi
+else
+  echo "  Warning: conformance-test-user-template.json not found, skipping"
+fi
+echo ""
+
+# --- Step 11: Generate OIDF conformance test config (IDA using OpenID Connect Core) ---
+echo "Step 11: Generating OIDF conformance test config (IDA using OpenID Connect Core)..."
+
+CONFORMANCE_TEMPLATE="${SCRIPT_DIR}/conformance-config-oidccore.json"
+if [ -f "${CONFORMANCE_TEMPLATE}" ]; then
+  CONFORMANCE_JSON=$(substitute_template "${CONFORMANCE_TEMPLATE}" \
+    "BASE_URL" "${AUTHORIZATION_SERVER_URL}" \
+    "PUBLIC_TENANT_ID" "${PUBLIC_TENANT_ID}" \
+    "CLIENT_ID" "${CLIENT_ID}" \
+    "CLIENT_SECRET" "${CLIENT_SECRET}" \
+    "CONFORMANCE_ALIAS" "${CONFORMANCE_ALIAS}")
+
+  # Align the expected verified_claims subject with the registered test user's sub
+  # (substitute_template only replaces string values, not the expected_verified_claims object key)
+  CONFORMANCE_JSON=$(echo "${CONFORMANCE_JSON}" | jq --arg sub "${CONFORMANCE_TEST_SUB}" '
+    .ekyc.userinfo.sub = $sub
+    | .ekyc.expected_verified_claims = { ($sub): (.ekyc.expected_verified_claims | to_entries[0].value) }
+  ')
+
+  echo "${CONFORMANCE_JSON}" | jq '.' > "${OUTPUT_DIR}/conformance-config-oidccore.json"
+  echo "  Saved: ${OUTPUT_DIR}/conformance-config-oidccore.json"
+  echo "  (Load this in the OpenID conformance suite for plan: ekyc-test-plan-oidccore)"
+else
+  echo "  Warning: conformance-config-oidccore.json template not found, skipping"
+fi
+echo ""
+
 # --- Summary ---
 echo "=========================================="
 echo "Setup Complete!"
@@ -478,6 +550,8 @@ echo "  ${OUTPUT_DIR}/authentication-policy.json"
 echo "  ${OUTPUT_DIR}/public-client.json"
 echo "  ${OUTPUT_DIR}/identity-verification-config.json"
 echo "  ${OUTPUT_DIR}/identity-verification-config-ongoing.json"
+echo "  ${OUTPUT_DIR}/conformance-test-user.json"
+echo "  ${OUTPUT_DIR}/conformance-config-oidccore.json"
 echo ""
 echo "Test Authorization Code Flow:"
 echo "  1. Open browser:"


### PR DESCRIPTION
## 概要

eKYC (OpenID for Identity Assurance) の OIDF conformance テスト（`ekyc-test-plan-oidccore`）をローカル idp-server に対して実行できるよう、`config/templates/use-cases/ekyc` のセットアップに conformance テスト環境構築を統合した。`setup.sh` 一発で「verified_claims 付きテストユーザー登録 → conformance suite 用設定ファイル生成」まで完了する。

Closes #1643

## 変更内容

### 新規テンプレート
- `conformance-config-oidccore.json` — conformance suite 用設定（`client_secret_post`、`verified_claims_request_list`、`expected_verified_claims`）
- `conformance-test-user-template.json` — verified_claims 付きテストユーザー（管理API登録用）

### setup.sh
- **Step 10**: 管理API でテストユーザーを登録。`sub` は他IDと同様 `uuidgen` 再生成（`idp_user` グローバルPK衝突回避）
- **Step 11**: conformance config を生成（プレースホルダ置換 + `expected_verified_claims` のキーを登録 sub に jq リキー）
- `CONFORMANCE_ALIAS` で config の `alias` と client の emobix redirect_uri を1本化

### delete.sh
- public tenant 削除の前に conformance テストユーザーを削除（tenant 削除で cascade されず orphan → 再 run で duplicate-key になるため）

### config 整合（IDA メタデータ）
- `public-client-template.json`: conformance callback を `redirect_uris` に追加
- `public-tenant-template.json`: `documents_check_methods_supported: ["vpip"]` を追加
- verified_claims の `trust_framework` を `eidas` に統一（discovery 広告値と一致）、evidence に `document_details: {type: idcard}` を追加

### ドキュメント
- `CLAUDE.md`: Issue作業手順に「API仕様(OpenAPI)を先に確認」ステップを追加

> Note: `OrganizationUserCreateRequest`/`UpdateRequest` への `verified_claims` 追記（OpenAPI記載漏れ）は別PRでマージ済み。

## 検証

`./setup.sh` 実行 → 実機で確認済み:
- テストユーザーの `verified_claims` が永続化（GET で確認）
- client に redirect_uri 2つ（app + emobix）登録
- discovery / 登録ユーザー / config の trust_framework・evidence が整合
- conformance suite: evidence 系 IA-8（document_details / documents_check_methods_supported）が解消

## スコープ外（残ブロッカー）

- **#1628**（UserInfo の `claims` パラメータ経由 verified_claims 未実装）: happy path / userinfo-only 系の IA-6/IA-8 はこれが解消されるまで PASS しない（コード機能のため本PRのスコープ外）

🤖 Generated with [Claude Code](https://claude.com/claude-code)