### PR TITLE
test(identity-verification): IDA spec準拠E2E の未対応項目を it化（#1649 module #2-6 / IA-8 / §7 / electronic_records）

### DIFF
--- a/config/examples/e2e/test-tenant/authorization-server/idp-server.json
+++ b/config/examples/e2e/test-tenant/authorization-server/idp-server.json
@@ -219,12 +219,14 @@
   "verified_claims_supported": true,
   "trust_frameworks_supported":[
     "nist_800_63A_ial_2",
-    "nist_800_63A_ial_3"
+    "nist_800_63A_ial_3",
+    "eidas"
   ],
   "evidence_supported":[
     "id_document",
     "utility_bill",
-    "qes"
+    "qes",
+    "electronic_record"
   ],
   "documents_supported":[
     "idcard",
@@ -235,6 +237,10 @@
     "pipp",
     "sripp",
     "eid"
+  ],
+  "electronic_records_supported":[
+    "bank_account",
+    "mortgage_account"
   ],
   "claims_in_verified_claims_supported":[
     "given_name",

--- a/e2e/src/tests/spec/oidc_for_identity_assurance.test.js
+++ b/e2e/src/tests/spec/oidc_for_identity_assurance.test.js
@@ -229,9 +229,23 @@ describe("OpenID Connect for Identity Assurance 1.0", () => {
       expect(payload.verified_claims.claims.given_name).toEqual("Sarah");
     });
 
-    xit("For each claim, the value is either `null` (default), or an object. (requested with an empty JSON object {} — eKYC module #2 ekyc-server-happypath-emptyobject)", async () => {});
+    it("For each claim, the value is either `null` (default), or an object. (requested with an empty JSON object {} — eKYC module #2 ekyc-server-happypath-emptyobject)", async () => {
+      const payload = await idTokenVerifiedClaims({
+        verification: { trust_framework: null },
+        claims: { given_name: {} },
+      });
+      expect(payload.verified_claims).toBeDefined();
+      expect(payload.verified_claims.claims.given_name).toEqual("Sarah");
+    });
 
-    xit('For each claim, the value is either `null` (default), or an object. (requested with {"essential": false}, an OIDC Core §5.5.1 member — eKYC module #3 ekyc-server-happypath-essentialfalse)', async () => {});
+    it('For each claim, the value is either `null` (default), or an object. (requested with {"essential": false}, an OIDC Core §5.5.1 member — eKYC module #3 ekyc-server-happypath-essentialfalse)', async () => {
+      const payload = await idTokenVerifiedClaims({
+        verification: { trust_framework: null },
+        claims: { given_name: { essential: false } },
+      });
+      expect(payload.verified_claims).toBeDefined();
+      expect(payload.verified_claims.claims.given_name).toEqual("Sarah");
+    });
   });
 
   describe("5.5 Defining further constraints on verification data", () => {
@@ -281,15 +295,39 @@ describe("OpenID Connect for Identity Assurance 1.0", () => {
       });
 
       // "does not understand/support the respective claim" — the unknown/unsupported-claim cases.
-      xit("If the OP does not have data about a certain claim, does not understand/support the respective claim, OPs shall omit the respective claim ... (unknown random-named claim — eKYC module #4 ekyc-server-unknown-claim-omitted)", async () => {});
+      it("If the OP does not have data about a certain claim, does not understand/support the respective claim, OPs shall omit the respective claim ... (unknown random-named claim — eKYC module #4 ekyc-server-unknown-claim-omitted)", async () => {
+        const payload = await idTokenVerifiedClaims({
+          verification: { trust_framework: null },
+          claims: { given_name: null, unknown_random_claim_xyz: null },
+        });
+        expect(payload.verified_claims).toBeDefined();
+        expect(payload.verified_claims.claims.given_name).toEqual("Sarah");
+        expect(payload.verified_claims.claims).not.toHaveProperty("unknown_random_claim_xyz");
+      });
 
-      xit("If the OP does not have data about a certain claim, does not understand/support the respective claim, OPs shall omit the respective claim ... (unknown claim requested with essential:true — eKYC module #5 ekyc-server-unknown-essential-claim-omitted)", async () => {});
+      it("If the OP does not have data about a certain claim, does not understand/support the respective claim, OPs shall omit the respective claim ... (unknown claim requested with essential:true — eKYC module #5 ekyc-server-unknown-essential-claim-omitted)", async () => {
+        const payload = await idTokenVerifiedClaims({
+          verification: { trust_framework: null },
+          claims: { given_name: null, unknown_essential_claim: { essential: true } },
+        });
+        expect(payload.verified_claims).toBeDefined();
+        expect(payload.verified_claims.claims.given_name).toEqual("Sarah");
+        expect(payload.verified_claims.claims).not.toHaveProperty("unknown_essential_claim");
+      });
 
-      xit("If the OP does not have data about a certain claim, does not understand/support the respective claim, OPs shall omit the respective claim ... (unknown claim whose name contains special characters — eKYC module #6 ekyc-server-unknown-claim-specialchars-omitted)", async () => {});
+      it("If the OP does not have data about a certain claim, does not understand/support the respective claim, OPs shall omit the respective claim ... (unknown claim whose name contains special characters — eKYC module #6 ekyc-server-unknown-claim-specialchars-omitted)", async () => {
+        const payload = await idTokenVerifiedClaims({
+          verification: { trust_framework: null },
+          claims: { given_name: null, "claim%1/a&,.b": null },
+        });
+        expect(payload.verified_claims).toBeDefined();
+        expect(payload.verified_claims.claims.given_name).toEqual("Sarah");
+        expect(payload.verified_claims.claims).not.toHaveProperty("claim%1/a&,.b");
+      });
     });
 
     describe("5.7.3 Non-consented data", () => {
-      xit("the OP shall omit from any corresponding ID Token or UserInfo response data that has not had end-user consent for sharing. (negative test not yet implemented)", async () => {});
+      xit("the OP shall omit from any corresponding ID Token or UserInfo response data that has not had end-user consent for sharing. (pending: requires driving a non-consented state through the consent flow — see #1649-B)", async () => {});
     });
 
     describe("5.7.4 Data not matching requirements", () => {
@@ -337,7 +375,15 @@ describe("OpenID Connect for Identity Assurance 1.0", () => {
   });
 
   describe("7 Requesting verified claims", () => {
-    xit("The OP shall not provide the RP with any data it did not request. (IA-7 data minimization; negative test not yet implemented)", async () => {});
+    it("The OP shall not provide the RP with any data it did not request. (IA-7 data minimization — only the requested claim appears in the response)", async () => {
+      // Only given_name is requested; nothing else (family_name, birthdate, address, ...) may leak.
+      const payload = await idTokenVerifiedClaims({
+        verification: { trust_framework: null },
+        claims: { given_name: null },
+      });
+      expect(payload.verified_claims).toBeDefined();
+      expect(Object.keys(payload.verified_claims.claims)).toEqual(["given_name"]);
+    });
   });
 
   describe("8 OP metadata", () => {
@@ -381,13 +427,42 @@ describe("OpenID Connect for Identity Assurance 1.0", () => {
       expect(metadata.documents_methods_supported).toContain("pipp");
     });
 
-    xit('documents_check_methods_supported: Optional. JSON array containing the check methods the OP supports for evidences of type "document". (not advertised by this OP)', () => {});
+    xit('documents_check_methods_supported: Optional. JSON array containing the check methods the OP supports for evidences of type "document". (pending: no document-evidence test data; advertising it needs a value set verified against the spec — see #1649-C)', () => {});
 
-    xit('electronic_records_supported: Required when evidence_supported contains "electronic_record". JSON array containing all electronic record types the OP supports. (no electronic_record evidence advertised by this OP)', () => {});
+    it('electronic_records_supported: Required when evidence_supported contains "electronic_record". JSON array containing all electronic record types the OP supports. When present this array shall have at least one member.', () => {
+      expect(Array.isArray(metadata.electronic_records_supported)).toBe(true);
+      expect(metadata.electronic_records_supported.length).toBeGreaterThan(0);
+    });
 
     it("legacy pre-1.0 draft names id_documents_supported / id_documents_verification_methods_supported are no longer advertised", () => {
       expect(metadata).not.toHaveProperty("id_documents_supported");
       expect(metadata).not.toHaveProperty("id_documents_verification_methods_supported");
+    });
+  });
+
+  // conformance E group (IA-8): every value returned inside verified_claims must be advertised in the
+  // OP's *_supported metadata (ValidateVerifiedClaimsInIdTokenAgainstOPMetadata / ...InUserinfo...).
+  describe("IA-8 returned verified_claims must be within the OP metadata", () => {
+    it("the trust_framework returned in verified_claims/verification is advertised in trust_frameworks_supported.", async () => {
+      const metaResponse = await getConfiguration({ endpoint: serverConfig.discoveryEndpoint });
+      const payload = await idTokenVerifiedClaims({
+        verification: { trust_framework: null },
+        claims: { given_name: null },
+      });
+      expect(metaResponse.data.trust_frameworks_supported).toContain(
+        payload.verified_claims.verification.trust_framework
+      );
+    });
+
+    it("every claim name returned in verified_claims/claims is advertised in claims_in_verified_claims_supported.", async () => {
+      const metaResponse = await getConfiguration({ endpoint: serverConfig.discoveryEndpoint });
+      const payload = await idTokenVerifiedClaims({
+        verification: { trust_framework: null },
+        claims: { given_name: null, family_name: null },
+      });
+      Object.keys(payload.verified_claims.claims).forEach((name) => {
+        expect(metaResponse.data.claims_in_verified_claims_supported).toContain(name);
+      });
     });
   });
 


### PR DESCRIPTION
## 概要

#1649（OIDC4IDA spec準拠E2E の網羅性改善）の一部に着手。`oidc_for_identity_assurance.test.js` の `xit`（未対応台帳）を実テストへ昇格し、その過程で見つかった **IA-8 不整合**（レスポンス値が OP metadata に未広告）を e2eテナント設定の修正で解消する。

**covered 17 `it` → 26 / pending 13 `xit` → 6**（全 it green）

## 変更

### 1. config — e2eテナントの verified_claims メタデータ整合（IA-8）
`verified_claims` が返す値が `*_supported` の広告内に収まるよう修正：
- `trust_frameworks_supported` に `eidas` 追加（返却値 `trust_framework="eidas"` が未広告だった）
- `evidence_supported` に `electronic_record` 追加
- `electronic_records_supported` を新設（`bank_account` / `mortgage_account`）

### 2. test — xit → it 昇格（9件）
- **eKYC module #2-6**: empty object / essential:false / unknown claim ×3。**実装は元から準拠**（テストで固定）
- **IA-8 整合**: 返した `trust_framework` / claim 名が `*_supported` に含まれることを検証する describe を追加
- **§7 データ最小化**: 要求していない claim がレスポンスに漏れないことを検証
- **§8 electronic_records_supported**: 上記メタデータ広告とセットで it 化

### 据え置き（xit に理由明記）
| xit | 理由 |
|-----|------|
| §5.5.2 max_age / purpose×3 | 実装が必要 → #1651 |
| §5.7.3 非同意 | consent フロー操作が必要（E2E整備が別途） |
| §8 documents_check_methods | document evidence のテストデータ無 / 値の spec 確認が必要 |

## 検証
- `npm test -- --testPathPattern="oidc_for_identity_assurance"` → **26 passed / 6 skipped** ✅
- discovery metadata に `eidas` / `electronic_record` / `electronic_records_supported` の反映を実機確認

## 関連
- #1649（spec準拠E2E 網羅性改善）/ #1651（実装不足）/ #1650（再構成・マージ済み）

🤖 Generated with [Claude Code](https://claude.com/claude-code)