### PR TITLE
feat(identity-verification): OIDC4IDA §5.5.2 max_age 鮮度判定を実装 (#1651)

### DIFF
--- a/config/examples/e2e/test-tenant/user/ida-verified-user.json
+++ b/config/examples/e2e/test-tenant/user/ida-verified-user.json
@@ -1,0 +1,49 @@
+{
+  "sub": "0a1da001-0000-4000-8000-000000000001",
+  "provider_id": "idp-server",
+  "external_user_id": "0a1da001-0000-4000-8000-000000000001",
+  "name": "Sarah Meredyth",
+  "given_name": "Sarah",
+  "family_name": "Meredyth",
+  "preferred_username": "ida-verified-user",
+  "email": "ida.verified.user@gmail.com",
+  "email_verified": true,
+  "birthdate": "1976-03-11",
+  "raw_password": "successUserCode001",
+  "verified_claims": {
+    "claims": {
+      "address": {
+        "country": "UK",
+        "locality": "Edinburgh",
+        "postal_code": "EH1 9GP",
+        "street_address": "122 Burns Crescent"
+      },
+      "birthdate": "1976-03-11",
+      "given_name": "Sarah",
+      "family_name": "Meredyth",
+      "place_of_birth": { "country": "UK" }
+    },
+    "verification": {
+      "time": "2021-04-09T14:12Z",
+      "evidence": [
+        {
+          "time": "2021-04-09T14:12Z",
+          "type": "electronic_record",
+          "record": { "type": "mortgage_account", "source": { "name": "TheCreditBureau" } },
+          "check_details": [
+            { "txn": "kbv1-hf934hn09234ng03jj3", "check_method": "kbv", "organization": "TheCreditBureau" }
+          ]
+        },
+        {
+          "time": "2021-04-09T14:12Z",
+          "type": "electronic_record",
+          "record": { "type": "bank_account", "source": { "name": "TheBank" } },
+          "check_details": [
+            { "txn": "kbv2-nm0f23u9459fj38u5j6", "check_method": "kbv", "organization": "OpenBankingTPP" }
+          ]
+        }
+      ],
+      "trust_framework": "eidas"
+    }
+  }
+}

--- a/config/scripts/e2e-test-data.sh
+++ b/config/scripts/e2e-test-data.sh
@@ -91,6 +91,23 @@ echo "tenant-a"
   -a "${ACCESS_TOKEN}" \
   -d "${DRY_RUN}"
 
+## user (dedicated, non-privileged IDA verified-claims test user)
+# Kept separate from the shared ito.ichiro super-user so its verified_claims (incl. the top-level
+# verification.time that drives the §5.5.2 max_age tests) can be refreshed by re-running this seed
+# without disturbing other tests. Consumed by e2e/.../spec/oidc_for_identity_assurance.test.js.
+
+echo "-------------------------------------------------"
+echo ""
+echo "user (ida-verified-user)"
+
+./config/scripts/upsert-user.sh \
+  -t "${TENANT_ID}" \
+  -o "${ORGANIZATION_ID}" \
+  -f "./config/examples/e2e/test-tenant/user/ida-verified-user.json" \
+  -b "${AUTHORIZATION_SERVER_URL}" \
+  -a "${ACCESS_TOKEN}" \
+  -d "${DRY_RUN}"
+
 ## authorization-server
 
 echo "-------------------------------------------------"

--- a/documentation/docs/content_11_learning/16-oauth-oidc-rfc/advanced-identity/oidc-ida.md
+++ b/documentation/docs/content_11_learning/16-oauth-oidc-rfc/advanced-identity/oidc-ida.md
@@ -333,6 +333,34 @@ OIDC for IDA:
 ```
 
 
+### レスポンスの配信先と省略ルール（§5.2 / §5.7）
+
+#### id_token / userinfo の使い分け（§5.2）
+
+verified_claims は `claims` パラメータの `id_token` メンバ・`userinfo` メンバのどちらでも要求でき、**要求した側のレスポンスにのみ**返される。
+
+```json
+{
+  "id_token": { "verified_claims": { "claims": { "given_name": null } } },
+  "userinfo": { "verified_claims": { "claims": { "address": null } } }
+}
+```
+
+- `id_token` で要求 → ID Token に含まれ、UserInfo には含まれない
+- `userinfo` で要求 → UserInfo に含まれ、ID Token には含まれない
+
+#### 要求どおり返るとは限らない（データ最小化・§5.7）
+
+RP が要求した verified_claims が、そのままレスポンスに返るとは限らない。OP は §5.7 のルールに従って一部を省略する。
+
+| ルール | § | OP の挙動 |
+|--------|---|----------|
+| 保持していない／非対応のクレーム | 5.7.2 | 当該クレームを省略 |
+| 同意されていないデータ | 5.7.3 | 共有同意が無いデータを省略 |
+| 制約に合致しないデータ | 5.7.4 | `value`/`values` 不一致が **claims 内**なら当該クレームを省略、**verification 内**なら verified_claims 全体を省略 |
+
+いずれの場合も **OP はエラーを返さず**、返せる範囲のみ返す（§5.7.4）。要求クレームがすべて落ちて `claims` が空になっても、`verification` が有効なら verified_claims は返る（空の `claims` を許容）。
+
 ### ディスカバリーメタデータ
 
 ```json

--- a/e2e/src/tests/spec/oidc_for_identity_assurance.test.js
+++ b/e2e/src/tests/spec/oidc_for_identity_assurance.test.js
@@ -310,6 +310,8 @@ describe("OpenID Connect for Identity Assurance 1.0", () => {
         });
         expect(payload.verified_claims.claims.given_name).toEqual("Sarah");
       });
