### PR TITLE
feat: 認証ポリシー駆動の動的認証UI /auth を追加 (#1373)

### DIFF
--- a/app-view/src/auth/http.ts
+++ b/app-view/src/auth/http.ts
@@ -1,0 +1,23 @@
+/**
+ * Extracts a user-facing message from a failed interaction response.
+ *
+ * idp-server returns structured errors ({@code { error, error_description }}); prefer the
+ * description, then the code, then the caller's generic fallback.
+ */
+export const readErrorMessage = async (
+  response: Response,
+  fallback: string,
+): Promise<string> => {
+  try {
+    const body = await response.json();
+    if (typeof body?.error_description === "string" && body.error_description) {
+      return body.error_description;
+    }
+    if (typeof body?.error === "string" && body.error) {
+      return body.error;
+    }
+  } catch {
+    // non-JSON body — fall through to the generic message
+  }
+  return fallback;
+};

--- a/app-view/src/auth/types.ts
+++ b/app-view/src/auth/types.ts
@@ -27,9 +27,20 @@ export type AuthenticationPolicy = {
   [key: string]: unknown;
 };
 
+/** One entry of view-data `available_federations` (mirrors AvailableFederation.toMap). */
+export type Federation = {
+  id?: string;
+  type: string; // e.g. "oidc"
+  sso_provider: string; // e.g. "google"
+  auto_selected?: boolean;
+};
+
 export type ViewData = {
   client_name?: string;
+  logo_uri?: string;
+  scopes?: string[];
   authentication_policy?: AuthenticationPolicy;
+  available_federations?: Federation[];
   custom_params?: Record<string, string>;
   tos_uri?: string;
   policy_uri?: string;

--- a/app-view/src/auth/types.ts
+++ b/app-view/src/auth/types.ts
@@ -1,0 +1,61 @@
+/**
+ * Types for the config-driven authentication flow (Issue #1373).
+ *
+ * The flow is driven entirely by data the backend already returns:
+ * - `view-data` → `authentication_policy.step_definitions` (the ordered step config)
+ * - `authentication-status` → `interaction_results` / `status` (reload-safe progress)
+ *
+ * No backend changes are required; this is the frontend-only contract.
+ */
+
+export type RegistrationMode = "allowed" | "required" | "disabled";
+
+/** One step in `authentication_policy.step_definitions` (mirrors AuthenticationStepDefinition). */
+export type StepDefinition = {
+  method: string; // "password" | "email" | "fido2" | "fido-uaf" | "sms"
+  order: number;
+  requires_user?: boolean; // false = 1st factor (identify), true = 2nd factor (verify)
+  allow_registration?: boolean;
+  registration_mode?: RegistrationMode;
+  user_identity_source?: string; // "email" | "phone_number" | "username"
+  verification_source?: string;
+};
+
+export type AuthenticationPolicy = {
+  step_definitions?: StepDefinition[];
+  available_methods?: string[];
+  [key: string]: unknown;
+};
+
+export type ViewData = {
+  client_name?: string;
+  authentication_policy?: AuthenticationPolicy;
+  custom_params?: Record<string, string>;
+  tos_uri?: string;
+  policy_uri?: string;
+  [key: string]: unknown;
+};
+
+/** One entry of `authentication-status.interaction_results` (mirrors AuthenticationInteractionResult.toMap). */
+export type InteractionResult = {
+  operation_type: string; // "challenge" | "authentication" | "registration" | "deny" | ...
+  method: string;
+  call_count: number;
+  success_count: number;
+  failure_count: number;
+  interaction_time?: string;
+};
+
+/** A step augmented with progress derived from the server status. */
+export type StepView = StepDefinition & {
+  completed: boolean;
+  current: boolean;
+};
+
+export type FlowStatus = "in_progress" | "success" | "failure" | "locked";
+
+export type AuthStatus = {
+  status: FlowStatus | string;
+  interaction_results: Record<string, InteractionResult>;
+  authentication_methods: string[];
+};

--- a/app-view/src/auth/useAuthFlow.ts
+++ b/app-view/src/auth/useAuthFlow.ts
@@ -21,13 +21,21 @@ const TERMINAL_OPERATIONS = new Set(["authentication", "registration"]);
 /** Interaction method that bootstraps account creation for a 1st-factor identify step. */
 const INITIAL_REGISTRATION = "initial-registration";
 
+/** Methods the UI can render; others in available_methods are ignored for step derivation. */
+const KNOWN_METHODS = new Set(["password", "email", "sms", "fido2", "fido-uaf"]);
+
+const singleStep = (method: string): StepDefinition => ({
+  method,
+  order: 1,
+  requires_user: false,
+  allow_registration: false,
+});
+
 /**
- * Fallback flow used when a policy defines no `step_definitions`: a single password authentication
- * step (`allow_registration: false` so it renders as login, not registration).
+ * Fallback flow used when a policy defines neither `step_definitions` nor usable
+ * `available_methods`: a single password authentication step.
  */
-const DEFAULT_STEPS: StepDefinition[] = [
-  { method: "password", order: 1, requires_user: false, allow_registration: false },
-];
+const DEFAULT_STEPS: StepDefinition[] = [singleStep("password")];
 
 const computeCompletedMethods = (status?: AuthStatus): Set<string> => {
   const completed = new Set<string>();
@@ -103,8 +111,22 @@ export const useAuthFlow = (tenantId?: string, id?: string) => {
   const configured: StepDefinition[] = [
     ...(viewData?.authentication_policy?.step_definitions ?? []),
   ].sort((a, b) => a.order - b.order);
-  // No step_definitions configured -> default to password authentication.
-  const definitions = configured.length > 0 ? configured : DEFAULT_STEPS;
+
+  const availableMethods = (
+    viewData?.authentication_policy?.available_methods ?? []
+  ).filter((method) => method !== "initial-registration" && KNOWN_METHODS.has(method));
+
+  // Step source: explicit step_definitions win. Otherwise derive from available_methods — exactly
+  // one method becomes a single step, several methods are offered via a picker (steps stay empty),
+  // and none falls back to password.
+  const definitions =
+    configured.length > 0
+      ? configured
+      : availableMethods.length === 1
+        ? [singleStep(availableMethods[0])]
+        : availableMethods.length === 0
+          ? DEFAULT_STEPS
+          : [];
 
   const completedMethods = computeCompletedMethods(status);
   const flowStatus: FlowStatus | string = status?.status ?? "in_progress";
@@ -131,6 +153,7 @@ export const useAuthFlow = (tenantId?: string, id?: string) => {
     viewData,
     steps,
     currentStep,
+    availableMethods,
     status: flowStatus,
     isComplete,
     isLoading: enabled && (viewDataQuery.isPending || statusQuery.isPending),

--- a/app-view/src/auth/useAuthFlow.ts
+++ b/app-view/src/auth/useAuthFlow.ts
@@ -1,0 +1,142 @@
+import { useQuery } from "@tanstack/react-query";
+import { backendUrl } from "@/pages/_app";
+import {
+  AuthStatus,
+  FlowStatus,
+  StepDefinition,
+  StepView,
+  ViewData,
+} from "./types";
+
+/**
+ * Operation types that mark a step's method as "done".
+ *
+ * A `challenge` also records a success_count (the code was sent), so it must be excluded — the step
+ * is only complete once the matching `authentication` / `registration` succeeds. Using
+ * `interaction_results` (not `authentication_methods`) is required because the latter excludes
+ * registration operations, which the signup flow relies on.
+ */
+const TERMINAL_OPERATIONS = new Set(["authentication", "registration"]);
+
+/** Interaction method that bootstraps account creation for a 1st-factor identify step. */
+const INITIAL_REGISTRATION = "initial-registration";
+
+/**
+ * Fallback flow used when a policy defines no `step_definitions`: a single password authentication
+ * step (`allow_registration: false` so it renders as login, not registration).
+ */
+const DEFAULT_STEPS: StepDefinition[] = [
+  { method: "password", order: 1, requires_user: false, allow_registration: false },
+];
+
+const computeCompletedMethods = (status?: AuthStatus): Set<string> => {
+  const completed = new Set<string>();
+  const results = status?.interaction_results;
+  if (!results) return completed;
+  for (const result of Object.values(results)) {
+    if (
+      result.success_count > 0 &&
+      TERMINAL_OPERATIONS.has((result.operation_type ?? "").toLowerCase())
+    ) {
+      completed.add(result.method);
+    }
+  }
+  return completed;
+};
+
+/**
+ * Interaction methods that satisfy a step.
+ *
+ * The step's own method always counts. Account creation (`initial-registration`, recorded method
+ * "initial-registration") only satisfies a password-based 1st-factor step, where creating the
+ * account with a password *is* the factor. For email / sms 1st-factor steps the factor is a
+ * separate verification (email-authentication / sms-authentication), so the bridge must NOT apply
+ * there — otherwise the step would complete prematurely on account creation, before verification.
+ */
+const acceptingMethods = (step: StepDefinition): string[] => {
+  const methods = [step.method];
+  if (step.method === "password" && step.requires_user === false) {
+    methods.push(INITIAL_REGISTRATION);
+  }
+  return methods;
+};
+
+const fetchJson = async <T>(url: string, label: string): Promise<T> => {
+  const response = await fetch(url, { credentials: "include" });
+  if (!response.ok) throw new Error(`${label} ${response.status}`);
+  return response.json();
+};
+
+/**
+ * Drives the config-driven authentication flow from server data only.
+ *
+ * @returns the ordered steps (with completion derived from the server), the current step
+ *     (lowest-order incomplete), the terminal flow status, and a `refetch` to advance after each
+ *     interaction.
+ */
+export const useAuthFlow = (tenantId?: string, id?: string) => {
+  const enabled = Boolean(tenantId && id);
+
+  const viewDataQuery = useQuery({
+    queryKey: ["auth", "view-data", tenantId, id],
+    enabled,
+    queryFn: () =>
+      fetchJson<ViewData>(
+        `${backendUrl}/${tenantId}/v1/authorizations/${id}/view-data`,
+        "view-data",
+      ),
+  });
+
+  const statusQuery = useQuery({
+    queryKey: ["auth", "status", tenantId, id],
+    enabled,
+    queryFn: () =>
+      fetchJson<AuthStatus>(
+        `${backendUrl}/${tenantId}/v1/authorizations/${id}/authentication-status`,
+        "authentication-status",
+      ),
+  });
+
+  const viewData = viewDataQuery.data;
+  const status = statusQuery.data;
+
+  const configured: StepDefinition[] = [
+    ...(viewData?.authentication_policy?.step_definitions ?? []),
+  ].sort((a, b) => a.order - b.order);
+  // No step_definitions configured -> default to password authentication.
+  const definitions = configured.length > 0 ? configured : DEFAULT_STEPS;
+
+  const completedMethods = computeCompletedMethods(status);
+  const flowStatus: FlowStatus | string = status?.status ?? "in_progress";
+  const isComplete = flowStatus === "success";
+
+  const firstIncompleteOrder = definitions.find(
+    (step) => !acceptingMethods(step).some((m) => completedMethods.has(m)),
+  )?.order;
+
+  const steps: StepView[] = definitions.map((step) => {
+    const completed =
+      isComplete ||
+      acceptingMethods(step).some((m) => completedMethods.has(m));
+    return {
+      ...step,
+      completed,
+      current: !isComplete && step.order === firstIncompleteOrder,
+    };
+  });
+
+  const currentStep = steps.find((step) => step.current) ?? null;
+
+  return {
+    viewData,
+    steps,
+    currentStep,
+    status: flowStatus,
+    isComplete,
+    isLoading: enabled && (viewDataQuery.isPending || statusQuery.isPending),
+    isError: viewDataQuery.isError || statusQuery.isError,
+    refetch: async () => {
+      await Promise.all([viewDataQuery.refetch(), statusQuery.refetch()]);
+    },
+  };
+};

--- a/app-view/src/auth/webauthn.ts
+++ b/app-view/src/auth/webauthn.ts
@@ -1,0 +1,25 @@
+/**
+ * WebAuthn binary <-> Base64URL helpers.
+ *
+ * WebAuthn transmits binary data (challenge, credential id, attestation) as Base64URL strings.
+ * Extracted here so every step component shares one implementation (Safari needs manual
+ * serialization of the credential response).
+ */
+
+/** Convert a Base64URL string to a Uint8Array. */
+export const base64UrlToBuffer = (base64url: string): Uint8Array => {
+  const base64 = base64url.replace(/-/g, "+").replace(/_/g, "/");
+  const binaryString = atob(base64);
+  return Uint8Array.from(binaryString, (char) => char.charCodeAt(0));
+};
+
+/** Convert an ArrayBuffer to a Base64URL string. */
+export const bufferToBase64Url = (buffer: ArrayBuffer): string => {
+  const bytes = new Uint8Array(buffer);
+  let binary = "";
+  for (let i = 0; i < bytes.byteLength; i++) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+  const base64 = btoa(binary);
+  return base64.replace(/\+/g, "-").replace(/\//g, "_").replace(/=/g, "");
+};

--- a/app-view/src/components/auth/AuthAlert.tsx
+++ b/app-view/src/components/auth/AuthAlert.tsx
@@ -1,0 +1,24 @@
+import { Alert } from "@mui/material";
+
+type Props = {
+  message?: string;
+  severity?: "error" | "success" | "info" | "warning";
+};
+
+/**
+ * Inline alert for step feedback. Uses `role="alert"` so screen readers announce errors when they
+ * appear, and renders nothing when there is no message.
+ */
+export const AuthAlert = ({ message, severity = "error" }: Props) => {
+  if (!message) return null;
+  return (
+    <Alert
+      severity={severity}
+      variant="outlined"
+      role="alert"
+      sx={{ borderRadius: 2, alignItems: "center", py: 0.5 }}
+    >
+      {message}
+    </Alert>
+  );
+};

--- a/app-view/src/components/auth/AuthCard.tsx
+++ b/app-view/src/components/auth/AuthCard.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import { ReactNode } from "react";
+import { Box, Paper, Stack, Typography } from "@mui/material";
+import ShieldOutlinedIcon from "@mui/icons-material/ShieldOutlined";
+
+const BrandMark = () => (
+  <Box
+    sx={{
+      width: 48,
+      height: 48,
+      borderRadius: 2.5,
+      bgcolor: "primary.main",
+      color: "primary.contrastText",
+      display: "grid",
+      placeItems: "center",
+      boxShadow: "0 4px 12px rgba(99,91,255,0.35)",
+    }}
+  >
+    <ShieldOutlinedIcon />
+  </Box>
+);
+
+type Props = {
+  title?: string;
+  subtitle?: string;
+  children: ReactNode;
+};
+
+/**
+ * Shared authentication screen frame: a vertically centered, softly elevated card with a branded
+ * header. Every auth screen renders through this so spacing, elevation and the header stay
+ * consistent in one place.
+ */
+export const AuthCard = ({ title, subtitle, children }: Props) => (
+  <Box
+    sx={{
+      minHeight: "100vh",
+      display: "flex",
+      alignItems: "center",
+      justifyContent: "center",
+      bgcolor: "background.default",
+      px: 2,
+      py: 6,
+    }}
+  >
+    <Paper
+      elevation={0}
+      sx={{
+        width: "100%",
+        maxWidth: 420,
+        p: { xs: 3, sm: 5 },
+        borderRadius: 3,
+        border: "1px solid",
+        borderColor: "divider",
+        boxShadow:
+          "0 8px 24px rgba(60,66,87,0.08), 0 2px 6px rgba(0,0,0,0.04)",
+      }}
+    >
+      <Stack spacing={3.5}>
+        <Stack spacing={1.5} alignItems="center" textAlign="center">
+          <BrandMark />
+          {title && (
+            <Typography variant="h5" component="h1">
+              {title}
+            </Typography>
+          )}
+          {subtitle && (
+            <Typography variant="body2" color="text.secondary">
+              {subtitle}
+            </Typography>
+          )}
+        </Stack>
+        {children}
+      </Stack>
+    </Paper>
+  </Box>
+);

--- a/app-view/src/components/auth/AuthCard.tsx
+++ b/app-view/src/components/auth/AuthCard.tsx
@@ -1,29 +1,44 @@
 "use client";
 
 import { ReactNode } from "react";
-import { Box, Paper, Stack, Typography } from "@mui/material";
+import { Avatar, Box, Paper, Stack, Typography } from "@mui/material";
 import ShieldOutlinedIcon from "@mui/icons-material/ShieldOutlined";
 
-const BrandMark = () => (
-  <Box
-    sx={{
-      width: 48,
-      height: 48,
-      borderRadius: 2.5,
-      bgcolor: "primary.main",
-      color: "primary.contrastText",
-      display: "grid",
-      placeItems: "center",
-      boxShadow: "0 4px 12px rgba(99,91,255,0.35)",
-    }}
-  >
-    <ShieldOutlinedIcon />
-  </Box>
-);
+const BrandMark = ({ logoUri }: { logoUri?: string }) => {
+  // Prefer the client's own logo (view-data logo_uri); fall back to a neutral brand mark.
+  if (logoUri) {
+    return (
+      <Avatar
+        src={logoUri}
+        variant="rounded"
+        sx={{ width: 56, height: 56, bgcolor: "background.default", color: "text.secondary" }}
+      >
+        <ShieldOutlinedIcon />
+      </Avatar>
+    );
+  }
+  return (
+    <Box
+      sx={{
+        width: 48,
+        height: 48,
+        borderRadius: 2.5,
+        bgcolor: "primary.main",
+        color: "primary.contrastText",
+        display: "grid",
+        placeItems: "center",
+        boxShadow: "0 4px 12px rgba(99,91,255,0.35)",
+      }}
+    >
+      <ShieldOutlinedIcon />
+    </Box>
+  );
+};
 
 type Props = {
   title?: string;
   subtitle?: string;
+  logoUri?: string;
   children: ReactNode;
 };
 
@@ -32,7 +47,7 @@ type Props = {
  * header. Every auth screen renders through this so spacing, elevation and the header stay
  * consistent in one place.
  */
-export const AuthCard = ({ title, subtitle, children }: Props) => (
+export const AuthCard = ({ title, subtitle, logoUri, children }: Props) => (
   <Box
     sx={{
       minHeight: "100vh",
@@ -59,7 +74,7 @@ export const AuthCard = ({ title, subtitle, children }: Props) => (
     >
       <Stack spacing={3.5}>
         <Stack spacing={1.5} alignItems="center" textAlign="center">
-          <BrandMark />
+          <BrandMark logoUri={logoUri} />
           {title && (
             <Typography variant="h5" component="h1">
               {title}

--- a/app-view/src/components/auth/AuthCard.tsx
+++ b/app-view/src/components/auth/AuthCard.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { ReactNode } from "react";
-import { Avatar, Box, Paper, Stack, Typography } from "@mui/material";
+import { Avatar, Box, Link, Paper, Stack, Typography } from "@mui/material";
 import ShieldOutlinedIcon from "@mui/icons-material/ShieldOutlined";
 
 const BrandMark = ({ logoUri }: { logoUri?: string }) => {
@@ -39,7 +39,38 @@ type Props = {
   title?: string;
   subtitle?: string;
   logoUri?: string;
+  tosUri?: string;
+  policyUri?: string;
+  /** Replaces the default brand mark in the header (e.g. an error badge). */
+  icon?: ReactNode;
   children: ReactNode;
+};
+
+const LegalFooter = ({
+  tosUri,
+  policyUri,
+}: {
+  tosUri?: string;
+  policyUri?: string;
+}) => {
+  if (!tosUri && !policyUri) return null;
+  return (
+    <Typography variant="caption" color="text.secondary" textAlign="center">
+      By continuing you agree to our{" "}
+      {tosUri && (
+        <Link href={tosUri} target="_blank" rel="noopener" underline="hover">
+          Terms
+        </Link>
+      )}
+      {tosUri && policyUri && " and "}
+      {policyUri && (
+        <Link href={policyUri} target="_blank" rel="noopener" underline="hover">
+          Privacy Policy
+        </Link>
+      )}
+      .
+    </Typography>
+  );
 };
 
 /**
@@ -47,7 +78,15 @@ type Props = {
  * header. Every auth screen renders through this so spacing, elevation and the header stay
  * consistent in one place.
  */
-export const AuthCard = ({ title, subtitle, logoUri, children }: Props) => (
+export const AuthCard = ({
+  title,
+  subtitle,
+  logoUri,
+  tosUri,
+  policyUri,
+  icon,
+  children,
+}: Props) => (
   <Box
     sx={{
       minHeight: "100vh",
@@ -74,7 +113,7 @@ export const AuthCard = ({ title, subtitle, logoUri, children }: Props) => (
     >
       <Stack spacing={3.5}>
         <Stack spacing={1.5} alignItems="center" textAlign="center">
-          <BrandMark logoUri={logoUri} />
+          {icon ?? <BrandMark logoUri={logoUri} />}
           {title && (
             <Typography variant="h5" component="h1">
               {title}
@@ -87,6 +126,7 @@ export const AuthCard = ({ title, subtitle, logoUri, children }: Props) => (
           )}
         </Stack>
         {children}
+        <LegalFooter tosUri={tosUri} policyUri={policyUri} />
       </Stack>
     </Paper>
   </Box>

--- a/app-view/src/components/auth/ConfigDrivenStepper.tsx
+++ b/app-view/src/components/auth/ConfigDrivenStepper.tsx
@@ -1,0 +1,45 @@
+import { Step, StepLabel, Stepper } from "@mui/material";
+import { StepView } from "@/auth/types";
+
+const METHOD_LABELS: Record<string, string> = {
+  password: "Account",
+  email: "Email",
+  sms: "SMS",
+  fido2: "Passkey",
+  "fido-uaf": "Device",
+};
+
+const labelFor = (step: StepView): string =>
+  METHOD_LABELS[step.method] ?? step.method;
+
+type Props = {
+  steps: StepView[];
+  isComplete: boolean;
+};
+
+/**
+ * Progress stepper generated from `step_definitions` (no hardcoded step list).
+ *
+ * Completion/active state is derived server-side in {@link useAuthFlow}, so the stepper survives
+ * reload and direct page access.
+ */
+export const ConfigDrivenStepper = ({ steps, isComplete }: Props) => {
+  if (steps.length === 0) return null;
+
+  const activeIndex = isComplete
+    ? steps.length
+    : steps.findIndex((step) => step.current);
+
+  return (
+    <Stepper
+      activeStep={activeIndex === -1 ? steps.length : activeIndex}
+      alternativeLabel
+    >
+      {steps.map((step) => (
+        <Step key={`${step.order}-${step.method}`} completed={step.completed}>
+          <StepLabel>{labelFor(step)}</StepLabel>
+        </Step>
+      ))}
+    </Stepper>
+  );
+};

--- a/app-view/src/components/auth/MethodPicker.tsx
+++ b/app-view/src/components/auth/MethodPicker.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { Button, Stack, Typography } from "@mui/material";
+
+const METHOD_LABELS: Record<string, string> = {
+  password: "Password",
+  email: "Email code",
+  sms: "SMS code",
+  fido2: "Passkey",
+  "fido-uaf": "Registered device",
+};
+
+const labelFor = (method: string): string => METHOD_LABELS[method] ?? method;
+
+type Props = {
+  methods: string[];
+  onSelect: (method: string) => void;
+};
+
+/**
+ * Lets the user choose how to verify when a policy offers several methods but no fixed step order
+ * (e.g. an ACR step-up allowing passkey or registered device).
+ */
+export const MethodPicker = ({ methods, onSelect }: Props) => (
+  <Stack spacing={1.5}>
+    <Typography variant="body2" color="text.secondary">
+      Choose how to verify your identity.
+    </Typography>
+    {methods.map((method) => (
+      <Button
+        key={method}
+        variant="outlined"
+        color="inherit"
+        fullWidth
+        onClick={() => onSelect(method)}
+        sx={{
+          justifyContent: "flex-start",
+          borderColor: "divider",
+          color: "text.primary",
+          py: 1.2,
+        }}
+      >
+        {labelFor(method)}
+      </Button>
+    ))}
+  </Stack>
+);

--- a/app-view/src/components/auth/OtpInput.tsx
+++ b/app-view/src/components/auth/OtpInput.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+import {
+  ChangeEvent,
+  ClipboardEvent,
+  KeyboardEvent,
+  useRef,
+} from "react";
+import { Stack, TextField } from "@mui/material";
+
+type Props = {
+  value: string;
+  onChange: (value: string) => void;
+  length?: number;
+  autoFocus?: boolean;
+  disabled?: boolean;
+};
+
+/**
+ * Segmented one-time-code input: one box per digit with auto-advance, backspace-to-previous,
+ * arrow navigation and full paste support. The value is the joined string (e.g. "123456").
+ */
+export const OtpInput = ({
+  value,
+  onChange,
+  length = 6,
+  autoFocus,
+  disabled,
+}: Props) => {
+  const refs = useRef<Array<HTMLInputElement | null>>([]);
+
+  const setChar = (index: number, char: string) => {
+    const chars = value.split("");
+    chars[index] = char;
+    onChange(chars.join("").slice(0, length));
+  };
+
+  const handleChange =
+    (index: number) => (event: ChangeEvent<HTMLInputElement>) => {
+      const digit = event.target.value.replace(/\D/g, "").slice(-1);
+      if (!digit) return;
+      setChar(index, digit);
+      if (index < length - 1) refs.current[index + 1]?.focus();
+    };
+
+  const handleKeyDown =
+    (index: number) => (event: KeyboardEvent<HTMLInputElement>) => {
+      if (event.key === "Backspace") {
+        event.preventDefault();
+        if (value[index]) {
+          setChar(index, "");
+        } else if (index > 0) {
+          setChar(index - 1, "");
+          refs.current[index - 1]?.focus();
+        }
+      } else if (event.key === "ArrowLeft" && index > 0) {
+        refs.current[index - 1]?.focus();
+      } else if (event.key === "ArrowRight" && index < length - 1) {
+        refs.current[index + 1]?.focus();
+      }
+    };
+
+  const handlePaste = (event: ClipboardEvent<HTMLInputElement>) => {
+    event.preventDefault();
+    const digits = event.clipboardData
+      .getData("text")
+      .replace(/\D/g, "")
+      .slice(0, length);
+    if (!digits) return;
+    onChange(digits);
+    refs.current[Math.min(digits.length, length - 1)]?.focus();
+  };
+
+  return (
+    <Stack
+      direction="row"
+      spacing={1}
+      justifyContent="center"
+      onPaste={handlePaste}
+    >
+      {Array.from({ length }).map((_, index) => (
+        <TextField
+          key={index}
+          inputRef={(el: HTMLInputElement | null) => {
+            refs.current[index] = el;
+          }}
+          value={value[index] ?? ""}
+          onChange={handleChange(index)}
+          onKeyDown={handleKeyDown(index)}
+          autoFocus={autoFocus && index === 0}
+          disabled={disabled}
+          inputProps={{
+            inputMode: "numeric",
+            maxLength: 1,
+            "aria-label": `Digit ${index + 1}`,
+            autoComplete: index === 0 ? "one-time-code" : "off",
+            style: {
+              textAlign: "center",
+              fontSize: "1.25rem",
+              padding: "10px 0",
+            },
+          }}
+          sx={{ width: 44 }}
+        />
+      ))}
+    </Stack>
+  );
+};

--- a/app-view/src/components/auth/SsoButtons.tsx
+++ b/app-view/src/components/auth/SsoButtons.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import { useState } from "react";
+import { Button, Stack, Typography } from "@mui/material";
+import Image from "next/image";
+import { backendUrl } from "@/pages/_app";
+import { Federation } from "@/auth/types";
+
+/** Display label / logo per known SSO provider; unknown providers fall back to a capitalized name. */
+const PROVIDER_META: Record<string, { label: string; logo?: string }> = {
+  google: { label: "Google", logo: "/logos/google.svg" },
+  yahoo: { label: "Yahoo! JAPAN", logo: "/logos/yahoo_japan_icon_64.png" },
+};
+
+const labelFor = (provider: string): string =>
+  PROVIDER_META[provider]?.label ??
+  provider.charAt(0).toUpperCase() + provider.slice(1);
+
+type Props = {
+  tenantId: string;
+  id: string;
+  federations: Federation[];
+};
+
+/**
+ * Federated sign-in buttons, driven by view-data `available_federations`.
+ *
+ * Each button starts the federation by POSTing to
+ * `/{tenant}/v1/authorizations/{id}/federations/{type}/{sso_provider}` and following the returned
+ * redirect_uri to the upstream IdP.
+ */
+export const SsoButtons = ({ tenantId, id, federations }: Props) => {
+  const [pending, setPending] = useState<string | null>(null);
+  const [message, setMessage] = useState("");
+
+  const start = async (federation: Federation) => {
+    setPending(federation.sso_provider);
+    setMessage("");
+    try {
+      const response = await fetch(
+        `${backendUrl}/${tenantId}/v1/authorizations/${id}/federations/${federation.type}/${federation.sso_provider}`,
+        {
+          method: "POST",
+          credentials: "include",
+          headers: { "Content-Type": "application/json" },
+        },
+      );
+      const body = await response.json().catch(() => ({}));
+      if (response.ok && body.redirect_uri) {
+        window.location.href = body.redirect_uri;
+        return;
+      }
+      setMessage("We couldn't start that sign-in. Please try again.");
+    } catch {
+      setMessage("We couldn't start that sign-in. Please try again.");
+    } finally {
+      setPending(null);
+    }
+  };
+
+  return (
+    <Stack spacing={1.5}>
+      {federations.map((federation) => {
+        const meta = PROVIDER_META[federation.sso_provider];
+        return (
+          <Button
+            key={federation.id ?? `${federation.type}-${federation.sso_provider}`}
+            variant="outlined"
+            color="inherit"
+            fullWidth
+            disabled={pending !== null}
+            onClick={() => start(federation)}
+            startIcon={
+              meta?.logo ? (
+                <Image src={meta.logo} alt="" width={18} height={18} />
+              ) : undefined
+            }
+            sx={{
+              justifyContent: "center",
+              borderColor: "divider",
+              color: "text.primary",
+              py: 1.1,
+            }}
+          >
+            Continue with {labelFor(federation.sso_provider)}
+          </Button>
+        );
+      })}
+      {message && (
+        <Typography variant="caption" color="error">
+          {message}
+        </Typography>
+      )}
+    </Stack>
+  );
+};

--- a/app-view/src/components/auth/StepRenderer.tsx
+++ b/app-view/src/components/auth/StepRenderer.tsx
@@ -10,6 +10,7 @@ import { EmailVerifyStep } from "./steps/EmailVerifyStep";
 import { SmsStep } from "./steps/SmsStep";
 import { Fido2Step } from "./steps/Fido2Step";
 import { Fido2AuthStep } from "./steps/Fido2AuthStep";
+import { FidoUafStep } from "./steps/FidoUafStep";
 
 /**
  * Whether a step verifies an existing credential rather than registering a new one.
@@ -45,6 +46,8 @@ const resolveStepComponent = (
       return SmsStep;
     case "fido2":
       return isAuthenticateOnly(step) ? Fido2AuthStep : Fido2Step;
+    case "fido-uaf":
+      return FidoUafStep;
     default:
       return undefined;
   }

--- a/app-view/src/components/auth/StepRenderer.tsx
+++ b/app-view/src/components/auth/StepRenderer.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import { ComponentType } from "react";
+import { Typography } from "@mui/material";
+import { StepView } from "@/auth/types";
+import { StepProps } from "./steps/StepProps";
+import { RegisterStep } from "./steps/RegisterStep";
+import { PasswordAuthStep } from "./steps/PasswordAuthStep";
+import { EmailVerifyStep } from "./steps/EmailVerifyStep";
+import { SmsStep } from "./steps/SmsStep";
+import { Fido2Step } from "./steps/Fido2Step";
+import { Fido2AuthStep } from "./steps/Fido2AuthStep";
+
+/**
+ * Whether a step verifies an existing credential rather than registering a new one.
+ *
+ * `allow_registration: false` (or `registration_mode: "disabled"`) marks a pure 2nd-factor
+ * verification — e.g. the financial-grade `fido2` step that uses `fido2-authentication`. Otherwise
+ * the step may register a new credential.
+ */
+const isAuthenticateOnly = (step: StepView): boolean =>
+  step.allow_registration === false || step.registration_mode === "disabled";
+
+/**
+ * Resolves a step to its component from `method` plus the register/authenticate distinction.
+ *
+ * Adding a new method (or a new register/authenticate variant) means editing only this resolver —
+ * no new page or route. Steps with no mapping fall back to a notice.
+ */
+const resolveStepComponent = (
+  step: StepView,
+  passwordRegister?: boolean,
+): ComponentType<StepProps> | undefined => {
+  switch (step.method) {
+    case "password":
+      // The page may override login vs. registration via the account toggle; otherwise fall back
+      // to the step's own register/authenticate distinction.
+      if (passwordRegister !== undefined) {
+        return passwordRegister ? RegisterStep : PasswordAuthStep;
+      }
+      return isAuthenticateOnly(step) ? PasswordAuthStep : RegisterStep;
+    case "email":
+      return EmailVerifyStep;
+    case "sms":
+      return SmsStep;
+    case "fido2":
+      return isAuthenticateOnly(step) ? Fido2AuthStep : Fido2Step;
+    default:
+      return undefined;
+  }
+};
+
+type StepRendererProps = StepProps & {
+  /** Overrides the password step between registration (true) and login (false). */
+  passwordRegister?: boolean;
+};
+
+export const StepRenderer = ({ passwordRegister, ...props }: StepRendererProps) => {
+  const Component = resolveStepComponent(props.step, passwordRegister);
+  if (!Component) {
+    return (
+      <Typography color="text.secondary" variant="body2">
+        Unsupported authentication step: {props.step.method}
+      </Typography>
+    );
+  }
+  return <Component {...props} />;
+};

--- a/app-view/src/components/auth/steps/ConsentStep.tsx
+++ b/app-view/src/components/auth/steps/ConsentStep.tsx
@@ -2,8 +2,20 @@
 
 import { useState } from "react";
 import { Box, Button, CircularProgress, Stack, Typography } from "@mui/material";
+import CheckCircleOutlineIcon from "@mui/icons-material/CheckCircleOutline";
 import { backendUrl } from "@/pages/_app";
 import { ViewData } from "@/auth/types";
+
+/** Human-readable labels for common scopes; unknown scopes are shown as-is. */
+const SCOPE_LABELS: Record<string, string> = {
+  profile: "Your basic profile",
+  email: "Your email address",
+  phone: "Your phone number",
+  address: "Your address",
+  offline_access: "Keep you signed in",
+};
+
+const describeScope = (scope: string): string => SCOPE_LABELS[scope] ?? scope;
 
 type Props = {
   tenantId: string;
@@ -19,6 +31,12 @@ type Props = {
  */
 export const ConsentStep = ({ tenantId, id, viewData }: Props) => {
   const [loading, setLoading] = useState(false);
+
+  const clientName = viewData?.client_name ?? "the application";
+  // "openid" is a protocol marker, not a user-facing permission.
+  const permissions = (viewData?.scopes ?? []).filter(
+    (scope) => scope !== "openid",
+  );
 
   const submit = async (action: "authorize" | "deny") => {
     setLoading(true);
@@ -45,9 +63,40 @@ export const ConsentStep = ({ tenantId, id, viewData }: Props) => {
   return (
     <Stack spacing={3}>
       <Typography variant="body2" color="text.secondary">
-        Continue to {viewData?.client_name ?? "the application"} to finish signing
-        in.
+        Continue to {clientName} to finish signing in.
       </Typography>
+      {permissions.length > 0 && (
+        <Box
+          sx={{
+            borderRadius: 2,
+            border: "1px solid",
+            borderColor: "divider",
+            p: 2,
+          }}
+        >
+          <Typography variant="caption" color="text.secondary">
+            {clientName} will be able to access
+          </Typography>
+          <Stack
+            component="ul"
+            spacing={1}
+            sx={{ listStyle: "none", pl: 0, m: 0, mt: 1 }}
+          >
+            {permissions.map((scope) => (
+              <Stack
+                key={scope}
+                component="li"
+                direction="row"
+                spacing={1}
+                alignItems="center"
+              >
+                <CheckCircleOutlineIcon fontSize="small" color="success" />
+                <Typography variant="body2">{describeScope(scope)}</Typography>
+              </Stack>
+            ))}
+          </Stack>
+        </Box>
+      )}
       <Box display="flex" justifyContent="space-between" gap={2}>
         <Button
           variant="outlined"

--- a/app-view/src/components/auth/steps/ConsentStep.tsx
+++ b/app-view/src/components/auth/steps/ConsentStep.tsx
@@ -45,7 +45,8 @@ export const ConsentStep = ({ tenantId, id, viewData }: Props) => {
   return (
     <Stack spacing={3}>
       <Typography variant="body2" color="text.secondary">
-        Continue to {viewData?.client_name ?? "the application"}.
+        Continue to {viewData?.client_name ?? "the application"} to finish signing
+        in.
       </Typography>
       <Box display="flex" justifyContent="space-between" gap={2}>
         <Button

--- a/app-view/src/components/auth/steps/ConsentStep.tsx
+++ b/app-view/src/components/auth/steps/ConsentStep.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import { useState } from "react";
+import { Box, Button, CircularProgress, Stack, Typography } from "@mui/material";
+import { backendUrl } from "@/pages/_app";
+import { ViewData } from "@/auth/types";
+
+type Props = {
+  tenantId: string;
+  id: string;
+  viewData?: ViewData;
+};
+
+/**
+ * Terminal consent step, shown once the authentication flow status is "success".
+ *
+ * Allow → `authorize`, Deny → `deny`; both redirect back to the client via the returned
+ * `redirect_uri`.
+ */
+export const ConsentStep = ({ tenantId, id, viewData }: Props) => {
+  const [loading, setLoading] = useState(false);
+
+  const submit = async (action: "authorize" | "deny") => {
+    setLoading(true);
+    try {
+      const response = await fetch(
+        `${backendUrl}/${tenantId}/v1/authorizations/${id}/${action}`,
+        {
+          method: "POST",
+          credentials: "include",
+          headers: { "Content-Type": "application/json" },
+          body:
+            action === "authorize"
+              ? JSON.stringify({ action: "signup" })
+              : undefined,
+        },
+      );
+      const body = await response.json().catch(() => ({}));
+      if (body.redirect_uri) window.location.href = body.redirect_uri;
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Stack spacing={3}>
+      <Typography variant="body2" color="text.secondary">
+        Continue to {viewData?.client_name ?? "the application"}.
+      </Typography>
+      <Box display="flex" justifyContent="space-between" gap={2}>
+        <Button
+          variant="outlined"
+          disabled={loading}
+          onClick={() => submit("deny")}
+          sx={{ textTransform: "none" }}
+          fullWidth
+        >
+          Cancel
+        </Button>
+        <Button
+          variant="contained"
+          disabled={loading}
+          onClick={() => submit("authorize")}
+          sx={{ textTransform: "none" }}
+          fullWidth
+        >
+          {loading ? <CircularProgress size={24} /> : "Continue"}
+        </Button>
+      </Box>
+    </Stack>
+  );
+};

--- a/app-view/src/components/auth/steps/EmailVerifyStep.tsx
+++ b/app-view/src/components/auth/steps/EmailVerifyStep.tsx
@@ -67,7 +67,7 @@ export const EmailVerifyStep = ({ tenantId, id, onCompleted }: StepProps) => {
         },
       );
       if (!response.ok) {
-        setMessage("Invalid verification code. Please check and try again.");
+        setMessage("That code is incorrect or has expired. Please try again.");
         return;
       }
       await onCompleted();
@@ -79,7 +79,8 @@ export const EmailVerifyStep = ({ tenantId, id, onCompleted }: StepProps) => {
   return (
     <Stack spacing={3}>
       <Typography variant="body2" color="text.secondary">
-        Enter the 6-digit code we sent to {identifier || "your email"}.
+        We sent a 6-digit code to {identifier || "your email"}. Enter it below to
+        continue.
       </Typography>
       <TextField
         label="Verification code"

--- a/app-view/src/components/auth/steps/EmailVerifyStep.tsx
+++ b/app-view/src/components/auth/steps/EmailVerifyStep.tsx
@@ -84,9 +84,14 @@ export const EmailVerifyStep = ({ tenantId, id, onCompleted }: StepProps) => {
       </Typography>
       <TextField
         label="Verification code"
+        autoFocus
         value={code}
         onChange={(e) => setCode(e.target.value)}
-        inputProps={{ inputMode: "numeric" }}
+        inputProps={{
+          inputMode: "numeric",
+          autoComplete: "one-time-code",
+          maxLength: 6,
+        }}
       />
       {message && (
         <Typography color="error" variant="body2">

--- a/app-view/src/components/auth/steps/EmailVerifyStep.tsx
+++ b/app-view/src/components/auth/steps/EmailVerifyStep.tsx
@@ -1,18 +1,16 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
-import {
-  Box,
-  Button,
-  CircularProgress,
-  Stack,
-  TextField,
-  Typography,
-} from "@mui/material";
+import { Box, Button, CircularProgress, Stack, Typography } from "@mui/material";
 import { useAtom } from "jotai";
 import { backendUrl } from "@/pages/_app";
+import { readErrorMessage } from "@/auth/http";
 import { authIdentifierAtom } from "@/state/AuthState";
+import { AuthAlert } from "@/components/auth/AuthAlert";
+import { OtpInput } from "@/components/auth/OtpInput";
 import { StepProps } from "./StepProps";
+
+const CODE_LENGTH = 6;
 
 /**
  * Email verification step (method "email").
@@ -67,7 +65,12 @@ export const EmailVerifyStep = ({ tenantId, id, onCompleted }: StepProps) => {
         },
       );
       if (!response.ok) {
-        setMessage("That code is incorrect or has expired. Please try again.");
+        setMessage(
+          await readErrorMessage(
+            response,
+            "That code is incorrect or has expired. Please try again.",
+          ),
+        );
         return;
       }
       await onCompleted();
@@ -82,22 +85,8 @@ export const EmailVerifyStep = ({ tenantId, id, onCompleted }: StepProps) => {
         We sent a 6-digit code to {identifier || "your email"}. Enter it below to
         continue.
       </Typography>
-      <TextField
-        label="Verification code"
-        autoFocus
-        value={code}
-        onChange={(e) => setCode(e.target.value)}
-        inputProps={{
-          inputMode: "numeric",
-          autoComplete: "one-time-code",
-          maxLength: 6,
-        }}
-      />
-      {message && (
-        <Typography color="error" variant="body2">
-          {message}
-        </Typography>
-      )}
+      <OtpInput value={code} onChange={setCode} length={CODE_LENGTH} autoFocus />
+      <AuthAlert message={message} />
       <Box display="flex" justifyContent="space-between" alignItems="center">
         <Button
           variant="text"
@@ -109,7 +98,7 @@ export const EmailVerifyStep = ({ tenantId, id, onCompleted }: StepProps) => {
         </Button>
         <Button
           variant="contained"
-          disabled={loading || !code}
+          disabled={loading || code.length < CODE_LENGTH}
           onClick={handleVerify}
           sx={{ textTransform: "none" }}
         >

--- a/app-view/src/components/auth/steps/EmailVerifyStep.tsx
+++ b/app-view/src/components/auth/steps/EmailVerifyStep.tsx
@@ -1,0 +1,115 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import {
+  Box,
+  Button,
+  CircularProgress,
+  Stack,
+  TextField,
+  Typography,
+} from "@mui/material";
+import { useAtom } from "jotai";
+import { backendUrl } from "@/pages/_app";
+import { authIdentifierAtom } from "@/state/AuthState";
+import { StepProps } from "./StepProps";
+
+/**
+ * Email verification step (method "email").
+ *
+ * Sends the challenge on mount (once) using the persisted identifier, then verifies the code. The
+ * identifier comes from {@link authIdentifierAtom}, so this works on reload / direct access.
+ */
+export const EmailVerifyStep = ({ tenantId, id, onCompleted }: StepProps) => {
+  const [identifier] = useAtom(authIdentifierAtom);
+  const [code, setCode] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [resending, setResending] = useState(false);
+  const [message, setMessage] = useState("");
+  const challengeSent = useRef(false);
+
+  const sendChallenge = async () => {
+    if (!identifier) return;
+    setResending(true);
+    try {
+      await fetch(
+        `${backendUrl}/${tenantId}/v1/authorizations/${id}/email-authentication-challenge`,
+        {
+          method: "POST",
+          credentials: "include",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ email: identifier }),
+        },
+      );
+    } finally {
+      setResending(false);
+    }
+  };
+
+  useEffect(() => {
+    if (challengeSent.current) return;
+    challengeSent.current = true;
+    void sendChallenge();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const handleVerify = async () => {
+    setLoading(true);
+    setMessage("");
+    try {
+      const response = await fetch(
+        `${backendUrl}/${tenantId}/v1/authorizations/${id}/email-authentication`,
+        {
+          method: "POST",
+          credentials: "include",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ verification_code: code }),
+        },
+      );
+      if (!response.ok) {
+        setMessage("Invalid verification code. Please check and try again.");
+        return;
+      }
+      await onCompleted();
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Stack spacing={3}>
+      <Typography variant="body2" color="text.secondary">
+        Enter the 6-digit code we sent to {identifier || "your email"}.
+      </Typography>
+      <TextField
+        label="Verification code"
+        value={code}
+        onChange={(e) => setCode(e.target.value)}
+        inputProps={{ inputMode: "numeric" }}
+      />
+      {message && (
+        <Typography color="error" variant="body2">
+          {message}
+        </Typography>
+      )}
+      <Box display="flex" justifyContent="space-between" alignItems="center">
+        <Button
+          variant="text"
+          disabled={resending}
+          onClick={sendChallenge}
+          sx={{ textTransform: "none" }}
+        >
+          {resending ? "Sending..." : "Resend code"}
+        </Button>
+        <Button
+          variant="contained"
+          disabled={loading || !code}
+          onClick={handleVerify}
+          sx={{ textTransform: "none" }}
+        >
+          {loading ? <CircularProgress size={24} /> : "Verify"}
+        </Button>
+      </Box>
+    </Stack>
+  );
+};

--- a/app-view/src/components/auth/steps/Fido2AuthStep.tsx
+++ b/app-view/src/components/auth/steps/Fido2AuthStep.tsx
@@ -12,8 +12,10 @@ import {
 import FingerprintIcon from "@mui/icons-material/Fingerprint";
 import { useAtom } from "jotai";
 import { backendUrl } from "@/pages/_app";
+import { readErrorMessage } from "@/auth/http";
 import { authIdentifierAtom } from "@/state/AuthState";
 import { base64UrlToBuffer, bufferToBase64Url } from "@/auth/webauthn";
+import { AuthAlert } from "@/components/auth/AuthAlert";
 import { StepProps } from "./StepProps";
 
 type Credential = {
@@ -69,7 +71,12 @@ export const Fido2AuthStep = ({ tenantId, id, onCompleted }: StepProps) => {
         },
       );
       if (!challengeRes.ok) {
-        setMessage("We couldn't start passkey sign-in. Please try again.");
+        setMessage(
+          await readErrorMessage(
+            challengeRes,
+            "We couldn't start passkey sign-in. Please try again.",
+          ),
+        );
         return;
       }
 
@@ -138,7 +145,12 @@ export const Fido2AuthStep = ({ tenantId, id, onCompleted }: StepProps) => {
         },
       );
       if (!authRes.ok) {
-        setMessage("We couldn't verify your passkey. Please try again.");
+        setMessage(
+          await readErrorMessage(
+            authRes,
+            "We couldn't verify your passkey. Please try again.",
+          ),
+        );
         return;
       }
       await onCompleted();
@@ -174,11 +186,7 @@ export const Fido2AuthStep = ({ tenantId, id, onCompleted }: StepProps) => {
       <Box display="flex" justifyContent="center">
         <FingerprintIcon sx={{ fontSize: 40, color: "primary.main" }} />
       </Box>
-      {message && (
-        <Typography color="error" variant="body2" align="center">
-          {message}
-        </Typography>
-      )}
+      <AuthAlert message={message} />
       <Button
         variant="contained"
         disabled={loading}

--- a/app-view/src/components/auth/steps/Fido2AuthStep.tsx
+++ b/app-view/src/components/auth/steps/Fido2AuthStep.tsx
@@ -49,7 +49,9 @@ export const Fido2AuthStep = ({ tenantId, id, onCompleted }: StepProps) => {
     setMessage("");
     try {
       if (!window.PublicKeyCredential) {
-        setMessage("Your browser does not support passkeys.");
+        setMessage(
+          "This browser doesn't support passkeys. Try a different browser or device.",
+        );
         return;
       }
 
@@ -67,7 +69,7 @@ export const Fido2AuthStep = ({ tenantId, id, onCompleted }: StepProps) => {
         },
       );
       if (!challengeRes.ok) {
-        setMessage("Failed to get authentication challenge. Please try again.");
+        setMessage("We couldn't start passkey sign-in. Please try again.");
         return;
       }
 
@@ -103,7 +105,7 @@ export const Fido2AuthStep = ({ tenantId, id, onCompleted }: StepProps) => {
         mediation: "optional",
       })) as PublicKeyCredential | null;
       if (!credential) {
-        setMessage("No credential received from authenticator.");
+        setMessage("No passkey was used. Please try again.");
         return;
       }
 
@@ -136,7 +138,7 @@ export const Fido2AuthStep = ({ tenantId, id, onCompleted }: StepProps) => {
         },
       );
       if (!authRes.ok) {
-        setMessage("Passkey authentication failed.");
+        setMessage("We couldn't verify your passkey. Please try again.");
         return;
       }
       await onCompleted();
@@ -145,9 +147,9 @@ export const Fido2AuthStep = ({ tenantId, id, onCompleted }: StepProps) => {
         error instanceof Error &&
         (error.name === "NotAllowedError" || error.name === "AbortError")
       ) {
-        setMessage("Authentication was cancelled. Please try again.");
+        setMessage("Passkey sign-in was cancelled. Please try again.");
       } else {
-        setMessage("An error occurred during authentication.");
+        setMessage("Something went wrong verifying your passkey. Please try again.");
       }
     } finally {
       setLoading(false);
@@ -157,7 +159,7 @@ export const Fido2AuthStep = ({ tenantId, id, onCompleted }: StepProps) => {
   return (
     <Stack spacing={3}>
       <Typography variant="body2" color="text.secondary">
-        Verify with your passkey to continue.
+        Use your passkey to continue.
       </Typography>
       {!identifier && (
         <TextField
@@ -181,7 +183,7 @@ export const Fido2AuthStep = ({ tenantId, id, onCompleted }: StepProps) => {
         fullWidth
         sx={{ textTransform: "none" }}
       >
-        {loading ? <CircularProgress size={24} /> : "Verify Passkey"}
+        {loading ? <CircularProgress size={24} /> : "Use passkey"}
       </Button>
     </Stack>
   );

--- a/app-view/src/components/auth/steps/Fido2AuthStep.tsx
+++ b/app-view/src/components/auth/steps/Fido2AuthStep.tsx
@@ -164,6 +164,9 @@ export const Fido2AuthStep = ({ tenantId, id, onCompleted }: StepProps) => {
       {!identifier && (
         <TextField
           label="Email"
+          type="email"
+          autoComplete="email"
+          autoFocus
           value={username}
           onChange={(e) => setUsername(e.target.value)}
         />

--- a/app-view/src/components/auth/steps/Fido2AuthStep.tsx
+++ b/app-view/src/components/auth/steps/Fido2AuthStep.tsx
@@ -1,0 +1,188 @@
+"use client";
+
+import { useState } from "react";
+import {
+  Box,
+  Button,
+  CircularProgress,
+  Stack,
+  TextField,
+  Typography,
+} from "@mui/material";
+import FingerprintIcon from "@mui/icons-material/Fingerprint";
+import { useAtom } from "jotai";
+import { backendUrl } from "@/pages/_app";
+import { authIdentifierAtom } from "@/state/AuthState";
+import { base64UrlToBuffer, bufferToBase64Url } from "@/auth/webauthn";
+import { StepProps } from "./StepProps";
+
+type Credential = {
+  id: string;
+  type: string;
+  transports?: AuthenticatorTransport[];
+};
+
+type ChallengeResponse = {
+  challenge: string;
+  timeout?: number;
+  rp_id?: string;
+  rp?: { id?: string };
+  allowCredentials?: Credential[];
+  user_verification?: UserVerificationRequirement;
+};
+
+/**
+ * Passkey authentication step (method "fido2", 2nd factor — `allow_registration: false`).
+ *
+ * Verifies an existing passkey via {@code navigator.credentials.get}. The username comes from the
+ * persisted identifier so it survives reload. Use {@code Fido2Step} instead when the step registers
+ * a new passkey.
+ */
+export const Fido2AuthStep = ({ tenantId, id, onCompleted }: StepProps) => {
+  const [identifier] = useAtom(authIdentifierAtom);
+  const [username, setUsername] = useState(identifier);
+  const [loading, setLoading] = useState(false);
+  const [message, setMessage] = useState("");
+
+  const handleAuthenticate = async () => {
+    setLoading(true);
+    setMessage("");
+    try {
+      if (!window.PublicKeyCredential) {
+        setMessage("Your browser does not support passkeys.");
+        return;
+      }
+
+      const challengeRes = await fetch(
+        `${backendUrl}/${tenantId}/v1/authorizations/${id}/fido2-authentication-challenge`,
+        {
+          method: "POST",
+          credentials: "include",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            username,
+            userVerification: "required",
+            timeout: 60000,
+          }),
+        },
+      );
+      if (!challengeRes.ok) {
+        setMessage("Failed to get authentication challenge. Please try again.");
+        return;
+      }
+
+      const {
+        challenge,
+        timeout = 60000,
+        rp_id,
+        rp,
+        allowCredentials = [],
+        user_verification = "required",
+      }: ChallengeResponse = await challengeRes.json();
+
+      const publicKeyOptions: PublicKeyCredentialRequestOptions = {
+        challenge: base64UrlToBuffer(challenge),
+        timeout,
+        userVerification: user_verification,
+      };
+      const rpId = rp_id || rp?.id;
+      if (rpId) publicKeyOptions.rpId = rpId;
+      if (allowCredentials.length > 0) {
+        publicKeyOptions.allowCredentials = allowCredentials.map((cred) => {
+          const descriptor: PublicKeyCredentialDescriptor = {
+            type: cred.type as PublicKeyCredentialType,
+            id: base64UrlToBuffer(cred.id),
+          };
+          if (cred.transports?.length) descriptor.transports = cred.transports;
+          return descriptor;
+        });
+      }
+
+      const credential = (await navigator.credentials.get({
+        publicKey: publicKeyOptions,
+        mediation: "optional",
+      })) as PublicKeyCredential | null;
+      if (!credential) {
+        setMessage("No credential received from authenticator.");
+        return;
+      }
+
+      const assertionResponse =
+        credential.response as AuthenticatorAssertionResponse;
+      const credentialData = {
+        id: credential.id,
+        rawId: bufferToBase64Url(credential.rawId),
+        type: credential.type,
+        response: {
+          clientDataJSON: bufferToBase64Url(assertionResponse.clientDataJSON),
+          authenticatorData: bufferToBase64Url(
+            assertionResponse.authenticatorData,
+          ),
+          signature: bufferToBase64Url(assertionResponse.signature),
+          userHandle: assertionResponse.userHandle
+            ? bufferToBase64Url(assertionResponse.userHandle)
+            : null,
+        },
+        clientExtensionResults: credential.getClientExtensionResults(),
+      };
+
+      const authRes = await fetch(
+        `${backendUrl}/${tenantId}/v1/authorizations/${id}/fido2-authentication`,
+        {
+          method: "POST",
+          credentials: "include",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(credentialData),
+        },
+      );
+      if (!authRes.ok) {
+        setMessage("Passkey authentication failed.");
+        return;
+      }
+      await onCompleted();
+    } catch (error) {
+      if (
+        error instanceof Error &&
+        (error.name === "NotAllowedError" || error.name === "AbortError")
+      ) {
+        setMessage("Authentication was cancelled. Please try again.");
+      } else {
+        setMessage("An error occurred during authentication.");
+      }
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Stack spacing={3}>
+      <Typography variant="body2" color="text.secondary">
+        Verify with your passkey to continue.
+      </Typography>
+      {!identifier && (
+        <TextField
+          label="Email"
+          value={username}
+          onChange={(e) => setUsername(e.target.value)}
+        />
+      )}
+      <Box display="flex" justifyContent="center">
+        <FingerprintIcon sx={{ fontSize: 40, color: "primary.main" }} />
+      </Box>
+      {message && (
+        <Typography color="error" variant="body2" align="center">
+          {message}
+        </Typography>
+      )}
+      <Button
+        variant="contained"
+        disabled={loading}
+        onClick={handleAuthenticate}
+        fullWidth
+        sx={{ textTransform: "none" }}
+      >
+        {loading ? <CircularProgress size={24} /> : "Verify Passkey"}
+      </Button>
+    </Stack>
+  );
+};

--- a/app-view/src/components/auth/steps/Fido2Step.tsx
+++ b/app-view/src/components/auth/steps/Fido2Step.tsx
@@ -166,6 +166,9 @@ export const Fido2Step = ({ tenantId, id, onCompleted }: StepProps) => {
       {!identifier && (
         <TextField
           label="Email"
+          type="email"
+          autoComplete="email"
+          autoFocus
           value={identifier}
           onChange={(e) => setIdentifier(e.target.value)}
         />

--- a/app-view/src/components/auth/steps/Fido2Step.tsx
+++ b/app-view/src/components/auth/steps/Fido2Step.tsx
@@ -40,14 +40,16 @@ export const Fido2Step = ({ tenantId, id, onCompleted }: StepProps) => {
 
   const handleRegister = async () => {
     if (!identifier) {
-      setMessage("Please enter your email to continue.");
+      setMessage("Enter your email to continue.");
       return;
     }
     setLoading(true);
     setMessage("");
     try {
       if (!window.PublicKeyCredential) {
-        setMessage("Your browser does not support passkeys.");
+        setMessage(
+          "This browser doesn't support passkeys. Try a different browser or device.",
+        );
         return;
       }
 
@@ -70,7 +72,7 @@ export const Fido2Step = ({ tenantId, id, onCompleted }: StepProps) => {
         },
       );
       if (!challengeRes.ok) {
-        setMessage("Failed to get registration challenge. Please try again.");
+        setMessage("We couldn't start passkey setup. Please try again.");
         return;
       }
 
@@ -109,7 +111,7 @@ export const Fido2Step = ({ tenantId, id, onCompleted }: StepProps) => {
         publicKey: publicKeyOptions,
       })) as PublicKeyCredential | null;
       if (!credential) {
-        setMessage("No credential received from authenticator.");
+        setMessage("No passkey was created. Please try again.");
         return;
       }
 
@@ -141,15 +143,15 @@ export const Fido2Step = ({ tenantId, id, onCompleted }: StepProps) => {
         },
       );
       if (!registerRes.ok) {
-        setMessage("Passkey registration failed.");
+        setMessage("We couldn't register your passkey. Please try again.");
         return;
       }
       await onCompleted();
     } catch (error) {
       if (error instanceof Error && error.name === "NotAllowedError") {
-        setMessage("Registration was not allowed. Please try again.");
+        setMessage("Passkey setup was cancelled or not allowed. Please try again.");
       } else {
-        setMessage("An error occurred during registration.");
+        setMessage("Something went wrong setting up your passkey. Please try again.");
       }
     } finally {
       setLoading(false);
@@ -159,7 +161,7 @@ export const Fido2Step = ({ tenantId, id, onCompleted }: StepProps) => {
   return (
     <Stack spacing={3}>
       <Typography variant="body2" color="text.secondary">
-        Secure your account with a passkey for fast, passwordless sign-in.
+        Set up a passkey to sign in securely next time — no password needed.
       </Typography>
       {!identifier && (
         <TextField
@@ -183,7 +185,7 @@ export const Fido2Step = ({ tenantId, id, onCompleted }: StepProps) => {
         fullWidth
         sx={{ textTransform: "none" }}
       >
-        {loading ? <CircularProgress size={24} /> : "Register Passkey"}
+        {loading ? <CircularProgress size={24} /> : "Set up passkey"}
       </Button>
     </Stack>
   );

--- a/app-view/src/components/auth/steps/Fido2Step.tsx
+++ b/app-view/src/components/auth/steps/Fido2Step.tsx
@@ -1,0 +1,190 @@
+"use client";
+
+import { useState } from "react";
+import {
+  Box,
+  Button,
+  CircularProgress,
+  Stack,
+  TextField,
+  Typography,
+} from "@mui/material";
+import KeyIcon from "@mui/icons-material/Key";
+import { useAtom } from "jotai";
+import { backendUrl } from "@/pages/_app";
+import { authIdentifierAtom } from "@/state/AuthState";
+import { base64UrlToBuffer, bufferToBase64Url } from "@/auth/webauthn";
+import { StepProps } from "./StepProps";
+
+type ChallengeResponse = {
+  challenge: string;
+  rp?: { id?: string; name: string };
+  user: { id: string; name: string; displayName: string };
+  pubKeyCredParams?: PublicKeyCredentialParameters[];
+  timeout?: number;
+  attestation?: AttestationConveyancePreference;
+  extensions?: AuthenticationExtensionsClientInputs;
+};
+
+/**
+ * Passkey registration step (method "fido2").
+ *
+ * The username is the persisted identifier ({@link authIdentifierAtom}), which survives reload and
+ * direct access — this is the fix for the original bug where the username came from the in-memory
+ * AppContext and was sent empty after a reload, causing a `forbidden` error (Issue #1373).
+ */
+export const Fido2Step = ({ tenantId, id, onCompleted }: StepProps) => {
+  const [identifier, setIdentifier] = useAtom(authIdentifierAtom);
+  const [loading, setLoading] = useState(false);
+  const [message, setMessage] = useState("");
+
+  const handleRegister = async () => {
+    if (!identifier) {
+      setMessage("Please enter your email to continue.");
+      return;
+    }
+    setLoading(true);
+    setMessage("");
+    try {
+      if (!window.PublicKeyCredential) {
+        setMessage("Your browser does not support passkeys.");
+        return;
+      }
+
+      const challengeRes = await fetch(
+        `${backendUrl}/${tenantId}/v1/authorizations/${id}/fido2-registration-challenge`,
+        {
+          method: "POST",
+          credentials: "include",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            username: identifier,
+            displayName: identifier,
+            authenticatorSelection: {
+              requireResidentKey: true,
+              userVerification: "required",
+            },
+            attestation: "direct",
+            extensions: { credProps: true },
+          }),
+        },
+      );
+      if (!challengeRes.ok) {
+        setMessage("Failed to get registration challenge. Please try again.");
+        return;
+      }
+
+      const {
+        challenge,
+        rp = { name: "IdP Server" },
+        user,
+        pubKeyCredParams,
+        timeout = 60000,
+        attestation = "direct",
+        extensions,
+      }: ChallengeResponse = await challengeRes.json();
+
+      const publicKeyOptions: PublicKeyCredentialCreationOptions = {
+        challenge: base64UrlToBuffer(challenge),
+        rp,
+        user: {
+          id: base64UrlToBuffer(user.id),
+          name: user.name,
+          displayName: user.displayName,
+        },
+        authenticatorSelection: {
+          requireResidentKey: true,
+          userVerification: "required",
+        },
+        pubKeyCredParams: pubKeyCredParams || [
+          { type: "public-key", alg: -7 },
+          { type: "public-key", alg: -257 },
+        ],
+        timeout,
+        attestation,
+      };
+      if (extensions) publicKeyOptions.extensions = extensions;
+
+      const credential = (await navigator.credentials.create({
+        publicKey: publicKeyOptions,
+      })) as PublicKeyCredential | null;
+      if (!credential) {
+        setMessage("No credential received from authenticator.");
+        return;
+      }
+
+      const attestationResponse =
+        credential.response as AuthenticatorAttestationResponse;
+      const credentialData = {
+        id: credential.id,
+        rawId: bufferToBase64Url(credential.rawId),
+        type: credential.type,
+        response: {
+          clientDataJSON: bufferToBase64Url(attestationResponse.clientDataJSON),
+          attestationObject: bufferToBase64Url(
+            attestationResponse.attestationObject,
+          ),
+          transports: attestationResponse.getTransports
+            ? attestationResponse.getTransports()
+            : [],
+        },
+        clientExtensionResults: credential.getClientExtensionResults(),
+      };
+
+      const registerRes = await fetch(
+        `${backendUrl}/${tenantId}/v1/authorizations/${id}/fido2-registration`,
+        {
+          method: "POST",
+          credentials: "include",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(credentialData),
+        },
+      );
+      if (!registerRes.ok) {
+        setMessage("Passkey registration failed.");
+        return;
+      }
+      await onCompleted();
+    } catch (error) {
+      if (error instanceof Error && error.name === "NotAllowedError") {
+        setMessage("Registration was not allowed. Please try again.");
+      } else {
+        setMessage("An error occurred during registration.");
+      }
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Stack spacing={3}>
+      <Typography variant="body2" color="text.secondary">
+        Secure your account with a passkey for fast, passwordless sign-in.
+      </Typography>
+      {!identifier && (
+        <TextField
+          label="Email"
+          value={identifier}
+          onChange={(e) => setIdentifier(e.target.value)}
+        />
+      )}
+      <Box display="flex" justifyContent="center">
+        <KeyIcon sx={{ fontSize: 40, color: "primary.main" }} />
+      </Box>
+      {message && (
+        <Typography color="error" variant="body2" align="center">
+          {message}
+        </Typography>
+      )}
+      <Button
+        variant="contained"
+        disabled={loading}
+        onClick={handleRegister}
+        fullWidth
+        sx={{ textTransform: "none" }}
+      >
+        {loading ? <CircularProgress size={24} /> : "Register Passkey"}
+      </Button>
+    </Stack>
+  );
+};

--- a/app-view/src/components/auth/steps/Fido2Step.tsx
+++ b/app-view/src/components/auth/steps/Fido2Step.tsx
@@ -12,8 +12,10 @@ import {
 import KeyIcon from "@mui/icons-material/Key";
 import { useAtom } from "jotai";
 import { backendUrl } from "@/pages/_app";
+import { readErrorMessage } from "@/auth/http";
 import { authIdentifierAtom } from "@/state/AuthState";
 import { base64UrlToBuffer, bufferToBase64Url } from "@/auth/webauthn";
+import { AuthAlert } from "@/components/auth/AuthAlert";
 import { StepProps } from "./StepProps";
 
 type ChallengeResponse = {
@@ -72,7 +74,12 @@ export const Fido2Step = ({ tenantId, id, onCompleted }: StepProps) => {
         },
       );
       if (!challengeRes.ok) {
-        setMessage("We couldn't start passkey setup. Please try again.");
+        setMessage(
+          await readErrorMessage(
+            challengeRes,
+            "We couldn't start passkey setup. Please try again.",
+          ),
+        );
         return;
       }
 
@@ -143,7 +150,12 @@ export const Fido2Step = ({ tenantId, id, onCompleted }: StepProps) => {
         },
       );
       if (!registerRes.ok) {
-        setMessage("We couldn't register your passkey. Please try again.");
+        setMessage(
+          await readErrorMessage(
+            registerRes,
+            "We couldn't register your passkey. Please try again.",
+          ),
+        );
         return;
       }
       await onCompleted();
@@ -176,11 +188,7 @@ export const Fido2Step = ({ tenantId, id, onCompleted }: StepProps) => {
       <Box display="flex" justifyContent="center">
         <KeyIcon sx={{ fontSize: 40, color: "primary.main" }} />
       </Box>
-      {message && (
-        <Typography color="error" variant="body2" align="center">
-          {message}
-        </Typography>
-      )}
+      <AuthAlert message={message} />
       <Button
         variant="contained"
         disabled={loading}

--- a/app-view/src/components/auth/steps/FidoUafStep.tsx
+++ b/app-view/src/components/auth/steps/FidoUafStep.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { Box, Button, CircularProgress, Stack, Typography } from "@mui/material";
+import PhonelinkLockIcon from "@mui/icons-material/PhonelinkLock";
+import { backendUrl } from "@/pages/_app";
+import { readErrorMessage } from "@/auth/http";
+import { AuthAlert } from "@/components/auth/AuthAlert";
+import { StepProps } from "./StepProps";
+
+/**
+ * FIDO-UAF device approval step (method "fido-uaf").
+ *
+ * Sends a push challenge to the user's registered device, then polls the flow (via onCompleted →
+ * status refetch) until the device approves out-of-band and the step advances. Polling stops on
+ * unmount, which happens automatically once the flow moves past this step.
+ */
+export const FidoUafStep = ({ tenantId, id, onCompleted }: StepProps) => {
+  const [waiting, setWaiting] = useState(false);
+  const [message, setMessage] = useState("");
+  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const stopPolling = () => {
+    if (pollRef.current) {
+      clearInterval(pollRef.current);
+      pollRef.current = null;
+    }
+  };
+
+  useEffect(() => stopPolling, []);
+
+  const start = async () => {
+    setMessage("");
+    setWaiting(true);
+    try {
+      const response = await fetch(
+        `${backendUrl}/${tenantId}/v1/authorizations/${id}/fido-uaf-authentication-challenge`,
+        {
+          method: "POST",
+          credentials: "include",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({}),
+        },
+      );
+      if (!response.ok) {
+        setMessage(
+          await readErrorMessage(
+            response,
+            "We couldn't reach your device. Please try again.",
+          ),
+        );
+        setWaiting(false);
+        return;
+      }
+      // Approval happens on the device; poll the flow until the status advances past this step.
+      stopPolling();
+      pollRef.current = setInterval(() => {
+        void onCompleted();
+      }, 2500);
+    } catch {
+      setMessage("We couldn't reach your device. Please try again.");
+      setWaiting(false);
+    }
+  };
+
+  const cancel = () => {
+    stopPolling();
+    setWaiting(false);
+  };
+
+  return (
+    <Stack spacing={3} alignItems="center" textAlign="center">
+      <Box sx={{ color: "primary.main" }}>
+        <PhonelinkLockIcon sx={{ fontSize: 40 }} />
+      </Box>
+      <Typography variant="body2" color="text.secondary">
+        {waiting
+          ? "Approve the sign-in on your registered device…"
+          : "We'll send a sign-in request to your registered device."}
+      </Typography>
+      {waiting && <CircularProgress size={28} />}
+      <AuthAlert message={message} />
+      {waiting ? (
+        <Button variant="text" onClick={cancel} sx={{ textTransform: "none" }}>
+          Cancel
+        </Button>
+      ) : (
+        <Button
+          variant="contained"
+          fullWidth
+          onClick={start}
+          sx={{ textTransform: "none" }}
+        >
+          Send request
+        </Button>
+      )}
+    </Stack>
+  );
+};

--- a/app-view/src/components/auth/steps/PasswordAuthStep.tsx
+++ b/app-view/src/components/auth/steps/PasswordAuthStep.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import { useState } from "react";
+import {
+  Box,
+  Button,
+  CircularProgress,
+  InputAdornment,
+  Stack,
+  TextField,
+  Typography,
+} from "@mui/material";
+import { Email, Lock } from "@mui/icons-material";
+import { useAtom } from "jotai";
+import { backendUrl } from "@/pages/_app";
+import { authIdentifierAtom } from "@/state/AuthState";
+import { StepProps } from "./StepProps";
+
+/**
+ * Password authentication step (method "password", verify-only).
+ *
+ * Used for existing-user login and as the default step when a policy has no `step_definitions`.
+ * Persists the email to {@link authIdentifierAtom} so later steps can recover it after a reload.
+ * Use {@code RegisterStep} instead when the step creates a new account.
+ */
+export const PasswordAuthStep = ({ tenantId, id, onCompleted }: StepProps) => {
+  const [identifier, setIdentifier] = useAtom(authIdentifierAtom);
+  const [email, setEmail] = useState(identifier);
+  const [password, setPassword] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [message, setMessage] = useState("");
+
+  const handleSubmit = async () => {
+    setLoading(true);
+    setMessage("");
+    try {
+      const response = await fetch(
+        `${backendUrl}/${tenantId}/v1/authorizations/${id}/password-authentication`,
+        {
+          method: "POST",
+          credentials: "include",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ username: email, password }),
+        },
+      );
+      if (!response.ok) {
+        setMessage("Incorrect email or password. Please try again.");
+        return;
+      }
+      setIdentifier(email);
+      await onCompleted();
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Stack spacing={3}>
+      <Typography variant="body2" color="text.secondary">
+        Enter your email and password to continue.
+      </Typography>
+      <TextField
+        label="Email"
+        value={email}
+        onChange={(e) => setEmail(e.target.value)}
+        InputProps={{
+          startAdornment: (
+            <InputAdornment position="start">
+              <Email />
+            </InputAdornment>
+          ),
+        }}
+      />
+      <TextField
+        label="Password"
+        type="password"
+        value={password}
+        onChange={(e) => setPassword(e.target.value)}
+        InputProps={{
+          startAdornment: (
+            <InputAdornment position="start">
+              <Lock />
+            </InputAdornment>
+          ),
+        }}
+      />
+      {message && (
+        <Typography color="error" variant="body2">
+          {message}
+        </Typography>
+      )}
+      <Box display="flex" justifyContent="flex-end">
+        <Button
+          variant="contained"
+          disabled={loading || !email || !password}
+          onClick={handleSubmit}
+          sx={{ textTransform: "none" }}
+        >
+          {loading ? <CircularProgress size={24} /> : "Sign in"}
+        </Button>
+      </Box>
+    </Stack>
+  );
+};

--- a/app-view/src/components/auth/steps/PasswordAuthStep.tsx
+++ b/app-view/src/components/auth/steps/PasswordAuthStep.tsx
@@ -5,12 +5,13 @@ import {
   Box,
   Button,
   CircularProgress,
+  IconButton,
   InputAdornment,
   Stack,
   TextField,
   Typography,
 } from "@mui/material";
-import { Email, Lock } from "@mui/icons-material";
+import { Email, Lock, Visibility, VisibilityOff } from "@mui/icons-material";
 import { useAtom } from "jotai";
 import { backendUrl } from "@/pages/_app";
 import { authIdentifierAtom } from "@/state/AuthState";
@@ -27,6 +28,7 @@ export const PasswordAuthStep = ({ tenantId, id, onCompleted }: StepProps) => {
   const [identifier, setIdentifier] = useAtom(authIdentifierAtom);
   const [email, setEmail] = useState(identifier);
   const [password, setPassword] = useState("");
+  const [showPassword, setShowPassword] = useState(false);
   const [loading, setLoading] = useState(false);
   const [message, setMessage] = useState("");
 
@@ -61,6 +63,9 @@ export const PasswordAuthStep = ({ tenantId, id, onCompleted }: StepProps) => {
       </Typography>
       <TextField
         label="Email"
+        type="email"
+        autoComplete="email"
+        autoFocus
         value={email}
         onChange={(e) => setEmail(e.target.value)}
         InputProps={{
@@ -73,13 +78,25 @@ export const PasswordAuthStep = ({ tenantId, id, onCompleted }: StepProps) => {
       />
       <TextField
         label="Password"
-        type="password"
+        type={showPassword ? "text" : "password"}
+        autoComplete="current-password"
         value={password}
         onChange={(e) => setPassword(e.target.value)}
         InputProps={{
           startAdornment: (
             <InputAdornment position="start">
               <Lock />
+            </InputAdornment>
+          ),
+          endAdornment: (
+            <InputAdornment position="end">
+              <IconButton
+                onClick={() => setShowPassword((prev) => !prev)}
+                edge="end"
+                aria-label={showPassword ? "Hide password" : "Show password"}
+              >
+                {showPassword ? <VisibilityOff /> : <Visibility />}
+              </IconButton>
             </InputAdornment>
           ),
         }}

--- a/app-view/src/components/auth/steps/PasswordAuthStep.tsx
+++ b/app-view/src/components/auth/steps/PasswordAuthStep.tsx
@@ -44,7 +44,7 @@ export const PasswordAuthStep = ({ tenantId, id, onCompleted }: StepProps) => {
         },
       );
       if (!response.ok) {
-        setMessage("Incorrect email or password. Please try again.");
+        setMessage("The email or password is incorrect. Please try again.");
         return;
       }
       setIdentifier(email);
@@ -57,7 +57,7 @@ export const PasswordAuthStep = ({ tenantId, id, onCompleted }: StepProps) => {
   return (
     <Stack spacing={3}>
       <Typography variant="body2" color="text.secondary">
-        Enter your email and password to continue.
+        Welcome back. Enter your email and password to continue.
       </Typography>
       <TextField
         label="Email"
@@ -96,7 +96,7 @@ export const PasswordAuthStep = ({ tenantId, id, onCompleted }: StepProps) => {
           onClick={handleSubmit}
           sx={{ textTransform: "none" }}
         >
-          {loading ? <CircularProgress size={24} /> : "Sign in"}
+          {loading ? <CircularProgress size={24} /> : "Continue"}
         </Button>
       </Box>
     </Stack>

--- a/app-view/src/components/auth/steps/PasswordAuthStep.tsx
+++ b/app-view/src/components/auth/steps/PasswordAuthStep.tsx
@@ -14,7 +14,9 @@ import {
 import { Email, Lock, Visibility, VisibilityOff } from "@mui/icons-material";
 import { useAtom } from "jotai";
 import { backendUrl } from "@/pages/_app";
+import { readErrorMessage } from "@/auth/http";
 import { authIdentifierAtom } from "@/state/AuthState";
+import { AuthAlert } from "@/components/auth/AuthAlert";
 import { StepProps } from "./StepProps";
 
 /**
@@ -46,7 +48,12 @@ export const PasswordAuthStep = ({ tenantId, id, onCompleted }: StepProps) => {
         },
       );
       if (!response.ok) {
-        setMessage("The email or password is incorrect. Please try again.");
+        setMessage(
+          await readErrorMessage(
+            response,
+            "The email or password is incorrect. Please try again.",
+          ),
+        );
         return;
       }
       setIdentifier(email);
@@ -101,11 +108,7 @@ export const PasswordAuthStep = ({ tenantId, id, onCompleted }: StepProps) => {
           ),
         }}
       />
-      {message && (
-        <Typography color="error" variant="body2">
-          {message}
-        </Typography>
-      )}
+      <AuthAlert message={message} />
       <Box display="flex" justifyContent="flex-end">
         <Button
           variant="contained"

--- a/app-view/src/components/auth/steps/RegisterStep.tsx
+++ b/app-view/src/components/auth/steps/RegisterStep.tsx
@@ -31,7 +31,7 @@ export const RegisterStep = ({ tenantId, id, onCompleted }: StepProps) => {
 
   const handleSubmit = async () => {
     if (!email.includes("@") || password.length < 8) {
-      setMessage("Enter a valid email and a password of at least 8 characters.");
+      setMessage("Enter a valid email and a password with at least 8 characters.");
       return;
     }
     setLoading(true);
@@ -47,7 +47,7 @@ export const RegisterStep = ({ tenantId, id, onCompleted }: StepProps) => {
         },
       );
       if (!response.ok) {
-        setMessage("Sign up failed. Please try again.");
+        setMessage("We couldn't create your account. Please try again.");
         return;
       }
       setIdentifier(email);
@@ -60,7 +60,7 @@ export const RegisterStep = ({ tenantId, id, onCompleted }: StepProps) => {
   return (
     <Stack spacing={3}>
       <Typography variant="body2" color="text.secondary">
-        Create your account to continue.
+        Enter your email and choose a password to get started.
       </Typography>
       <TextField
         label="Email"
@@ -99,7 +99,7 @@ export const RegisterStep = ({ tenantId, id, onCompleted }: StepProps) => {
           onClick={handleSubmit}
           sx={{ textTransform: "none" }}
         >
-          {loading ? <CircularProgress size={24} /> : "Next"}
+          {loading ? <CircularProgress size={24} /> : "Continue"}
         </Button>
       </Box>
     </Stack>

--- a/app-view/src/components/auth/steps/RegisterStep.tsx
+++ b/app-view/src/components/auth/steps/RegisterStep.tsx
@@ -1,0 +1,107 @@
+"use client";
+
+import { useState } from "react";
+import {
+  Box,
+  Button,
+  CircularProgress,
+  InputAdornment,
+  Stack,
+  TextField,
+  Typography,
+} from "@mui/material";
+import { Email, Lock } from "@mui/icons-material";
+import { useAtom } from "jotai";
+import { backendUrl } from "@/pages/_app";
+import { authIdentifierAtom } from "@/state/AuthState";
+import { StepProps } from "./StepProps";
+
+/**
+ * 1st-factor identify + account creation step (method "password" with registration allowed).
+ *
+ * Persists the entered email to {@link authIdentifierAtom} so later steps (e.g. FIDO2) can recover
+ * the username after a reload.
+ */
+export const RegisterStep = ({ tenantId, id, onCompleted }: StepProps) => {
+  const [identifier, setIdentifier] = useAtom(authIdentifierAtom);
+  const [email, setEmail] = useState(identifier);
+  const [password, setPassword] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [message, setMessage] = useState("");
+
+  const handleSubmit = async () => {
+    if (!email.includes("@") || password.length < 8) {
+      setMessage("Enter a valid email and a password of at least 8 characters.");
+      return;
+    }
+    setLoading(true);
+    setMessage("");
+    try {
+      const response = await fetch(
+        `${backendUrl}/${tenantId}/v1/authorizations/${id}/initial-registration`,
+        {
+          method: "POST",
+          credentials: "include",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ name: email, email, password }),
+        },
+      );
+      if (!response.ok) {
+        setMessage("Sign up failed. Please try again.");
+        return;
+      }
+      setIdentifier(email);
+      await onCompleted();
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Stack spacing={3}>
+      <Typography variant="body2" color="text.secondary">
+        Create your account to continue.
+      </Typography>
+      <TextField
+        label="Email"
+        value={email}
+        onChange={(e) => setEmail(e.target.value)}
+        InputProps={{
+          startAdornment: (
+            <InputAdornment position="start">
+              <Email />
+            </InputAdornment>
+          ),
+        }}
+      />
+      <TextField
+        label="Password"
+        type="password"
+        value={password}
+        onChange={(e) => setPassword(e.target.value)}
+        InputProps={{
+          startAdornment: (
+            <InputAdornment position="start">
+              <Lock />
+            </InputAdornment>
+          ),
+        }}
+      />
+      {message && (
+        <Typography color="error" variant="body2">
+          {message}
+        </Typography>
+      )}
+      <Box display="flex" justifyContent="flex-end">
+        <Button
+          variant="contained"
+          disabled={loading || !email || !password}
+          onClick={handleSubmit}
+          sx={{ textTransform: "none" }}
+        >
+          {loading ? <CircularProgress size={24} /> : "Next"}
+        </Button>
+      </Box>
+    </Stack>
+  );
+};

--- a/app-view/src/components/auth/steps/RegisterStep.tsx
+++ b/app-view/src/components/auth/steps/RegisterStep.tsx
@@ -5,12 +5,13 @@ import {
   Box,
   Button,
   CircularProgress,
+  IconButton,
   InputAdornment,
   Stack,
   TextField,
   Typography,
 } from "@mui/material";
-import { Email, Lock } from "@mui/icons-material";
+import { Email, Lock, Visibility, VisibilityOff } from "@mui/icons-material";
 import { useAtom } from "jotai";
 import { backendUrl } from "@/pages/_app";
 import { authIdentifierAtom } from "@/state/AuthState";
@@ -26,6 +27,7 @@ export const RegisterStep = ({ tenantId, id, onCompleted }: StepProps) => {
   const [identifier, setIdentifier] = useAtom(authIdentifierAtom);
   const [email, setEmail] = useState(identifier);
   const [password, setPassword] = useState("");
+  const [showPassword, setShowPassword] = useState(false);
   const [loading, setLoading] = useState(false);
   const [message, setMessage] = useState("");
 
@@ -64,6 +66,9 @@ export const RegisterStep = ({ tenantId, id, onCompleted }: StepProps) => {
       </Typography>
       <TextField
         label="Email"
+        type="email"
+        autoComplete="email"
+        autoFocus
         value={email}
         onChange={(e) => setEmail(e.target.value)}
         InputProps={{
@@ -76,13 +81,25 @@ export const RegisterStep = ({ tenantId, id, onCompleted }: StepProps) => {
       />
       <TextField
         label="Password"
-        type="password"
+        type={showPassword ? "text" : "password"}
+        autoComplete="new-password"
         value={password}
         onChange={(e) => setPassword(e.target.value)}
         InputProps={{
           startAdornment: (
             <InputAdornment position="start">
               <Lock />
+            </InputAdornment>
+          ),
+          endAdornment: (
+            <InputAdornment position="end">
+              <IconButton
+                onClick={() => setShowPassword((prev) => !prev)}
+                edge="end"
+                aria-label={showPassword ? "Hide password" : "Show password"}
+              >
+                {showPassword ? <VisibilityOff /> : <Visibility />}
+              </IconButton>
             </InputAdornment>
           ),
         }}

--- a/app-view/src/components/auth/steps/RegisterStep.tsx
+++ b/app-view/src/components/auth/steps/RegisterStep.tsx
@@ -14,7 +14,9 @@ import {
 import { Email, Lock, Visibility, VisibilityOff } from "@mui/icons-material";
 import { useAtom } from "jotai";
 import { backendUrl } from "@/pages/_app";
+import { readErrorMessage } from "@/auth/http";
 import { authIdentifierAtom } from "@/state/AuthState";
+import { AuthAlert } from "@/components/auth/AuthAlert";
 import { StepProps } from "./StepProps";
 
 /**
@@ -49,7 +51,12 @@ export const RegisterStep = ({ tenantId, id, onCompleted }: StepProps) => {
         },
       );
       if (!response.ok) {
-        setMessage("We couldn't create your account. Please try again.");
+        setMessage(
+          await readErrorMessage(
+            response,
+            "We couldn't create your account. Please try again.",
+          ),
+        );
         return;
       }
       setIdentifier(email);
@@ -104,11 +111,7 @@ export const RegisterStep = ({ tenantId, id, onCompleted }: StepProps) => {
           ),
         }}
       />
-      {message && (
-        <Typography color="error" variant="body2">
-          {message}
-        </Typography>
-      )}
+      <AuthAlert message={message} />
       <Box display="flex" justifyContent="flex-end">
         <Button
           variant="contained"

--- a/app-view/src/components/auth/steps/SmsStep.tsx
+++ b/app-view/src/components/auth/steps/SmsStep.tsx
@@ -70,7 +70,7 @@ export const SmsStep = ({ tenantId, id, step, onCompleted }: StepProps) => {
         },
       );
       if (!response.ok) {
-        setMessage("Invalid code. Please check and try again.");
+        setMessage("That code is incorrect or has expired. Please try again.");
         return;
       }
       await onCompleted();
@@ -82,7 +82,9 @@ export const SmsStep = ({ tenantId, id, step, onCompleted }: StepProps) => {
   return (
     <Stack spacing={3}>
       <Typography variant="body2" color="text.secondary">
-        Enter the code we sent by SMS.
+        {needsPhoneInput
+          ? "Enter your phone number and we'll text you a verification code."
+          : "We sent a verification code to your phone. Enter it below to continue."}
       </Typography>
       {needsPhoneInput && (
         <TextField

--- a/app-view/src/components/auth/steps/SmsStep.tsx
+++ b/app-view/src/components/auth/steps/SmsStep.tsx
@@ -89,16 +89,22 @@ export const SmsStep = ({ tenantId, id, step, onCompleted }: StepProps) => {
       {needsPhoneInput && (
         <TextField
           label="Phone number"
+          autoFocus
           value={phone}
           onChange={(e) => setPhone(e.target.value)}
-          inputProps={{ inputMode: "tel" }}
+          inputProps={{ inputMode: "tel", autoComplete: "tel" }}
         />
       )}
       <TextField
         label="Verification code"
+        autoFocus={!needsPhoneInput}
         value={code}
         onChange={(e) => setCode(e.target.value)}
-        inputProps={{ inputMode: "numeric" }}
+        inputProps={{
+          inputMode: "numeric",
+          autoComplete: "one-time-code",
+          maxLength: 6,
+        }}
       />
       {message && (
         <Typography color="error" variant="body2">

--- a/app-view/src/components/auth/steps/SmsStep.tsx
+++ b/app-view/src/components/auth/steps/SmsStep.tsx
@@ -1,0 +1,126 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import {
+  Box,
+  Button,
+  CircularProgress,
+  Stack,
+  TextField,
+  Typography,
+} from "@mui/material";
+import { backendUrl } from "@/pages/_app";
+import { StepProps } from "./StepProps";
+
+/**
+ * SMS one-time-code step (method "sms").
+ *
+ * Challenge + verification-code is the same ceremony whether the step registers a phone number or
+ * authenticates an existing one, so a single component covers both. For a 2nd-factor step the
+ * server resolves the phone number from the identified user, so the challenge body can be empty.
+ */
+export const SmsStep = ({ tenantId, id, step, onCompleted }: StepProps) => {
+  const [phone, setPhone] = useState("");
+  const [code, setCode] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [resending, setResending] = useState(false);
+  const [message, setMessage] = useState("");
+  const challengeSent = useRef(false);
+
+  // A 1st-factor step identifies the user, so the phone number must be entered here; a 2nd-factor
+  // step verifies the already-identified user, so the server resolves the number.
+  const needsPhoneInput = step.requires_user === false;
+
+  const sendChallenge = async () => {
+    if (needsPhoneInput && !phone) return;
+    setResending(true);
+    try {
+      await fetch(
+        `${backendUrl}/${tenantId}/v1/authorizations/${id}/sms-authentication-challenge`,
+        {
+          method: "POST",
+          credentials: "include",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(needsPhoneInput ? { phone_number: phone } : {}),
+        },
+      );
+    } finally {
+      setResending(false);
+    }
+  };
+
+  useEffect(() => {
+    if (challengeSent.current || needsPhoneInput) return;
+    challengeSent.current = true;
+    void sendChallenge();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const handleVerify = async () => {
+    setLoading(true);
+    setMessage("");
+    try {
+      const response = await fetch(
+        `${backendUrl}/${tenantId}/v1/authorizations/${id}/sms-authentication`,
+        {
+          method: "POST",
+          credentials: "include",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ verification_code: code }),
+        },
+      );
+      if (!response.ok) {
+        setMessage("Invalid code. Please check and try again.");
+        return;
+      }
+      await onCompleted();
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Stack spacing={3}>
+      <Typography variant="body2" color="text.secondary">
+        Enter the code we sent by SMS.
+      </Typography>
+      {needsPhoneInput && (
+        <TextField
+          label="Phone number"
+          value={phone}
+          onChange={(e) => setPhone(e.target.value)}
+          inputProps={{ inputMode: "tel" }}
+        />
+      )}
+      <TextField
+        label="Verification code"
+        value={code}
+        onChange={(e) => setCode(e.target.value)}
+        inputProps={{ inputMode: "numeric" }}
+      />
+      {message && (
+        <Typography color="error" variant="body2">
+          {message}
+        </Typography>
+      )}
+      <Box display="flex" justifyContent="space-between" alignItems="center">
+        <Button
+          variant="text"
+          disabled={resending}
+          onClick={sendChallenge}
+          sx={{ textTransform: "none" }}
+        >
+          {resending ? "Sending..." : "Send code"}
+        </Button>
+        <Button
+          variant="contained"
+          disabled={loading || !code}
+          onClick={handleVerify}
+          sx={{ textTransform: "none" }}
+        >
+          {loading ? <CircularProgress size={24} /> : "Verify"}
+        </Button>
+      </Box>
+    </Stack>
+  );
+};

--- a/app-view/src/components/auth/steps/SmsStep.tsx
+++ b/app-view/src/components/auth/steps/SmsStep.tsx
@@ -10,7 +10,12 @@ import {
   Typography,
 } from "@mui/material";
 import { backendUrl } from "@/pages/_app";
+import { readErrorMessage } from "@/auth/http";
+import { AuthAlert } from "@/components/auth/AuthAlert";
+import { OtpInput } from "@/components/auth/OtpInput";
 import { StepProps } from "./StepProps";
+
+const CODE_LENGTH = 6;
 
 /**
  * SMS one-time-code step (method "sms").
@@ -70,7 +75,12 @@ export const SmsStep = ({ tenantId, id, step, onCompleted }: StepProps) => {
         },
       );
       if (!response.ok) {
-        setMessage("That code is incorrect or has expired. Please try again.");
+        setMessage(
+          await readErrorMessage(
+            response,
+            "That code is incorrect or has expired. Please try again.",
+          ),
+        );
         return;
       }
       await onCompleted();
@@ -95,22 +105,13 @@ export const SmsStep = ({ tenantId, id, step, onCompleted }: StepProps) => {
           inputProps={{ inputMode: "tel", autoComplete: "tel" }}
         />
       )}
-      <TextField
-        label="Verification code"
-        autoFocus={!needsPhoneInput}
+      <OtpInput
         value={code}
-        onChange={(e) => setCode(e.target.value)}
-        inputProps={{
-          inputMode: "numeric",
-          autoComplete: "one-time-code",
-          maxLength: 6,
-        }}
+        onChange={setCode}
+        length={CODE_LENGTH}
+        autoFocus={!needsPhoneInput}
       />
-      {message && (
-        <Typography color="error" variant="body2">
-          {message}
-        </Typography>
-      )}
+      <AuthAlert message={message} />
       <Box display="flex" justifyContent="space-between" alignItems="center">
         <Button
           variant="text"
@@ -122,7 +123,7 @@ export const SmsStep = ({ tenantId, id, step, onCompleted }: StepProps) => {
         </Button>
         <Button
           variant="contained"
-          disabled={loading || !code}
+          disabled={loading || code.length < CODE_LENGTH}
           onClick={handleVerify}
           sx={{ textTransform: "none" }}
         >

--- a/app-view/src/components/auth/steps/StepProps.ts
+++ b/app-view/src/components/auth/steps/StepProps.ts
@@ -1,0 +1,10 @@
+import { StepView } from "@/auth/types";
+
+/** Common props passed to every config-driven step component. */
+export type StepProps = {
+  tenantId: string;
+  id: string;
+  step: StepView;
+  /** Advance the flow (re-reads server state to resolve the next step). */
+  onCompleted: () => void | Promise<void>;
+};

--- a/app-view/src/pages/_app.tsx
+++ b/app-view/src/pages/_app.tsx
@@ -1,9 +1,19 @@
 import { AppProps } from "next/app";
 import { CssBaseline } from "@mui/material";
+import { ThemeProvider } from "@mui/material/styles";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { Inter } from "next/font/google";
 import { createContext, useContext, useState } from "react";
+import { createAppTheme } from "@/theme/theme";
 
 const queryClient = new QueryClient();
+
+const inter = Inter({
+  subsets: ["latin"],
+  weight: ["400", "500", "600", "700"],
+  display: "swap",
+});
+const theme = createAppTheme(inter.style.fontFamily);
 
 // Use empty string for same-origin deployment (via nginx proxy at /auth-views/)
 // This ensures AUTH_SESSION cookies are sent with SameSite=Lax
@@ -37,15 +47,17 @@ export default function App({ Component, pageProps }: AppProps) {
   const [email, setEmail] = useState<string>("");
 
   return (
-    <>
-      <AppContext.Provider
-        value={{ id, setId, tenantId, setTenantId, userId, setUserId,  email, setEmail }}
-      >
+    <AppContext.Provider
+      value={{ id, setId, tenantId, setTenantId, userId, setUserId, email, setEmail }}
+    >
+      <ThemeProvider theme={theme}>
         <CssBaseline />
         <QueryClientProvider client={queryClient}>
-          <Component {...pageProps} />
+          <main className={inter.className}>
+            <Component {...pageProps} />
+          </main>
         </QueryClientProvider>
-      </AppContext.Provider>
-    </>
+      </ThemeProvider>
+    </AppContext.Provider>
   );
 }

--- a/app-view/src/pages/auth/index.tsx
+++ b/app-view/src/pages/auth/index.tsx
@@ -1,17 +1,10 @@
 "use client";
 
-import {
-  Container,
-  Link,
-  Paper,
-  Stack,
-  Typography,
-  alpha,
-  useTheme,
-} from "@mui/material";
+import { Link, Stack, Typography } from "@mui/material";
 import { useState } from "react";
 import { useRouter } from "next/router";
 import { useAuthFlow } from "@/auth/useAuthFlow";
+import { AuthCard } from "@/components/auth/AuthCard";
 import { ConfigDrivenStepper } from "@/components/auth/ConfigDrivenStepper";
 import { StepRenderer } from "@/components/auth/StepRenderer";
 import { ConsentStep } from "@/components/auth/steps/ConsentStep";
@@ -29,7 +22,6 @@ const asString = (value: string | string[] | undefined): string =>
  */
 export default function AuthPage() {
   const router = useRouter();
-  const theme = useTheme();
   const tenantId = asString(router.query.tenant_id);
   const id = asString(router.query.id);
 
@@ -49,19 +41,34 @@ export default function AuthPage() {
   // initial-registration works without any configuration, so account creation is available by
   // default; it is hidden only when the step explicitly disables registration.
   const canRegister = currentStep?.registration_mode !== "disabled";
+  const isPasswordStep = currentStep?.method === "password";
 
   if (!router.isReady || isLoading) return <Loading />;
 
+  const title = isComplete
+    ? "You're all set"
+    : registerMode && isPasswordStep
+      ? "Create your account"
+      : "Sign in";
+  const subtitle =
+    !isComplete && viewData?.client_name
+      ? `Continue to ${viewData.client_name}`
+      : undefined;
+
   const renderBody = () => {
     if (isError) {
-      return <Typography color="error">Failed to load the authentication flow.</Typography>;
+      return (
+        <Typography color="error" align="center">
+          {"We couldn't load this sign-in. Please return to the app and try again."}
+        </Typography>
+      );
     }
     if (status === "failure" || status === "locked") {
       return (
-        <Typography color="error">
+        <Typography color="error" align="center">
           {status === "locked"
-            ? "Your account is temporarily locked. Please try again later."
-            : "Authentication failed. Please start over."}
+            ? "Too many attempts. Your account is temporarily locked — please try again later."
+            : "We couldn't sign you in. Please return to the app and start over."}
         </Typography>
       );
     }
@@ -73,19 +80,16 @@ export default function AuthPage() {
       // interaction and the status refetch).
       return <Loading />;
     }
-    const showAccountToggle = currentStep.method === "password" && canRegister;
     return (
-      <Stack spacing={2}>
+      <Stack spacing={2.5}>
         <StepRenderer
           tenantId={tenantId}
           id={id}
           step={currentStep}
           onCompleted={refetch}
-          passwordRegister={
-            currentStep.method === "password" ? registerMode : undefined
-          }
+          passwordRegister={isPasswordStep ? registerMode : undefined}
         />
-        {showAccountToggle && (
+        {isPasswordStep && canRegister && (
           <Link
             component="button"
             type="button"
@@ -104,31 +108,11 @@ export default function AuthPage() {
   };
 
   return (
-    <Container maxWidth="xs">
-      <Paper
-        elevation={0}
-        sx={{
-          borderRadius: 4,
-          px: 5,
-          py: 6,
-          mt: 8,
-          backgroundColor:
-            theme.palette.mode === "light"
-              ? "#fcfcfd"
-              : alpha(theme.palette.common.white, 0.035),
-          border: `1px solid ${alpha(theme.palette.divider, 0.08)}`,
-        }}
-      >
-        <Typography variant="h5" fontWeight={600} gutterBottom>
-          {viewData?.client_name ?? "Sign in"}
-        </Typography>
-        <Stack spacing={4} mt={2}>
-          {steps.length > 0 && (
-            <ConfigDrivenStepper steps={steps} isComplete={isComplete} />
-          )}
-          {renderBody()}
-        </Stack>
-      </Paper>
-    </Container>
+    <AuthCard title={title} subtitle={subtitle}>
+      {steps.length > 1 && (
+        <ConfigDrivenStepper steps={steps} isComplete={isComplete} />
+      )}
+      {renderBody()}
+    </AuthCard>
   );
 }

--- a/app-view/src/pages/auth/index.tsx
+++ b/app-view/src/pages/auth/index.tsx
@@ -1,11 +1,12 @@
 "use client";
 
-import { Link, Stack, Typography } from "@mui/material";
+import { Divider, Link, Stack, Typography } from "@mui/material";
 import { useState } from "react";
 import { useRouter } from "next/router";
 import { useAuthFlow } from "@/auth/useAuthFlow";
 import { AuthCard } from "@/components/auth/AuthCard";
 import { ConfigDrivenStepper } from "@/components/auth/ConfigDrivenStepper";
+import { SsoButtons } from "@/components/auth/SsoButtons";
 import { StepRenderer } from "@/components/auth/StepRenderer";
 import { ConsentStep } from "@/components/auth/steps/ConsentStep";
 import { Loading } from "@/components/Loading";
@@ -42,6 +43,13 @@ export default function AuthPage() {
   // default; it is hidden only when the step explicitly disables registration.
   const canRegister = currentStep?.registration_mode !== "disabled";
   const isPasswordStep = currentStep?.method === "password";
+
+  // Federated sign-in belongs on the initial identification step (1st factor).
+  const federations = viewData?.available_federations ?? [];
+  const showSso =
+    !isComplete &&
+    currentStep?.requires_user === false &&
+    federations.length > 0;
 
   if (!router.isReady || isLoading) return <Loading />;
 
@@ -82,6 +90,16 @@ export default function AuthPage() {
     }
     return (
       <Stack spacing={2.5}>
+        {showSso && (
+          <>
+            <SsoButtons tenantId={tenantId} id={id} federations={federations} />
+            <Divider>
+              <Typography variant="caption" color="text.secondary">
+                or
+              </Typography>
+            </Divider>
+          </>
+        )}
         <StepRenderer
           tenantId={tenantId}
           id={id}
@@ -108,7 +126,7 @@ export default function AuthPage() {
   };
 
   return (
-    <AuthCard title={title} subtitle={subtitle}>
+    <AuthCard title={title} subtitle={subtitle} logoUri={viewData?.logo_uri}>
       {steps.length > 1 && (
         <ConfigDrivenStepper steps={steps} isComplete={isComplete} />
       )}

--- a/app-view/src/pages/auth/index.tsx
+++ b/app-view/src/pages/auth/index.tsx
@@ -4,11 +4,14 @@ import { Divider, Link, Stack, Typography } from "@mui/material";
 import { useState } from "react";
 import { useRouter } from "next/router";
 import { useAuthFlow } from "@/auth/useAuthFlow";
+import { StepView } from "@/auth/types";
 import { AuthCard } from "@/components/auth/AuthCard";
 import { ConfigDrivenStepper } from "@/components/auth/ConfigDrivenStepper";
+import { MethodPicker } from "@/components/auth/MethodPicker";
 import { SsoButtons } from "@/components/auth/SsoButtons";
 import { StepRenderer } from "@/components/auth/StepRenderer";
 import { ConsentStep } from "@/components/auth/steps/ConsentStep";
+import { AuthAlert } from "@/components/auth/AuthAlert";
 import { Loading } from "@/components/Loading";
 
 const asString = (value: string | string[] | undefined): string =>
@@ -30,6 +33,7 @@ export default function AuthPage() {
     viewData,
     steps,
     currentStep,
+    availableMethods,
     status,
     isComplete,
     isLoading,
@@ -38,17 +42,39 @@ export default function AuthPage() {
   } = useAuthFlow(tenantId, id);
 
   const [registerMode, setRegisterMode] = useState(false);
+  const [selectedMethod, setSelectedMethod] = useState<string | null>(null);
+
+  // When a policy offers several methods with no fixed order, the user picks one and we render it
+  // as a single step.
+  const showPicker =
+    !isComplete &&
+    steps.length === 0 &&
+    availableMethods.length >= 2 &&
+    !selectedMethod;
+  const pickedStep: StepView | null = selectedMethod
+    ? {
+        method: selectedMethod,
+        order: 1,
+        requires_user: false,
+        allow_registration: false,
+        completed: false,
+        current: true,
+      }
+    : null;
+  const effectiveStep = currentStep ?? pickedStep;
 
   // initial-registration works without any configuration, so account creation is available by
   // default; it is hidden only when the step explicitly disables registration.
-  const canRegister = currentStep?.registration_mode !== "disabled";
-  const isPasswordStep = currentStep?.method === "password";
+  const canRegister = effectiveStep?.registration_mode !== "disabled";
+  const isPasswordStep = effectiveStep?.method === "password";
+  const canPickAnother = availableMethods.length >= 2 && selectedMethod !== null;
 
   // Federated sign-in belongs on the initial identification step (1st factor).
   const federations = viewData?.available_federations ?? [];
   const showSso =
     !isComplete &&
-    currentStep?.requires_user === false &&
+    !showPicker &&
+    effectiveStep?.requires_user === false &&
     federations.length > 0;
 
   if (!router.isReady || isLoading) return <Loading />;
@@ -66,24 +92,29 @@ export default function AuthPage() {
   const renderBody = () => {
     if (isError) {
       return (
-        <Typography color="error" align="center">
-          {"We couldn't load this sign-in. Please return to the app and try again."}
-        </Typography>
+        <AuthAlert message="We couldn't load this sign-in. Please return to the app and try again." />
       );
     }
     if (status === "failure" || status === "locked") {
       return (
-        <Typography color="error" align="center">
-          {status === "locked"
-            ? "Too many attempts. Your account is temporarily locked — please try again later."
-            : "We couldn't sign you in. Please return to the app and start over."}
-        </Typography>
+        <AuthAlert
+          message={
+            status === "locked"
+              ? "Too many attempts. Your account is temporarily locked — please try again later."
+              : "We couldn't sign you in. Please return to the app and start over."
+          }
+        />
       );
     }
     if (isComplete) {
       return <ConsentStep tenantId={tenantId} id={id} viewData={viewData} />;
     }
-    if (!currentStep) {
+    if (showPicker) {
+      return (
+        <MethodPicker methods={availableMethods} onSelect={setSelectedMethod} />
+      );
+    }
+    if (!effectiveStep) {
       // All known steps are done but the server has not reported success yet (transient between an
       // interaction and the status refetch).
       return <Loading />;
@@ -103,7 +134,7 @@ export default function AuthPage() {
         <StepRenderer
           tenantId={tenantId}
           id={id}
-          step={currentStep}
+          step={effectiveStep}
           onCompleted={refetch}
           passwordRegister={isPasswordStep ? registerMode : undefined}
         />
@@ -121,12 +152,30 @@ export default function AuthPage() {
               : "Don't have an account? Sign up"}
           </Link>
         )}
+        {canPickAnother && (
+          <Link
+            component="button"
+            type="button"
+            variant="body2"
+            underline="hover"
+            onClick={() => setSelectedMethod(null)}
+            sx={{ alignSelf: "center" }}
+          >
+            Use a different method
+          </Link>
+        )}
       </Stack>
     );
   };
 
   return (
-    <AuthCard title={title} subtitle={subtitle} logoUri={viewData?.logo_uri}>
+    <AuthCard
+      title={title}
+      subtitle={subtitle}
+      logoUri={viewData?.logo_uri}
+      tosUri={viewData?.tos_uri}
+      policyUri={viewData?.policy_uri}
+    >
       {steps.length > 1 && (
         <ConfigDrivenStepper steps={steps} isComplete={isComplete} />
       )}

--- a/app-view/src/pages/auth/index.tsx
+++ b/app-view/src/pages/auth/index.tsx
@@ -1,0 +1,134 @@
+"use client";
+
+import {
+  Container,
+  Link,
+  Paper,
+  Stack,
+  Typography,
+  alpha,
+  useTheme,
+} from "@mui/material";
+import { useState } from "react";
+import { useRouter } from "next/router";
+import { useAuthFlow } from "@/auth/useAuthFlow";
+import { ConfigDrivenStepper } from "@/components/auth/ConfigDrivenStepper";
+import { StepRenderer } from "@/components/auth/StepRenderer";
+import { ConsentStep } from "@/components/auth/steps/ConsentStep";
+import { Loading } from "@/components/Loading";
+
+const asString = (value: string | string[] | undefined): string =>
+  Array.isArray(value) ? (value[0] ?? "") : (value ?? "");
+
+/**
+ * Config-driven authentication screen (Issue #1373).
+ *
+ * A single URL (`/auth?id=..&tenant_id=..`) renders the whole flow. The step order comes from
+ * `authentication_policy.step_definitions` (view-data) and the current step is derived from the
+ * server `authentication-status`, so reload and direct access reconstruct state instead of breaking.
+ */
+export default function AuthPage() {
+  const router = useRouter();
+  const theme = useTheme();
+  const tenantId = asString(router.query.tenant_id);
+  const id = asString(router.query.id);
+
+  const {
+    viewData,
+    steps,
+    currentStep,
+    status,
+    isComplete,
+    isLoading,
+    isError,
+    refetch,
+  } = useAuthFlow(tenantId, id);
+
+  const [registerMode, setRegisterMode] = useState(false);
+
+  // initial-registration works without any configuration, so account creation is available by
+  // default; it is hidden only when the step explicitly disables registration.
+  const canRegister = currentStep?.registration_mode !== "disabled";
+
+  if (!router.isReady || isLoading) return <Loading />;
+
+  const renderBody = () => {
+    if (isError) {
+      return <Typography color="error">Failed to load the authentication flow.</Typography>;
+    }
+    if (status === "failure" || status === "locked") {
+      return (
+        <Typography color="error">
+          {status === "locked"
+            ? "Your account is temporarily locked. Please try again later."
+            : "Authentication failed. Please start over."}
+        </Typography>
+      );
+    }
+    if (isComplete) {
+      return <ConsentStep tenantId={tenantId} id={id} viewData={viewData} />;
+    }
+    if (!currentStep) {
+      // All known steps are done but the server has not reported success yet (transient between an
+      // interaction and the status refetch).
+      return <Loading />;
+    }
+    const showAccountToggle = currentStep.method === "password" && canRegister;
+    return (
+      <Stack spacing={2}>
+        <StepRenderer
+          tenantId={tenantId}
+          id={id}
+          step={currentStep}
+          onCompleted={refetch}
+          passwordRegister={
+            currentStep.method === "password" ? registerMode : undefined
+          }
+        />
+        {showAccountToggle && (
+          <Link
+            component="button"
+            type="button"
+            variant="body2"
+            underline="hover"
+            onClick={() => setRegisterMode((prev) => !prev)}
+            sx={{ alignSelf: "center" }}
+          >
+            {registerMode
+              ? "Already have an account? Sign in"
+              : "Don't have an account? Sign up"}
+          </Link>
+        )}
+      </Stack>
+    );
+  };
+
+  return (
+    <Container maxWidth="xs">
+      <Paper
+        elevation={0}
+        sx={{
+          borderRadius: 4,
+          px: 5,
+          py: 6,
+          mt: 8,
+          backgroundColor:
+            theme.palette.mode === "light"
+              ? "#fcfcfd"
+              : alpha(theme.palette.common.white, 0.035),
+          border: `1px solid ${alpha(theme.palette.divider, 0.08)}`,
+        }}
+      >
+        <Typography variant="h5" fontWeight={600} gutterBottom>
+          {viewData?.client_name ?? "Sign in"}
+        </Typography>
+        <Stack spacing={4} mt={2}>
+          {steps.length > 0 && (
+            <ConfigDrivenStepper steps={steps} isComplete={isComplete} />
+          )}
+          {renderBody()}
+        </Stack>
+      </Paper>
+    </Container>
+  );
+}

--- a/app-view/src/pages/error/index.tsx
+++ b/app-view/src/pages/error/index.tsx
@@ -1,118 +1,78 @@
 "use client";
 
-import {
-  Box,
-  Container,
-  Paper,
-  Stack,
-  Typography,
-  useTheme,
-  alpha,
-} from "@mui/material";
+import { Box, Stack, Typography, alpha } from "@mui/material";
 import { useRouter } from "next/router";
 import ErrorOutlineRoundedIcon from "@mui/icons-material/ErrorOutlineRounded";
+import { AuthCard } from "@/components/auth/AuthCard";
 import { Loading } from "@/components/Loading";
+
+const asString = (value: string | string[] | undefined): string =>
+  Array.isArray(value) ? (value[0] ?? "") : (value ?? "");
+
+const ErrorBadge = () => (
+  <Box
+    sx={{
+      width: 48,
+      height: 48,
+      borderRadius: 2.5,
+      display: "grid",
+      placeItems: "center",
+      color: "error.main",
+      bgcolor: (theme) => alpha(theme.palette.error.main, 0.1),
+    }}
+  >
+    <ErrorOutlineRoundedIcon />
+  </Box>
+);
+
+const DetailField = ({ label, value }: { label: string; value: string }) => (
+  <Box textAlign="left">
+    <Typography
+      variant="caption"
+      color="text.secondary"
+      fontWeight={600}
+      display="block"
+      gutterBottom
+    >
+      {label}
+    </Typography>
+    <Typography
+      variant="body2"
+      sx={{
+        px: 2,
+        py: 1,
+        borderRadius: 2,
+        bgcolor: "background.default",
+        border: "1px solid",
+        borderColor: "divider",
+        fontFamily: "monospace",
+        wordBreak: "break-word",
+      }}
+    >
+      {value}
+    </Typography>
+  </Box>
+);
 
 export default function AuthorizationError() {
   const router = useRouter();
-  const theme = useTheme();
 
-  if (!router.isReady) {
-    return <Loading />
-  }
+  if (!router.isReady) return <Loading />;
 
-  const { error, error_description: errorDescription } = router.query;
+  const error = asString(router.query.error) || "unknown_error";
+  const errorDescription =
+    asString(router.query.error_description) || "No description provided.";
 
   return (
-    <Container maxWidth="xs">
-      <Paper
-        elevation={0}
-        sx={{
-          borderRadius: 4,
-          px: 5,
-          py: 6,
-          mt: 10,
-          textAlign: "center",
-          backgroundColor:
-            theme.palette.mode === "light"
-              ? "#fff"
-              : alpha(theme.palette.background.paper, 0.1),
-          border: `1px solid ${alpha(theme.palette.divider, 0.08)}`,
-          boxShadow:
-            theme.palette.mode === "light"
-              ? "0 8px 24px rgba(0,0,0,0.04)"
-              : "0 0 0 1px rgba(255,255,255,0.06)",
-        }}
-      >
-        <Stack spacing={3} alignItems="center">
-          <ErrorOutlineRoundedIcon
-            color="error"
-            sx={{ fontSize: 50 }}
-          />
-
-          <Typography variant="h5" fontWeight={700} color="error.main">
-            Authorization Failed
-          </Typography>
-
-          <Typography variant="body2" color="text.secondary">
-            {"We couldn't complete the authorization request."}
-          </Typography>
-
-          <Box width="100%" textAlign="left" mt={2}>
-            <Typography
-              variant="caption"
-              color="text.secondary"
-              fontWeight={600}
-              gutterBottom
-            >
-              Error
-            </Typography>
-            <Typography
-              variant="body2"
-              sx={{
-                backgroundColor:
-                  theme.palette.mode === "light"
-                    ? "grey.100"
-                    : alpha(theme.palette.common.white, 0.05),
-                px: 2,
-                py: 1,
-                borderRadius: 2,
-                fontWeight: 500,
-                wordBreak: "break-word",
-              }}
-            >
-              {error || "Unknown Error"}
-            </Typography>
-
-            <Typography
-              variant="caption"
-              color="text.secondary"
-              fontWeight={600}
-              mt={2}
-              gutterBottom
-              display="block"
-            >
-              Description
-            </Typography>
-            <Typography
-              variant="body2"
-              sx={{
-                backgroundColor:
-                  theme.palette.mode === "light"
-                    ? "grey.50"
-                    : alpha(theme.palette.common.white, 0.03),
-                px: 2,
-                py: 1,
-                borderRadius: 2,
-                wordBreak: "break-word",
-              }}
-            >
-              {errorDescription || "No description provided."}
-            </Typography>
-          </Box>
-
-        </Stack>
-      </Paper>
-    </Container>
+    <AuthCard
+      icon={<ErrorBadge />}
+      title="Authorization failed"
+      subtitle="We couldn't complete the authorization request."
+    >
+      <Stack spacing={2}>
+        <DetailField label="Error" value={error} />
+        <DetailField label="Description" value={errorDescription} />
+      </Stack>
+    </AuthCard>
   );
 }

--- a/app-view/src/state/AuthState.ts
+++ b/app-view/src/state/AuthState.ts
@@ -2,7 +2,7 @@ import { atomWithStorage, createJSONStorage } from "jotai/utils";
 
 const sessionStorage =
   typeof window !== "undefined"
-    ? createJSONStorage(() => window.sessionStorage)
+    ? createJSONStorage<string>(() => window.sessionStorage)
     : undefined;
 
 export const authSessionIdAtom = atomWithStorage(
@@ -16,6 +16,22 @@ export const authSessionIdAtom = atomWithStorage(
 
 export const authSessionTenantIdAtom = atomWithStorage(
   "authSessionTenantId",
+  "",
+  sessionStorage,
+  {
+    getOnInit: true,
+  },
+);
+
+/**
+ * Identifier (email / username) used to identify the user during the flow.
+ *
+ * <p>Persisted in sessionStorage so it survives reload / direct page access. This is the source for
+ * the FIDO2 registration username, which previously lived only in the in-memory AppContext and was
+ * lost on reload (Issue #1373).
+ */
+export const authIdentifierAtom = atomWithStorage(
+  "authIdentifier",
   "",
   sessionStorage,
   {

--- a/app-view/src/theme/theme.ts
+++ b/app-view/src/theme/theme.ts
@@ -1,0 +1,57 @@
+import { createTheme, Theme } from "@mui/material/styles";
+
+/**
+ * App-wide MUI theme — a light, spacious, trust-oriented look.
+ *
+ * Centralizes palette / typography / shape / component defaults so screens stay consistent and
+ * don't re-implement styling per page. Pass the active font family (e.g. from next/font).
+ */
+export const createAppTheme = (fontFamily: string): Theme =>
+  createTheme({
+    palette: {
+      mode: "light",
+      primary: { main: "#635bff", dark: "#4b45c6", light: "#8a84ff", contrastText: "#ffffff" },
+      background: { default: "#f6f9fc", paper: "#ffffff" },
+      text: { primary: "#1a1f36", secondary: "#697386" },
+      divider: "#e3e8ee",
+      error: { main: "#df1b41" },
+      success: { main: "#1a7f5a" },
+    },
+    shape: { borderRadius: 10 },
+    typography: {
+      fontFamily,
+      h5: { fontWeight: 700, letterSpacing: "-0.02em" },
+      h6: { fontWeight: 600, letterSpacing: "-0.01em" },
+      subtitle1: { fontWeight: 600 },
+      button: { textTransform: "none", fontWeight: 600 },
+    },
+    components: {
+      MuiCssBaseline: {
+        styleOverrides: {
+          body: { backgroundColor: "#f6f9fc" },
+        },
+      },
+      MuiButton: {
+        defaultProps: { disableElevation: true },
+        styleOverrides: {
+          root: { borderRadius: 8, paddingTop: 10, paddingBottom: 10, fontSize: "0.95rem" },
+          containedPrimary: {
+            boxShadow: "0 1px 1px rgba(0,0,0,0.03), 0 2px 5px rgba(60,66,87,0.15)",
+            "&:hover": {
+              backgroundColor: "#4b45c6",
+              boxShadow: "0 1px 2px rgba(0,0,0,0.05), 0 4px 10px rgba(60,66,87,0.22)",
+            },
+          },
+        },
+      },
+      MuiTextField: { defaultProps: { variant: "outlined", fullWidth: true } },
+      MuiOutlinedInput: {
+        styleOverrides: {
+          root: { borderRadius: 8, backgroundColor: "#ffffff" },
+          notchedOutline: { borderColor: "#e3e8ee" },
+        },
+      },
+      MuiPaper: { styleOverrides: { root: { backgroundImage: "none" } } },
+      MuiLink: { styleOverrides: { root: { fontWeight: 600, cursor: "pointer" } } },
+    },
+  });


### PR DESCRIPTION
## 概要

Issue #1373 の「認証ポリシー駆動の動的UI」を、**バックエンド変更なし・既存フロー非破壊**で新規 `/auth` ページとして実装。view-data の `authentication_policy.step_definitions` と `authentication-status` からフローを組み立て、リロード/直アクセスでも状態を復元する。あわせて全画面共通の MUI テーマ（明るい・余白広め）と共有 `AuthCard` を導入し、`/error` も統一。

## 背景（#1373 の課題）

- ページ遷移＋AppContext（インメモリ）依存で、リロード/直アクセスで状態消失 → FIDO2 が `forbidden`
- 認証ポリシー変更のたびに UI コード修正が必要
- signin/signup で状態管理が不統一

## 変更内容

**設定駆動エンジン**
- `useAuthFlow`: view-data + authentication-status から、順序付きステップ・完了判定（`interaction_results` ベース＝リロード耐性）・current step・終端 status を算出
- `StepRenderer`: `method` × register/authenticate でコンポーネント解決（password / email / sms / fido2 / fido-uaf）
- step_definitions 無し時：`available_methods` が複数 → method picker、1件 → 単一ステップ、0件 → パスワード
- `authIdentifierAtom`(sessionStorage) で identifier 永続化 → FIDO2 username 消失バグを解消

**UI / UX**
- 共通テーマ（`ThemeProvider` + Inter）＋共有 `AuthCard`（縦センタリング・柔らかい影・ロゴ/ブランドマーク）
- SSO/Federation ボタン（`available_federations` 駆動）、同意 scope 表示、ToS/Privacy リンク
- パスワード表示トグル、`autoComplete`/`autoFocus`、OTP 6桁セグメント入力
- エラーは Alert（`role="alert"`/aria-live）＋ サーバー `error_description` 表示
- `/error` を `AuthCard` に統一（死んだダークモード三項を撤去）

## 動作確認

- `app-view`：`tsc --noEmit` / `next lint` / `next build` すべて緑（全17ページ生成、`/auth` 含む）
- ※ブラウザ実機の通し確認は未（実 authorization セッションが必要）

## スコープ外 / 既知の前提（follow-up）

- **追加のみ・非破壊**：既存 `/signin` `/signup` `/add-passkey` は未変更（`AuthCard` 未移行の取り残しあり）
- **未配線**：テナントは現状 `/signin`・`/signup` に遷移。`/auth` を実認証UIにするには配線（設定/ルーティング）が必要 ＝ **土台/プレビュー段階**
- **自動テスト無し**（app-view にテスト基盤が無い）
- **fido-uaf** は push＋ステータスポーリングのベストエフォート（実機未検証）

## レビュー観点

- 設定駆動の完了判定（`interaction_results` / `initial-registration` ブリッジ / 終端は条件ツリー status）
- `method` × register/authenticate の解決と method picker
- アクセシビリティ（aria-live / autoComplete / OTP キーボード操作）

Refs #1373

🤖 Generated with [Claude Code](https://claude.com/claude-code)
