### PR TITLE
fix: CIBA authorization_pending を専用例外化しログレベルを info に変更 (#1408)

### DIFF
--- a/libs/idp-server-core-extension-ciba/src/main/java/org/idp/server/core/extension/ciba/token/CibaGrantBaseVerifier.java
+++ b/libs/idp-server-core-extension-ciba/src/main/java/org/idp/server/core/extension/ciba/token/CibaGrantBaseVerifier.java
@@ -24,6 +24,7 @@ import org.idp.server.core.openid.oauth.clientauthenticator.clientcredentials.Cl
 import org.idp.server.core.openid.oauth.configuration.AuthorizationServerConfiguration;
 import org.idp.server.core.openid.oauth.configuration.client.ClientConfiguration;
 import org.idp.server.core.openid.token.TokenRequestContext;
+import org.idp.server.core.openid.token.exception.TokenAuthorizationPendingException;
 import org.idp.server.core.openid.token.exception.TokenBadRequestException;
 import org.idp.server.platform.date.SystemDateTime;
 
@@ -120,8 +121,7 @@ public class CibaGrantBaseVerifier implements CibaGrantVerifierInterface {
    */
   void throwExceptionIfAuthorizedPending(CibaGrant cibaGrant) {
     if (cibaGrant.isAuthorizationPending()) {
-      throw new TokenBadRequestException(
-          "authorization_pending",
+      throw new TokenAuthorizationPendingException(
           "The authorization request is still pending as the end-user hasn't yet been authenticated.");
     }
   }

--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/token/exception/TokenAuthorizationPendingException.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/token/exception/TokenAuthorizationPendingException.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2025 Hirokazu Kobayashi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.idp.server.core.openid.token.exception;
+
+/**
+ * Represents the CIBA {@code authorization_pending} token error response.
+ *
+ * <p>{@code authorization_pending} is a normal intermediate response defined in <a
+ * href="https://openid.net/specs/openid-client-initiated-backchannel-authentication-core-1_0.html#rfc.section.11">CIBA
+ * Core, Section 11</a>: it is returned repeatedly while a polling-mode client waits for the
+ * end-user to be authenticated. It is therefore expected traffic rather than a fault, so {@link
+ * org.idp.server.core.openid.token.handler.token.TokenRequestErrorHandler} logs it at INFO instead
+ * of WARN.
+ *
+ * <p>Modeled as a subclass of {@link TokenBadRequestException} so it keeps the same 400 Bad Request
+ * response mapping while the error handler can branch on the concrete type to lower the log level.
+ * The dedicated branch must be evaluated before the {@link TokenBadRequestException} branch so the
+ * subclass matches first.
+ */
+public class TokenAuthorizationPendingException extends TokenBadRequestException {
+
+  public TokenAuthorizationPendingException(String errorDescription) {
+    super("authorization_pending", errorDescription);
+  }
+}

--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/token/handler/token/TokenRequestErrorHandler.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/token/handler/token/TokenRequestErrorHandler.java
@@ -24,6 +24,7 @@ import org.idp.server.core.openid.oauth.configuration.exception.ServerConfigurat
 import org.idp.server.core.openid.oauth.type.oauth.Error;
 import org.idp.server.core.openid.oauth.type.oauth.ErrorDescription;
 import org.idp.server.core.openid.token.TokenErrorResponse;
+import org.idp.server.core.openid.token.exception.TokenAuthorizationPendingException;
 import org.idp.server.core.openid.token.exception.TokenBadRequestException;
 import org.idp.server.core.openid.token.exception.TokenUnSupportedGrantException;
 import org.idp.server.core.openid.token.handler.token.io.TokenRequestResponse;
@@ -37,6 +38,18 @@ public class TokenRequestErrorHandler {
     log.trace(
         "Token request error handling started: exception_type={}",
         exception.getClass().getSimpleName());
+
+    if (exception instanceof TokenAuthorizationPendingException pending) {
+      // CIBA authorization_pending is a normal intermediate polling response (CIBA Core §11), not a
+      // fault. Logged at INFO to avoid warn-level noise. Must precede the TokenBadRequestException
+      // branch below so this subclass matches first.
+      log.info(
+          "CIBA token request pending (normal polling response): error={}, description={}",
+          pending.error().value(),
+          pending.errorDescription().value());
+      return new TokenRequestResponse(
+          BAD_REQUEST, new TokenErrorResponse(pending.error(), pending.errorDescription()));
+    }
 
     if (exception instanceof TokenBadRequestException badRequest) {
       log.warn(


### PR DESCRIPTION
## 概要

CIBA の `authorization_pending` 専用例外クラスを追加し、ログレベルを **warn → info** に変更する。

Closes #1408

## 背景

warn ログ分析（過去2日間）で **1,859件中918件（49.4%）** が CIBA `authorization_pending` レスポンスによるものだった。`authorization_pending` は [CIBA Core §11](https://openid.net/specs/openid-client-initiated-backchannel-authentication-core-1_0.html#rfc.section.11) で定義された正常な中間レスポンスであり、polling モードで繰り返し発生するのは仕様通り。warn レベルは不適切。

## 変更内容

1. `TokenAuthorizationPendingException` を `TokenBadRequestException` のサブクラスとして新規追加（`error="authorization_pending"` 固定）
2. `CibaGrantBaseVerifier#throwExceptionIfAuthorizedPending` で新例外を throw
3. `TokenRequestErrorHandler` に新例外の分岐を **`TokenBadRequestException` より前**に追加（サブクラス優先マッチ）し、`log.info` で記録

レスポンスは **400 + `authorization_pending`** のまま不変。クライアント向け挙動に変更なし。

## 検証

- `idp-server-core` / `idp-server-core-extension-ciba` コンパイル成功
- CIBA E2E green（`spec/ciba_token_request` / `spec/ciba_authentication_request` 計 35 passed）— 400 + `authorization_pending` + error_description 完全一致を含む
- 実サーバーログ（2インスタンス両方）で新ログが `level=INFO` で出力、旧 warn 行が消滅したことを確認

## 期待効果

- warn ログの約50%削減
- 運用上注視すべき警告の視認性向上

🤖 Generated with [Claude Code](https://claude.com/claude-code)