### PR TITLE
chore(deps): bouncycastle (bcprov/bcpkix-jdk18on) を 1.84 へ更新（セキュリティ強化）

### DIFF
--- a/libs/idp-server-platform/build.gradle
+++ b/libs/idp-server-platform/build.gradle
@@ -21,8 +21,8 @@ dependencies {
 	//jose
 	implementation 'com.nimbusds:nimbus-jose-jwt:10.9.1'
 	// BouncyCastle for PEM key parsing
-	implementation 'org.bouncycastle:bcprov-jdk18on:1.78'
-	implementation 'org.bouncycastle:bcpkix-jdk18on:1.78'
+	implementation 'org.bouncycastle:bcprov-jdk18on:1.84'
+	implementation 'org.bouncycastle:bcpkix-jdk18on:1.84'
 	//log
 	implementation("org.slf4j:slf4j-api:2.0.12")
 


### PR DESCRIPTION
## 概要

依存ライブラリのセキュリティ強化として、`idp-server-platform` の **BouncyCastle（`bcprov-jdk18on` / `bcpkix-jdk18on`）を `1.78 → 1.84`** に更新する。脆弱性スキャンで検出された古いバージョンを最新安定版へ上げる。

Part of #1690

## 変更

`libs/idp-server-platform/build.gradle` の 2 行のみ:

```diff
-	implementation 'org.bouncycastle:bcprov-jdk18on:1.78'
-	implementation 'org.bouncycastle:bcpkix-jdk18on:1.78'
+	implementation 'org.bouncycastle:bcprov-jdk18on:1.84'
+	implementation 'org.bouncycastle:bcpkix-jdk18on:1.84'
```

BouncyCastle の直接利用は `JsonWebSignatureFactory` の **PEM 秘密鍵パース 1 箇所のみ**。使用 API（`PEMParser` / `PrivateKeyInfo` / `JcaPEMKeyConverter`）は `1.78→1.84` で非互換な変更はなく、影響は当該パッケージ内部に閉じる（他モジュールは BouncyCastle を直接 import しない）。

## 検証

- **依存解決**: Maven Central に 1.84 実在を確認。`bcpkix → bcutil → bcprov` すべて 1.84 で整合（クラスパス安定）
- **コンパイル**: platform main / test とも破壊的 API 変更なし
- **単体テスト（platform）**: 1,195 件 green / 0 失敗
- **単体テスト（全モジュール）**: 強制再実行（`--rerun-tasks`）で **1,688 件 green / 0 失敗 / 0 skip**
- **E2E**: 別途実機で確認中（PEM 鍵署名経路: private_key_jwt / request object 署名 / FAPI 署名 等）

🤖 Generated with [Claude Code](https://claude.com/claude-code)