### PR TITLE
test/docs(identity-verification): purpose を spec準拠台帳から削除＋学習コンテンツ注記（final で削除済み）

### DIFF
--- a/documentation/docs/content_11_learning/16-oauth-oidc-rfc/advanced-identity/oidc-ida.md
+++ b/documentation/docs/content_11_learning/16-oauth-oidc-rfc/advanced-identity/oidc-ida.md
@@ -258,6 +258,10 @@ OIDC for IDA:
 
 #### purpose（目的の指定）
 
+:::warning 仕様ステータス
+`purpose` は OIDC4IDA Implementer's Draft §5.1 で定義されていたが、**OIDC4IDA 1.0 final（2024-10-01）で仕様から削除**された（OpenID Connect Core §5.5.1 にも無く、essential / value / values のみ）。OIDF eKYC conformance test plan（`EKYCWithOIDCCoreTestPlan`）には要件が **TODO コメント（タグ `IA-9`）として残るのみで、実行可能なテストモジュールは未実装**。下記は歴史的な参考例。
+:::
+
 ```json
 {
   "userinfo": {

--- a/e2e/src/tests/spec/oidc_for_identity_assurance.test.js
+++ b/e2e/src/tests/spec/oidc_for_identity_assurance.test.js
@@ -518,9 +518,10 @@ describe("OpenID Connect for Identity Assurance 1.0", () => {
   // `purpose` claims-request member: intentionally NOT tracked in this ledger. It was defined in
   // OIDC4IDA Implementer's Draft §5.1 but was REMOVED from the OIDC4IDA 1.0 final spec (1 Oct 2024),
   // and it is not in OpenID Connect Core §5.5.1 (essential / value / values only) — so it is not a
-  // requirement of any spec this conformance ledger tracks. The eKYC OP conformance suite still
-  // exercises it (tag IA-9); a reference implementation (3–300 length validation → invalid_request,
-  // plus HTML-escaped exposure in the authorization view-data) lives on branch
-  // feat/ida-purpose-1651 (see #1651), to be revisited if/when purpose returns to the spec.
+  // requirement of any spec this conformance ledger tracks. The OIDF eKYC test plan
+  // (EKYCWithOIDCCoreTestPlan) only documents it as an unimplemented TODO (tag IA-9), not a runnable
+  // test module. A reference implementation (3–300 length validation → invalid_request, plus
+  // HTML-escaped exposure in the authorization view-data) lives on branch feat/ida-purpose-1651
+  // (see #1651), to be revisited if/when purpose returns to the spec.
 
 });

--- a/e2e/src/tests/spec/oidc_for_identity_assurance.test.js
+++ b/e2e/src/tests/spec/oidc_for_identity_assurance.test.js
@@ -16,7 +16,7 @@ import { get } from "../../lib/http";
 //   - unimplemented / untested requirements are listed as `xit` so the coverage ledger
 //     (covered = it / known-pending = xit / missing = absent) is readable at a glance.
 // Verbatim quotes are from OIDC for Identity Assurance 1.0 unless marked otherwise. Where a case
-// derives from OIDC Core §5.5.1 (empty object / essential / purpose) the source is named explicitly,
+// derives from OIDC Core §5.5.1 (empty object / essential) the source is named explicitly,
 // because IDA itself does not define those sentences. eKYC module #N references the external OIDF
 // conformance-suite repo (github.com/openid/conformance-suite, eKYC-IDA test plan) — not a file in
 // this repo.
@@ -515,15 +515,12 @@ describe("OpenID Connect for Identity Assurance 1.0", () => {
     });
   });
 
-  // The `purpose` claims-request member is defined by OpenID Connect Core §5.5.1, not by IDA itself,
-  // so the titles below cite OIDC Core rather than quoting IDA. The eKYC conformance catalog (§10,
-  // tag IA-9) lists purpose validation as a TODO. idp-server does not yet validate it.
-  describe("'purpose' claims-request member (OIDC Core §5.5.1; eKYC catalog §10 / IA-9 — not implemented)", () => {
-    xit("OIDC Core §5.5.1 purpose member: a purpose shorter than 3 characters MUST be rejected with invalid_request.", async () => {});
-
-    xit("OIDC Core §5.5.1 purpose member: a purpose longer than 300 characters MUST be rejected with invalid_request.", async () => {});
-
-    xit("OIDC Core §5.5.1 purpose member: a purpose containing HTML special characters is escaped in the consent UI (XSS prevention).", async () => {});
-  });
+  // `purpose` claims-request member: intentionally NOT tracked in this ledger. It was defined in
+  // OIDC4IDA Implementer's Draft §5.1 but was REMOVED from the OIDC4IDA 1.0 final spec (1 Oct 2024),
+  // and it is not in OpenID Connect Core §5.5.1 (essential / value / values only) — so it is not a
+  // requirement of any spec this conformance ledger tracks. The eKYC OP conformance suite still
+  // exercises it (tag IA-9); a reference implementation (3–300 length validation → invalid_request,
+  // plus HTML-escaped exposure in the authorization view-data) lives on branch
+  // feat/ida-purpose-1651 (see #1651), to be revisited if/when purpose returns to the spec.
 
 });


### PR DESCRIPTION
## 概要

`purpose` claims-request member が **OIDC4IDA 1.0 final で仕様から削除済み**である事実を、spec準拠台帳と学習コンテンツに正しく反映する。

## 背景

原文を当たった結果（詳細は #1651 コメント）：

- `purpose` は **OIDC4IDA Implementer's Draft §5.1** で定義されていたが、**OIDC4IDA 1.0 final（2024-10-01）で削除**された。[OIDC Core §5.5.1](https://openid.net/specs/openid-connect-core-1_0.html) にも無い（essential / value / values のみ）。
- OIDF 公式 conformance suite（`EKYCWithOIDCCoreTestPlan`）でも、purpose（タグ `IA-9`）は `@TestPlan` の外の**コメントブロックに置かれた未実装 TODO** であり、12個の runnable テストモジュールには**含まれていない**。

## 変更

1. **spec準拠台帳**（`oidc_for_identity_assurance.test.js`）から `purpose` の describe（`xit` 3本）を削除。経緯と参考実装ブランチ `feat/ida-purpose-1651` への tombstone コメントを残す（誤って再追加されるのを防止）。
2. **学習コンテンツ**（`oidc-ida.md`）の `purpose` セクションに「final で削除済み / OIDF conformance は TODO のみ」の注記を追加。
3. ヘッダの「§5.5.1 由来ケース」一覧から `purpose` を除去。

## 補足（参考実装は別途保持）

検証（3–300 → `invalid_request`）＋ view-data の HTML エスケープ露出の**参考実装は `feat/ida-purpose-1651` ブランチに保持**（mainline 非マージ）。purpose が将来仕様へ再追加された際に備える。

## テスト

- `oidc_for_identity_assurance` フル実行: **30 passed / 3 skipped / 0 failed**（purpose 3本減、regression なし）

Refs #1651

🤖 Generated with [Claude Code](https://claude.com/claude-code)
