### PR TITLE
feat: redirect_uri の fragment 禁止（RFC6749 §3.1.2）を OIDC/FAPI プロファイルに適用 (#1673)

### DIFF
--- a/e2e/src/tests/spec/fapi_advance.test.js
+++ b/e2e/src/tests/spec/fapi_advance.test.js
@@ -261,6 +261,40 @@ describe("Financial-grade API Security Profile 1.0 - Part 2: Advanced", () => {
       expect(authorizationResponse.errorDescription).toContain("When FAPI Advance profile, shall require the response_type value code id_token, or the response_type value code in conjunction with the response_mode value jwt");
     });
 
+    it ("The endpoint URI MUST NOT include a fragment component. (RFC 6749 Section 3.1.2, inherited by FAPI Advanced)", async () => {
+      const codeVerifier = generateCodeVerifier(64);
+      const codeChallenge = calculateCodeChallengeWithS256(codeVerifier);
+      const request = createJwtWithPrivateKey({
+        payload: {
+          response_type: "code id_token",
+          state: "aiueo",
+          scope: "openid profile phone email " + selfSignedTlsAuthClient.fapiAdvanceScope,
+          redirect_uri: selfSignedTlsAuthClient.redirectUri + "#fragment",
+          client_id: selfSignedTlsAuthClient.clientId,
+          nonce: "nonce",
+          aud: serverConfig.issuer,
+          iss: selfSignedTlsAuthClient.clientId,
+          sub: selfSignedTlsAuthClient.clientId,
+          code_challenge: codeChallenge,
+          code_challenge_method: "S256",
+          exp: toEpocTime({ adjusted: 3000 }),
+          iat: toEpocTime({}),
+          nbf: toEpocTime({}),
+          jti: generateJti(),
+        },
+        privateKey: selfSignedTlsAuthClient.requestKey,
+      });
+      const { authorizationResponse } = await requestAuthorizations({
+        endpoint: serverConfig.authorizationEndpoint,
+        request,
+        clientId: selfSignedTlsAuthClient.clientId,
+      });
+      console.log(authorizationResponse);
+
+      expect(authorizationResponse.error).toEqual("invalid_request");
+      expect(authorizationResponse.errorDescription).toContain("redirect_uri must not fragment");
+    });
+
     it ("5. shall only issue sender-constrained access tokens;", async () => {
       const codeVerifier = generateCodeVerifier(64);
       const codeChallenge = calculateCodeChallengeWithS256(codeVerifier);

--- a/e2e/src/tests/spec/fapi_baseline.test.js
+++ b/e2e/src/tests/spec/fapi_baseline.test.js
@@ -255,6 +255,25 @@ describe("Financial-grade API Security Profile 1.0 - Part 1: Baseline", () => {
       expect(error.error_description).toContain("When FAPI Baseline profile, shall require the value of redirect_uri to exactly match one of the pre-registered redirect URIs");
     });
 
+    it("The endpoint URI MUST NOT include a fragment component. (RFC 6749 Section 3.1.2, inherited by FAPI Baseline)", async () => {
+      const codeVerifier = generateCodeVerifier(64);
+      const codeChallenge = calculateCodeChallengeWithS256(codeVerifier);
+      const { error } = await requestAuthorizations({
+        endpoint: serverConfig.authorizationEndpoint,
+        responseType: "code",
+        state: "aiueo",
+        scope: "profile phone email " + privateKeyJwtClient.fapiBaselineScope,
+        clientId: privateKeyJwtClient.clientId,
+        redirectUri: privateKeyJwtClient.redirectUri + "#fragment",
+        nonce: "nonce",
+        codeChallenge,
+        codeChallengeMethod: "S256",
+      });
+      console.log(error);
+      expect(error.error).toEqual("invalid_request");
+      expect(error.error_description).toContain("redirect_uri must not fragment");
+    });
+
     it("19. shall return an invalid_client error as defined in 5.2 of RFC6749 when mis-matched client identifiers were provided through the client authentication methods that permits sending the client identifier in more than one way;", async () => {
       const codeVerifier = generateCodeVerifier(64);
       const codeChallenge = calculateCodeChallengeWithS256(codeVerifier);

--- a/e2e/src/tests/spec/oidc_core_3_1_code.test.js
+++ b/e2e/src/tests/spec/oidc_core_3_1_code.test.js
@@ -90,6 +90,24 @@ describe("OpenID Connect Core 1.0 incorporating errata set 1 code", () => {
     expect(tokenResponse.data).toHaveProperty("id_token");
   });
 
+  describe("3.1.2.  Authorization Endpoint (RFC 6749 Section 3.1.2)", () => {
+    it("The endpoint URI MUST NOT include a fragment component. (inherited by OIDC from RFC 6749 Section 3.1.2)", async () => {
+      const { error } = await requestAuthorizations({
+        endpoint: serverConfig.authorizationEndpoint,
+        clientId: clientSecretPostClient.clientId,
+        responseType: "code",
+        redirectUri: clientSecretPostClient.redirectUri + "#fragment",
+        scope: "openid " + clientSecretPostClient.scope,
+        state: "fragment-test-state",
+        nonce: "fragment-test-nonce",
+      });
+      console.log(error);
+
+      expect(error.error).toEqual("invalid_request");
+      expect(error.error_description).toContain("redirect_uri must not fragment");
+    });
+  });
+
   describe("3.1.2.1.  Authentication Request", () => {
     it("scope REQUIRED. OpenID Connect requests MUST contain the openid scope value. If the openid scope value is not present, the behavior is entirely unspecified. Other scope values MAY be present. Scope values used that are not understood by an implementation SHOULD be ignored. See Sections 5.4 and 11 for additional scope values defined by this specification.", async () => {
       const { status, authorizationResponse } = await requestAuthorizations({

--- a/libs/idp-server-core-extension-fapi/src/main/java/org/idp/server/core/openid/extension/fapi/FapiAdvanceVerifier.java
+++ b/libs/idp-server-core-extension-fapi/src/main/java/org/idp/server/core/openid/extension/fapi/FapiAdvanceVerifier.java
@@ -128,6 +128,11 @@ public class FapiAdvanceVerifier implements AuthorizationRequestVerifier {
   public void verify(OAuthRequestContext context) {
     throwIfExceptionInvalidConfig(context);
 
+    // RFC 6749 3.1.2: redirect_uri MUST NOT include a fragment component. Checked before the base
+    // delegation so it is enforced ahead of any redirectable error (Section 3.1.2.4), covering both
+    // the OIDC and non-OIDC (JARM) request paths.
+    oAuthRequestBaseVerifier.throwExceptionIfRedirectUriContainsFragment(context);
+
     // --- OAuth 2.0 / OIDC base requirements ---
     if (context.isOidcRequest()) {
       oidcRequestBaseVerifier.verify(context);

--- a/libs/idp-server-core-extension-fapi/src/main/java/org/idp/server/core/openid/extension/fapi/FapiBaselineVerifier.java
+++ b/libs/idp-server-core-extension-fapi/src/main/java/org/idp/server/core/openid/extension/fapi/FapiBaselineVerifier.java
@@ -78,6 +78,7 @@ public class FapiBaselineVerifier implements AuthorizationRequestVerifier {
   public void verify(OAuthRequestContext context) {
     throwExceptionIfUnregisteredRedirectUri(context);
     throwExceptionIfNotContainsRedirectUri(context);
+    oAuthRequestBaseVerifier.throwExceptionIfRedirectUriContainsFragment(context);
     throwExceptionUnMatchRedirectUri(context);
     throwExceptionIfNotHttpsRedirectUri(context);
     if (context.isOidcRequest()) {

--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/oauth/verifier/OAuth2RequestVerifier.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/oauth/verifier/OAuth2RequestVerifier.java
@@ -21,9 +21,7 @@ import org.idp.server.core.openid.oauth.OAuthRequestContext;
 import org.idp.server.core.openid.oauth.exception.OAuthBadRequestException;
 import org.idp.server.core.openid.oauth.type.extension.RegisteredRedirectUris;
 import org.idp.server.core.openid.oauth.verifier.base.OAuthRequestBaseVerifier;
-import org.idp.server.platform.http.InvalidUriException;
 import org.idp.server.platform.http.UriMatcher;
-import org.idp.server.platform.http.UriWrapper;
 
 public class OAuth2RequestVerifier implements AuthorizationRequestVerifier {
 
@@ -53,7 +51,7 @@ public class OAuth2RequestVerifier implements AuthorizationRequestVerifier {
   void throwExceptionIfInvalidRedirectUri(OAuthRequestContext context) {
     if (context.hasRedirectUriInRequest()) {
       throwExceptionIfNotAbsoluteRedirectUri(context);
-      throwExceptionIfRedirectUriContainsFragment(context);
+      baseVerifier.throwExceptionIfRedirectUriContainsFragment(context);
       throwExceptionIfUnMatchRedirectUri(context);
     } else {
       throwExceptionIfMultiRegisteredRedirectUri(context);
@@ -74,34 +72,6 @@ public class OAuth2RequestVerifier implements AuthorizationRequestVerifier {
       throw new OAuthBadRequestException(
           "invalid_request",
           String.format("redirect_uri must be an absolute URI (%s)", context.redirectUri().value()),
-          context.tenant());
-    }
-  }
-
-  /**
-   * The redirection endpoint URI MUST be an absolute URI as defined by [RFC3986] Section 4.3. The
-   * endpoint URI MAY include an "application/x-www-form-urlencoded" formatted (per Appendix B)
-   * query component ([RFC3986] Section 3.4), which MUST be retained when adding additional query
-   * parameters. The endpoint URI MUST NOT include a fragment component.
-   *
-   * @param context
-   * @see <a href="https://www.rfc-editor.org/rfc/rfc6749#section-3.1.2">3.1.2. Redirection
-   *     Endpoint</a>
-   */
-  void throwExceptionIfRedirectUriContainsFragment(OAuthRequestContext context) {
-    try {
-      UriWrapper uri = new UriWrapper(context.redirectUri().value());
-      if (uri.hasFragment()) {
-        throw new OAuthBadRequestException(
-            "invalid_request",
-            String.format("redirect_uri must not fragment (%s)", context.redirectUri().value()),
-            context.tenant());
-      }
-    } catch (InvalidUriException exception) {
-      throw new OAuthBadRequestException(
-          "invalid_request",
-          String.format(
-              "authorization request redirect_uri is invalid (%s)", context.redirectUri().value()),
           context.tenant());
     }
   }

--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/oauth/verifier/base/OAuthRequestBaseVerifier.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/oauth/verifier/base/OAuthRequestBaseVerifier.java
@@ -18,11 +18,14 @@ package org.idp.server.core.openid.oauth.verifier.base;
 
 import org.idp.server.core.openid.oauth.AuthorizationProfile;
 import org.idp.server.core.openid.oauth.OAuthRequestContext;
+import org.idp.server.core.openid.oauth.exception.OAuthBadRequestException;
 import org.idp.server.core.openid.oauth.exception.OAuthRedirectableBadRequestException;
 import org.idp.server.core.openid.oauth.type.OAuthRequestKey;
 import org.idp.server.core.openid.oauth.type.oauth.ResponseType;
 import org.idp.server.core.openid.oauth.type.oauth.Scopes;
 import org.idp.server.core.openid.oauth.verifier.AuthorizationRequestVerifier;
+import org.idp.server.platform.http.InvalidUriException;
+import org.idp.server.platform.http.UriWrapper;
 
 /**
  * oauth2.0 base verifier
@@ -151,6 +154,44 @@ public class OAuthRequestBaseVerifier implements AuthorizationRequestVerifier {
               "authorization request does not contains valid scope (%s)",
               context.getParams(OAuthRequestKey.scope)),
           context);
+    }
+  }
+
+  /**
+   * The redirection endpoint URI MUST be an absolute URI as defined by [RFC3986] Section 4.3. The
+   * endpoint URI MAY include an "application/x-www-form-urlencoded" formatted (per Appendix B)
+   * query component ([RFC3986] Section 3.4), which MUST be retained when adding additional query
+   * parameters. The endpoint URI MUST NOT include a fragment component.
+   *
+   * <p>RFC 6749 Section 3.1.2 is a core OAuth 2.0 requirement inherited by the OIDC and FAPI
+   * profiles, so this check is exposed here and invoked explicitly by every profile verifier (right
+   * before the registered redirect_uri match) instead of being duplicated per profile. A fragment
+   * in the redirect_uri causes response parameters to leak into the fragment component, so an
+   * invalid redirect_uri must not be redirected to (Section 3.1.2.4); hence this throws the
+   * non-redirectable {@link OAuthBadRequestException}.
+   *
+   * @param context authorization request context
+   * @see <a href="https://www.rfc-editor.org/rfc/rfc6749#section-3.1.2">3.1.2. Redirection
+   *     Endpoint</a>
+   */
+  public void throwExceptionIfRedirectUriContainsFragment(OAuthRequestContext context) {
+    if (!context.hasRedirectUriInRequest()) {
+      return;
+    }
+    try {
+      UriWrapper uri = new UriWrapper(context.redirectUri().value());
+      if (uri.hasFragment()) {
+        throw new OAuthBadRequestException(
+            "invalid_request",
+            String.format("redirect_uri must not fragment (%s)", context.redirectUri().value()),
+            context.tenant());
+      }
+    } catch (InvalidUriException exception) {
+      throw new OAuthBadRequestException(
+          "invalid_request",
+          String.format(
+              "authorization request redirect_uri is invalid (%s)", context.redirectUri().value()),
+          context.tenant());
     }
   }
 }

--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/oauth/verifier/base/OidcRequestBaseVerifier.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/oauth/verifier/base/OidcRequestBaseVerifier.java
@@ -65,6 +65,7 @@ public class OidcRequestBaseVerifier implements AuthorizationRequestVerifier {
   public void verify(OAuthRequestContext context) {
     throwExceptionIfNotContainsRedirectUri(context);
     throwExceptionIfNotAbsoluteRedirectUri(context);
+    baseVerifier.throwExceptionIfRedirectUriContainsFragment(context);
     throwExceptionIfUnRegisteredRedirectUri(context);
     throwExceptionIfHttpRedirectUriAndImplicitFlow(context);
     throwExceptionIfNotContainsNonceAndImplicitFlowOrHybridFlow(context);


### PR DESCRIPTION
## 概要

`redirect_uri` に fragment component を含めてはならない（RFC 6749 §3.1.2「The endpoint URI MUST NOT include a fragment component」）の検証を、**OIDC / FAPI_BASELINE / FAPI_ADVANCE プロファイル** にも適用します。

これまで fragment チェックは OAUTH2 プロファイル（openid なしの素の OAuth2）でしか実行されておらず、`openid` / FAPI スコープを含む実トラフィックの大半では未適用でした。

Closes #1673

## 原因

認可リクエストの verifier はプロファイルごとに 1 つ選択され（`OAuthRequestVerifier`）、redirect_uri 検証は各プロファイル verifier が個別に保持していました。fragment チェックは `OAuth2RequestVerifier` にしか存在せず、`OidcRequestBaseVerifier` / `FapiBaselineVerifier` / `FapiAdvanceVerifier` には無い状態でした。

## 対応

`throwExceptionIfRedirectUriContainsFragment` を共通基底の `OAuthRequestBaseVerifier` に public メソッドとして集約（`hasRedirectUriInRequest()` ガード内蔵）し、各プロファイル verifier が **登録一致（exact match）チェックの直前** で明示的に呼ぶようにしました。

| Verifier | 挿入位置 |
|----------|----------|
| `OAuth2RequestVerifier` | 自前メソッドを base へ委譲（**挙動・順序とも不変**） |
| `OidcRequestBaseVerifier` | `notAbsolute` の後・`unregistered` の前 |
| `FapiBaselineVerifier` | `notContains` の後・exact match の前 |
| `FapiAdvanceVerifier` | base 委譲の前（非 OIDC / JARM 経路もカバー） |

### 設計上のポイント

- **明示呼び出し（verify への自動組込みではない）**: OIDC は登録一致チェックを base 委譲より前で実行するため、fragment チェックを後ろに置くと `<registered>#fragment` が「does not register」で弾かれ `"must not fragment"` が出ない。各 verifier の登録一致チェックの直前に明示挿入することで、エラーの精度と OAUTH2 との挙動一貫性を担保。
- **非リダイレクトで拒否**: fragment は response パラメータの意図しない漏えい（covert redirect 系のリーク）につながり、不正な redirect_uri へリダイレクトしてはならない（§3.1.2.4）。そのため redirectable ではない `OAuthBadRequestException` を投げる。

## テスト

`spec/` に §3.1.2 fragment ケースを各プロファイルで追加。

| ファイル | 内容 |
|----------|------|
| `oidc_core_3_1_code.test.js` | OIDC（openid スコープ）で fragment 拒否 |
| `fapi_baseline.test.js` | FAPI Baseline（code_challenge 付き）で fragment 拒否 |
| `fapi_advance.test.js` | FAPI Advanced（署名リクエストオブジェクト）で fragment 拒否 |

実機（ローカルスタック）で実行し、対象 4 ファイル **130 passed / 0 failed**（既存 OAUTH2 fragment テスト含め回帰なし）を確認。各プロファイルで実エラー `redirect_uri must not fragment (...)` が返ることを確認済み。

## スコープ外（別 Issue）

- クライアント**登録/更新時**の fragment 拒否（control-plane）は #1676 に分割。

## 参考

- [RFC 6749 §3.1.2 Redirection Endpoint](https://www.rfc-editor.org/rfc/rfc6749#section-3.1.2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
