### PR TITLE
feat: SMS配信を外部HTTP APIへ委譲する HttpRequestSmsSender を追加 (#1394)

### DIFF
--- a/config/templates/use-cases/mfa-sms/README.md
+++ b/config/templates/use-cases/mfa-sms/README.md
@@ -18,6 +18,8 @@
 
 > **外部API委譲（http_request）モード**: SMS送信機能はidp-serverに内蔵されていないため、デフォルトで外部APIに委譲する設定になっています。ローカル開発では付属のモックサーバー（`mock-server.js`、ポート4004）を使用します。本番環境では `SMS_SERVICE_CHALLENGE_URL` / `SMS_SERVICE_VERIFY_URL` を実際のSMS送信サービス（Twilio等）のURLに変更してください。
 
+> **代替モード（OTPは内部生成・送信のみ委譲）**: このテンプレートは OTP の生成・検証も外部サービスに委譲します。OTP を idp-server 内部で生成・検証しつつ SMS 送信だけを任意の HTTP API に委譲したい場合は `sender_type: "http_request"` を使います。設定方法は SMS認証ドキュメント（`documentation/docs/content_06_developer-guide/05-configuration/authn/sms.md` の「sender_type `http_request`」）を参照してください。
+
 ## ファイル構成
 
 | ファイル | 用途 | API |

--- a/documentation/docs/content_06_developer-guide/05-configuration/authn/sms.md
+++ b/documentation/docs/content_06_developer-guide/05-configuration/authn/sms.md
@@ -179,7 +179,8 @@ idp-server内部でワンタイムパスワードを生成・検証し、外部S
 | 項目                             | 説明                                      |
 |--------------------------------|-----------------------------------------|
 | `execution.function`           | `sms_authentication_challenge` 固定       |
-| `execution.details.sender_type` | SMSサービスタイプ（`twilio`, `no_action`など）    |
+| `execution.details.sender_type` | SMSサービスタイプ（`http_request`, `twilio`, `no_action`など） |
+| `execution.details.settings`   | 送信プロバイダ固有の設定。`sender_type` が `http_request` の場合は `http_request` キーに外部API設定を記述（後述） |
 | `execution.details.templates`  | テンプレート定義（`{VERIFICATION_CODE}`プレースホルダー使用） |
 | `execution.details.retry_count_limitation` | 検証リトライ上限回数（デフォルト: 5）                    |
 | `execution.details.expire_seconds` | OTP有効期限（秒）（デフォルト: 300）                  |
@@ -214,6 +215,108 @@ idp-server内部でワンタイムパスワードを生成・検証し、外部S
         "function": "sms_authentication_challenge",
         "details": {
           "sender_type": "no_action",
+          "templates": {
+            "registration": {
+              "subject": "[ID Verification] Your signup SMS confirmation code",
+              "body": "Hello,\n\nPlease enter the following verification code:\n\n【{VERIFICATION_CODE}】\n\nThis code will expire in {EXPIRE_SECONDS} seconds.\n\n– IDP Support"
+            },
+            "authentication": {
+              "subject": "[ID Verification] Your login SMS confirmation code",
+              "body": "Hello,\n\nPlease enter the following verification code:\n\n【{VERIFICATION_CODE}】\n\nThis code will expire in {EXPIRE_SECONDS} seconds.\n\n– IDP Support"
+            }
+          },
+          "retry_count_limitation": 5,
+          "expire_seconds": 300
+        }
+      },
+      "response": {
+        "body_mapping_rules": [
+          { "from": "$.response_body", "to": "*" }
+        ]
+      }
+    },
+    "sms-authentication": {
+      "execution": {
+        "function": "sms_authentication",
+        "details": {
+          "retry_count_limitation": 5,
+          "expire_seconds": 300
+        }
+      }
+    }
+  }
+}
+```
+
+#### sender_type `http_request`: 任意の外部HTTP APIへ送信を委譲
+
+OTPの生成・検証は idp-server 内部で行いつつ、SMS送信のみを任意の外部HTTP API（Twilio等のSMS配信API）へ委譲する場合は、`sender_type` に `http_request` を指定します。送信先APIの設定は `execution.details.settings.http_request` に `HttpRequestExecutionConfig` 形式で記述します（外部サービス連携の HTTP Request Executor と同じ設定構造）。
+
+##### `settings.http_request` 設定項目
+
+| 項目                     | 説明                              |
+|------------------------|---------------------------------|
+| `url`                  | SMS送信APIのエンドポイントURL             |
+| `method`               | HTTPメソッド（通常 `POST`）             |
+| `oauth_authorization`  | OAuth認証設定（外部APIがOAuthを要求する場合）   |
+| `header_mapping_rules` | リクエストヘッダーのマッピングルール              |
+| `body_mapping_rules`   | リクエストボディのマッピングルール               |
+
+`body_mapping_rules` の `from` で参照できる送信データは以下の2つです（idp-serverが組み立てた送信内容）：
+
+| パス                   | 内容                                                   |
+|----------------------|------------------------------------------------------|
+| `$.request_body.to`  | 送信先電話番号                                              |
+| `$.request_body.body` | 送信本文（テンプレートに `{VERIFICATION_CODE}` 等を埋め込んだ後の文字列） |
+
+送信先APIが2xxを返せば送信成功（challenge成功）、4xx/5xxを返すと送信失敗として扱われます。OTPはレスポンスに含まれず idp-server 内部に保持され、`sms-authentication` で検証されます。
+
+##### 設定例
+
+```json
+{
+  "id": "0f12803e-37b6-437e-8ca9-5822bd852b74",
+  "type": "sms",
+  "metadata": {
+    "type": "internal",
+    "verification_code_param": "verification_code"
+  },
+  "interactions": {
+    "sms-authentication-challenge": {
+      "execution": {
+        "function": "sms_authentication_challenge",
+        "details": {
+          "sender_type": "http_request",
+          "settings": {
+            "http_request": {
+              "url": "https://external-sms-service.com/send",
+              "method": "POST",
+              "oauth_authorization": {
+                "type": "password",
+                "token_endpoint": "https://external-sms-service.com/token",
+                "client_id": "your-client-id",
+                "username": "username",
+                "password": "password",
+                "scope": "application"
+              },
+              "header_mapping_rules": [
+                {
+                  "static_value": "application/json",
+                  "to": "Content-Type"
+                }
+              ],
+              "body_mapping_rules": [
+                {
+                  "from": "$.request_body.to",
+                  "to": "phone_number"
+                },
+                {
+                  "from": "$.request_body.body",
+                  "to": "message"
+                }
+              ]
+            }
+          },
           "templates": {
             "registration": {
               "subject": "[ID Verification] Your signup SMS confirmation code",

--- a/e2e/src/tests/usecase/mfa/mfa-26-sms-http-request-sender-mfa-flow.test.js
+++ b/e2e/src/tests/usecase/mfa/mfa-26-sms-http-request-sender-mfa-flow.test.js
@@ -1,0 +1,565 @@
+import { describe, expect, it, beforeAll, afterAll } from "@jest/globals";
+import { onboarding } from "../../../api/managementClient";
+import { deletion, get, postWithJson } from "../../../lib/http";
+import {
+  requestToken,
+  getAuthorizations,
+  postAuthentication,
+  authorize,
+} from "../../../api/oauthClient";
+import { generateECP256JWKS, verifyAndDecodeJwt } from "../../../lib/jose";
+import { adminServerConfig, backendUrl, mockApiBaseUrl } from "../../testConfig";
+import { v4 as uuidv4 } from "uuid";
+import crypto from "crypto";
+import {
+  convertNextAction,
+  convertToAuthorizationResponse,
+} from "../../../lib/util";
+
+/**
+ * Issue #1394: HttpRequestSmsSender (SMS delivery delegated to an external API)
+ *
+ * Pattern #2 of the SMS authentication matrix:
+ *   function    = sms_authentication_challenge  (OTP generated/verified INSIDE idp-server)
+ *   sender_type = http_request                  (SMS delivery delegated to an external API)
+ *
+ * Because the OTP stays internal, it is NOT returned in the challenge response
+ * (SmsChallengeAuthenticationExecutor returns success(Map.of())). The test reads the
+ * internally-generated OTP from the stored interaction via the Management API
+ * (authentication-transactions -> authentication-interactions -> payload.verification_code),
+ * which is the same mechanism scenario-01 uses for the internal email OTP.
+ *
+ * Verifies that HttpRequestSmsSender (new) delegates delivery to the mock SMS API and that
+ * the full Password (1st) + SMS OTP (2nd) MFA login completes with amr = [password, sms].
+ */
+describe("MFA Use Case: SMS OTP via HttpRequestSmsSender (Issue #1394)", () => {
+  let systemAccessToken;
+  let organizationId;
+  let tenantId;
+  let clientId;
+  let clientSecret;
+  let mgmtAccessToken;
+  let testEmail;
+  let testPassword;
+  const testPhone = "+819012345678";
+  const redirectUri =
+    "https://www.certification.openid.net/test/a/idp_oidc_basic/callback";
+
+  beforeAll(async () => {
+    const tokenResponse = await requestToken({
+      endpoint: adminServerConfig.tokenEndpoint,
+      grantType: "password",
+      username: adminServerConfig.oauth.username,
+      password: adminServerConfig.oauth.password,
+      scope: adminServerConfig.adminClient.scope,
+      clientId: adminServerConfig.adminClient.clientId,
+      clientSecret: adminServerConfig.adminClient.clientSecret,
+    });
+    expect(tokenResponse.status).toBe(200);
+    systemAccessToken = tokenResponse.data.access_token;
+
+    const timestamp = Date.now();
+    organizationId = uuidv4();
+    tenantId = uuidv4();
+    const adminUserId = uuidv4();
+    clientId = uuidv4();
+    clientSecret = `client-secret-${crypto.randomBytes(16).toString("hex")}`;
+    const jwksContent = await generateECP256JWKS();
+    const adminEmail = `admin-${timestamp}@mfa-sms-http.example.com`;
+    const adminPassword = `AdminPass_${timestamp}!`;
+
+    const onboardingResponse = await onboarding({
+      body: {
+        organization: {
+          id: organizationId,
+          name: `MFA SMS HTTP Test Org ${timestamp}`,
+          description: "E2E test for HttpRequestSmsSender (#1394)",
+        },
+        tenant: {
+          id: tenantId,
+          name: `MFA SMS HTTP Test Tenant ${timestamp}`,
+          domain: backendUrl,
+          authorization_provider: "idp-server",
+          identity_policy_config: {
+            identity_unique_key_type: "EMAIL",
+          },
+          session_config: {
+            cookie_name: `MFA_SMS_HTTP_${organizationId.substring(0, 8)}`,
+            use_secure_cookie: false,
+          },
+          cors_config: {
+            allow_origins: [backendUrl],
+          },
+        },
+        authorization_server: {
+          issuer: `${backendUrl}/${tenantId}`,
+          authorization_endpoint: `${backendUrl}/${tenantId}/v1/authorizations`,
+          token_endpoint: `${backendUrl}/${tenantId}/v1/tokens`,
+          token_endpoint_auth_methods_supported: ["client_secret_post"],
+          userinfo_endpoint: `${backendUrl}/${tenantId}/v1/userinfo`,
+          jwks_uri: `${backendUrl}/${tenantId}/v1/jwks`,
+          jwks: jwksContent,
+          grant_types_supported: [
+            "authorization_code",
+            "refresh_token",
+            "password",
+          ],
+          token_signed_key_id: "signing_key_1",
+          id_token_signed_key_id: "signing_key_1",
+          scopes_supported: [
+            "openid",
+            "profile",
+            "email",
+            "management",
+            "org-management",
+          ],
+          claims_supported: [
+            "sub",
+            "iss",
+            "auth_time",
+            "acr",
+            "name",
+            "email",
+            "email_verified",
+          ],
+          response_types_supported: ["code"],
+          response_modes_supported: ["query"],
+          subject_types_supported: ["public"],
+          id_token_signing_alg_values_supported: ["ES256"],
+          extension: {
+            access_token_type: "JWT",
+          },
+        },
+        user: {
+          sub: adminUserId,
+          provider_id: "idp-server",
+          name: "Admin User",
+          email: adminEmail,
+          email_verified: true,
+          raw_password: adminPassword,
+        },
+        client: {
+          client_id: clientId,
+          client_secret: clientSecret,
+          redirect_uris: [redirectUri],
+          response_types: ["code"],
+          grant_types: ["authorization_code", "refresh_token", "password"],
+          scope: "openid profile email management org-management",
+          client_name: "MFA SMS HTTP Test Client",
+          token_endpoint_auth_method: "client_secret_post",
+          application_type: "web",
+        },
+      },
+      headers: { Authorization: `Bearer ${systemAccessToken}` },
+    });
+    if (onboardingResponse.status !== 201) {
+      console.error(
+        "Onboarding failed:",
+        JSON.stringify(onboardingResponse.data, null, 2)
+      );
+    }
+    expect(onboardingResponse.status).toBe(201);
+
+    // Get management token
+    const mgmtTokenResponse = await requestToken({
+      endpoint: `${backendUrl}/${tenantId}/v1/tokens`,
+      grantType: "password",
+      username: adminEmail,
+      password: adminPassword,
+      scope: "management org-management",
+      clientId,
+      clientSecret,
+    });
+    expect(mgmtTokenResponse.status).toBe(200);
+    mgmtAccessToken = mgmtTokenResponse.data.access_token;
+
+    // Register initial-registration config
+    const initialRegResp = await postWithJson({
+      url: `${backendUrl}/v1/management/organizations/${organizationId}/tenants/${tenantId}/authentication-configurations`,
+      headers: { Authorization: `Bearer ${mgmtAccessToken}` },
+      body: {
+        id: uuidv4(),
+        type: "initial-registration",
+        attributes: {},
+        metadata: {},
+        interactions: {
+          "initial-registration": {
+            request: {
+              schema: {
+                type: "object",
+                required: ["email", "password", "name"],
+                properties: {
+                  name: { type: "string", maxLength: 255 },
+                  email: { type: "string", format: "email", maxLength: 255 },
+                  password: { type: "string", maxLength: 64, minLength: 8 },
+                  phone_number: { type: "string", maxLength: 255 },
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+    expect(initialRegResp.status).toBe(201);
+
+    // Register password authentication config
+    const passwordAuthResp = await postWithJson({
+      url: `${backendUrl}/v1/management/organizations/${organizationId}/tenants/${tenantId}/authentication-configurations`,
+      headers: { Authorization: `Bearer ${mgmtAccessToken}` },
+      body: {
+        id: uuidv4(),
+        type: "password",
+        attributes: {},
+        metadata: { type: "password" },
+        interactions: {
+          "password-authentication": {
+            request: {
+              schema: {
+                type: "object",
+                properties: {
+                  username: { type: "string" },
+                  password: { type: "string" },
+                },
+                required: ["username", "password"],
+              },
+            },
+            pre_hook: {},
+            execution: { function: "password_verification" },
+            post_hook: {},
+            response: {
+              body_mapping_rules: [
+                { from: "$.user_id", to: "user_id" },
+                { from: "$.username", to: "username" },
+                { from: "$.error", to: "error" },
+                { from: "$.error_description", to: "error_description" },
+              ],
+            },
+          },
+        },
+      },
+    });
+    expect(passwordAuthResp.status).toBe(201);
+
+    // Register SMS authentication config (Pattern #2: internal OTP + http_request sender)
+    // function "sms_authentication_challenge" generates/verifies the OTP internally;
+    // sender_type "http_request" delegates ONLY the SMS delivery to the mock external API
+    // through the new HttpRequestSmsSender.
+    const smsAuthResp = await postWithJson({
+      url: `${backendUrl}/v1/management/organizations/${organizationId}/tenants/${tenantId}/authentication-configurations`,
+      headers: { Authorization: `Bearer ${mgmtAccessToken}` },
+      body: {
+        id: uuidv4(),
+        type: "sms",
+        attributes: {},
+        metadata: {
+          type: "internal",
+          transaction_id_param: "transaction_id",
+          verification_code_param: "verification_code",
+        },
+        interactions: {
+          "sms-authentication-challenge": {
+            request: {
+              schema: {
+                type: "object",
+                properties: {
+                  phone_number: { type: "string" },
+                  template: { type: "string" },
+                },
+              },
+            },
+            pre_hook: {},
+            execution: {
+              function: "sms_authentication_challenge",
+              details: {
+                sender_type: "http_request",
+                settings: {
+                  http_request: {
+                    url: `${mockApiBaseUrl}/sms-authentication-challenge`,
+                    method: "POST",
+                    oauth_authorization: {
+                      type: "password",
+                      token_endpoint: `${mockApiBaseUrl}/token`,
+                      client_id: "your-client-id",
+                      username: "username",
+                      password: "password",
+                      scope: "application",
+                    },
+                    header_mapping_rules: [
+                      { static_value: "application/json", to: "Content-Type" },
+                    ],
+                    body_mapping_rules: [
+                      { from: "$.request_body.to", to: "phone_number" },
+                      { from: "$.request_body.body", to: "message" },
+                    ],
+                  },
+                },
+                templates: {
+                  registration: {
+                    subject: "[ID Verification] Your signup sms confirmation code",
+                    body: "Hello,\n\nPlease enter the following verification code:\n\n【{VERIFICATION_CODE}】\n\nThis code will expire in {EXPIRE_SECONDS} seconds.\n\n– IDP Support",
+                  },
+                  authentication: {
+                    subject: "[ID Verification] Your login sms confirmation code",
+                    body: "Hello,\n\nPlease enter the following verification code:\n\n【{VERIFICATION_CODE}】\n\nThis code will expire in {EXPIRE_SECONDS} seconds.\n\n– IDP Support",
+                  },
+                },
+                retry_count_limitation: 5,
+                expire_seconds: 300,
+              },
+            },
+            post_hook: {},
+            response: {
+              body_mapping_rules: [{ from: "$.response_body", to: "*" }],
+            },
+          },
+          "sms-authentication": {
+            request: {
+              schema: {
+                type: "object",
+                properties: {
+                  verification_code: { type: "string" },
+                },
+              },
+            },
+            execution: {
+              function: "sms_authentication",
+              details: {
+                retry_count_limitation: 5,
+                expire_seconds: 300,
+              },
+            },
+          },
+        },
+      },
+    });
+    expect(smsAuthResp.status).toBe(201);
+
+    // Create MFA authentication policy: Password (1st) + SMS (2nd)
+    const authPolicyResp = await postWithJson({
+      url: `${backendUrl}/v1/management/organizations/${organizationId}/tenants/${tenantId}/authentication-policies`,
+      headers: { Authorization: `Bearer ${mgmtAccessToken}` },
+      body: {
+        id: uuidv4(),
+        flow: "oauth",
+        enabled: true,
+        policies: [
+          {
+            description: "mfa_password_sms_http_request",
+            priority: 1,
+            conditions: {},
+            available_methods: ["password", "sms", "initial-registration"],
+            step_definitions: [
+              {
+                method: "password",
+                order: 1,
+                requires_user: false,
+                user_identity_source: "username",
+              },
+              {
+                method: "sms",
+                order: 2,
+                requires_user: true,
+              },
+            ],
+            success_conditions: {
+              any_of: [
+                [
+                  {
+                    path: "$.password-authentication.success_count",
+                    type: "integer",
+                    operation: "gte",
+                    value: 1,
+                  },
+                  {
+                    path: "$.sms-authentication.success_count",
+                    type: "integer",
+                    operation: "gte",
+                    value: 1,
+                  },
+                ],
+                [
+                  {
+                    path: "$.initial-registration.success_count",
+                    type: "integer",
+                    operation: "gte",
+                    value: 1,
+                  },
+                ],
+              ],
+            },
+          },
+        ],
+      },
+    });
+    expect(authPolicyResp.status).toBe(201);
+
+    // Phase 1: Register test user
+    testEmail = `sms-http-user-${timestamp}@mfa-sms-http.example.com`;
+    testPassword = "SmsHttpTestPass_1!";
+
+    const regAuthResp = await getAuthorizations({
+      endpoint: `${backendUrl}/${tenantId}/v1/authorizations`,
+      clientId,
+      responseType: "code",
+      state: `reg-${timestamp}`,
+      scope: "openid profile email",
+      redirectUri,
+    });
+    expect(regAuthResp.status).toBe(302);
+    const { params: regParams } = convertNextAction(regAuthResp.headers.location);
+    const regAuthId = regParams.get("id");
+
+    const regResp = await postWithJson({
+      url: `${backendUrl}/${tenantId}/v1/authorizations/${regAuthId}/initial-registration`,
+      body: {
+        email: testEmail,
+        password: testPassword,
+        name: "MFA SMS HTTP Test User",
+        phone_number: testPhone,
+      },
+    });
+    expect(regResp.status).toBe(200);
+
+    const regAuthorize = await authorize({
+      endpoint: `${backendUrl}/${tenantId}/v1/authorizations/{id}/authorize`,
+      id: regAuthId,
+      body: {},
+    });
+    const regResult = convertToAuthorizationResponse(
+      regAuthorize.data.redirect_uri
+    );
+    await requestToken({
+      endpoint: `${backendUrl}/${tenantId}/v1/tokens`,
+      grantType: "authorization_code",
+      code: regResult.code,
+      redirectUri,
+      clientId,
+      clientSecret,
+    });
+  });
+
+  afterAll(async () => {
+    if (mgmtAccessToken) {
+      await deletion({
+        url: `${backendUrl}/v1/management/organizations/${organizationId}/tenants/${tenantId}`,
+        headers: { Authorization: `Bearer ${mgmtAccessToken}` },
+      }).catch(() => {});
+    }
+    if (systemAccessToken) {
+      await deletion({
+        url: `${backendUrl}/v1/management/orgs/${organizationId}`,
+        headers: { Authorization: `Bearer ${systemAccessToken}` },
+      }).catch(() => {});
+    }
+  });
+
+  it("delegates SMS delivery via HttpRequestSmsSender and completes Password + SMS OTP MFA (amr = password, sms)", async () => {
+    // Step 1: Start new authorization flow
+    const state = `mfa-sms-http-${Date.now()}`;
+    const authResp = await getAuthorizations({
+      endpoint: `${backendUrl}/${tenantId}/v1/authorizations`,
+      clientId,
+      responseType: "code",
+      state,
+      scope: "openid profile email",
+      redirectUri,
+      prompt: "login",
+    });
+    expect(authResp.status).toBe(302);
+    const { params } = convertNextAction(authResp.headers.location);
+    const authId = params.get("id");
+    expect(authId).toBeDefined();
+
+    // Step 2: Password Authentication (1st factor)
+    const passwordResp = await postAuthentication({
+      endpoint: `${backendUrl}/${tenantId}/v1/authorizations/{id}/password-authentication`,
+      id: authId,
+      body: {
+        username: testEmail,
+        password: testPassword,
+      },
+    });
+    expect(passwordResp.status).toBe(200);
+
+    // Step 3: SMS OTP Challenge (2nd factor)
+    // HttpRequestSmsSender posts {to, body} to the mock SMS API; a 2xx => challenge success.
+    const challengeResp = await postWithJson({
+      url: `${backendUrl}/${tenantId}/v1/authorizations/${authId}/sms-authentication-challenge`,
+      body: {
+        phone_number: testPhone,
+        template: "authentication",
+      },
+    });
+    expect(challengeResp.status).toBe(200);
+
+    // Step 4: Retrieve the internally-generated OTP via the Management API.
+    // The OTP is NOT in the challenge response (HttpRequestSmsSender only delegates delivery);
+    // it is persisted on the stored sms-authentication-challenge interaction.
+    const txnListResp = await get({
+      url: `${backendUrl}/v1/management/organizations/${organizationId}/tenants/${tenantId}/authentication-transactions?authorization_id=${authId}`,
+      headers: { Authorization: `Bearer ${mgmtAccessToken}` },
+    });
+    expect(txnListResp.status).toBe(200);
+    const transactionId = txnListResp.data.list[0].id;
+
+    const interactionResp = await get({
+      url: `${backendUrl}/v1/management/organizations/${organizationId}/tenants/${tenantId}/authentication-interactions/${transactionId}/sms-authentication-challenge`,
+      headers: { Authorization: `Bearer ${mgmtAccessToken}` },
+    });
+    expect(interactionResp.status).toBe(200);
+    const verificationCode = interactionResp.data.payload.verification_code;
+    expect(verificationCode).toBeDefined();
+
+    // Step 5: SMS OTP Verification (internal)
+    const smsAuthResp = await postWithJson({
+      url: `${backendUrl}/${tenantId}/v1/authorizations/${authId}/sms-authentication`,
+      body: {
+        verification_code: verificationCode,
+      },
+    });
+    expect(smsAuthResp.status).toBe(200);
+
+    // Step 6: Authorize (consent grant)
+    const authorizeResp = await authorize({
+      endpoint: `${backendUrl}/${tenantId}/v1/authorizations/{id}/authorize`,
+      id: authId,
+      body: {},
+    });
+    expect(authorizeResp.status).toBe(200);
+    const authResult = convertToAuthorizationResponse(
+      authorizeResp.data.redirect_uri
+    );
+    expect(authResult.code).toBeDefined();
+    expect(authResult.state).toBe(state);
+
+    // Step 7: Token Exchange
+    const tokenResp = await requestToken({
+      endpoint: `${backendUrl}/${tenantId}/v1/tokens`,
+      grantType: "authorization_code",
+      code: authResult.code,
+      redirectUri,
+      clientId,
+      clientSecret,
+    });
+    expect(tokenResp.status).toBe(200);
+    expect(tokenResp.data.access_token).toBeDefined();
+    expect(tokenResp.data.id_token).toBeDefined();
+    expect(tokenResp.data.refresh_token).toBeDefined();
+
+    // Step 8: Verify amr in ID Token contains both password and sms
+    const jwksResp = await get({
+      url: `${backendUrl}/${tenantId}/v1/jwks`,
+    });
+    expect(jwksResp.status).toBe(200);
+
+    const { payload } = verifyAndDecodeJwt({
+      jwt: tokenResp.data.id_token,
+      jwks: jwksResp.data,
+    });
+    expect(payload.sub).toBeDefined();
+    expect(payload.iss).toBe(`${backendUrl}/${tenantId}`);
+    expect(payload.amr).toBeDefined();
+    expect(payload.amr).toContain("sms");
+    expect(payload.amr).toContain("password");
+  });
+});

--- a/libs/idp-server-platform/src/main/java/org/idp/server/platform/notification/sms/HttpRequestSmsSender.java
+++ b/libs/idp-server-platform/src/main/java/org/idp/server/platform/notification/sms/HttpRequestSmsSender.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2025 Hirokazu Kobayashi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.idp.server.platform.notification.sms;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.idp.server.platform.http.HttpRequestBaseParams;
+import org.idp.server.platform.http.HttpRequestExecutionConfig;
+import org.idp.server.platform.http.HttpRequestExecutor;
+import org.idp.server.platform.http.HttpRequestResult;
+import org.idp.server.platform.json.JsonConverter;
+import org.idp.server.platform.log.LoggerWrapper;
+
+/**
+ * SmsSender that delegates only the SMS delivery to an external API (e.g. Twilio) via {@link
+ * HttpRequestExecutor}. OTP generation and verification stay inside idp-server. This is the SMS
+ * counterpart of {@code HttpRequestEmailSender}.
+ *
+ * <p>The {@code setting} map is expected to carry the external API configuration under the {@code
+ * http_request} key, which is deserialized into {@link HttpRequestExecutionConfig}.
+ */
+public class HttpRequestSmsSender implements SmsSender {
+
+  HttpRequestExecutor httpRequestExecutor;
+  JsonConverter jsonConverter;
+  LoggerWrapper log = LoggerWrapper.getLogger(HttpRequestSmsSender.class);
+
+  /**
+   * Factory constructor with dependency injection support. This constructor enables OAuth token
+   * caching and proper DI integration.
+   *
+   * @param httpRequestExecutor the HTTP request executor with OAuth caching support
+   */
+  public HttpRequestSmsSender(HttpRequestExecutor httpRequestExecutor) {
+    this.httpRequestExecutor = httpRequestExecutor;
+    this.jsonConverter = JsonConverter.snakeCaseInstance();
+  }
+
+  @Override
+  public SmsSenderType type() {
+    return new SmsSenderType("http_request");
+  }
+
+  @Override
+  public SmsSendResult send(SmsSendingRequest request, Map<String, Object> setting) {
+    try {
+      HttpRequestExecutionConfig configuration =
+          jsonConverter.read(setting.get("http_request"), HttpRequestExecutionConfig.class);
+
+      Map<String, Object> param = new HashMap<>();
+      param.put("request_body", request.toMap());
+
+      HttpRequestBaseParams httpRequestBaseParams = new HttpRequestBaseParams(param);
+
+      HttpRequestResult executionResult =
+          httpRequestExecutor.execute(configuration, httpRequestBaseParams);
+
+      if (executionResult.isClientError()) {
+        return new SmsSendResult(false, Map.of("http_request", executionResult.toMap()));
+      }
+
+      if (executionResult.isServerError()) {
+        return new SmsSendResult(false, Map.of("http_request", executionResult.toMap()));
+      }
+
+      return new SmsSendResult(true, Map.of("http_request", executionResult.toMap()));
+    } catch (Exception e) {
+
+      log.error(e.getMessage(), e);
+      return new SmsSendResult(
+          false,
+          Map.of("http_request", Map.of("error", "server_error", "error_message", e.getMessage())));
+    }
+  }
+}

--- a/libs/idp-server-platform/src/main/java/org/idp/server/platform/notification/sms/HttpRequestSmsSenderFactory.java
+++ b/libs/idp-server-platform/src/main/java/org/idp/server/platform/notification/sms/HttpRequestSmsSenderFactory.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2025 Hirokazu Kobayashi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.idp.server.platform.notification.sms;
+
+import org.idp.server.platform.dependency.ApplicationComponentDependencyContainer;
+import org.idp.server.platform.http.HttpRequestExecutor;
+
+/**
+ * Factory for creating {@link HttpRequestSmsSender} instances with dependency injection support.
+ * This factory enables OAuth token caching by injecting {@link HttpRequestExecutor} from the DI
+ * container. It is the SMS counterpart of {@code HttpRequestEmailSenderFactory}.
+ *
+ * <p>Benefits of using this factory:
+ *
+ * <ul>
+ *   <li>OAuth token caching support (performance improvement)
+ *   <li>Tenant/service-specific cache configuration
+ *   <li>Proper dependency injection integration
+ * </ul>
+ */
+public class HttpRequestSmsSenderFactory implements SmsSenderFactory {
+
+  @Override
+  public SmsSender create(ApplicationComponentDependencyContainer container) {
+    // Resolve HttpRequestExecutor from DI container (with OAuth caching support)
+    HttpRequestExecutor httpRequestExecutor = container.resolve(HttpRequestExecutor.class);
+
+    // Create SmsSender with DI-injected dependencies
+    return new HttpRequestSmsSender(httpRequestExecutor);
+  }
+
+  @Override
+  public String type() {
+    return "http_request";
+  }
+
+  @Override
+  public SmsSenderType smsSenderType() {
+    return new SmsSenderType("http_request");
+  }
+}

--- a/libs/idp-server-platform/src/main/java/org/idp/server/platform/notification/sms/NoActionSmsSender.java
+++ b/libs/idp-server-platform/src/main/java/org/idp/server/platform/notification/sms/NoActionSmsSender.java
@@ -31,7 +31,7 @@ public class NoActionSmsSender implements SmsSender {
   @Override
   public SmsSendResult send(SmsSendingRequest request, Map<String, Object> setting) {
 
-    log.info("EmailSender: NoActionEmailSender sending request");
+    log.info("SmsSender: NoActionSmsSender sending request");
 
     return new SmsSendResult(true, Map.of());
   }

--- a/libs/idp-server-platform/src/main/java/org/idp/server/platform/notification/sms/SmsSendingRequest.java
+++ b/libs/idp-server-platform/src/main/java/org/idp/server/platform/notification/sms/SmsSendingRequest.java
@@ -16,6 +16,9 @@
 
 package org.idp.server.platform.notification.sms;
 
+import java.util.HashMap;
+import java.util.Map;
+
 public class SmsSendingRequest {
   String to;
   String body;
@@ -31,5 +34,12 @@ public class SmsSendingRequest {
 
   public String body() {
     return body;
+  }
+
+  public Map<String, Object> toMap() {
+    HashMap<String, Object> result = new HashMap<>();
+    result.put("to", to);
+    result.put("body", body);
+    return result;
   }
 }

--- a/libs/idp-server-platform/src/main/resources/META-INF/services/org.idp.server.platform.notification.sms.SmsSenderFactory
+++ b/libs/idp-server-platform/src/main/resources/META-INF/services/org.idp.server.platform.notification.sms.SmsSenderFactory
@@ -1,0 +1,1 @@
+org.idp.server.platform.notification.sms.HttpRequestSmsSenderFactory


### PR DESCRIPTION
## 概要

Issue #1394 対応。OTP の生成・検証は idp-server 内部のまま、**SMS 配信だけ**を外部 HTTP API（Twilio 等）へ委譲する `http_request` 型 SMS sender を追加します。既存の `HttpRequestEmailSender` の SMS 版で、確立済みのパターンを踏襲しています。

## 変更内容

| 種別 | 内容 |
|------|------|
| `feat` | `HttpRequestSmsSender` / `HttpRequestSmsSenderFactory` を追加（`HttpRequestExecutor` を DI 解決し OAuth トークンキャッシュ対応）。SPI に Factory を追加登録（`NoActionSmsSender` と共存）。`SmsSendingRequest#toMap()` を追加 |
| `test` | E2E `mfa-26`：Password + SMS OTP のフル MFA フローを `amr=[password, sms]` まで検証 |
| `docs` | SMS 認証ドキュメントに `sender_type: "http_request"`（送信のみ委譲）を追記。`mfa-sms` テンプレ README に代替モードへのポインタを追加 |
| `fix` | `NoActionSmsSender` のログ文言が Email 表記になっていたコピペ残りを SMS に修正（別件・同梱） |

## 設定（パターン2: 内部OTP + 送信のみ委譲）

```jsonc
"execution": {
  "function": "sms_authentication_challenge",   // OTP は内部生成
  "details": {
    "sender_type": "http_request",              // 送信のみ委譲
    "settings": { "http_request": { /* url, method, oauth_authorization, mapping_rules */ } }
  }
}
```

`body_mapping_rules` で参照可能な送信データは `$.request_body.to`（電話番号）と `$.request_body.body`（本文）の2つ。

## テスト

- E2E `mfa-26` 通過確認済み（Password → SMS OTP → token → ID Token の `amr` 検証）
- `./gradlew spotlessCheck` 通過

## 備考

- 結果セマンティクス：2xx = 送信成功 / 4xx・5xx = 失敗（Email 版と同一）
- 新たな Repository 操作・攻撃面なし（URL/OAuth はテナント管理者設定由来 + 中央 `HttpRequestExecutor` 経由）

Closes #1394

🤖 Generated with [Claude Code](https://claude.com/claude-code)
