### PR TITLE
feat(consent): 認可 view-data レスポンスに要求claimを含める (#1653 step①)

### DIFF
--- a/documentation/openapi/swagger-authentication-interaction-ja.yaml
+++ b/documentation/openapi/swagger-authentication-interaction-ja.yaml
@@ -263,6 +263,7 @@ paths:
         ## レスポンスデータ
         - **クライアント情報**: クライアント名、ロゴURI、利用規約URIなど
         - **スコープ情報**: 要求されているスコープの一覧
+        - **クレーム情報**: 要求されているクレームの一覧（id_token / userinfo / verified_claims）。クレーム単位の同意表示に使用します
         - **セッション情報**: セッション有効化フラグ
         - **フェデレーション情報**: 利用可能な外部IdP連携情報
         - **カスタムパラメータ**: クライアント固有のカスタムパラメータ
@@ -293,6 +294,10 @@ paths:
                     tos_uri: "https://client.example.com/terms"
                     policy_uri: "https://client.example.com/privacy"
                     scopes: ["openid", "profile", "email"]
+                    claims:
+                      id_token: ["given_name", "family_name", "email"]
+                      userinfo: ["given_name", "family_name", "email"]
+                      verified_claims: []
                     session_enabled: true
                     custom_params:
                       organization_id: "org123"
@@ -1181,6 +1186,38 @@ components:
             type: string
           description: 要求されているスコープ一覧
           example: ["openid", "profile", "email"]
+        claims:
+          type: object
+          description: |
+            このリクエストで要求されているクレーム一覧。consent画面でクレーム単位の表示・同意に使用します。
+            id_token / userinfo はスコープおよびclaimsパラメータから解決されたクレーム名、
+            verified_claims はclaimsパラメータ経由で要求された本人確認済みクレーム名です。
+
+            注: `verified_claims:*` スコープ経由で要求された本人確認済みクレームは
+            `claims.verified_claims` には含まれず、`scopes` 側に残ります。
+          properties:
+            id_token:
+              type: array
+              items:
+                type: string
+              description: IDトークンで要求されているクレーム名
+              example: ["given_name", "family_name", "email"]
+            userinfo:
+              type: array
+              items:
+                type: string
+              description: UserInfoで要求されているクレーム名
+              example: ["given_name", "family_name", "email"]
+            verified_claims:
+              type: array
+              items:
+                type: string
+              description: claimsパラメータ経由で要求された本人確認済みクレーム名
+              example: ["given_name", "family_name"]
+          example:
+            id_token: ["given_name", "family_name", "email"]
+            userinfo: ["given_name", "family_name", "email"]
+            verified_claims: ["given_name", "family_name"]
         session_enabled:
           type: boolean
           description: セッション有効化フラグ

--- a/e2e/src/tests/scenario/application/scenario-consent-view-data-requested-claims.test.js
+++ b/e2e/src/tests/scenario/application/scenario-consent-view-data-requested-claims.test.js
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "@jest/globals";
+
+import { backendUrl, clientSecretPostClient, serverConfig } from "../../testConfig";
+import { get } from "../../../lib/http";
+
+/**
+ * Consent view-data exposes the requested claims so the consent UI can present them per-claim.
+ *
+ * This is the foundation for claim-level consent (OIDC4IDA §5.7.3 "omit non-consented data"):
+ * before the user can consent to / deny individual claims, the authorization view-data must tell
+ * the UI which claims are being requested. The `claims` member mirrors token/userinfo issuance:
+ *   - claims.id_token / claims.userinfo : standard claim names resolved from scope + claims param
+ *   - claims.verified_claims            : verified claim names requested via the `claims` parameter
+ *
+ * verified_claims requested via `verified_claims:*` scopes remain visible in `scopes`.
+ */
+const startAuthorization = async ({ scope, claims }) => {
+  const params = new URLSearchParams({
+    response_type: "code",
+    client_id: clientSecretPostClient.clientId,
+    redirect_uri: clientSecretPostClient.redirectUri,
+    scope,
+    state: `view-data-claims-${Date.now()}`,
+  });
+  if (claims) {
+    params.set("claims", claims);
+  }
+
+  const authorizeResponse = await get({
+    url: `${backendUrl}/${serverConfig.tenantId}/v1/authorizations?${params.toString()}`,
+    headers: {},
+  });
+  expect(authorizeResponse.status).toBe(302);
+
+  const location = authorizeResponse.headers.location;
+  const authId = new URL(location, backendUrl).searchParams.get("id");
+  expect(authId).toBeTruthy();
+
+  const viewDataResponse = await get({
+    url: `${backendUrl}/${serverConfig.tenantId}/v1/authorizations/${authId}/view-data`,
+    headers: {},
+  });
+  expect(viewDataResponse.status).toBe(200);
+  return viewDataResponse.data;
+};
+
+describe("Consent view-data exposes requested claims (foundation for OIDC4IDA §5.7.3 claim-level consent)", () => {
+  it("surfaces scope-derived standard claims under claims.userinfo (and id_token / verified_claims keys)", async () => {
+    const viewData = await startAuthorization({ scope: "openid profile email" });
+    console.log(JSON.stringify(viewData.claims, null, 2));
+
+    expect(viewData.claims).toBeDefined();
+    expect(Array.isArray(viewData.claims.id_token)).toBe(true);
+    expect(Array.isArray(viewData.claims.userinfo)).toBe(true);
+    expect(Array.isArray(viewData.claims.verified_claims)).toBe(true);
+
+    // userinfo claims are scope-driven (independent of id_token strict mode):
+    // profile scope -> given_name / family_name ; email scope -> email
+    expect(viewData.claims.userinfo).toEqual(
+      expect.arrayContaining(["given_name", "family_name", "email"])
+    );
+    // address scope not requested -> absent
+    expect(viewData.claims.userinfo).not.toContain("address");
+    // no claims parameter / verified_claims:* scope -> no verified claims
+    expect(viewData.claims.verified_claims).toHaveLength(0);
+  });
+
+  it("surfaces verified_claims requested via the claims parameter under claims.verified_claims", async () => {
+    const claims = JSON.stringify({
+      id_token: {
+        verified_claims: {
+          verification: { trust_framework: null },
+          claims: { given_name: null, family_name: null },
+        },
+      },
+    });
+    const viewData = await startAuthorization({ scope: "openid", claims });
+    console.log(JSON.stringify(viewData.claims, null, 2));
+
+    expect(viewData.claims.verified_claims).toEqual(
+      expect.arrayContaining(["given_name", "family_name"])
+    );
+    // openid-only scope -> no standard profile/email claims
+    expect(viewData.claims.id_token).not.toContain("email");
+  });
+});

--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/identity/id_token/VerifiedClaimsObject.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/identity/id_token/VerifiedClaimsObject.java
@@ -16,6 +16,8 @@
 
 package org.idp.server.core.openid.identity.id_token;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import org.idp.server.platform.json.JsonNodeWrapper;
 import org.idp.server.platform.json.JsonReadable;
@@ -37,5 +39,17 @@ public class VerifiedClaimsObject implements JsonReadable {
 
   public JsonNodeWrapper claimsNodeWrapper() {
     return JsonNodeWrapper.fromMap(claims);
+  }
+
+  /**
+   * Requested verified claim names (the keys of the OIDC4IDA {@code claims} member), e.g. {@code
+   * given_name}, {@code family_name}. Used to surface which verified claims are being requested
+   * (consent view data); returns an empty list when no verified claims are requested.
+   */
+  public List<String> requestedClaimNames() {
+    if (claims == null || claims.isEmpty()) {
+      return new ArrayList<>();
+    }
+    return new ArrayList<>(claims.keySet());
   }
 }

--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/oauth/view/OAuthViewData.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/oauth/view/OAuthViewData.java
@@ -29,6 +29,7 @@ public class OAuthViewData {
   String tosUri;
   String policyUri;
   List<String> scopes;
+  Map<String, Object> requestedClaims;
   boolean sessionEnabled;
   List<Map<String, Object>> availableFederations;
   Map<String, String> customParams;
@@ -43,6 +44,7 @@ public class OAuthViewData {
       String tosUri,
       String policyUri,
       List<String> scopes,
+      Map<String, Object> requestedClaims,
       boolean sessionEnabled,
       List<Map<String, Object>> availableFederations,
       Map<String, String> customParams,
@@ -55,6 +57,7 @@ public class OAuthViewData {
     this.tosUri = tosUri;
     this.policyUri = policyUri;
     this.scopes = scopes;
+    this.requestedClaims = requestedClaims;
     this.sessionEnabled = sessionEnabled;
     this.availableFederations = availableFederations;
     this.customParams = customParams;
@@ -93,6 +96,10 @@ public class OAuthViewData {
     return scopes;
   }
 
+  public Map<String, Object> requestedClaims() {
+    return requestedClaims;
+  }
+
   public Map<String, String> customParams() {
     return customParams;
   }
@@ -107,6 +114,7 @@ public class OAuthViewData {
     contents.put("tos_uri", tosUri);
     contents.put("policy_uri", policyUri);
     contents.put("scopes", scopes);
+    contents.put("claims", requestedClaims);
     contents.put("session_enabled", sessionEnabled);
 
     if (availableFederations != null && !availableFederations.isEmpty()) {

--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/oauth/view/OAuthViewDataCreator.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/oauth/view/OAuthViewDataCreator.java
@@ -17,11 +17,18 @@
 package org.idp.server.core.openid.oauth.view;
 
 import java.time.Instant;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import org.idp.server.core.openid.grant_management.grant.GrantIdTokenClaims;
+import org.idp.server.core.openid.grant_management.grant.GrantUserinfoClaims;
+import org.idp.server.core.openid.identity.id_token.VerifiedClaimsObject;
 import org.idp.server.core.openid.oauth.configuration.AuthorizationServerConfiguration;
 import org.idp.server.core.openid.oauth.configuration.client.ClientConfiguration;
 import org.idp.server.core.openid.oauth.request.AuthorizationRequest;
+import org.idp.server.core.openid.oauth.type.oauth.Scopes;
 import org.idp.server.core.openid.session.OPSession;
 
 public class OAuthViewDataCreator {
@@ -55,6 +62,7 @@ public class OAuthViewDataCreator {
     String policyUri = clientConfiguration.policyUri();
     Map<String, String> customParams = authorizationRequest.customParams().values();
     List<String> scopes = authorizationRequest.scopes().toStringList();
+    Map<String, Object> requestedClaims = createRequestedClaims();
     boolean sessionEnabled = isSessionEnabled();
     List<Map<String, Object>> availableFederationsAsMapList =
         clientConfiguration.availableFederationsAsMapList();
@@ -76,10 +84,58 @@ public class OAuthViewDataCreator {
         tosUri,
         policyUri,
         scopes,
+        requestedClaims,
         sessionEnabled,
         availableFederationsAsMapList,
         customParams,
         additionalViewData);
+  }
+
+  /**
+   * Resolves the claims that would be released for this request so the consent view can present
+   * them per-claim (foundation for claim-level consent, OIDC4IDA Section 5.7.3). Reuses the same
+   * scope/claims resolution as token and userinfo issuance ({@link GrantIdTokenClaims} / {@link
+   * GrantUserinfoClaims}). verified_claims requested via the {@code claims} parameter are surfaced
+   * by name; verified_claims requested via {@code verified_claims:*} scopes remain visible in
+   * {@code scopes}.
+   */
+  private Map<String, Object> createRequestedClaims() {
+    Scopes scopes = authorizationRequest.scopes();
+    List<String> supportedClaims = authorizationServerConfiguration.claimsSupported();
+
+    GrantIdTokenClaims idTokenClaims =
+        GrantIdTokenClaims.create(
+            scopes,
+            authorizationRequest.responseType(),
+            supportedClaims,
+            authorizationRequest.requestedIdTokenClaims(),
+            authorizationServerConfiguration.isIdTokenStrictMode());
+    GrantUserinfoClaims userinfoClaims =
+        GrantUserinfoClaims.create(
+            scopes, supportedClaims, authorizationRequest.requestedUserinfoClaims());
+
+    Map<String, Object> requestedClaims = new HashMap<>();
+    requestedClaims.put("id_token", sorted(idTokenClaims.toStringSet()));
+    requestedClaims.put("userinfo", sorted(userinfoClaims.toStringSet()));
+    requestedClaims.put("verified_claims", requestedVerifiedClaimNames());
+    return requestedClaims;
+  }
+
+  private List<String> requestedVerifiedClaimNames() {
+    Set<String> names = new LinkedHashSet<>();
+    VerifiedClaimsObject idToken = authorizationRequest.requestedIdTokenClaims().verifiedClaims();
+    VerifiedClaimsObject userinfo = authorizationRequest.requestedUserinfoClaims().verifiedClaims();
+    if (idToken != null) {
+      names.addAll(idToken.requestedClaimNames());
+    }
+    if (userinfo != null) {
+      names.addAll(userinfo.requestedClaimNames());
+    }
+    return sorted(names);
+  }
+
+  private List<String> sorted(Set<String> values) {
+    return values.stream().sorted().toList();
   }
 
   /**


### PR DESCRIPTION
## 概要

認可同意画面の view-data レスポンス（`GET /{tenant}/v1/authorizations/{id}/view-data`）に、そのリクエストで要求されている **claim** を含めます。consent UI が claim 単位で「共有する/しない」を提示できるようにするための土台です。

claim-level consent（OIDC4IDA §5.7.3「非同意データ省略」、#1653）の **step ①**。

Closes #1678

## 背景

#1653 の調査で、consent / deny は **view-data に提示されたプロパティをユーザーが選択して deny する**設計が自然と判明しました。ところが現状 view-data が露出しているのは **scope のみ**で、個別 claim（given_name 等）は出していません。claim 単位 consent の前提として、まず view-data が「要求されている claim」を返す必要があります。

## 変更内容

token / userinfo 発行と**同じ claim 解決ロジック**（`GrantIdTokenClaims` / `GrantUserinfoClaims`）を再利用して要求 claim を解決し、view-data に `claims` を追加します（二重実装なし）。

- **`OAuthViewData`**: `requestedClaims` フィールド追加、`contents()` に `"claims"` を出力（`scopes` と並列）
- **`OAuthViewDataCreator`**: `createRequestedClaims()` で `id_token` / `userinfo` / `verified_claims` を解決
- **`VerifiedClaimsObject`**: `requestedClaimNames()`（null安全、`claims` のキー＝要求 verified claim 名）を追加

レスポンス形：
```json
"claims": {
  "id_token": ["given_name", "family_name", "email", ...],
  "userinfo": ["given_name", "family_name", "email", ...],
  "verified_claims": ["given_name", "family_name"]
}
```

### 設計メモ
- `verified_claims` は `claims` パラメータ経由で要求された verified claim 名を展開。`verified_claims:*` scope 経由のものは**モジュール境界**（`SelectiveVerifiedClaims` は extension-ida 側）の都合で core の view creator からは参照できないため、引き続き生 `scopes` で可視。
- `id_token` の claim は id_token strict mode の設定に依存するため、E2E の強い検証は scope 駆動で安定する `userinfo` 側に寄せている。

## テスト

`e2e/src/tests/scenario/application/scenario-consent-view-data-requested-claims.test.js`（新規）

- scope（`openid profile email`）由来の標準 claim が `claims.userinfo` に出る／未要求の `address` は出ない／verified_claims は空
- `claims` パラメータ経由の verified_claims（given_name / family_name）が `claims.verified_claims` に出る

実機（ローカルスタック）で実行し **2/2 pass**。view-data 成功レスポンスを厳密スキーマ照合しているテストは無く、`claims` 追加は純粋に additive（回帰なし）。spec/ ではなく scenario/ に配置（view-data 露出は idp-server 固有能力のため、準拠台帳ルールに混ぜない）。

## 全体ロードマップ（#1653）

| Step | 内容 | 本PR |
|------|------|------|
| **① view-data に claims 露出** | Grant*Claims 再利用、`claims` 追加 | ✅ 本PR |
| ② deny 入力の受け口 | authorize/deny API に拒否 claim/scope 入力 | 次 |
| ③ ConsentClaims 記録 | `OAuthAuthorizeContext` で同意/拒否 claim を記録 | — |
| ④ Assembler consent フィルタ＋xit化 | `VerifiedClaimsAssembler` に consent フィルタ、§5.7.3 xit→it | — |

## 関連
- #1653（親 / claim-level consent §5.7.3）
- #1649（spec準拠E2E。§5.7.3 xit 据え置き中）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
