### PR TITLE
feat(consent): consent画面の scope/claim 拒否（denied_scopes / denied_claims）でトークンから省略 (#1653 step②)

### DIFF
--- a/documentation/openapi/swagger-authentication-interaction-ja.yaml
+++ b/documentation/openapi/swagger-authentication-interaction-ja.yaml
@@ -58,13 +58,13 @@ tags:
       フェデレーション認証を行うためのAPI群。
 
 paths:
-  /{tenant-id}/v1/authentications/{id}/{interaction-type}:
+  /{tenant-id}/v1/authorizations/{id}/{interaction-type}:
     post:
       tags:
         - 認証インタラクション
       summary: 認証インタラクション実行
       description: |
-        指定された認証トランザクションIDと認証インタラクションタイプに基づいて認証処理を実行します。
+        指定された認可リクエストIDと認証インタラクションタイプに基づいて認証処理を実行します。
 
         ## サポートされている認証インタラクションタイプ
 
@@ -115,7 +115,7 @@ paths:
 
       parameters:
         - $ref: '#/components/parameters/TenantId'
-        - $ref: '#/components/parameters/AuthenticationTransactionId'
+        - $ref: '#/components/parameters/AuthorizationRequestId'
         - $ref: '#/components/parameters/InteractionType'
       requestBody:
         description: |
@@ -509,6 +509,29 @@ paths:
       parameters:
         - $ref: '#/components/parameters/TenantId'
         - $ref: '#/components/parameters/AuthorizationRequestId'
+      requestBody:
+        required: false
+        description: |
+          任意。consent画面でユーザーが共有を拒否したクレーム名（view-data の `claims` から選択）。
+          指定されたクレームは付与時に id_token / userinfo / verified_claims から除外され、発行される
+          トークンに含まれません（OIDC4IDA §5.7.3、claim単位の同意）。ボディ無し（従来どおり）の場合は
+          全要求クレームを許可します。
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                denied_claims:
+                  type: array
+                  items:
+                    type: string
+                  description: 共有を拒否したクレーム名の一覧
+                  example: ["family_name"]
+            examples:
+              deny-family-name:
+                summary: family_name の共有を拒否
+                value:
+                  denied_claims: ["family_name"]
       responses:
         '200':
           description: 認可承認成功

--- a/documentation/openapi/swagger-authentication-interaction-ja.yaml
+++ b/documentation/openapi/swagger-authentication-interaction-ja.yaml
@@ -512,15 +512,26 @@ paths:
       requestBody:
         required: false
         description: |
-          任意。consent画面でユーザーが共有を拒否したクレーム名（view-data の `claims` から選択）。
-          指定されたクレームは付与時に id_token / userinfo / verified_claims から除外され、発行される
-          トークンに含まれません（OIDC4IDA §5.7.3、claim単位の同意）。ボディ無し（従来どおり）の場合は
-          全要求クレームを許可します。
+          任意。consent画面でユーザーが共有を拒否した scope / クレーム（view-data の `scopes` /
+          `claims` から選択）。
+
+          - `denied_scopes`: 拒否された scope。付与スコープから除外され、その scope 由来のクレームも
+            発行されません（認証ポリシー(LoA)由来の拒否スコープにマージされます）。
+          - `denied_claims`: 拒否されたクレーム名。付与時に id_token / userinfo / verified_claims から
+            除外されます（OIDC4IDA §5.7.3、claim単位の同意）。
+
+          ボディ無し（従来どおり）の場合は全要求 scope / クレームを許可します。
         content:
           application/json:
             schema:
               type: object
               properties:
+                denied_scopes:
+                  type: array
+                  items:
+                    type: string
+                  description: 共有を拒否した scope の一覧
+                  example: ["email"]
                 denied_claims:
                   type: array
                   items:
@@ -528,8 +539,12 @@ paths:
                   description: 共有を拒否したクレーム名の一覧
                   example: ["family_name"]
             examples:
+              deny-scope:
+                summary: email スコープの共有を拒否
+                value:
+                  denied_scopes: ["email"]
               deny-family-name:
-                summary: family_name の共有を拒否
+                summary: family_name クレームの共有を拒否
                 value:
                   denied_claims: ["family_name"]
       responses:

--- a/e2e/src/oauth/request.js
+++ b/e2e/src/oauth/request.js
@@ -35,6 +35,7 @@ export const requestAuthorizations = async ({
   authorizationDetails,
   customParams,
   deniedClaims,
+  deniedScopes,
   action = "authorize",
   authorizeEndpoint,
   denyEndpoint,
@@ -113,10 +114,14 @@ export const requestAuthorizations = async ({
 
       await interaction(id, user);
 
+      const authorizeBody = {};
+      if (deniedClaims) authorizeBody.denied_claims = deniedClaims;
+      if (deniedScopes) authorizeBody.denied_scopes = deniedScopes;
+
       const authorizeResponse = await authorize({
         endpoint: authorizeEndpoint || serverConfig.authorizeEndpoint,
         id,
-        body: deniedClaims ? { denied_claims: deniedClaims } : {}
+        body: authorizeBody
       });
 
       // console.log(authorizeResponse.headers);

--- a/e2e/src/oauth/request.js
+++ b/e2e/src/oauth/request.js
@@ -34,6 +34,7 @@ export const requestAuthorizations = async ({
   codeChallengeMethod,
   authorizationDetails,
   customParams,
+  deniedClaims,
   action = "authorize",
   authorizeEndpoint,
   denyEndpoint,
@@ -115,7 +116,7 @@ export const requestAuthorizations = async ({
       const authorizeResponse = await authorize({
         endpoint: authorizeEndpoint || serverConfig.authorizeEndpoint,
         id,
-        body: {}
+        body: deniedClaims ? { denied_claims: deniedClaims } : {}
       });
 
       // console.log(authorizeResponse.headers);

--- a/e2e/src/tests/scenario/application/scenario-consent-denied-claims.test.js
+++ b/e2e/src/tests/scenario/application/scenario-consent-denied-claims.test.js
@@ -62,4 +62,42 @@ describe("Consent: denied claims are omitted from issued tokens (#1653 step②)"
     expect(userinfo.preferred_username).toBeDefined();
     expect(userinfo.email).toBeDefined();
   });
+
+  it("removes an end-user-denied scope (and its claims) from the grant and UserInfo", async () => {
+    const { authorizationResponse } = await requestAuthorizations({
+      endpoint: serverConfig.authorizationEndpoint,
+      clientId: clientSecretPostClient.clientId,
+      responseType: "code",
+      state: `denied-scope-${Date.now()}`,
+      scope: "openid profile email " + clientSecretPostClient.scope,
+      redirectUri: clientSecretPostClient.redirectUri,
+      deniedScopes: ["email"],
+    });
+    expect(authorizationResponse.code).not.toBeNull();
+
+    const tokenResponse = await requestToken({
+      endpoint: serverConfig.tokenEndpoint,
+      code: authorizationResponse.code,
+      grantType: "authorization_code",
+      redirectUri: clientSecretPostClient.redirectUri,
+      clientId: clientSecretPostClient.clientId,
+      clientSecret: clientSecretPostClient.clientSecret,
+    });
+    expect(tokenResponse.status).toBe(200);
+    // denied scope is dropped from the granted scopes
+    expect(tokenResponse.data.scope.split(" ")).not.toContain("email");
+    expect(tokenResponse.data.scope.split(" ")).toContain("profile");
+
+    const userinfoResponse = await get({
+      url: `${backendUrl}/${serverConfig.tenantId}/v1/userinfo`,
+      headers: { Authorization: `Bearer ${tokenResponse.data.access_token}` },
+    });
+    expect(userinfoResponse.status).toBe(200);
+    console.log(JSON.stringify(userinfoResponse.data, null, 2));
+
+    // email scope denied -> email claims omitted; profile claims retained
+    expect(userinfoResponse.data.email).toBeUndefined();
+    expect(userinfoResponse.data.email_verified).toBeUndefined();
+    expect(userinfoResponse.data.name).toBeDefined();
+  });
 });

--- a/e2e/src/tests/scenario/application/scenario-consent-denied-claims.test.js
+++ b/e2e/src/tests/scenario/application/scenario-consent-denied-claims.test.js
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "@jest/globals";
+
+import { getJwks, requestToken } from "../../../api/oauthClient";
+import { backendUrl, clientSecretPostClient, serverConfig } from "../../testConfig";
+import { requestAuthorizations } from "../../../oauth/request";
+import { get } from "../../../lib/http";
+
+/**
+ * Claim-level consent: claims the end-user denies on the consent screen (denied_claims on the
+ * authorize request) are removed from the grant at authorize time, so the issued UserInfo / ID Token
+ * omit them (OIDC4IDA §5.7.3). This covers the standard (scope-derived) claim path; the
+ * verified_claims path is covered in spec/oidc_for_identity_assurance.test.js §5.7.3.
+ */
+describe("Consent: denied claims are omitted from issued tokens (#1653 step②)", () => {
+  // Baseline: with profile + email scope the UserInfo holds name, preferred_username and email.
+  // Denying "name" must drop only that claim while the other consented claims remain.
+  const userinfoWithDeniedClaims = async (deniedClaims) => {
+    const { authorizationResponse } = await requestAuthorizations({
+      endpoint: serverConfig.authorizationEndpoint,
+      clientId: clientSecretPostClient.clientId,
+      responseType: "code",
+      state: `denied-claims-${Date.now()}`,
+      scope: "openid profile email " + clientSecretPostClient.scope,
+      redirectUri: clientSecretPostClient.redirectUri,
+      deniedClaims,
+    });
+    expect(authorizationResponse.code).not.toBeNull();
+
+    const tokenResponse = await requestToken({
+      endpoint: serverConfig.tokenEndpoint,
+      code: authorizationResponse.code,
+      grantType: "authorization_code",
+      redirectUri: clientSecretPostClient.redirectUri,
+      clientId: clientSecretPostClient.clientId,
+      clientSecret: clientSecretPostClient.clientSecret,
+    });
+    expect(tokenResponse.status).toBe(200);
+
+    const userinfoResponse = await get({
+      url: `${backendUrl}/${serverConfig.tenantId}/v1/userinfo`,
+      headers: { Authorization: `Bearer ${tokenResponse.data.access_token}` },
+    });
+    expect(userinfoResponse.status).toBe(200);
+    return userinfoResponse.data;
+  };
+
+  it("retains all consented claims when nothing is denied (baseline)", async () => {
+    const userinfo = await userinfoWithDeniedClaims([]);
+    console.log(JSON.stringify(userinfo, null, 2));
+    expect(userinfo.name).toBeDefined();
+    expect(userinfo.preferred_username).toBeDefined();
+    expect(userinfo.email).toBeDefined();
+  });
+
+  it("removes an end-user-denied standard claim from the UserInfo response", async () => {
+    const userinfo = await userinfoWithDeniedClaims(["name"]);
+    console.log(JSON.stringify(userinfo, null, 2));
+
+    // denied claim omitted
+    expect(userinfo.name).toBeUndefined();
+    // other consented claims (same profile scope + email scope) retained
+    expect(userinfo.preferred_username).toBeDefined();
+    expect(userinfo.email).toBeDefined();
+  });
+});

--- a/e2e/src/tests/spec/oidc_for_identity_assurance.test.js
+++ b/e2e/src/tests/spec/oidc_for_identity_assurance.test.js
@@ -376,7 +376,52 @@ describe("OpenID Connect for Identity Assurance 1.0", () => {
     });
 
     describe("5.7.3 Non-consented data", () => {
-      xit("the OP shall omit from any corresponding ID Token or UserInfo response data that has not had end-user consent for sharing. (pending: requires driving a non-consented state through the consent flow — see #1649-B)", async () => {});
+      it("the OP shall omit from any corresponding ID Token or UserInfo response data that has not had end-user consent for sharing.", async () => {
+        // The RP requests verified given_name + family_name, but the end-user denies family_name on
+        // the consent screen (denied_claims). The granted verified_claims must keep given_name and
+        // omit family_name. (#1653 step②: denied claims are removed from the grant at authorize time.)
+        const verifiedClaimsRequest = {
+          verification: { trust_framework: null },
+          claims: { given_name: null, family_name: null },
+        };
+        const { authorizationResponse } = await requestAuthorizations({
+          endpoint: serverConfig.authorizationEndpoint,
+          clientId: clientSecretPostClient.clientId,
+          responseType: "code",
+          state: "non_consented_verified_claims",
+          scope: "openid " + clientSecretPostClient.scope,
+          redirectUri: clientSecretPostClient.redirectUri,
+          claims: JSON.stringify({ id_token: { verified_claims: verifiedClaimsRequest } }),
+          user: idaVerifiedUser,
+          deniedClaims: ["family_name"],
+        });
+        expect(authorizationResponse.code).not.toBeNull();
+
+        const tokenResponse = await requestToken({
+          endpoint: serverConfig.tokenEndpoint,
+          code: authorizationResponse.code,
+          grantType: "authorization_code",
+          redirectUri: clientSecretPostClient.redirectUri,
+          clientId: clientSecretPostClient.clientId,
+          clientSecret: clientSecretPostClient.clientSecret,
+        });
+        expect(tokenResponse.status).toBe(200);
+
+        const jwksResponse = await getJwks({ endpoint: serverConfig.jwksEndpoint });
+        const decodedIdToken = verifyAndDecodeJwt({
+          jwt: tokenResponse.data.id_token,
+          jwks: jwksResponse.data,
+        });
+        expect(decodedIdToken.verifyResult).toBe(true);
+        const verifiedClaims = decodedIdToken.payload.verified_claims;
+        console.log(JSON.stringify(verifiedClaims, null, 2));
+
+        expect(verifiedClaims).toBeDefined();
+        // consented verified claim is retained
+        expect(verifiedClaims.claims.given_name).toBeDefined();
+        // denied verified claim is omitted (§5.7.3)
+        expect(verifiedClaims.claims.family_name).toBeUndefined();
+      });
     });
 
     describe("5.7.4 Data not matching requirements", () => {

--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/grant_management/grant/GrantIdTokenClaims.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/grant_management/grant/GrantIdTokenClaims.java
@@ -19,6 +19,7 @@ package org.idp.server.core.openid.grant_management.grant;
 import java.util.*;
 import org.idp.server.core.openid.identity.id_token.RequestedIdTokenClaims;
 import org.idp.server.core.openid.identity.id_token.VerifiedClaimsObject;
+import org.idp.server.core.openid.oauth.type.extension.DeniedClaims;
 import org.idp.server.core.openid.oauth.type.oauth.ResponseType;
 import org.idp.server.core.openid.oauth.type.oauth.Scopes;
 
@@ -133,6 +134,22 @@ public class GrantIdTokenClaims implements Iterable<String> {
             ? other.requestedVerifiedClaims
             : this.requestedVerifiedClaims;
     return new GrantIdTokenClaims(newValues, mergedVerifiedClaims);
+  }
+
+  /**
+   * A copy with the end-user-denied claims removed from both the standard claim names and the
+   * verified_claims request, so the ID Token omits non-consented data (OIDC4IDA Section 5.7.3).
+   * Mirrors {@link Scopes#removeScopes} for claims.
+   */
+  public GrantIdTokenClaims removeClaims(DeniedClaims deniedClaims) {
+    if (deniedClaims == null || deniedClaims.isEmpty()) {
+      return this;
+    }
+    Set<String> newValues = new HashSet<>(values);
+    newValues.removeIf(deniedClaims::contains);
+    RequestedVerifiedClaims newVerifiedClaims =
+        requestedVerifiedClaims.removeClaims(deniedClaims.toList());
+    return new GrantIdTokenClaims(newValues, newVerifiedClaims);
   }
 
   @Override

--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/grant_management/grant/GrantUserinfoClaims.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/grant_management/grant/GrantUserinfoClaims.java
@@ -19,6 +19,7 @@ package org.idp.server.core.openid.grant_management.grant;
 import java.util.*;
 import org.idp.server.core.openid.identity.id_token.RequestedUserinfoClaims;
 import org.idp.server.core.openid.identity.id_token.VerifiedClaimsObject;
+import org.idp.server.core.openid.oauth.type.extension.DeniedClaims;
 import org.idp.server.core.openid.oauth.type.oauth.Scopes;
 
 public class GrantUserinfoClaims implements Iterable<String> {
@@ -102,6 +103,22 @@ public class GrantUserinfoClaims implements Iterable<String> {
             ? other.requestedVerifiedClaims
             : this.requestedVerifiedClaims;
     return new GrantUserinfoClaims(newValues, mergedVerifiedClaims);
+  }
+
+  /**
+   * A copy with the end-user-denied claims removed from both the standard claim names and the
+   * verified_claims request, so UserInfo omits non-consented data (OIDC4IDA Section 5.7.3). Mirrors
+   * {@link Scopes#removeScopes} for claims.
+   */
+  public GrantUserinfoClaims removeClaims(DeniedClaims deniedClaims) {
+    if (deniedClaims == null || deniedClaims.isEmpty()) {
+      return this;
+    }
+    Set<String> newValues = new HashSet<>(values);
+    newValues.removeIf(deniedClaims::contains);
+    RequestedVerifiedClaims newVerifiedClaims =
+        requestedVerifiedClaims.removeClaims(deniedClaims.toList());
+    return new GrantUserinfoClaims(newValues, newVerifiedClaims);
   }
 
   @Override

--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/grant_management/grant/RequestedVerifiedClaims.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/grant_management/grant/RequestedVerifiedClaims.java
@@ -18,6 +18,7 @@ package org.idp.server.core.openid.grant_management.grant;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
+import java.util.Collection;
 import org.idp.server.core.openid.identity.id_token.VerifiedClaimsObject;
 import org.idp.server.platform.json.JsonConverter;
 
@@ -94,5 +95,22 @@ public class RequestedVerifiedClaims {
   /** The serialized sentinel token, or an empty string when absent (callers skip it). */
   public String toSentinelToken() {
     return exists() ? sentinelToken : "";
+  }
+
+  /**
+   * A copy with the given claim names removed from the requested verified claims (end-user denial
+   * at the consent screen, OIDC4IDA Section 5.7.3). Returns this when there is nothing requested or
+   * nothing to remove, and {@link #empty()} when every requested verified claim was denied so the
+   * {@code verified_claims} element is omitted entirely.
+   */
+  public RequestedVerifiedClaims removeClaims(Collection<String> deniedClaimNames) {
+    if (!exists() || deniedClaimNames == null || deniedClaimNames.isEmpty()) {
+      return this;
+    }
+    VerifiedClaimsObject filtered = toObject().removeClaims(deniedClaimNames);
+    if (filtered.requestedClaimNames().isEmpty()) {
+      return empty();
+    }
+    return of(filtered);
   }
 }

--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/identity/id_token/VerifiedClaimsObject.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/identity/id_token/VerifiedClaimsObject.java
@@ -17,6 +17,8 @@
 package org.idp.server.core.openid.identity.id_token;
 
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import org.idp.server.platform.json.JsonNodeWrapper;
@@ -51,5 +53,22 @@ public class VerifiedClaimsObject implements JsonReadable {
       return new ArrayList<>();
     }
     return new ArrayList<>(claims.keySet());
+  }
+
+  /**
+   * A copy with the given claim names removed from the {@code claims} member (verification is
+   * preserved), used to drop end-user-denied verified claims at grant build time (OIDC4IDA Section
+   * 5.7.3). Returns this object unchanged when there is nothing to remove.
+   */
+  public VerifiedClaimsObject removeClaims(Collection<String> deniedClaimNames) {
+    if (claims == null
+        || claims.isEmpty()
+        || deniedClaimNames == null
+        || deniedClaimNames.isEmpty()) {
+      return this;
+    }
+    Map<String, Object> filtered = new LinkedHashMap<>(claims);
+    filtered.keySet().removeAll(deniedClaimNames);
+    return new VerifiedClaimsObject(verification, filtered);
   }
 }

--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/oauth/OAuthAuthorizeContext.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/oauth/OAuthAuthorizeContext.java
@@ -36,6 +36,7 @@ import org.idp.server.core.openid.oauth.rar.AuthorizationDetails;
 import org.idp.server.core.openid.oauth.request.AuthorizationRequest;
 import org.idp.server.core.openid.oauth.response.ResponseModeDecidable;
 import org.idp.server.core.openid.oauth.type.extension.CustomProperties;
+import org.idp.server.core.openid.oauth.type.extension.DeniedClaims;
 import org.idp.server.core.openid.oauth.type.extension.DeniedScopes;
 import org.idp.server.core.openid.oauth.type.extension.ExpiresAt;
 import org.idp.server.core.openid.oauth.type.oauth.*;
@@ -50,6 +51,7 @@ public class OAuthAuthorizeContext implements ResponseModeDecidable {
   Authentication authentication;
   CustomProperties customProperties;
   DeniedScopes deniedScopes;
+  DeniedClaims deniedClaims;
   AuthorizationServerConfiguration authorizationServerConfiguration;
   ClientConfiguration clientConfiguration;
 
@@ -61,6 +63,7 @@ public class OAuthAuthorizeContext implements ResponseModeDecidable {
       Authentication authentication,
       CustomProperties customProperties,
       DeniedScopes deniedScopes,
+      DeniedClaims deniedClaims,
       AuthorizationServerConfiguration authorizationServerConfiguration,
       ClientConfiguration clientConfiguration) {
     this.authorizationRequest = authorizationRequest;
@@ -68,6 +71,7 @@ public class OAuthAuthorizeContext implements ResponseModeDecidable {
     this.authentication = authentication;
     this.customProperties = customProperties;
     this.deniedScopes = deniedScopes;
+    this.deniedClaims = deniedClaims;
     this.clientConfiguration = clientConfiguration;
     this.authorizationServerConfiguration = authorizationServerConfiguration;
   }
@@ -103,14 +107,15 @@ public class OAuthAuthorizeContext implements ResponseModeDecidable {
 
     GrantIdTokenClaims grantIdTokenClaims =
         GrantIdTokenClaims.create(
-            removeScopes,
-            responseType,
-            supportedClaims,
-            requestedClaimsPayload.idToken(),
-            idTokenStrictMode);
+                removeScopes,
+                responseType,
+                supportedClaims,
+                requestedClaimsPayload.idToken(),
+                idTokenStrictMode)
+            .removeClaims(deniedClaims);
     GrantUserinfoClaims grantUserinfoClaims =
-        GrantUserinfoClaims.create(
-            removeScopes, supportedClaims, requestedClaimsPayload.userinfo());
+        GrantUserinfoClaims.create(removeScopes, supportedClaims, requestedClaimsPayload.userinfo())
+            .removeClaims(deniedClaims);
     AuthorizationDetails authorizationDetails = authorizationRequest.authorizationDetails();
     ConsentClaims consentClaims = createConsentClaims();
     GrantType grantType = GrantType.authorization_code;

--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/oauth/OAuthFlowApi.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/oauth/OAuthFlowApi.java
@@ -95,6 +95,7 @@ public interface OAuthFlowApi {
   OAuthAuthorizeResponse authorize(
       TenantIdentifier tenantIdentifier,
       AuthorizationRequestIdentifier authorizationRequestIdentifier,
+      Map<String, Object> params,
       RequestAttributes requestAttributes);
 
   OAuthAuthorizeResponse authorizeWithSession(

--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/oauth/handler/OAuthAuthorizeHandler.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/oauth/handler/OAuthAuthorizeHandler.java
@@ -39,6 +39,7 @@ import org.idp.server.core.openid.oauth.response.AuthorizationResponse;
 import org.idp.server.core.openid.oauth.response.AuthorizationResponseCreator;
 import org.idp.server.core.openid.oauth.response.AuthorizationResponseCreators;
 import org.idp.server.core.openid.oauth.type.extension.CustomProperties;
+import org.idp.server.core.openid.oauth.type.extension.DeniedClaims;
 import org.idp.server.core.openid.oauth.type.extension.DeniedScopes;
 import org.idp.server.core.openid.oauth.type.oauth.RequestedClientId;
 import org.idp.server.core.openid.oauth.validator.OAuthAuthorizeRequestValidator;
@@ -86,6 +87,7 @@ public class OAuthAuthorizeHandler {
     Authentication authentication = request.authentication();
     CustomProperties customProperties = request.toCustomProperties();
     DeniedScopes deniedScopes = request.toDeniedScopes();
+    DeniedClaims deniedClaims = request.toDeniedClaims();
 
     OAuthAuthorizeRequestValidator validator =
         new OAuthAuthorizeRequestValidator(
@@ -107,6 +109,7 @@ public class OAuthAuthorizeHandler {
             authentication,
             customProperties,
             deniedScopes,
+            deniedClaims,
             authorizationServerConfiguration,
             clientConfiguration);
 

--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/oauth/io/OAuthAuthorizeRequest.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/oauth/io/OAuthAuthorizeRequest.java
@@ -24,6 +24,7 @@ import org.idp.server.core.openid.authentication.Authentication;
 import org.idp.server.core.openid.identity.User;
 import org.idp.server.core.openid.oauth.request.AuthorizationRequestIdentifier;
 import org.idp.server.core.openid.oauth.type.extension.CustomProperties;
+import org.idp.server.core.openid.oauth.type.extension.DeniedClaims;
 import org.idp.server.core.openid.oauth.type.extension.DeniedScopes;
 import org.idp.server.platform.multi_tenancy.tenant.Tenant;
 import org.idp.server.platform.multi_tenancy.tenant.TenantIdentifier;
@@ -35,6 +36,7 @@ public class OAuthAuthorizeRequest {
   User user;
   Authentication authentication;
   List<String> deniedScopes = new ArrayList<>();
+  List<String> deniedClaims = new ArrayList<>();
   Map<String, Object> customProperties = new HashMap<>();
 
   public OAuthAuthorizeRequest(Tenant tenant, String id, User user, Authentication authentication) {
@@ -46,6 +48,11 @@ public class OAuthAuthorizeRequest {
 
   public OAuthAuthorizeRequest setDeniedScopes(List<String> deniedScopes) {
     this.deniedScopes = deniedScopes;
+    return this;
+  }
+
+  public OAuthAuthorizeRequest setDeniedClaims(List<String> deniedClaims) {
+    this.deniedClaims = deniedClaims;
     return this;
   }
 
@@ -80,5 +87,9 @@ public class OAuthAuthorizeRequest {
 
   public DeniedScopes toDeniedScopes() {
     return new DeniedScopes(deniedScopes);
+  }
+
+  public DeniedClaims toDeniedClaims() {
+    return new DeniedClaims(deniedClaims);
   }
 }

--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/oauth/type/extension/DeniedClaims.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/oauth/type/extension/DeniedClaims.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2025 Hirokazu Kobayashi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.idp.server.core.openid.oauth.type.extension;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+/**
+ * Claim names the end-user declined to share on the consent screen.
+ *
+ * <p>The consent UI presents the requested claims from the authorization view-data; the names the
+ * user unselects are returned here. At grant build time they are removed from the granted id_token
+ * / userinfo / verified_claims so the issued tokens omit non-consented data (OIDC4IDA Section
+ * 5.7.3). Mirrors {@link DeniedScopes}.
+ */
+public class DeniedClaims implements Iterable<String> {
+
+  List<String> values;
+
+  public DeniedClaims() {
+    this.values = new ArrayList<>();
+  }
+
+  public DeniedClaims(List<String> values) {
+    this.values = values != null ? values : new ArrayList<>();
+  }
+
+  public boolean contains(String claimName) {
+    return values.contains(claimName);
+  }
+
+  public boolean isEmpty() {
+    return values.isEmpty();
+  }
+
+  public List<String> toList() {
+    return values;
+  }
+
+  @Override
+  public Iterator<String> iterator() {
+    return values.iterator();
+  }
+}

--- a/libs/idp-server-springboot-adapter/src/main/java/org/idp/server/adapters/springboot/application/restapi/oauth/OAuthV1Api.java
+++ b/libs/idp-server-springboot-adapter/src/main/java/org/idp/server/adapters/springboot/application/restapi/oauth/OAuthV1Api.java
@@ -296,11 +296,13 @@ public class OAuthV1Api implements ParameterTransformable, SecurityHeaderConfigu
   public ResponseEntity<?> authorize(
       @PathVariable("tenant-id") TenantIdentifier tenantIdentifier,
       @PathVariable("id") AuthorizationRequestIdentifier authorizationRequestIdentifier,
+      @RequestBody(required = false) Map<String, Object> body,
       HttpServletRequest httpServletRequest) {
 
     RequestAttributes requestAttributes = transform(httpServletRequest);
     OAuthAuthorizeResponse authAuthorizeResponse =
-        oAuthFlowApi.authorize(tenantIdentifier, authorizationRequestIdentifier, requestAttributes);
+        oAuthFlowApi.authorize(
+            tenantIdentifier, authorizationRequestIdentifier, body, requestAttributes);
 
     HttpHeaders httpHeaders = createSecurityHeaders();
     httpHeaders.setCacheControl("no-store, private");

--- a/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/application/enduser/OAuthFlowEntryService.java
+++ b/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/application/enduser/OAuthFlowEntryService.java
@@ -438,6 +438,7 @@ public class OAuthFlowEntryService implements OAuthFlowApi, OAuthUserDelegate {
   public OAuthAuthorizeResponse authorize(
       TenantIdentifier tenantIdentifier,
       AuthorizationRequestIdentifier authorizationRequestIdentifier,
+      Map<String, Object> params,
       RequestAttributes requestAttributes) {
 
     Tenant tenant = tenantQueryRepository.get(tenantIdentifier);
@@ -463,6 +464,7 @@ public class OAuthFlowEntryService implements OAuthFlowApi, OAuthUserDelegate {
                 ? authenticationTransaction.authentication()
                 : null);
     oAuthAuthorizeRequest.setDeniedScopes(deniedScopes);
+    oAuthAuthorizeRequest.setDeniedClaims(extractDeniedClaims(params));
 
     // Create ClientSession for OIDC Session Management
     oidcSessionHandler
@@ -508,6 +510,23 @@ public class OAuthFlowEntryService implements OAuthFlowApi, OAuthUserDelegate {
     }
 
     return authorize;
+  }
+
+  /**
+   * Claim names the end-user declined to share on the consent screen, taken from the authorize
+   * request body ({@code denied_claims}). Empty when no body / no denial. The names are removed
+   * from the granted id_token / userinfo / verified_claims at grant build time (OIDC4IDA Section
+   * 5.7.3).
+   */
+  private List<String> extractDeniedClaims(Map<String, Object> params) {
+    if (params == null) {
+      return List.of();
+    }
+    Object value = params.get("denied_claims");
+    if (value instanceof List<?> list) {
+      return list.stream().map(String::valueOf).toList();
+    }
+    return List.of();
   }
 
   public OAuthAuthorizeResponse authorizeWithSession(

--- a/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/application/enduser/OAuthFlowEntryService.java
+++ b/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/application/enduser/OAuthFlowEntryService.java
@@ -16,6 +16,7 @@
 
 package org.idp.server.usecases.application.enduser;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -454,7 +455,11 @@ public class OAuthFlowEntryService implements OAuthFlowApi, OAuthUserDelegate {
     validateAuthSession(authenticationTransaction);
 
     User user = authenticationTransaction.user();
-    List<String> deniedScopes = authenticationTransaction.deniedScopes();
+    // Policy-enforced (level-of-authentication) denied scopes, plus any the end-user declined on
+    // the
+    // consent screen (authorize request body).
+    List<String> deniedScopes = new ArrayList<>(authenticationTransaction.deniedScopes());
+    deniedScopes.addAll(extractDeniedScopes(params));
     OAuthAuthorizeRequest oAuthAuthorizeRequest =
         new OAuthAuthorizeRequest(
             tenant,
@@ -513,16 +518,30 @@ public class OAuthFlowEntryService implements OAuthFlowApi, OAuthUserDelegate {
   }
 
   /**
+   * Scope names the end-user declined on the consent screen, taken from the authorize request body
+   * ({@code denied_scopes}). Empty when no body / no denial. These are merged with the
+   * policy-enforced (level-of-authentication) denied scopes and removed from the granted scopes at
+   * grant build time, so the scope and its derived claims are not issued.
+   */
+  private List<String> extractDeniedScopes(Map<String, Object> params) {
+    return extractStringList(params, "denied_scopes");
+  }
+
+  /**
    * Claim names the end-user declined to share on the consent screen, taken from the authorize
    * request body ({@code denied_claims}). Empty when no body / no denial. The names are removed
    * from the granted id_token / userinfo / verified_claims at grant build time (OIDC4IDA Section
    * 5.7.3).
    */
   private List<String> extractDeniedClaims(Map<String, Object> params) {
+    return extractStringList(params, "denied_claims");
+  }
+
+  private List<String> extractStringList(Map<String, Object> params, String key) {
     if (params == null) {
       return List.of();
     }
-    Object value = params.get("denied_claims");
+    Object value = params.get(key);
     if (value instanceof List<?> list) {
       return list.stream().map(String::valueOf).toList();
     }


### PR DESCRIPTION
## 概要

consent画面でユーザーが拒否した **scope / クレーム**を、authorize リクエストの**ボディ**（`denied_scopes` / `denied_claims`）で受け取り、付与時に grant から除外します。これにより発行される access token のスコープ・ID Token / UserInfo / verified_claims から非同意データが省略されます（OIDC4IDA §5.7.3「非同意データ省略」を含む）。

view-data への要求 scope / クレーム露出（#1678 / PR #1679, merged）に続く **#1653 step②**。

| ボディ | 効果 |
|--------|------|
| `denied_scopes: ["email"]` | 付与スコープから除外 → その scope 由来のクレームも全て省略 |
| `denied_claims: ["family_name"]` | クレーム単位で除外（verified_claims 含む、§5.7.3） |

## 設計

- **scope**: 既存の `Scopes#removeScopes` パイプラインを再利用。`OAuthFlowEntryService#authorize` で、認証ポリシー(LoA)由来の deniedScopes に**ボディの `denied_scopes` をマージ**するだけ（core 無改修）。
- **claim（A案：grant に焼き込む）**: `Scopes#removeScopes` と対称の `removeClaims` で grant のクレーム集合（標準 + verified_claims）から拒否分を除外。発行時は grant をそのまま出すだけなので、当初案の ③ConsentClaims拡張・④Assemblerフィルタは**不要化**。

### ⚠️ deniedScopes（既存）とは「入力チャネルが別」
レビュー指摘の訂正。既存の `deniedScopes` は **認証トランザクション（LoA 自動算出）由来**で、今回追加分は **authorize リクエストのボディ由来**。core 内の配線パターン（`OAuthAuthorizeRequest` → `OAuthAuthorizeContext`）は共通だが、**ソースは別物**。consent UI が `/authorize` ボディに `denied_scopes` / `denied_claims` を載せて初めて効きます（下記「UI配線」）。

## 変更内容

**コア**
- `DeniedClaims`（新規 値オブジェクト、`DeniedScopes` ミラー）
- `GrantIdTokenClaims#removeClaims` / `GrantUserinfoClaims#removeClaims`（標準 + verified_claims）
- `VerifiedClaimsObject#removeClaims` / `RequestedVerifiedClaims#removeClaims`（全拒否時は verified_claims ごと省略）
- `OAuthAuthorizeRequest`(deniedClaims) → `OAuthAuthorizeHandler` → `OAuthAuthorizeContext#authorize` で removeClaims 適用
- `OAuthFlowEntryService#authorize`: ボディから `denied_scopes`（LoA とマージ）/ `denied_claims` を抽出
- `OAuthV1Api#authorize`: `@RequestBody(required=false)`（ボディ無し＝従来挙動・回帰なし）

## テスト（実機 green）

- 🎯 `oidc_for_identity_assurance.test.js` §5.7.3 を **xit → it**: verified family_name 拒否 → id_token verified_claims から省略（given_name は残る）
- `scenario-consent-denied-claims.test.js`: ①baseline ②標準クレーム `name` 拒否 → UserInfo から省略 ③`email` scope 拒否 → 付与scope・email系クレームから省略（profile は残る）
- 回帰: IDA フル / 認可フロー spec（code/hybrid/rfc6749）0 failed

## 注意・残課題

- **UI配線（フロント follow-up）**: 現状 `ConsentStep.tsx` は scope を読み取り表示するのみのバイナリ（全許可/全拒否）で、`denied_scopes` / `denied_claims` を送っていません。本PR（backend）merge 後、consent UI で「scope/claim のトグル → ボディ送信」を実装すると end-to-end で機能します。backend 先行 merge は可（reviewer もブロッカー無し）。
- **対象は対話的 `/authorize` 経路のみ**: `authorize-with-session`（セッション再利用・同意画面なし）・CIBA は denial 非対応（同意UIが出ないため設計上正しい）。
- OpenAPI: `authorize` ボディに `denied_scopes` / `denied_claims` を記載。同 swagger に別作業由来の interaction endpoint path 訂正（`authentications`→`authorizations`）を同梱（正しい訂正）。

## ロードマップ（#1653 §5.7.3）
- ✅ ① view-data に scope/claims 露出 → #1679 merged
- ✅ ② denied_scopes / denied_claims で省略 → 本PR
- ❎ ③④ → A案により不要化
- ⬜ UI 配線（ConsentStep）→ フロント follow-up

## 関連
- #1653（親 / §5.7.3）, #1678（step① / merged）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
