### PR TITLE
feat: パスワードグラントのトークンに amr(password) と auth_time を付与 (#1464)

### DIFF
--- a/e2e/src/tests/spec/rfc6749_4_3_resource_owner_password_credentials.test.js
+++ b/e2e/src/tests/spec/rfc6749_4_3_resource_owner_password_credentials.test.js
@@ -1,7 +1,8 @@
 import { describe, expect, it } from "@jest/globals";
 
-import { requestToken } from "../../api/oauthClient";
+import { getJwks, inspectToken, requestToken } from "../../api/oauthClient";
 import { clientSecretPostClient, serverConfig, unsupportedServerConfig, unsupportedClient } from "../testConfig";
+import { verifyAndDecodeJwt } from "../../lib/jose";
 
 describe("The OAuth 2.0 Authorization Framework resource owner password credentials", () => {
   const oauth = serverConfig.oauth;
@@ -133,6 +134,74 @@ describe("The OAuth 2.0 Authorization Framework resource owner password credenti
       expect(tokenResponse.data.error_description).toEqual(
         "this request grant_type is password, but client does not support"
       );
+    });
+  });
+
+  // The password grant authenticates the resource owner with a username/password at the token
+  // endpoint. Per RFC 9068 the issued JWT access token MAY carry authentication information claims,
+  // and per RFC 8176 the password authentication method is recorded in amr. idp-server records the
+  // method as "password" (StandardAuthenticationMethod.PASSWORD) consistently across all flows.
+  describe("RFC 9068 2.2.1. Authentication Information Claims / RFC 8176 amr", () => {
+    it("amr OPTIONAL. JSON array of strings ... identifiers for authentication methods used. The password grant MUST record the password method, so the issued access token amr MUST contain \"password\" and auth_time MUST be present.", async () => {
+      const tokenResponse = await requestToken({
+        endpoint: serverConfig.tokenEndpoint,
+        grantType: "password",
+        clientId: clientSecretPostClient.clientId,
+        clientSecret: clientSecretPostClient.clientSecret,
+        scope: "openid " + clientSecretPostClient.scope,
+        username: oauth.username,
+        password: oauth.password,
+      });
+      console.log(tokenResponse.data);
+      expect(tokenResponse.status).toBe(200);
+      expect(tokenResponse.data.access_token).toBeDefined();
+
+      const introspectionResponse = await inspectToken({
+        endpoint: serverConfig.tokenIntrospectionEndpoint,
+        token: tokenResponse.data.access_token,
+        clientId: clientSecretPostClient.clientId,
+        clientSecret: clientSecretPostClient.clientSecret,
+      });
+      console.log(JSON.stringify(introspectionResponse.data, null, 2));
+      expect(introspectionResponse.status).toBe(200);
+      expect(introspectionResponse.data.active).toBe(true);
+
+      expect(introspectionResponse.data.amr).toBeDefined();
+      expect(Array.isArray(introspectionResponse.data.amr)).toBe(true);
+      expect(introspectionResponse.data.amr).toContain("password");
+
+      expect(introspectionResponse.data).toHaveProperty("auth_time");
+      expect(typeof introspectionResponse.data.auth_time).toBe("number");
+      expect(introspectionResponse.data.auth_time).toBeGreaterThan(0);
+    });
+
+    it("amr OPTIONAL. When the openid scope is granted, the issued ID Token amr MUST contain \"password\" and auth_time MUST be present.", async () => {
+      const tokenResponse = await requestToken({
+        endpoint: serverConfig.tokenEndpoint,
+        grantType: "password",
+        clientId: clientSecretPostClient.clientId,
+        clientSecret: clientSecretPostClient.clientSecret,
+        scope: "openid " + clientSecretPostClient.scope,
+        username: oauth.username,
+        password: oauth.password,
+      });
+      console.log(tokenResponse.data);
+      expect(tokenResponse.status).toBe(200);
+      expect(tokenResponse.data.id_token).toBeDefined();
+
+      const jwksResponse = await getJwks({ endpoint: serverConfig.jwksEndpoint });
+      const decodedIdToken = verifyAndDecodeJwt({
+        jwt: tokenResponse.data.id_token,
+        jwks: jwksResponse.data,
+      });
+      console.log("ID Token payload:", decodedIdToken.payload);
+
+      expect(decodedIdToken.payload).toHaveProperty("amr");
+      expect(Array.isArray(decodedIdToken.payload.amr)).toBe(true);
+      expect(decodedIdToken.payload.amr).toContain("password");
+
+      expect(decodedIdToken.payload).toHaveProperty("auth_time");
+      expect(typeof decodedIdToken.payload.auth_time).toBe("number");
     });
   });
 });

