### PR TITLE
refactor: 未使用の弱いハッシュ(MD5/SHA-1)を MessageDigestable/HashAlgorithm から削除 (CodeQL #173)

### DIFF
--- a/libs/idp-server-platform/src/main/java/org/idp/server/platform/hash/HashAlgorithm.java
+++ b/libs/idp-server-platform/src/main/java/org/idp/server/platform/hash/HashAlgorithm.java
@@ -21,8 +21,6 @@ import java.security.NoSuchAlgorithmException;
 
 /** HashAlgorithm */
 enum HashAlgorithm {
-  MD5("MD5"),
-  SHA_1("SHA-1"),
   SHA_256("SHA-256"),
   SHA_384("SHA-384"),
   SHA_512("SHA-512");

--- a/libs/idp-server-platform/src/main/java/org/idp/server/platform/hash/MessageDigestable.java
+++ b/libs/idp-server-platform/src/main/java/org/idp/server/platform/hash/MessageDigestable.java
@@ -20,16 +20,6 @@ import java.security.MessageDigest;
 
 public interface MessageDigestable {
 
-  default byte[] digestWithMD5(String value) {
-    MessageDigest messageDigest = HashAlgorithm.MD5.messageDigest();
-    return messageDigest.digest(value.getBytes());
-  }
-
-  default byte[] digestWithSha1(String value) {
-    MessageDigest messageDigest = HashAlgorithm.SHA_1.messageDigest();
-    return messageDigest.digest(value.getBytes());
-  }
-
   default byte[] digestWithSha256(String value) {
     MessageDigest messageDigest = HashAlgorithm.SHA_256.messageDigest();
     return messageDigest.digest(value.getBytes());
@@ -43,16 +33,6 @@ public interface MessageDigestable {
   default byte[] digestWithSha512(String value) {
     MessageDigest messageDigest = HashAlgorithm.SHA_512.messageDigest();
     return messageDigest.digest(value.getBytes());
-  }
-
-  default byte[] digestWithMD5(byte[] value) {
-    MessageDigest messageDigest = HashAlgorithm.MD5.messageDigest();
-    return messageDigest.digest(value);
-  }
-
-  default byte[] digestWithSha1(byte[] value) {
-    MessageDigest messageDigest = HashAlgorithm.SHA_1.messageDigest();
-    return messageDigest.digest(value);
   }
 
   default byte[] digestWithSha256(byte[] value) {


### PR DESCRIPTION
Closes #1684

## 概要
CodeQL code-scanning **#173**（`java/potentially-weak-cryptographic-algorithm` / CWE-327, CWE-328）で指摘された MD5/SHA-1 利用を削除する。調査の結果、これらは **API に定義のみ存在し呼び出しゼロのデッドコード**だったため、dismiss ではなく**削除して正当にクローズ**する。

## 変更
- `MessageDigestable` から `digestWithMD5` / `digestWithSha1`（String・byte[] の計4メソッド）を削除
- `HashAlgorithm` enum から `MD5` / `SHA_1` を削除（`SHA_256` / `384` / `512` は維持）

## 調査・検証
- 全リポジトリ grep で、削除対象メソッド・enum 値への参照は **MessageDigestable 内部のみ（外部呼び出しゼロ）** を確認
- `HashAlgorithm.valueOf` / 文字列 `"MD5"` `"SHA-1"` 経由の利用も無し（`Uuid5Function` の `getInstance("SHA-1")` は `HashAlgorithm` 非経由の別件＝CodeQL #174 で dismiss 済、本 PR では非対象）
- 実ハッシュ利用はすべて SHA-256 以上（mTLS `x5t#S256` / `at_hash`・`c_hash` / PKCE `S256`）で無修正
- `./gradlew spotlessApply` → `build -x test`（全モジュール compile）→ `:libs:idp-server-platform:test` すべて緑
  - `MessageDigestableThreadSafetyTest` は `digestWithSha256` のみ使用＝削除対象に依存なし

## 受け入れ条件
- [x] MD5 / SHA-1 が `MessageDigestable` / `HashAlgorithm` から除去
- [x] 既存呼び出し（SHA-256+）が無修正でコンパイル・テスト緑
- [ ] CodeQL アラート #173 が次回スキャンで解消（マージ後に確認）

🤖 Generated with [Claude Code](https://claude.com/claude-code)