### PR TITLE
chore(deps): Spring Boot を 4.0.7 へ更新（セキュリティ強化）

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,6 +1,6 @@
 plugins {
 	id 'java'
-	id 'org.springframework.boot' version '4.0.6'
+	id 'org.springframework.boot' version '4.0.7'
 	id 'io.spring.dependency-management' version '1.1.7'
 	id "com.diffplug.spotless" version "6.24.0"
 }

--- a/libs/idp-server-springboot-adapter/build.gradle
+++ b/libs/idp-server-springboot-adapter/build.gradle
@@ -1,6 +1,6 @@
 plugins {
 	id 'java'
-	id 'org.springframework.boot' version '4.0.6'
+	id 'org.springframework.boot' version '4.0.7'
 	id 'io.spring.dependency-management' version '1.1.7'
 	id "com.diffplug.spotless" version "6.24.0"
 }


### PR DESCRIPTION
## 概要

依存ライブラリのセキュリティ強化として、`org.springframework.boot` Gradle プラグインを **`4.0.6 → 4.0.7`** に更新する。Spring Boot 4.0 系の最新パッチへ追従する。

Part of #1690

## 変更

Spring Boot プラグインを宣言している 2 モジュールの `build.gradle`:

```diff
-	id 'org.springframework.boot' version '4.0.6'
+	id 'org.springframework.boot' version '4.0.7'
```

- `app/build.gradle`
- `libs/idp-server-springboot-adapter/build.gradle`

パッチバンプ（4.0.6→4.0.7）のため API 互換性は維持される。`io.spring.dependency-management` (1.1.7) は据え置き。

## 抜け漏れ確認（grep）

Spring Boot バージョンを管理している箇所はこの 2 ファイルのみであることを確認:

- version catalog (`libs.versions.toml`): 未使用
- `gradle.properties` でのバージョン定義: なし
- BOM / parent (`spring-boot-dependencies` / `mavenBom` / starter-parent): 未使用（プラグイン管理のみ）
- CI workflow: バージョン固定なし

## 検証

- **依存解決**: Spring Boot Gradle プラグイン / BOM 4.0.7 とも実在を確認
- **単体テスト**: 全モジュール強制再実行（`--rerun-tasks`）で **1,688 件 green / 0 失敗**
- **E2E**: オールグリーン

🤖 Generated with [Claude Code](https://claude.com/claude-code)