+
+      xit("max_age: Optional. JSON number value only applicable to claims that contain dates or timestamps. The OP should try to fulfill this requirement. (nested evidence freshness — verification.evidence[].time / evidence[].check_details[].time — is NOT enforced: VerifiedClaimsAssembler applies max_age only to top-level verification elements and top-level claims, it does not recurse into the evidence array)", async () => {});
     });
   });
 

--- a/e2e/src/tests/spec/oidc_for_identity_assurance.test.js
+++ b/e2e/src/tests/spec/oidc_for_identity_assurance.test.js
@@ -21,10 +21,16 @@ import { get } from "../../lib/http";
 // conformance-suite repo (github.com/openid/conformance-suite, eKYC-IDA test plan) — not a file in
 // this repo.
 //
-// The default end-user (ito.ichiro@gmail.com, signed in via the clientSecretPostClient flow) has
-// stored verified_claims with verification.trust_framework = "eidas" and claims given_name "Sarah" /
-// family_name "Meredyth" / birthdate / address. middle_name and gender are intentionally NOT stored
-// (treated as unavailable).
+// The end-user is a dedicated, non-privileged IDA fixture (ida.verified.user@gmail.com), provisioned
+// by config/scripts/e2e-test-data.sh from config/examples/e2e/test-tenant/user/ida-verified-user.json
+// — kept separate from the shared ito.ichiro super-user so its verified_claims can be tuned for these
+// tests without side effects elsewhere. It holds verification.trust_framework = "eidas",
+// verification.time (drives §5.5.2 max_age), and claims given_name "Sarah" / family_name "Meredyth" /
+// birthdate / address. middle_name and gender are intentionally NOT stored (treated as unavailable).
+const idaVerifiedUser = {
+  username: "ida.verified.user@gmail.com",
+  password: "successUserCode001",
+};
 describe("OpenID Connect for Identity Assurance 1.0", () => {
 
   // Drives verified_claims via the `claims` parameter's id_token member; returns the ID Token payload.
@@ -38,6 +44,7 @@ describe("OpenID Connect for Identity Assurance 1.0", () => {
       scope: "openid " + clientSecretPostClient.scope,
       redirectUri: clientSecretPostClient.redirectUri,
       claims: JSON.stringify({ id_token: { verified_claims: verifiedClaimsRequest } }),
+      user: idaVerifiedUser,
     });
     expect(authorizationResponse.code).not.toBeNull();
 
@@ -74,6 +81,7 @@ describe("OpenID Connect for Identity Assurance 1.0", () => {
       scope: "openid " + clientSecretPostClient.scope,
       redirectUri: clientSecretPostClient.redirectUri,
       claims: JSON.stringify({ userinfo: { verified_claims: verifiedClaimsRequest } }),
+      user: idaVerifiedUser,
     });
     expect(authorizationResponse.code).not.toBeNull();
 
@@ -176,6 +184,7 @@ describe("OpenID Connect for Identity Assurance 1.0", () => {
             verified_claims: verifiedClaims,
           }
         }),
+        user: idaVerifiedUser,
       });
       expect(authorizationResponse.code).not.toBeNull();
 
