### PR TITLE
chore(deps): firebase-admin を 9.9.0 へ更新（grpc-netty-shaded の HTTP/2 DoS 対策）

### DIFF
--- a/libs/idp-server-notification-fcm-adapter/build.gradle
+++ b/libs/idp-server-notification-fcm-adapter/build.gradle
@@ -15,7 +15,7 @@ dependencies {
 	implementation project(':libs:idp-server-platform')
 	implementation project(':libs:idp-server-core')
 	implementation project(':libs:idp-server-authentication-interactors')
-	implementation 'com.google.firebase:firebase-admin:9.4.3'
+	implementation 'com.google.firebase:firebase-admin:9.9.0'
 
 	testImplementation platform('org.junit:junit-bom:5.10.0')
 	testImplementation 'org.junit.jupiter:junit-jupiter'


### PR DESCRIPTION
## 概要
`firebase-admin` を **9.4.3 → 9.9.0** へ更新。

## 背景
`./scripts/scan-dependencies.py` の OSV スキャンで以下の HIGH を検出：

| SEVERITY | PACKAGE | INSTALLED | FIXED | VULN |
|---|---|---|---|---|
| HIGH | io.grpc:grpc-netty-shaded | 1.69.0 | 1.75.0 | GHSA-prj3-ccx8-p6x4（Netty MadeYouReset HTTP/2 DDoS） |

`grpc-netty-shaded` は直接依存ではなく、`firebase-admin` → google-cloud（firestore/storage/opentelemetry exporter）経由の transitive。`libraries-bom:26.48.0` が grpc を 1.69.0 に固定していた。

## 対応
`firebase-admin` を 9.9.0（最新）へ上げると `libraries-bom` が **26.48.0 → 26.77.0** に上がり、`grpc-netty-shaded` が **1.69.0 → 1.76.3** に解決される（同梱 Netty が patched 版）。`dependencyInsight` で実測確認済み。

## 補足（到達性）
idp-server の grpc 利用は Google 向け **outbound クライアント**のみで、MadeYouReset（HTTP/2 サーバへの DoS）の実害到達性は低い。本 PR は firebase-admin の通常メンテ更新を兼ねた予防的対応。

## 確認
- [x] `dependencyInsight` で grpc-netty-shaded 1.76.3 を確認
- [x] `fcm-adapter:test` / `app`・`springboot-adapter` の compile 通過
- [x] スキャン再実行で HIGH 解消

## 未対応（別途）
- `opentelemetry-api`（MOD, GHSA-rcgg-9c38-7xpx）: outbound 計装のみで W3C Baggage の inbound パース経路なし＝到達性なし。Spring 検証済 BOM から逸脱するため見送り
- `jackson-databind` 2.21.4（MOD, CVE-2026-54515）: fixed の 2.21.5 が未リリース。アプリ本体が使う jackson3 は修正済（3.1.4）、2系はレガシー内部利用のみ。2.21.5 公開後に対応

🤖 Generated with [Claude Code](https://claude.com/claude-code)