### PR TITLE
fix: 自己登録の重複判定を identity_unique_key_type 準拠に（email 固定を是正）(#1669)

### DIFF
--- a/documentation/docs/content_09_project/v0.12.0-impact.md
+++ b/documentation/docs/content_09_project/v0.12.0-impact.md
@@ -15,6 +15,7 @@
 | 3 | パスワード 2 要素認証（`requires_user: true`）でパスワードの検証対象をセッションの認証済みユーザーに固定（CWE-287 認証識別子切り替え対策の強化）| 🟡 挙動変更 | password を 2nd factor に使うテナント（正規フローへの影響なし）|
 | 4 | SMS/Email 検証フェーズで `UserTooManyFoundResultException`（電話/メールが複数ユーザーにマッチ）を **500 → 400 `invalid_request`** に変換 | 🟡 挙動変更 | 電話番号/メールにユニーク制約のないテナント（同一値で複数ユーザーが存在しうる構成）|
 | 4 | 検証フェーズ `user_not_found` の Security Event 型を是正（Email `sms_verification_challenge_failure`→`email_verification_failure` / SMS →`sms_verification_failure`）| 🟡 挙動変更 | Security Event フック / SIEM でこれらのイベント型をフィルタ・集計している運用者 |
+| 5 | 自己登録（initial-registration）の重複判定を `identity_unique_key_type` 準拠（`preferred_username`）に変更（従来は email 固定）| 🟡 挙動変更 | email 以外をユニークキーにするテナント（`PHONE` / `USERNAME` / `EXTERNAL_USER_ID` 等）。同一 email・別ユニークキーの登録が可能に |
 
 > 種別: 🔴 破壊的 / 🟡 挙動変更 / 🟢 追加 / ⚙️ 内部・運用
 
@@ -233,3 +234,29 @@ SMS/Email 認証の**検証フェーズ**（`sms-authentication` / `email-authen
 | ケース | E2E テスト |
 |------|-----------|
 | too-many users（同一電話に 2 ユーザー）→ 400 `invalid_request` | `e2e/src/tests/usecase/mfa/mfa-27-sms-verification-too-many-users-400.test.js` |
+
+---
+
+## 5. 自己登録の重複判定を identity_unique_key_type 準拠に（Issue #1669）
+
+自己登録 `InitialRegistrationInteractor` の重複ユーザー判定が、テナントの `identity_unique_key_type` を無視して **email 固定**（`findByEmail`）になっていた問題を修正した。テナントのユニークキー方針が決める **`preferred_username`**（`applyIdentityPolicy` で email / phone / username / external_user_id から導出）で判定するよう変更し、永続化パスの `UserVerifier`（`findByPreferredUsername`）とロジックを一致させる。
+
+### 5.1 Before / After
+
+| 観点 | Before | After |
+|------|--------|-------|
+| 重複判定キー | email 固定（`findByEmail`）| `preferred_username`（`identity_unique_key_type` 準拠）|
+| 判定タイミング | `applyIdentityPolicy` の前 | `applyIdentityPolicy` の後 |
+| EMAIL ユニークのテナント | email で重複判定 | `preferred_username` = email なので **従来どおり** |
+| 非 EMAIL ユニーク（`PHONE` / `USERNAME` 等）| email で誤って重複ブロック | ユニークキーで判定（**同一 email・別ユニークキーの登録が可能**）|
+| 同一 email が既に複数存在する状態での登録 | `findByEmail` が複数ヒットし `UserTooManyFoundResultException` → **500** | `preferred_username` はユニークなので 500 リスクなし |
+
+### 5.2 影響
+
+> email を**ユニークキーにしないテナント**（`identity_unique_key_type` が `PHONE` / `USERNAME` / `EXTERNAL_USER_ID` 等）で、従来は同一 email の2人目以降の自己登録が `400 "user is conflict with username and password"` で弾かれていたのが、**ユニークキーが異なれば登録できる**ようになる。EMAIL ユニーク（既定 `EMAIL_OR_EXTERNAL_USER_ID` を含む、email 保持ユーザー）のテナントは挙動不変。設定変更・DB マイグレーション不要。
+
+### 5.3 動作確認
+
+| ケース | E2E テスト |
+|------|-----------|
+| `PHONE` ユニークで同一 email・別 phone の2ユーザー登録 → 成功、検証で too-many → 400 | `e2e/src/tests/usecase/mfa/mfa-28-email-verification-too-many-users-400.test.js` |

--- a/e2e/src/tests/usecase/mfa/mfa-28-email-verification-too-many-users-400.test.js
+++ b/e2e/src/tests/usecase/mfa/mfa-28-email-verification-too-many-users-400.test.js
@@ -1,0 +1,423 @@
+import { describe, expect, it, beforeAll, afterAll } from "@jest/globals";
+import { onboarding } from "../../../api/managementClient";
+import { deletion, get, postWithJson } from "../../../lib/http";
+import {
+  requestToken,
+  getAuthorizations,
+  authorize,
+} from "../../../api/oauthClient";
+import { generateECP256JWKS } from "../../../lib/jose";
+import { adminServerConfig, backendUrl } from "../../testConfig";
+import { v4 as uuidv4 } from "uuid";
+import crypto from "crypto";
+import { convertNextAction } from "../../../lib/util";
+
+/**
+ * Issue #1395 / #1667 (Email side) + #1669.
+ *
+ * - #1395: EmailAuthenticationInteractor must convert UserTooManyFoundResultException (thrown by
+ *   resolveUser -> findByEmail when several users share an email) into 400 invalid_request, not 500.
+ * - #1669: InitialRegistrationInteractor must dedupe by the tenant's unique key (preferred_username),
+ *   not a hardcoded email. With identity_unique_key_type=PHONE two users may share an email, so
+ *   self-registration of the second shared-email user must succeed (it used to 400-conflict).
+ *
+ * This test exercises both: it self-registers two users with the SAME email and DISTINCT phones
+ * (only possible once #1669 is fixed), then drives a 1st-factor email login whose verification hits
+ * findByEmail -> multiple users -> 400 (the #1395 fix).
+ *
+ * Email is the 1st factor (no step definition => requires_user=false => email-based identification),
+ * internal OTP (details.function=no_action so the code is read back via the Management API).
+ */
+describe("MFA Use Case: Email verification returns 400 (not 500) when email maps to many users (Issue #1395 / #1669)", () => {
+  let systemAccessToken;
+  let organizationId;
+  let tenantId;
+  let clientId;
+  let clientSecret;
+  let mgmtAccessToken;
+  const sharedEmail = `shared-${Date.now()}@mfa-email-toomany.example.com`;
+  const redirectUri =
+    "https://www.certification.openid.net/test/a/idp_oidc_basic/callback";
+
+  const emailTemplate = {
+    subject: "[ID Verification] Your login email confirmation code",
+    body: "Hello,\n\nPlease enter the following verification code:\n\n【{VERIFICATION_CODE}】\n\nThis code will expire in {EXPIRE_SECONDS} seconds.\n\n– IDP Support",
+  };
+
+  beforeAll(async () => {
+    const tokenResponse = await requestToken({
+      endpoint: adminServerConfig.tokenEndpoint,
+      grantType: "password",
+      username: adminServerConfig.oauth.username,
+      password: adminServerConfig.oauth.password,
+      scope: adminServerConfig.adminClient.scope,
+      clientId: adminServerConfig.adminClient.clientId,
+      clientSecret: adminServerConfig.adminClient.clientSecret,
+    });
+    expect(tokenResponse.status).toBe(200);
+    systemAccessToken = tokenResponse.data.access_token;
+
+    const timestamp = Date.now();
+    organizationId = uuidv4();
+    tenantId = uuidv4();
+    const adminUserId = uuidv4();
+    clientId = uuidv4();
+    clientSecret = `client-secret-${crypto.randomBytes(16).toString("hex")}`;
+    const jwksContent = await generateECP256JWKS();
+    const adminEmail = `admin-${timestamp}@mfa-email-toomany.example.com`;
+    const adminPassword = `AdminPass_${timestamp}!`;
+    // PHONE uniqueness => preferred_username is derived from the phone, so admin must log in by phone.
+    const adminPhone = `+8190${Math.floor(10000000 + Math.random() * 90000000)}`;
+
+    const onboardingResponse = await onboarding({
+      body: {
+        organization: {
+          id: organizationId,
+          name: `MFA Email TooMany Org ${timestamp}`,
+          description: "E2E test for Email verification too-many users (#1395/#1667/#1669)",
+        },
+        tenant: {
+          id: tenantId,
+          name: `MFA Email TooMany Tenant ${timestamp}`,
+          domain: backendUrl,
+          authorization_provider: "idp-server",
+          identity_policy_config: {
+            // PHONE uniqueness lets two users share one email (their phones differ).
+            identity_unique_key_type: "PHONE",
+          },
+          session_config: {
+            cookie_name: `MFA_EMAIL_TOOMANY_${organizationId.substring(0, 8)}`,
+            use_secure_cookie: false,
+          },
+          cors_config: {
+            allow_origins: [backendUrl],
+          },
+        },
+        authorization_server: {
+          issuer: `${backendUrl}/${tenantId}`,
+          authorization_endpoint: `${backendUrl}/${tenantId}/v1/authorizations`,
+          token_endpoint: `${backendUrl}/${tenantId}/v1/tokens`,
+          token_endpoint_auth_methods_supported: ["client_secret_post"],
+          userinfo_endpoint: `${backendUrl}/${tenantId}/v1/userinfo`,
+          jwks_uri: `${backendUrl}/${tenantId}/v1/jwks`,
+          jwks: jwksContent,
+          grant_types_supported: [
+            "authorization_code",
+            "refresh_token",
+            "password",
+          ],
+          token_signed_key_id: "signing_key_1",
+          id_token_signed_key_id: "signing_key_1",
+          scopes_supported: [
+            "openid",
+            "profile",
+            "email",
+            "phone",
+            "management",
+            "org-management",
+          ],
+          claims_supported: [
+            "sub",
+            "iss",
+            "auth_time",
+            "acr",
+            "name",
+            "email",
+            "email_verified",
+            "phone_number",
+          ],
+          response_types_supported: ["code"],
+          response_modes_supported: ["query"],
+          subject_types_supported: ["public"],
+          id_token_signing_alg_values_supported: ["ES256"],
+          extension: {
+            access_token_type: "JWT",
+          },
+        },
+        user: {
+          sub: adminUserId,
+          provider_id: "idp-server",
+          name: "Admin User",
+          email: adminEmail,
+          email_verified: true,
+          phone_number: adminPhone,
+          raw_password: adminPassword,
+        },
+        client: {
+          client_id: clientId,
+          client_secret: clientSecret,
+          redirect_uris: [redirectUri],
+          response_types: ["code"],
+          grant_types: ["authorization_code", "refresh_token", "password"],
+          scope: "openid profile email phone management org-management",
+          client_name: "MFA Email TooMany Test Client",
+          token_endpoint_auth_method: "client_secret_post",
+          application_type: "web",
+        },
+      },
+      headers: { Authorization: `Bearer ${systemAccessToken}` },
+    });
+    if (onboardingResponse.status !== 201) {
+      console.error(
+        "Onboarding failed:",
+        JSON.stringify(onboardingResponse.data, null, 2)
+      );
+    }
+    expect(onboardingResponse.status).toBe(201);
+
+    const mgmtTokenResponse = await requestToken({
+      endpoint: `${backendUrl}/${tenantId}/v1/tokens`,
+      grantType: "password",
+      username: adminPhone,
+      password: adminPassword,
+      scope: "management org-management",
+      clientId,
+      clientSecret,
+    });
+    expect(mgmtTokenResponse.status).toBe(200);
+    mgmtAccessToken = mgmtTokenResponse.data.access_token;
+
+    // initial-registration config (phone_number required so each user gets a distinct unique key)
+    const initialRegResp = await postWithJson({
+      url: `${backendUrl}/v1/management/organizations/${organizationId}/tenants/${tenantId}/authentication-configurations`,
+      headers: { Authorization: `Bearer ${mgmtAccessToken}` },
+      body: {
+        id: uuidv4(),
+        type: "initial-registration",
+        attributes: {},
+        metadata: {},
+        interactions: {
+          "initial-registration": {
+            request: {
+              schema: {
+                type: "object",
+                required: ["email", "password", "name", "phone_number"],
+                properties: {
+                  name: { type: "string", maxLength: 255 },
+                  email: { type: "string", format: "email", maxLength: 255 },
+                  password: { type: "string", maxLength: 64, minLength: 8 },
+                  phone_number: { type: "string", maxLength: 255 },
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+    expect(initialRegResp.status).toBe(201);
+
+    // Email authentication config: internal OTP + no_action sender (code readable via Management API)
+    const emailAuthResp = await postWithJson({
+      url: `${backendUrl}/v1/management/organizations/${organizationId}/tenants/${tenantId}/authentication-configurations`,
+      headers: { Authorization: `Bearer ${mgmtAccessToken}` },
+      body: {
+        id: uuidv4(),
+        type: "email",
+        attributes: {},
+        metadata: {
+          type: "no-action",
+          transaction_id_param: "transaction_id",
+          verification_code_param: "verification_code",
+        },
+        interactions: {
+          "email-authentication-challenge": {
+            request: {
+              schema: {
+                type: "object",
+                properties: {
+                  email: { type: "string" },
+                  template: { type: "string" },
+                },
+              },
+            },
+            pre_hook: {},
+            execution: {
+              function: "email_authentication_challenge",
+              details: {
+                function: "no_action",
+                sender: "noreply@test.example.com",
+                templates: {
+                  registration: emailTemplate,
+                  authentication: emailTemplate,
+                },
+                retry_count_limitation: 5,
+                expire_seconds: 300,
+              },
+            },
+            post_hook: {},
+            response: {
+              body_mapping_rules: [{ from: "$.response_body", to: "*" }],
+            },
+          },
+          "email-authentication": {
+            request: {
+              schema: {
+                type: "object",
+                properties: {
+                  verification_code: { type: "string" },
+                },
+              },
+            },
+            execution: {
+              function: "email_authentication",
+            },
+            response: {
+              body_mapping_rules: [{ from: "$.response_body", to: "*" }],
+            },
+          },
+        },
+      },
+    });
+    expect(emailAuthResp.status).toBe(201);
+
+    // Authentication policy: email as 1st factor (no step definition => email-based identification)
+    const authPolicyResp = await postWithJson({
+      url: `${backendUrl}/v1/management/organizations/${organizationId}/tenants/${tenantId}/authentication-policies`,
+      headers: { Authorization: `Bearer ${mgmtAccessToken}` },
+      body: {
+        id: uuidv4(),
+        flow: "oauth",
+        enabled: true,
+        policies: [
+          {
+            description: "email_first_factor_too_many_1395",
+            priority: 1,
+            conditions: {},
+            available_methods: ["email", "initial-registration"],
+            success_conditions: {
+              any_of: [
+                [
+                  {
+                    path: "$.email-authentication.success_count",
+                    type: "integer",
+                    operation: "gte",
+                    value: 1,
+                  },
+                ],
+                [
+                  {
+                    path: "$.initial-registration.success_count",
+                    type: "integer",
+                    operation: "gte",
+                    value: 1,
+                  },
+                ],
+              ],
+            },
+          },
+        ],
+      },
+    });
+    expect(authPolicyResp.status).toBe(201);
+
+    // Register two users that share the same email but have distinct phone numbers (unique key).
+    // The second shared-email registration succeeds only because of the #1669 fix (dedupe by
+    // preferred_username/phone, not email).
+    for (const label of ["one", "two"]) {
+      const distinctPhone = `+8190${Math.floor(10000000 + Math.random() * 90000000)}`;
+      const regAuthResp = await getAuthorizations({
+        endpoint: `${backendUrl}/${tenantId}/v1/authorizations`,
+        clientId,
+        responseType: "code",
+        state: `reg-${label}-${timestamp}`,
+        scope: "openid profile email phone",
+        redirectUri,
+      });
+      expect(regAuthResp.status).toBe(302);
+      const { params } = convertNextAction(regAuthResp.headers.location);
+      const regAuthId = params.get("id");
+
+      const regResp = await postWithJson({
+        url: `${backendUrl}/${tenantId}/v1/authorizations/${regAuthId}/initial-registration`,
+        body: {
+          email: sharedEmail,
+          password: "EmailTooManyPass_1!",
+          name: `Email TooMany User ${label}`,
+          phone_number: distinctPhone,
+        },
+      });
+      expect(regResp.status).toBe(200);
+
+      await authorize({
+        endpoint: `${backendUrl}/${tenantId}/v1/authorizations/{id}/authorize`,
+        id: regAuthId,
+        body: {},
+      });
+    }
+  });
+
+  afterAll(async () => {
+    if (mgmtAccessToken) {
+      await deletion({
+        url: `${backendUrl}/v1/management/organizations/${organizationId}/tenants/${tenantId}`,
+        headers: { Authorization: `Bearer ${mgmtAccessToken}` },
+      }).catch(() => {});
+    }
+    if (systemAccessToken) {
+      await deletion({
+        url: `${backendUrl}/v1/management/orgs/${organizationId}`,
+        headers: { Authorization: `Bearer ${systemAccessToken}` },
+      }).catch(() => {});
+    }
+  });
+
+  it("returns 400 invalid_request (not 500) when the verified email matches multiple users", async () => {
+    // Step 1: Start a fresh email-first authorization flow
+    const state = `mfa-email-toomany-${Date.now()}`;
+    const authResp = await getAuthorizations({
+      endpoint: `${backendUrl}/${tenantId}/v1/authorizations`,
+      clientId,
+      responseType: "code",
+      state,
+      scope: "openid profile email",
+      redirectUri,
+      prompt: "login",
+    });
+    expect(authResp.status).toBe(302);
+    const { params } = convertNextAction(authResp.headers.location);
+    const authId = params.get("id");
+    expect(authId).toBeDefined();
+
+    // Step 2: Email challenge with the shared email (challenge does NOT resolve the user, so it succeeds)
+    const challengeResp = await postWithJson({
+      url: `${backendUrl}/${tenantId}/v1/authorizations/${authId}/email-authentication-challenge`,
+      body: {
+        email: sharedEmail,
+        template: "authentication",
+      },
+    });
+    expect(challengeResp.status).toBe(200);
+
+    // Step 3: Read the internally-generated OTP via the Management API
+    const txnListResp = await get({
+      url: `${backendUrl}/v1/management/organizations/${organizationId}/tenants/${tenantId}/authentication-transactions?authorization_id=${authId}`,
+      headers: { Authorization: `Bearer ${mgmtAccessToken}` },
+    });
+    expect(txnListResp.status).toBe(200);
+    const transactionId = txnListResp.data.list[0].id;
+
+    const interactionResp = await get({
+      url: `${backendUrl}/v1/management/organizations/${organizationId}/tenants/${tenantId}/authentication-interactions/${transactionId}/email-authentication-challenge`,
+      headers: { Authorization: `Bearer ${mgmtAccessToken}` },
+    });
+    expect(interactionResp.status).toBe(200);
+    const verificationCode = interactionResp.data.payload.verification_code;
+    expect(verificationCode).toBeDefined();
+
+    // Step 4: Verify with the CORRECT OTP. Execution succeeds, so resolveUser runs findByEmail,
+    // which matches both users -> UserTooManyFoundResultException.
+    // Before #1395 this escaped as a 500; it must now be a 400 invalid_request.
+    const emailAuthResp = await postWithJson({
+      url: `${backendUrl}/${tenantId}/v1/authorizations/${authId}/email-authentication`,
+      body: {
+        verification_code: verificationCode,
+      },
+    });
+
+    expect(emailAuthResp.status).toBe(400);
+    expect(emailAuthResp.data.error).toBe("invalid_request");
+    expect(emailAuthResp.data.error_description).toContain(
+      "too many users found for email"
+    );
+  });
+});

--- a/libs/idp-server-authentication-interactors/src/main/java/org/idp/server/authentication/interactors/initial_registration/InitialRegistrationInteractor.java
+++ b/libs/idp-server-authentication-interactors/src/main/java/org/idp/server/authentication/interactors/initial_registration/InitialRegistrationInteractor.java
@@ -100,24 +100,6 @@ public class InitialRegistrationInteractor implements AuthenticationInteractor {
           DefaultSecurityEventType.user_initial_registration_failure);
     }
 
-    String email = request.optValueAsString("email", "");
-    String providerId = request.optValueAsString("provider_id", "idp-server");
-    User existingUser = userQueryRepository.findByEmail(tenant, email, providerId);
-
-    if (existingUser.exists()) {
-
-      Map<String, Object> response = new HashMap<>();
-      response.put("error", "invalid_request");
-      response.put("error_description", "user is conflict with username and password");
-
-      return AuthenticationInteractionRequestResult.clientError(
-          response,
-          type,
-          operationType(),
-          method(),
-          DefaultSecurityEventType.user_initial_registration_conflict);
-    }
-
     // Validate password against tenant password policy
     if (request.containsKey("password")) {
       try {
@@ -165,6 +147,28 @@ public class InitialRegistrationInteractor implements AuthenticationInteractor {
         new IdPUserCreator(jsonSchemaDefinition, request, passwordEncodeDelegation);
     User user = idPUserCreator.create();
     user.applyIdentityPolicy(tenant.identityPolicyConfig());
+
+    // Issue #1669: dedupe by the tenant's unique key (preferred_username, derived from
+    // identity_unique_key_type by applyIdentityPolicy) instead of a hardcoded email. This respects
+    // the tenant identity policy (e.g. PHONE / USERNAME tenants may legitimately share an email)
+    // and
+    // avoids the findByEmail too-many -> 500 risk when email is not the unique key. Mirrors
+    // UserVerifier#throwExceptionIfDuplicatePreferredUsername used in the persistence path.
+    String providerId = request.optValueAsString("provider_id", "idp-server");
+    User existingUser =
+        userQueryRepository.findByPreferredUsername(tenant, providerId, user.preferredUsername());
+    if (existingUser.exists()) {
+      Map<String, Object> response = new HashMap<>();
+      response.put("error", "invalid_request");
+      response.put("error_description", "user is conflict with username and password");
+
+      return AuthenticationInteractionRequestResult.clientError(
+          response,
+          type,
+          operationType(),
+          method(),
+          DefaultSecurityEventType.user_initial_registration_conflict);
+    }
 
     Map<String, Object> response = new HashMap<>();
     response.put("user", user.toMinimalizedMap());


### PR DESCRIPTION
## 概要

自己登録 `InitialRegistrationInteractor` の重複ユーザー判定が、テナントの `identity_unique_key_type` を無視して **email 固定**（`findByEmail`）になっていた問題（#1669）を修正。ポリシーが決める **`preferred_username`** で判定するよう変更し、永続化パスの `UserVerifier`（`findByPreferredUsername`）とロジックを一致させる。

## 変更内容

| 種別 | 内容 | Issue |
|------|------|------|
| `fix` | 重複判定を `applyIdentityPolicy` の**後**に移動し、`findByEmail` → `findByPreferredUsername`（ユニークキー準拠）へ変更 | #1669 |
| `test` | `mfa-28`：`PHONE` ユニークで同一 email・別 phone の2ユーザーを self-registration で作成 → 成功、Email 1st factor 検証で findByEmail 複数ヒット → 400 を確認 | #1669 / #1395 |
| `docs` | `v0.12.0-impact.md` に §5 を追記 | #1669 |

## Before / After

| 観点 | Before | After |
|------|--------|-------|
| 重複判定キー | email 固定（`findByEmail`）| `preferred_username`（`identity_unique_key_type` 準拠）|
| EMAIL ユニークのテナント | email で判定 | **従来どおり**（preferred_username = email）|
| 非 EMAIL ユニーク（`PHONE`/`USERNAME` 等）| email で誤ブロック | ユニークキーで判定（同一 email・別キーの登録可）|
| 同一 email が既に複数存在 | `findByEmail` 複数ヒット → `UserTooManyFoundResultException` → **500** | preferred_username はユニークなので 500 リスクなし |

## テスト

- E2E `mfa-28`：**実機で緑確認済み**（dup-email 登録成功 + 検証 too-many → 400 invalid_request）
- `./gradlew :libs:idp-server-authentication-interactors:compileJava` / `spotlessCheck` 通過
- 既存のイベント名・重複挙動への依存なし

## 影響

email を**ユニークキーにしないテナント**（`PHONE`/`USERNAME`/`EXTERNAL_USER_ID` 等）で、従来は同一 email の2人目以降の自己登録が `400 conflict` で弾かれていたのが、ユニークキーが異なれば登録できるようになる。EMAIL ユニーク（既定 `EMAIL_OR_EXTERNAL_USER_ID` 含む）のテナントは挙動不変。設定変更・DB マイグレーション不要。

Closes #1669

🤖 Generated with [Claude Code](https://claude.com/claude-code)