@@ -262,7 +271,45 @@ describe("OpenID Connect for Identity Assurance 1.0", () => {
     });
 
     describe("5.5.2 Max_age", () => {
-      xit("max_age: Optional. JSON number value only applicable to claims that contain dates or timestamps. The OP should try to fulfill this requirement. (verified_claims freshness is not enforced; out of scope in VerifiedClaimsAssembler)", async () => {});
+      it("max_age: Optional. JSON number value only applicable to claims that contain dates or timestamps. The OP should try to fulfill this requirement. (verification.time staler than max_age is dropped; trust_framework and the requested claim are still returned — a max_age miss is not whole-omitted, unlike a value/values miss)", async () => {
+        // verification.time is fixed at 2021-04-09; with max_age 3600s it is always far too old, so
+        // the OP drops just that element. trust_framework (REQUIRED floor) + claims remain.
+        const payload = await idTokenVerifiedClaims({
+          verification: { trust_framework: null, time: { max_age: 3600 } },
+          claims: { given_name: null },
+        });
+        expect(payload.verified_claims).toBeDefined();
+        expect(payload.verified_claims.verification.trust_framework).toEqual("eidas");
+        expect(payload.verified_claims.verification).not.toHaveProperty("time");
+        expect(payload.verified_claims.claims.given_name).toEqual("Sarah");
+      });
+
+      it("max_age: Optional. JSON number value only applicable to claims that contain dates or timestamps. The OP should try to fulfill this requirement. (verification.time within max_age is returned)", async () => {
+        // max_age effectively unbounded (~31700 years), so the 2021 timestamp is fresh enough.
+        const payload = await idTokenVerifiedClaims({
+          verification: { trust_framework: null, time: { max_age: 1000000000000 } },
+          claims: { given_name: null },
+        });
+        expect(payload.verified_claims.verification.time).toEqual("2021-04-09T14:12Z");
+      });
+
+      it("max_age: Optional. JSON number value only applicable to claims that contain dates or timestamps. The OP should try to fulfill this requirement. (a date claim staler than max_age is dropped individually; other claims are unaffected)", async () => {
+        const payload = await idTokenVerifiedClaims({
+          verification: { trust_framework: null },
+          claims: { birthdate: { max_age: 3600 }, given_name: null },
+        });
+        expect(payload.verified_claims).toBeDefined();
+        expect(payload.verified_claims.claims).not.toHaveProperty("birthdate");
+        expect(payload.verified_claims.claims.given_name).toEqual("Sarah");
+      });
+
+      it("max_age: Optional. JSON number value only applicable to claims that contain dates or timestamps. The OP should try to fulfill this requirement. (max_age on a non-date claim does not apply; the claim is returned)", async () => {
+        const payload = await idTokenVerifiedClaims({
+          verification: { trust_framework: null },
+          claims: { given_name: { max_age: 1 } },
+        });
+        expect(payload.verified_claims.claims.given_name).toEqual("Sarah");
+      });
     });
   });
 

--- a/libs/idp-server-core-extension-ida/src/main/java/org/idp/server/core/extension/identity/verified/UserinfoVerifiedClaimsCreator.java
+++ b/libs/idp-server-core-extension-ida/src/main/java/org/idp/server/core/extension/identity/verified/UserinfoVerifiedClaimsCreator.java
@@ -23,6 +23,7 @@ import org.idp.server.core.openid.identity.id_token.VerifiedClaimsObject;
 import org.idp.server.core.openid.oauth.configuration.AuthorizationServerConfiguration;
 import org.idp.server.core.openid.oauth.configuration.client.ClientConfiguration;
 import org.idp.server.core.openid.userinfo.plugin.UserinfoCustomIndividualClaimsCreator;
