### PR TITLE
ci: 依存ライブラリ脆弱性スキャン（Trivy / OSV.dev）を追加

### DIFF
--- a/.github/workflows/scan-dependencies.yml
+++ b/.github/workflows/scan-dependencies.yml
@@ -1,0 +1,69 @@
+name: Scan dependencies
+
+# Trivy で依存ライブラリ（fat jar に同梱される runtime 依存）の脆弱性を fs スキャンし、
+# 結果を GitHub Security タブ（Code scanning）に SARIF でアップロードする。
+# Keycloak の scan-dependencies.yml を Gradle 向けに調整したもの。
+#   - スキャン対象: ./gradlew :app:bootJar の生成物（同梱依存を持つ fat jar）
+#   - スキャナ: vuln のみ（依存の CVE 検出）
+#   - 方針: report-only（CVE 検出でも CI は落とさず、Security タブで可視化する）
+on:
+  schedule:
+    # 毎日 03:00 JST (18:00 UTC)。codeql.yml と同じ運用時刻。
+    - cron: "0 18 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  scan-dependencies:
+    name: Scan dependencies
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: "temurin"
+          java-version: "21"
+          cache: "gradle"
+
+      # 同梱依存をスキャン対象にするため fat jar をビルドする（テストはスキップ）。
+      - name: Build application jar
+        run: ./gradlew :app:bootJar -x test --no-daemon
+
+      # 第三者製のセキュリティスキャナ用 Action はサプライチェーン対策として SHA で固定する。
+      - name: Setup Trivy
+        uses: aquasecurity/setup-trivy@81e514348e19b6112ce2a7e3ecbafe19c1e1f567 # v0.3.1
+        with:
+          cache: true
+          version: v0.70.0
+
+      - name: Trivy scan (jar dependencies)
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          scan-type: "fs"
+          scan-ref: "app/build/libs"
+          format: "json"
+          output: "trivy-report.json"
+          scanners: "vuln"
+          skip-setup-trivy: true
+
+      - name: Display report
+        run: |
+          cat trivy-report.json | jq -r '"| ID | PKG | INSTALLED | FIXED | SEVERITY |", "| -- | -- | -- | -- | -- |", ([.Results[]? | select(.Vulnerabilities != null) | .Vulnerabilities[]] | unique_by(.VulnerabilityID) | .[] | "| \(.VulnerabilityID) | \(.PkgName) | \(.InstalledVersion) | \(.FixedVersion // "-") | \(.Severity) |")' >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Convert to SARIF
+        run: |
+          trivy convert --format sarif -o trivy-report.sarif --scanners vuln trivy-report.json
+
+      - name: Upload report
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: "trivy-report.sarif"
+          category: "dependencies"

