### PR TITLE
fix(ci): Trivy 依存スキャンを rootfs に変更（fs では検出 0 件だった）

### DIFF
--- a/.github/workflows/scan-dependencies.yml
+++ b/.github/workflows/scan-dependencies.yml
@@ -3,7 +3,7 @@ name: Scan dependencies
 # Trivy で依存ライブラリ（fat jar に同梱される runtime 依存）の脆弱性を fs スキャンし、
 # 結果を GitHub Security タブ（Code scanning）に SARIF でアップロードする。
 # Keycloak の scan-dependencies.yml を Gradle 向けに調整したもの。
-#   - スキャン対象: ./gradlew :app:bootJar の生成物（同梱依存を持つ fat jar）
+#   - スキャン対象: ./gradlew :app:bootJar の fat jar から展開した BOOT-INF/lib（同梱依存の jar 群）
 #   - スキャナ: vuln のみ（依存の CVE 検出）
 #   - 方針: report-only（CVE 検出でも CI は落とさず、Security タブで可視化する）
 on:
@@ -37,6 +37,14 @@ jobs:
       - name: Build application jar
         run: ./gradlew :app:bootJar -x test --no-daemon
 
+      # Trivy は Spring Boot の実行可能 fat jar の中（BOOT-INF/lib/*.jar）までは展開してくれず、
+      # そのまま fs スキャンすると依存を 0 件しか検出できない。各依存を素の jar として並べると
+      # それぞれの pom.properties から確実に同定できるため、BOOT-INF/lib を展開してスキャンする。
+      - name: Extract bundled dependencies
+        run: |
+          mkdir -p build/scan-libs
+          unzip -q -o app/build/libs/idp-server-*.jar 'BOOT-INF/lib/*' -d build/scan-libs
+
       # 第三者製のセキュリティスキャナ用 Action はサプライチェーン対策として SHA で固定する。
       - name: Setup Trivy
         uses: aquasecurity/setup-trivy@81e514348e19b6112ce2a7e3ecbafe19c1e1f567 # v0.3.1
@@ -48,7 +56,7 @@ jobs:
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           scan-type: "fs"
-          scan-ref: "app/build/libs"
+          scan-ref: "build/scan-libs"
           format: "json"
           output: "trivy-report.json"
           scanners: "vuln"

--- a/.github/workflows/scan-dependencies.yml
+++ b/.github/workflows/scan-dependencies.yml
@@ -1,9 +1,9 @@
 name: Scan dependencies
 
-# Trivy で依存ライブラリ（fat jar に同梱される runtime 依存）の脆弱性を fs スキャンし、
+# Trivy で依存ライブラリ（fat jar に同梱される runtime 依存）の脆弱性をスキャンし、
 # 結果を GitHub Security タブ（Code scanning）に SARIF でアップロードする。
-# Keycloak の scan-dependencies.yml を Gradle 向けに調整したもの。
-#   - スキャン対象: ./gradlew :app:bootJar の fat jar から展開した BOOT-INF/lib（同梱依存の jar 群）
+#   - スキャン対象: ./gradlew :app:bootJar の fat jar（同梱依存を含む）
+#   - スキャンモード: rootfs（fs と異なり jar アナライザが有効になり、fat jar 内の依存まで検出できる）
 #   - スキャナ: vuln のみ（依存の CVE 検出）
 #   - 方針: report-only（CVE 検出でも CI は落とさず、Security タブで可視化する）
 on:
@@ -37,13 +37,15 @@ jobs:
       - name: Build application jar
         run: ./gradlew :app:bootJar -x test --no-daemon
 
-      # Trivy は Spring Boot の実行可能 fat jar の中（BOOT-INF/lib/*.jar）までは展開してくれず、
-      # そのまま fs スキャンすると依存を 0 件しか検出できない。各依存を素の jar として並べると
-      # それぞれの pom.properties から確実に同定できるため、BOOT-INF/lib を展開してスキャンする。
-      - name: Extract bundled dependencies
-        run: |
-          mkdir -p build/scan-libs
-          unzip -q -o app/build/libs/idp-server-*.jar 'BOOT-INF/lib/*' -d build/scan-libs
+      # Trivy の脆弱性 DB / Java DB（数百 MB）の再取得を避けるためキャッシュする。
+      # 実行ごとに新しいキーで保存しつつ、restore-keys で前回分を復元する。
+      - name: Cache Trivy databases
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/trivy
+          key: trivy-db-${{ github.run_id }}
+          restore-keys: |
+            trivy-db-
 
       # 第三者製のセキュリティスキャナ用 Action はサプライチェーン対策として SHA で固定する。
       - name: Setup Trivy
@@ -55,8 +57,8 @@ jobs:
       - name: Trivy scan (jar dependencies)
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
-          scan-type: "fs"
-          scan-ref: "build/scan-libs"
+          scan-type: "rootfs"
+          scan-ref: "app/build/libs"
           format: "json"
           output: "trivy-report.json"
           scanners: "vuln"


### PR DESCRIPTION
## 概要

`Scan dependencies` ワークフロー（#1685）が**依存を 1 件も検出していなかった**（summary テーブルが空）問題を修正します。

## 原因

Trivy の `fs` スキャンは jar ファイルを言語ファイルとして認識せず（`Number of language-specific files num=0`）、Spring Boot 実行可能 fat jar の同梱依存を検出できていませんでした。BOOT-INF/lib を展開して `fs` スキャンしても同様に 0 件でした（`fs` モードでは jar アナライザが有効にならない）。

## 修正

- **`scan-type: fs` → `rootfs`**: `rootfs`（および `image`）モードでは jar アナライザが有効になり、fat jar の `BOOT-INF/lib/*.jar` まで潜って依存を検出できる。jar の展開は不要で `app/build/libs` を直接スキャン。
- **Trivy DB キャッシュ追加**: `rootfs`/`image` スキャンは Java DB（約 884MB）を取得するため、`actions/cache` で `~/.cache/trivy` をキャッシュし、2 回目以降の再取得を回避。

## 検証

- 手動 dispatch（run #3、本ブランチ）で **Success**、summary テーブルに CVE が多数表示されることを確認。
- 検出例: `tomcat-embed-core`（CRITICAL）, `grpc-netty-shaded` / `postgresql` / `netty` / `jackson-databind`（HIGH）等。ローカルの OSV.dev スクリプト結果とも一致。

## 補足（フォローアップ）

- 残る 2 件の Annotation 警告（Node.js 20 / CodeQL Action v3 の将来 deprecation）は別途対応可。
- 検出された CRITICAL/HIGH 依存の**アップデートは別 Issue/PR**で対応予定。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