+import org.idp.server.platform.date.SystemDateTime;
 import org.idp.server.platform.json.JsonNodeWrapper;
 
 /**
@@ -58,6 +59,6 @@ public class UserinfoVerifiedClaimsCreator implements UserinfoCustomIndividualCl
       ClientConfiguration clientConfiguration) {
     VerifiedClaimsObject requested = authorizationGrant.userinfoClaims().verifiedClaims();
     JsonNodeWrapper userVerifiedClaims = user.verifiedClaimsNodeWrapper();
-    return VerifiedClaimsAssembler.assemble(requested, userVerifiedClaims);
+    return VerifiedClaimsAssembler.assemble(requested, userVerifiedClaims, SystemDateTime.now());
   }
 }

--- a/libs/idp-server-core-extension-ida/src/main/java/org/idp/server/core/extension/identity/verified/VerifiedClaimsAssembler.java
+++ b/libs/idp-server-core-extension-ida/src/main/java/org/idp/server/core/extension/identity/verified/VerifiedClaimsAssembler.java
@@ -16,9 +16,15 @@
 
 package org.idp.server.core.extension.identity.verified;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.format.DateTimeParseException;
 import java.util.HashMap;
 import java.util.Map;
 import org.idp.server.core.openid.identity.id_token.VerifiedClaimsObject;
+import org.idp.server.platform.date.SystemDateTime;
 import org.idp.server.platform.json.JsonNodeWrapper;
 import org.idp.server.platform.log.LoggerWrapper;
 
@@ -69,19 +75,23 @@ public class VerifiedClaimsAssembler {
   /**
    * Assembles the {@code verified_claims} element, or an empty map when it must be omitted. Returns
    * a map with at most one entry, {@code "verified_claims"}.
+   *
+   * @param now the reference point for {@code max_age} freshness (§5.5.2), normally {@link
+   *     SystemDateTime#now()}
    */
   public static Map<String, Object> assemble(
-      VerifiedClaimsObject requested, JsonNodeWrapper userVerifiedClaims) {
+      VerifiedClaimsObject requested, JsonNodeWrapper userVerifiedClaims, LocalDateTime now) {
     HashMap<String, Object> result = new HashMap<>();
     if (requested == null) {
       return result;
     }
 
     // claims: resolve the requested claim names dynamically against the user's stored claims,
-    // honoring any value/values constraint. A claim that is unavailable (§5.7.2) or fails its
-    // constraint (§5.7.4, claims branch) is dropped individually.
+    // honoring any value/values constraint. A claim that is unavailable (§5.7.2), fails its
+    // constraint (§5.7.4, claims branch), or is staler than a requested max_age (§5.5.2) is dropped
+    // individually.
     Map<String, Object> claims =
-        selectClaims(requested.claimsNodeWrapper(), userBlock(userVerifiedClaims, "claims"));
+        selectClaims(requested.claimsNodeWrapper(), userBlock(userVerifiedClaims, "claims"), now);
 
     // An empty claims object is NOT a reason to omit verified_claims. The IDA schema
     // ([IDA-verified-claims] §5.3 "Claims element") states the claims element may be empty, so when
@@ -95,7 +105,9 @@ public class VerifiedClaimsAssembler {
 
     Map<String, Object> verification =
         selectVerification(
-            requested.verificationNodeWrapper(), userBlock(userVerifiedClaims, "verification"));
+            requested.verificationNodeWrapper(),
+            userBlock(userVerifiedClaims, "verification"),
+            now);
 
     // §5.7.4 (verification branch): a requested verification element failed its value/values
     // constraint, so the verification requirement is unmet — omit the whole verified_claims.
@@ -134,18 +146,23 @@ public class VerifiedClaimsAssembler {
 
   /**
    * Selects each requested claim that the user holds and whose stored value satisfies the requested
-   * {@code value} / {@code values} constraint. Unavailable or non-matching claims are dropped
-   * individually (§5.7.2 / §5.7.4 claims branch).
+   * {@code value} / {@code values} constraint and {@code max_age} freshness. Unavailable, stale, or
+   * non-matching claims are dropped individually (§5.7.2 / §5.5.2 / §5.7.4 claims branch).
    */
   private static Map<String, Object> selectClaims(
-      JsonNodeWrapper requestedClaims, Map<String, Object> userClaims) {
+      JsonNodeWrapper requestedClaims, Map<String, Object> userClaims, LocalDateTime now) {
     Map<String, Object> selected = new HashMap<>();
     for (String name : requestedClaims.fieldNamesAsList()) {
       if (!userClaims.containsKey(name)) {
         continue;
       }
       Object userValue = userClaims.get(name);
-      if (matchesConstraint(requestedClaims.getValueAsJsonNode(name), userValue)) {
+      JsonNodeWrapper constraint = requestedClaims.getValueAsJsonNode(name);
+      // §5.5.2: a date/timestamp claim staler than the requested max_age is dropped individually.
+      if (isStale(constraint, userValue, now)) {
+        continue;
+      }
+      if (matchesConstraint(constraint, userValue)) {
         selected.put(name, userValue);
       }
     }
@@ -158,9 +175,17 @@ public class VerifiedClaimsAssembler {
    * {@code evidence}) are opt-in via explicit request. Returns {@code null} when a requested
    * verification element fails its {@code value} / {@code values} constraint, signaling the whole
    * verified_claims must be omitted (§5.7.4).
+   *
+   * <p>A {@code max_age} miss (§5.5.2) is treated differently from a {@code value}/{@code values}
+   * miss: it is a SHOULD/best-effort freshness hint, so a stale date/timestamp element (e.g. {@code
+   * verification.time}) is dropped individually — like §5.7.2 unavailable data — rather than
+   * cascading to a whole-element omission. {@code trust_framework}, the REQUIRED floor, is never a
+   * date and so is never subject to freshness.
    */
   private static Map<String, Object> selectVerification(
-      JsonNodeWrapper requestedVerification, Map<String, Object> userVerification) {
+      JsonNodeWrapper requestedVerification,
+      Map<String, Object> userVerification,
+      LocalDateTime now) {
     Map<String, Object> selected = new HashMap<>();
 
     if (userVerification.containsKey("trust_framework")) {
@@ -177,7 +202,13 @@ public class VerifiedClaimsAssembler {
         continue;
       }
       Object userValue = userVerification.get(element);
-      if (!matchesConstraint(requestedVerification.getValueAsJsonNode(element), userValue)) {
+      JsonNodeWrapper constraint = requestedVerification.getValueAsJsonNode(element);
+      // §5.5.2: a stale date/timestamp element is dropped individually, NOT whole-omitted — its
+      // freshness is a best-effort SHOULD, unlike the value/values MUST below.
+      if (isStale(constraint, userValue, now)) {
+        continue;
+      }
+      if (!matchesConstraint(constraint, userValue)) {
         return null;
       }
       selected.put(element, userValue);
@@ -189,7 +220,7 @@ public class VerifiedClaimsAssembler {
    * Matches a stored value against a requested claim's {@code value} / {@code values} constraint
    * (OpenID Connect §5.5.1). A {@code null} request (no constraint object) or one carrying neither
    * {@code value} nor {@code values} always matches — the claim was requested, not constrained.
-   * {@code max_age} is out of scope.
+   * {@code max_age} freshness is handled separately by {@link #isStale}.
    */
   private static boolean matchesConstraint(JsonNodeWrapper constraint, Object userValue) {
     if (constraint == null || !constraint.exists() || !constraint.isObject()) {
@@ -211,5 +242,65 @@ public class VerifiedClaimsAssembler {
 
   private static boolean stringEquals(String requested, Object userValue) {
     return userValue != null && requested.equals(String.valueOf(userValue));
+  }
+
+  /**
+   * Evaluates the OIDC4IDA §5.5.2 {@code max_age} freshness hint: {@code true} when the requested
+   * element carries a {@code max_age} (seconds) AND the stored value is a date/timestamp older than
+   * that, so the element should be dropped.
+   *
+   * <p>{@code max_age} is "only applicable to claims that contain dates or timestamps", so a value
+   * that does not parse as a date is never stale (the hint does not apply). Elapsed time is
+   * measured, per the spec, "from the last valid second of the date value": a date-only value
+   * resolves to 23:59:59 of that day, a full timestamp to its own second. The OP "should try to
+   * fulfill" the hint (SHOULD), which this honors by omission rather than by attempting a
+   * re-verification.
+   */
+  private static boolean isStale(JsonNodeWrapper constraint, Object userValue, LocalDateTime now) {
+    if (constraint == null
+        || !constraint.exists()
+        || !constraint.isObject()
+        || !constraint.contains("max_age")) {
+      return false;
+    }
+    Long valueEpochSecond = lastValidSecondEpoch(userValue);
+    if (valueEpochSecond == null) {
+      return false;
+    }
+    long maxAge = constraint.getValueAsLong("max_age");
+    return SystemDateTime.toEpochSecond(now) - valueEpochSecond > maxAge;
+  }
+
+  /**
+   * Resolves a stored claim value to the epoch second of its "last valid second" for §5.5.2 max_age
+   * comparison, or {@code null} when the value is not a date/timestamp. Accepts an offset/Z-bearing
+   * instant (used as-is), a timezone-less local date-time (interpreted in the system zone), a
+   * date-only value (resolved to 23:59:59 of that day in the system zone), or a JSON number
+   * (treated as epoch seconds).
+   */
+  private static Long lastValidSecondEpoch(Object userValue) {
+    if (userValue instanceof Number number) {
+      return number.longValue();
+    }
+    if (!(userValue instanceof String text) || text.isBlank()) {
+      return null;
+    }
+    String value = text.trim();
+    try {
+      return OffsetDateTime.parse(value).toEpochSecond();
+    } catch (DateTimeParseException ignored) {
+      // not an offset/Z-bearing instant
+    }
+    try {
+      return SystemDateTime.toEpochSecond(LocalDateTime.parse(value));
+    } catch (DateTimeParseException ignored) {
+      // not a timezone-less local date-time
+    }
+    try {
+      return SystemDateTime.toEpochSecond(LocalDate.parse(value).atTime(LocalTime.MAX.withNano(0)));
+    } catch (DateTimeParseException ignored) {
+      // not a date-only value → max_age does not apply
+    }
+    return null;
   }
 }

--- a/libs/idp-server-core-extension-ida/src/main/java/org/idp/server/core/extension/identity/verified/VerifiedClaimsAssembler.java
+++ b/libs/idp-server-core-extension-ida/src/main/java/org/idp/server/core/extension/identity/verified/VerifiedClaimsAssembler.java
@@ -255,6 +255,10 @@ public class VerifiedClaimsAssembler {
    * resolves to 23:59:59 of that day, a full timestamp to its own second. The OP "should try to
    * fulfill" the hint (SHOULD), which this honors by omission rather than by attempting a
    * re-verification.
+   *
+   * <p>Freshness is evaluated before the {@code value}/{@code values} constraint (see {@link
+   * #selectClaims} / {@link #selectVerification}), so an element that carries both is dropped on
+   * staleness regardless of whether its value would have matched.
    */
   private static boolean isStale(JsonNodeWrapper constraint, Object userValue, LocalDateTime now) {
     if (constraint == null

--- a/libs/idp-server-core-extension-ida/src/main/java/org/idp/server/core/extension/identity/verified/VerifiedClaimsCreator.java
+++ b/libs/idp-server-core-extension-ida/src/main/java/org/idp/server/core/extension/identity/verified/VerifiedClaimsCreator.java
@@ -27,6 +27,7 @@ import org.idp.server.core.openid.identity.id_token.VerifiedClaimsObject;
 import org.idp.server.core.openid.identity.id_token.plugin.CustomIndividualClaimsCreator;
 import org.idp.server.core.openid.oauth.configuration.AuthorizationServerConfiguration;
 import org.idp.server.core.openid.oauth.configuration.client.ClientConfiguration;
+import org.idp.server.platform.date.SystemDateTime;
 import org.idp.server.platform.json.JsonNodeWrapper;
 
 /**
@@ -76,6 +77,6 @@ public class VerifiedClaimsCreator implements CustomIndividualClaimsCreator {
     }
     JsonNodeWrapper userVerifiedClaims = user.verifiedClaimsNodeWrapper();
 
-    return VerifiedClaimsAssembler.assemble(requested, userVerifiedClaims);
+    return VerifiedClaimsAssembler.assemble(requested, userVerifiedClaims, SystemDateTime.now());
   }
 }

--- a/libs/idp-server-core-extension-ida/src/test/java/org/idp/server/core/extension/identity/verified/VerifiedClaimsAssemblerTest.java
+++ b/libs/idp-server-core-extension-ida/src/test/java/org/idp/server/core/extension/identity/verified/VerifiedClaimsAssemblerTest.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright 2025 Hirokazu Kobayashi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.idp.server.core.extension.identity.verified;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.Map;
+import org.idp.server.core.openid.identity.User;
+import org.idp.server.core.openid.identity.id_token.RequestedClaimsPayload;
+import org.idp.server.core.openid.identity.id_token.VerifiedClaimsObject;
+import org.idp.server.platform.json.JsonConverter;
+import org.idp.server.platform.json.JsonNodeWrapper;
+import org.junit.jupiter.api.Test;
+
+/**
+ * OIDC4IDA §5.5.2 {@code max_age} freshness in {@link VerifiedClaimsAssembler}.
+ *
+ * <p>{@code max_age} is "only applicable to claims that contain dates or timestamps" and the OP
+ * "should try to fulfill" it (SHOULD). A stale element is dropped individually — like §5.7.2
+ * unavailable data — so the verification branch does NOT cascade to a whole {@code verified_claims}
+ * omission (that cascade is reserved for the value/values MUST, §5.7.4). Elapsed time is measured
+ * "from the last valid second of the date value", so a date-only value resolves to 23:59:59 of that
+ * day.
+ *
+ * <p>Calls {@code assemble} with a fixed {@code now} so the boundaries are deterministic.
+ */
+class VerifiedClaimsAssemblerTest {
+
+  private static VerifiedClaimsObject requested(String verifiedClaimsRequestJson) {
+    String json = "{\"id_token\":{\"verified_claims\":" + verifiedClaimsRequestJson + "}}";
+    return JsonConverter.snakeCaseInstance()
+        .read(json, RequestedClaimsPayload.class)
+        .idToken()
+        .verifiedClaims();
+  }
+
+  private static JsonNodeWrapper userVerifiedClaims(
+      Map<String, Object> verification, Map<String, Object> claims) {
+    Map<String, Object> verifiedClaims = new HashMap<>();
+    verifiedClaims.put("verification", verification);
+    verifiedClaims.put("claims", claims);
+    return new User().setVerifiedClaims(verifiedClaims).verifiedClaimsNodeWrapper();
+  }
+
+  @SuppressWarnings("unchecked")
+  private static Map<String, Object> verificationOf(Map<String, Object> result) {
+    return (Map<String, Object>)
+        ((Map<String, Object>) result.get("verified_claims")).get("verification");
+  }
+
+  @SuppressWarnings("unchecked")
+  private static Map<String, Object> claimsOf(Map<String, Object> result) {
+    return (Map<String, Object>)
+        ((Map<String, Object>) result.get("verified_claims")).get("claims");
+  }
+
+  @Test
+  void dropsStaleTimestampVerificationElementButKeepsTheRestOfVerifiedClaims() {
+    // verification.time is from 2021; now is 2026 — far older than max_age=3600s. The stale element
+    // is dropped, but trust_framework (the REQUIRED floor) and the requested claim are still
+    // returned: a max_age miss must NOT cascade to a whole verified_claims omission.
+    Map<String, Object> verification = new HashMap<>();
+    verification.put("trust_framework", "eidas");
+    verification.put("time", "2021-04-09T14:12Z");
+    JsonNodeWrapper user = userVerifiedClaims(verification, Map.of("given_name", "Sarah"));
+    VerifiedClaimsObject request =
+        requested(
+            "{\"verification\":{\"trust_framework\":null,\"time\":{\"max_age\":3600}},"
+                + "\"claims\":{\"given_name\":null}}");
+
+    Map<String, Object> result =
+        VerifiedClaimsAssembler.assemble(request, user, LocalDateTime.of(2026, 6, 20, 0, 0, 0));
+
+    assertTrue(result.containsKey("verified_claims"));
+    assertEquals("eidas", verificationOf(result).get("trust_framework"));
+    assertFalse(
+        verificationOf(result).containsKey("time"),
+        "stale verification.time must be dropped individually");
+    assertEquals(
+        "Sarah", claimsOf(result).get("given_name"), "verified_claims must not be whole-omitted");
+  }
+
+  @Test
+  void keepsTimestampVerificationElementWithinMaxAge() {
+    Map<String, Object> verification = new HashMap<>();
+    verification.put("trust_framework", "eidas");
+    verification.put("time", "2021-04-09T14:12Z");
+    JsonNodeWrapper user = userVerifiedClaims(verification, Map.of("given_name", "Sarah"));
+    // max_age huge (~31700 years) → 2021 → 2026 elapsed is well within it.
+    VerifiedClaimsObject request =
+        requested(
+            "{\"verification\":{\"trust_framework\":null,\"time\":{\"max_age\":1000000000000}},"
+                + "\"claims\":{\"given_name\":null}}");
+
+    Map<String, Object> result =
+        VerifiedClaimsAssembler.assemble(request, user, LocalDateTime.of(2026, 6, 20, 0, 0, 0));
+
+    assertEquals("2021-04-09T14:12Z", verificationOf(result).get("time"));
+  }
+
+  @Test
+  void dropsStaleDateClaimIndividually() {
+    JsonNodeWrapper user =
+        userVerifiedClaims(
+            Map.of("trust_framework", "eidas"),
+            Map.of("birthdate", "1976-03-11", "given_name", "Sarah"));
+    VerifiedClaimsObject request =
+        requested(
+            "{\"verification\":{\"trust_framework\":null},"
+                + "\"claims\":{\"birthdate\":{\"max_age\":3600},\"given_name\":null}}");
+
+    Map<String, Object> result =
+        VerifiedClaimsAssembler.assemble(request, user, LocalDateTime.of(2026, 6, 20, 0, 0, 0));
+
+    assertTrue(result.containsKey("verified_claims"));
+    assertFalse(claimsOf(result).containsKey("birthdate"), "stale date claim must be dropped");
+    assertEquals("Sarah", claimsOf(result).get("given_name"));
+  }
+
+  @Test
+  void doesNotApplyMaxAgeToNonDateClaim() {
+    // §5.5.2 is "only applicable to claims that contain dates or timestamps": a non-date value is
+    // never stale, so the claim is returned despite the (inapplicable) max_age.
+    JsonNodeWrapper user =
+        userVerifiedClaims(Map.of("trust_framework", "eidas"), Map.of("given_name", "Sarah"));
+    VerifiedClaimsObject request =
+        requested(
+            "{\"verification\":{\"trust_framework\":null},"
+                + "\"claims\":{\"given_name\":{\"max_age\":1}}}");
+
+    Map<String, Object> result =
+        VerifiedClaimsAssembler.assemble(request, user, LocalDateTime.of(2026, 6, 20, 0, 0, 0));
+
+    assertEquals("Sarah", claimsOf(result).get("given_name"));
+  }
+
+  @Test
+  void measuresElapsedFromTheLastValidSecondOfADateOnlyValue() {
+    // Stored date-only 2025-01-01 → last valid second 2025-01-01T23:59:59. now =
+    // 2025-01-02T20:00:00
+    // → elapsed ~20h, within max_age=86400s (1 day) → kept. Measuring from start-of-day (00:00:00)
+    // would make elapsed ~44h and wrongly drop it, so this pins the "last valid second" rule.
+    JsonNodeWrapper user =
+        userVerifiedClaims(
+            Map.of("trust_framework", "eidas"), Map.of("issuance_date", "2025-01-01"));
+    VerifiedClaimsObject request =
+        requested(
+            "{\"verification\":{\"trust_framework\":null},"
+                + "\"claims\":{\"issuance_date\":{\"max_age\":86400}}}");
+
+    Map<String, Object> result =
+        VerifiedClaimsAssembler.assemble(request, user, LocalDateTime.of(2025, 1, 2, 20, 0, 0));
+
+    assertEquals("2025-01-01", claimsOf(result).get("issuance_date"));
+  }
+}

--- a/libs/idp-server-core-extension-ida/src/test/java/org/idp/server/core/extension/identity/verified/VerifiedClaimsAssemblerTest.java
+++ b/libs/idp-server-core-extension-ida/src/test/java/org/idp/server/core/extension/identity/verified/VerifiedClaimsAssemblerTest.java
@@ -151,6 +151,29 @@ class VerifiedClaimsAssemblerTest {
   }
 
   @Test
+  void freshnessTakesPrecedenceOverAMatchingValueConstraint() {
+    // The same claim carries both max_age (stale) and a value that DOES match the stored data.
+    // Freshness is checked first, so the claim is dropped on staleness regardless of the match.
+    JsonNodeWrapper user =
+        userVerifiedClaims(
+            Map.of("trust_framework", "eidas"),
+            Map.of("birthdate", "1976-03-11", "given_name", "Sarah"));
+    VerifiedClaimsObject request =
+        requested(
+            "{\"verification\":{\"trust_framework\":null},"
+                + "\"claims\":{\"birthdate\":{\"max_age\":3600,\"value\":\"1976-03-11\"},"
+                + "\"given_name\":null}}");
+
+    Map<String, Object> result =
+        VerifiedClaimsAssembler.assemble(request, user, LocalDateTime.of(2026, 6, 20, 0, 0, 0));
+
+    assertFalse(
+        claimsOf(result).containsKey("birthdate"),
+        "stale element dropped even though its value matches");
+    assertEquals("Sarah", claimsOf(result).get("given_name"));
+  }
+
+  @Test
   void measuresElapsedFromTheLastValidSecondOfADateOnlyValue() {
     // Stored date-only 2025-01-01 → last valid second 2025-01-01T23:59:59. now =
     // 2025-01-02T20:00:00

--- a/libs/idp-server-platform/src/main/java/org/idp/server/platform/json/JsonNodeWrapper.java
+++ b/libs/idp-server-platform/src/main/java/org/idp/server/platform/json/JsonNodeWrapper.java
@@ -194,6 +194,10 @@ public class JsonNodeWrapper {
     return jsonNode.get(fieldName).asInt();
   }
 
+  public long getValueAsLong(String fieldName) {
+    return jsonNode.get(fieldName).asLong();
+  }
+
   public boolean getValueAsBoolean(String fieldName) {
     return jsonNode.get(fieldName).asBoolean();
   }


### PR DESCRIPTION
## 概要

[#1651](https://github.com/hirokazu-kobayashi-koba-hiro/idp-server/issues/1651) の**項目2「`max_age` 鮮度判定」**を実装。`VerifiedClaimsAssembler` の「`max_age` is out of scope」を解消し、OIDC4IDA §5.5.2 に準拠して verified_claims の鮮度フィルタを honor する。

## 仕様（§5.5.2）

> max_age: Optional. JSON number value **only applicable to claims that contain dates or timestamps**. ... The OP should make the calculation of elapsed time starting from the **last valid second of the date value**. The OP **should** try to fulfill this requirement.

公式サンプルの canonical な使い所は `verification.time`:
```json
"verification": { "trust_framework": {"value": "jp_aml"}, "time": {"max_age": 63113852} }
```

## 設計判断

| 論点 | 決定 | 根拠 |
|---|---|---|
| 失敗時挙動（verification 分岐） | **該当要素のみドロップ**（verified_claims 丸ごと省略しない） | §5.7.2 unavailable 相当。`max_age` は SHOULD/best-effort で value/values（MUST→§5.7.4 丸ごと省略）とは別系。`trust_framework` は REQUIRED floor なので残り verification は valid |
| 適用スコープ（v1） | **top-level のみ**（`verification.time` ＋ top-level claims） | 公式サンプルが `verification.time`。ネスト（`evidence[].time` 等）は assembler が再帰しないため follow-up |
| 経過秒の起点 | **date 値の "last valid second"**（date-only は当日 23:59:59） | §5.5.2 文言。start-of-day 起点だと最大1日ズレる |
| refresh | 実装せず**省略で充足** | 「OP **can** attempt to refresh」＝任意 |

## 変更

- **`VerifiedClaimsAssembler`**: `assemble` に `now` を注入。`isStale` ＋寛容な日付パーサ（`OffsetDateTime`/`Instant`/date-only/epoch、非日付→非適用）を追加。`selectClaims`/`selectVerification` 両分岐で stale 要素をドロップ
- **`JsonNodeWrapper#getValueAsLong`**: 長期 `max_age`（例: 数十年）の int オーバーフロー回避
- **`VerifiedClaimsCreator` / `UserinfoVerifiedClaimsCreator`**: `SystemDateTime.now()` を渡す
- **`VerifiedClaimsAssemblerTest`（新規）**: 固定 `now` で決定論的なユニットテスト5本（stale ドロップ / within max_age 保持 / claims 分岐 / 非日付非適用 / last-valid-second 境界）
- **E2E**: §5.5.2 の `xit` を `it` 4本に展開

### テスト用ユーザーの分離（共有ユーザーの汚染回避）

IDA spec テストは従来、共有のスーパーユーザー `ito.ichiro`（role: testistrator）でログインしていた。本 PR では **専用の非特権ユーザー `ida-verified-user`** を新設し、`config/scripts/e2e-test-data.sh` に `upsert-user` を配線（create-or-update で再シード可能）。`oidc_for_identity_assurance.test.js` 全体をこのユーザーへ repoint し、共有ユーザーの verified_claims を触らずに `verification.time` 等を自由に調整できるようにした。

## テスト結果

- ✅ **Java ユニット**: IDA モジュール green（新規5本＋既存 creator テスト）
- ✅ **E2E**（live サーバ / 専用ユーザー）: `oidc_for_identity_assurance` **30 passed, 5 skipped(xit), 0 failed**
  - うち §5.5.2 max_age 4本 green
- ✅ 全モジュール compile（main + test）、`spotlessApply` 適用済み

> 注: 当環境のデフォルト `node` は v25 で e2e 依存（jsonwebtoken系）が起動不可のため、`nodenv` 20.4.0 で実行。

## 残り（#1651 の他項目）

項目1 `purpose` / 項目3 `evidence_supported` 1.0値 / 項目4 §8 metadata は別 PR。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
