### PR TITLE
fix(identity-verification): evidence_supported を OIDC4IDA 1.0 値へ正規化 (#1651)

### DIFF
--- a/config/examples/e2e/test-tenant/authorization-server/idp-server.json
+++ b/config/examples/e2e/test-tenant/authorization-server/idp-server.json
@@ -223,9 +223,7 @@
     "eidas"
   ],
   "evidence_supported":[
-    "id_document",
-    "utility_bill",
-    "qes",
+    "document",
     "electronic_record"
   ],
   "documents_supported":[
@@ -237,6 +235,9 @@
     "pipp",
     "sripp",
     "eid"
+  ],
+  "documents_check_methods_supported":[
+    "vpip"
   ],
   "electronic_records_supported":[
     "bank_account",

--- a/config/examples/e2e/test-tenant/tenants/admin-tenant.json
+++ b/config/examples/e2e/test-tenant/tenants/admin-tenant.json
@@ -267,9 +267,7 @@
       "nist_800_63A_ial_3"
     ],
     "evidence_supported":[
-      "id_document",
-      "utility_bill",
-      "qes"
+      "document"
     ],
     "documents_supported":[
       "idcard",

--- a/config/templates/use-cases/financial-grade/financial-tenant-template.json
+++ b/config/templates/use-cases/financial-grade/financial-tenant-template.json
@@ -142,7 +142,7 @@
       "jp_aml"
     ],
     "evidence_supported": [
-      "id_document",
+      "document",
       "electronic_record"
     ],
     "claims_in_verified_claims_supported": [

--- a/e2e/src/tests/spec/oidc_for_identity_assurance.test.js
+++ b/e2e/src/tests/spec/oidc_for_identity_assurance.test.js
@@ -461,10 +461,12 @@ describe("OpenID Connect for Identity Assurance 1.0", () => {
     });
 
     it("evidence_supported: Required when one or more type of evidence is supported. JSON array containing all types of identity evidence the OP uses. This array shall have at least one member.", () => {
-      // NOTE: values are still pre-1.0 draft (id_document/utility_bill/qes); the rename to
-      // document/electronic_record/... is tracked as a separate gap. Here we assert presence + non-empty.
       expect(Array.isArray(metadata.evidence_supported)).toBe(true);
       expect(metadata.evidence_supported.length).toBeGreaterThan(0);
+      // OIDC4IDA 1.0 evidence types only; pre-1.0 draft values (id_document/utility_bill/qes) removed.
+      expect(metadata.evidence_supported).toContain("document");
+      expect(metadata.evidence_supported).toContain("electronic_record");
+      expect(metadata.evidence_supported).not.toContain("id_document");
     });
 
     it('documents_supported: Required when evidence_supported contains "document". JSON array containing all identity document types utilized by the OP for identity verification.', () => {
@@ -476,7 +478,9 @@ describe("OpenID Connect for Identity Assurance 1.0", () => {
       expect(metadata.documents_methods_supported).toContain("pipp");
     });
 
-    xit('documents_check_methods_supported: Optional. JSON array containing the check methods the OP supports for evidences of type "document". (pending: no document-evidence test data; advertising it needs a value set verified against the spec — see #1649-C)', () => {});
+    it('documents_check_methods_supported: Optional. JSON array containing the check methods the OP supports for evidences of type "document".', () => {
+      expect(metadata.documents_check_methods_supported).toContain("vpip");
+    });
 
     it('electronic_records_supported: Required when evidence_supported contains "electronic_record". JSON array containing all electronic record types the OP supports. When present this array shall have at least one member.', () => {
       expect(Array.isArray(metadata.electronic_records_supported)).toBe(true);


### PR DESCRIPTION
## 概要

OIDC4IDA §8 メタデータの `evidence_supported` の**値**が一部テナント設定で pre-1.0 draft 値（`id_document` / `utility_bill` / `qes`）のまま残っていたため、認定テンプレ（`config/templates/use-cases/ekyc/public-tenant-template.json`）を正解として **1.0 値へ正規化**する。

## 背景

§8 メタデータのフィールド名リネーム（`id_documents_supported`→`documents_supported` 等）・検証ロジック・emit 挙動・不足フィールド追加は **#1605（Closes #1513）で対応済み**。しかしその際、e2e / financial-grade のテナント設定の `evidence_supported` の**値**までは正規化されておらず、さらに #1649 の IA-8 整合修正で `electronic_record` が追記されて pre-1.0 値との混在状態になっていた。

→ 残作業は値合わせのみ。**破壊的変更ではない**（フィールド名・検証ロジックは #1605 で完了済み）。

## 変更

| ファイル | 変更 |
|---|---|
| e2e test-tenant `authorization-server/idp-server.json` | `evidence_supported` → `[document, electronic_record]`、`documents_check_methods_supported: [vpip]` 追加（認定テンプレと一致） |
| e2e test-tenant `tenants/admin-tenant.json` | `evidence_supported` → `[document]` |
| `financial-grade/financial-tenant-template.json` | `id_document` → `document` |
| E2E `oidc_for_identity_assurance.test.js` | `evidence_supported` の 1.0 値 assert 追加（`document`/`electronic_record` を含み `id_document` を含まない）、`documents_check_methods_supported` を `xit`→`it` 化（`vpip`） |

> `config/generated/` 配下（financial-grade 等）は gitignore 管理のため、テンプレ修正で再生成時に追従。

> 注: `electronic_records_supported` は e2e(`bank_account`/`mortgage_account`) と認定テンプレ(`utility_statement`) で意図的に別値。IA-8 整合のため各テナントのユーザーが返す record.type に合わせており、`evidence_supported`/`documents_check_methods_supported` の「認定テンプレと一致」はこの2フィールドに限る。

## テスト

config 再シード後の実機で確認：

- §8 対象テスト（evidence_supported 1.0値 / documents_check_methods=vpip）: **4 passed**
- `oidc_for_identity_assurance` ファイル全体: **31 passed / 2 skipped / 0 failed**（regression なし）

## 補足（別ギャップ）

financial-grade テンプレは `documents_supported` / `electronic_records_supported`（条件付き REQUIRED）自体が未設定で §8 的には不完全だが、これは本PRのスコープ外の既存ギャップ。本PRは evidence 値の正規化に限定。

Refs #1651（項目3 `evidence_supported` / 項目4 `documents_check_methods_supported`）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