--- a/scripts/scan-dependencies.py
+++ b/scripts/scan-dependencies.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+"""Local dependency vulnerability scan via the OSV.dev API.
+
+A lightweight, Trivy-free counterpart to the `Scan dependencies` CI workflow, for quick local
+checks. It resolves the Gradle runtime dependencies (the libraries bundled into the deployable fat
+jar) and queries https://osv.dev for known vulnerabilities (Maven ecosystem).
+
+Usage:
+    python3 scripts/scan-dependencies.py                 # scan :app runtimeClasspath
+    python3 scripts/scan-dependencies.py --module :app --configuration runtimeClasspath
+    python3 scripts/scan-dependencies.py --fail-on HIGH  # exit 1 if a >= HIGH vuln is found
+
+Report-only by default (exit 0) to mirror the CI policy. Needs only Python 3 and network access.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+import time
+import urllib.request
+
+OSV_QUERYBATCH = "https://api.osv.dev/v1/querybatch"
+OSV_VULN = "https://api.osv.dev/v1/vulns/"
+SEVERITY_ORDER = {"LOW": 1, "MEDIUM": 2, "MODERATE": 2, "HIGH": 3, "CRITICAL": 4}
+
+# Matches a Gradle dependency tree line's coordinate: "group:artifact", optional ":version",
+# optional "-> resolvedVersion". Internal "project :libs:..." rows are skipped by the caller.
+_COORD = re.compile(
+    r"^([\w.\-]+):([\w.\-]+)(?::([\w.\-]+))?(?:\s*->\s*([\w.\-]+))?$"
+)
+_TREE_LINE = re.compile(r"^[ |]*[+\\]---\s+(.*)$")
+
+
+def resolve_dependencies(module: str, configuration: str) -> list[tuple[str, str]]:
+    """Return sorted unique (``group:artifact``, version) from the Gradle dependency tree."""
+    cmd = ["./gradlew", "-q", f"{module}:dependencies", "--configuration", configuration]
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if result.returncode != 0:
+        sys.stderr.write(result.stdout)
+        sys.stderr.write(result.stderr)
+        raise SystemExit(f"gradle dependency resolution failed: {' '.join(cmd)}")
+
+    deps: set[tuple[str, str]] = set()
+    for raw in result.stdout.splitlines():
+        if "project :" in raw:
+            continue
+        line = _TREE_LINE.match(raw)
+        if not line:
+            continue
+        body = re.sub(r"\s*\([*cn]\)\s*$", "", line.group(1)).strip()
+        coord = _COORD.match(body)
+        if not coord:
+            continue
+        group, artifact, version, resolved = coord.groups()
+        version = resolved or version
+        if version:
+            deps.add((f"{group}:{artifact}", version))
+    return sorted(deps)
+
+
+def _request_json(url: str, payload: dict | None = None, retries: int = 4) -> dict:
+    """GET (or POST when ``payload`` is set) JSON with retries for transient network errors.
+
+    OSV.dev can drop connections under many rapid sequential requests, so retry with backoff.
+    """
+    data = json.dumps(payload).encode() if payload is not None else None
+    headers = {"Content-Type": "application/json"} if payload is not None else {}
+    last_error: Exception | None = None
+    for attempt in range(retries):
+        try:
+            req = urllib.request.Request(url, data=data, headers=headers)
+            with urllib.request.urlopen(req, timeout=60) as resp:
+                return json.load(resp)
+        except (OSError, ValueError) as error:  # network drop, timeout, malformed body
+            last_error = error
+            time.sleep(0.5 * (attempt + 1))
+    raise last_error if last_error else RuntimeError(f"request failed: {url}")
+
+
+def query_osv(deps: list[tuple[str, str]]) -> dict[tuple[str, str], list[str]]:
+    """Return {(name, version): [vuln_id, ...]} for deps with known vulnerabilities."""
+    found: dict[tuple[str, str], list[str]] = {}
+    for start in range(0, len(deps), 500):
+        chunk = deps[start : start + 500]
+        queries = [
+            {"package": {"ecosystem": "Maven", "name": name}, "version": version}
+            for name, version in chunk
+        ]
+        results = _request_json(OSV_QUERYBATCH, {"queries": queries}).get("results", [])
+        for dep, result in zip(chunk, results):
+            ids = [v["id"] for v in result.get("vulns", [])]
+            if ids:
+                found[dep] = ids
+    return found
+
+
+def summarize(vuln_id: str) -> tuple[str, str, str]:
+    """Return (severity, fixed_version, summary) for a vulnerability id (best effort)."""
+    try:
+        detail = _request_json(OSV_VULN + vuln_id)
+    except Exception:
+        return ("UNKNOWN", "-", "")
+    severity = (detail.get("database_specific", {}) or {}).get("severity", "UNKNOWN")
+    fixed = "-"
+    for affected in detail.get("affected", []):
+        for rng in affected.get("ranges", []):
+            for event in rng.get("events", []):
+                if "fixed" in event:
+                    fixed = event["fixed"]
+    aliases = ", ".join(detail.get("aliases", []))
+    summary = detail.get("summary", "") or aliases
+    return (str(severity).upper(), fixed, summary)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Local OSV.dev dependency vulnerability scan.")
+    parser.add_argument("--module", default=":app", help="Gradle module (default: :app)")
+    parser.add_argument(
+        "--configuration",
+        default="runtimeClasspath",
+        help="Gradle configuration (default: runtimeClasspath)",
+    )
+    parser.add_argument(
+        "--fail-on",
+        choices=["LOW", "MEDIUM", "HIGH", "CRITICAL"],
+        help="Exit 1 when a vulnerability at or above this severity is found (default: report-only)",
+    )
+    args = parser.parse_args()
+
+    print(f"Resolving {args.module}:{args.configuration} dependencies ...", file=sys.stderr)
+    deps = resolve_dependencies(args.module, args.configuration)
+    print(f"Scanning {len(deps)} dependencies against OSV.dev ...", file=sys.stderr)
+
+    vulnerable = query_osv(deps)
+    if not vulnerable:
+        print(f"\n✅ No known vulnerabilities found in {len(deps)} dependencies.")
+        return 0
+
+    rows = []
+    worst = 0
+    for (name, version), ids in sorted(vulnerable.items()):
+        for vuln_id in ids:
+            severity, fixed, summary = summarize(vuln_id)
+            worst = max(worst, SEVERITY_ORDER.get(severity, 0))
+            rows.append((severity, name, version, fixed, vuln_id, summary))
+
+    rows.sort(key=lambda r: SEVERITY_ORDER.get(r[0], 0), reverse=True)
+    print(f"\n⚠️  {len(rows)} vulnerabilities in {len(vulnerable)} dependencies:\n")
+    print(f"{'SEVERITY':<9} {'PACKAGE':<48} {'INSTALLED':<14} {'FIXED':<14} VULN")
+    print("-" * 110)
+    for severity, name, version, fixed, vuln_id, summary in rows:
+        print(f"{severity:<9} {name:<48} {version:<14} {fixed:<14} {vuln_id}")
+        if summary:
+            print(f"{'':<9} └ {summary[:96]}")
+
+    if args.fail_on and worst >= SEVERITY_ORDER[args.fail_on]:
+        print(f"\n❌ Found vulnerabilities at or above {args.fail_on}.", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## 概要

依存ライブラリの既知脆弱性（CVE）を継続的に検出する仕組みを追加します。Keycloak の `scan-dependencies.yml` を Gradle 向けに調整したもので、**CI（Trivy）** と **ローカル（OSV.dev API）** の2系統を提供します。

## ① CI — `.github/workflows/scan-dependencies.yml`

- `:app:bootJar` で生成される **fat jar（同梱 runtime 依存）** を **Trivy `fs` スキャン（`scanners: vuln`）**
- 結果を step summary に表で出力 ＋ **SARIF を GitHub Security タブ（Code scanning）へ**アップロード（category `dependencies`）
- トリガ: **毎日 03:00 JST + 手動（workflow_dispatch）**（`codeql.yml` と同運用時刻）
- 方針: **report-only**（CVE 検出でも CI は緑のまま。可視化に専念）
- 第三者製のスキャナ Action（`aquasecurity/*`）は**サプライチェーン対策として SHA 固定**

> Keycloak も image scan ではなく `fs`/`vuln` の依存スキャンを採用。idp-server は公開コンテナイメージを持たないため、同等の意図を fat jar スキャンで実現しています。

## ② ローカル — `scripts/scan-dependencies.py`

Trivy を入れずに手元で素早く確認するための補完スクリプト。

```bash
python3 scripts/scan-dependencies.py                 # :app runtimeClasspath を OSV.dev で照会
python3 scripts/scan-dependencies.py --fail-on HIGH  # HIGH 以上で exit 1（任意のゲート）
```

- Gradle の runtime 依存を解決 → **OSV.dev API（Maven ecosystem）** で照会
- **Python 標準ライブラリのみ**（Trivy 不要）、一時的なネットワーク断はリトライ
- 既定は report-only（exit 0）。重大度降順で表示

## 動作確認

- workflow YAML 構文 / Python 構文 検証済み
- ローカルスクリプトを実機実行：**190 依存をスキャン → 39 件検出**（CRITICAL 3 / HIGH 15 / MODERATE 20 / LOW 1）、exit 0
- ※ CI の Trivy 実行は GitHub 上（schedule / 手動 dispatch）で確認

## スコープ外（フォローアップ）

- 本PRは**検出の仕組み**のみ。検出された CRITICAL/HIGH 依存（例: `tomcat-embed-core 11.0.21→11.0.22`, `jackson-databind`, `netty` 系）の**アップデートは別Issue/PR**で対応予定。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