--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/token/service/ResourceOwnerPasswordCredentialsGrantService.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/token/service/ResourceOwnerPasswordCredentialsGrantService.java
@@ -19,6 +19,7 @@ package org.idp.server.core.openid.token.service;
 import java.util.List;
 import java.util.UUID;
 import org.idp.server.core.openid.authentication.Authentication;
+import org.idp.server.core.openid.authentication.StandardAuthenticationMethod;
 import org.idp.server.core.openid.grant_management.AuthorizationGranted;
 import org.idp.server.core.openid.grant_management.AuthorizationGrantedIdentifier;
 import org.idp.server.core.openid.grant_management.AuthorizationGrantedRepository;
@@ -45,6 +46,7 @@ import org.idp.server.core.openid.token.*;
 import org.idp.server.core.openid.token.repository.OAuthTokenCommandRepository;
 import org.idp.server.core.openid.token.validator.ResourceOwnerPasswordGrantValidator;
 import org.idp.server.core.openid.token.verifier.ResourceOwnerPasswordGrantVerifier;
+import org.idp.server.platform.date.SystemDateTime;
 import org.idp.server.platform.multi_tenancy.tenant.Tenant;
 
 /**
@@ -107,6 +109,11 @@ public class ResourceOwnerPasswordCredentialsGrantService
 
     CustomProperties customProperties = context.customProperties();
 
+    Authentication authentication =
+        new Authentication()
+            .setTime(SystemDateTime.now())
+            .addMethods(List.of(StandardAuthenticationMethod.PASSWORD.type()));
+
     List<String> supportedClaims = authorizationServerConfiguration.claimsSupported();
     boolean idTokenStrictMode = authorizationServerConfiguration.isIdTokenStrictMode();
     GrantIdTokenClaims grantIdTokenClaims =
@@ -123,6 +130,7 @@ public class ResourceOwnerPasswordCredentialsGrantService
         new AuthorizationGrantBuilder(
                 context.tenantIdentifier(), context.requestedClientId(), GrantType.password, scopes)
             .add(user)
+            .add(authentication)
             .add(clientConfiguration.clientAttributes())
             .add(customProperties)
             .add(grantIdTokenClaims)
@@ -147,7 +155,7 @@ public class ResourceOwnerPasswordCredentialsGrantService
       IdToken idToken =
           idTokenCreator.createIdToken(
               authorizationGrant.user(),
-              new Authentication(),
+              authentication,
               authorizationGrant,
               idTokenCustomClaims,
               new RequestedClaimsPayload(),


### PR DESCRIPTION
## 概要

パスワードグラント（Resource Owner Password Credentials Grant, RFC 6749 §4.3）で発行される JWT アクセストークン／ID トークンに `amr` と `auth_time` が含まれていなかった問題を修正します。

Closes #1464

## 原因

`ResourceOwnerPasswordCredentialsGrantService` が `AuthorizationGrantBuilder` に `Authentication` を渡しておらず、グラント内の `Authentication` が空のままだった。アクセストークンの `amr` は `AccessTokenCreator#issueAccessToken` で `authorizationGrant.authentication()` から導出されるため付与されず、ID トークン生成も `new Authentication()` を直接渡していたため同様に空だった。

## 対応

トークン発行時に password 認証メソッドを記録した `Authentication` を生成し、グラントと ID トークン生成の両方へ渡すことで、認可コードフローと同様に `amr: ["password"]` と `auth_time` を付与する。

- `amr` の値は他フロー（認可コード／MFA）と整合する `"password"`（`StandardAuthenticationMethod.PASSWORD`）を使用。RFC 8176 の登録値 `pwd` への正規化は影響範囲が全フローに及ぶため別件として扱う。
- アクセストークンの `amr` 付与は `Authentication#exists()`（= `auth_time` の有無）で判定されるため `setTime(now)` が必須。ROPC はトークン要求時にパスワード検証を行うため `auth_time = now` は意味的にも妥当（RFC 9068 §2.2.1）。
- ID トークン（`openid` スコープ時）にも同一の `Authentication` を渡し整合させる。

## テスト

`e2e/src/tests/spec/rfc6749_4_3_resource_owner_password_credentials.test.js` に検証を追加。

- アクセストークン: introspection で `amr` に `"password"` が含まれること・`auth_time` が付与されることを確認
- ID トークン: JWT をデコードし `amr` に `"password"` が含まれること・`auth_time` が付与されることを確認

実機（ローカルスタック）で実行し 10/10 pass を確認済み。実際の発行トークンにも `"amr":["password"]` / `"auth_time":...` が含まれることを確認。

## 参考

- RFC 9068 §2.2.1: JWT アクセストークンに `auth_time` / `acr` / `amr` を含めることが許可されている
- RFC 8176: Authentication Method Reference Values

🤖 Generated with [Claude Code](https://claude.com/claude-code)
