### PR TITLE
feat: claims:provider_id スコープで provider_id クレームを取得可能にする (#1380)

### DIFF
--- a/documentation/docs/content_06_developer-guide/04-implementation-guides/oauth-oidc/scope-claims-management.md
+++ b/documentation/docs/content_06_developer-guide/04-implementation-guides/oauth-oidc/scope-claims-management.md
@@ -413,6 +413,7 @@ public class ScopeMappingCustomClaimsCreator implements AccessTokenCustomClaimsC
 **対応しているクレーム**:
 - `claims:status` - ユーザーステータス
 - `claims:ex_sub` - 外部ユーザーID
+- `claims:provider_id` - アイデンティティプロバイダID
 - `claims:roles` - ロール一覧
 - `claims:permissions` - 権限一覧
 - `claims:assigned_tenants` - 割り当てテナント一覧

--- a/e2e/src/tests/spec/oidc_core_2_id_token_header_and_custom_claims.test.js
+++ b/e2e/src/tests/spec/oidc_core_2_id_token_header_and_custom_claims.test.js
@@ -159,6 +159,7 @@ describe("ID Token - JOSE Header & Custom Claims Verification", () => {
               "email",
               "management",
               "claims:ex_sub",
+              "claims:provider_id",
               "claims:status",
               "claims:roles",
               "claims:permissions",
@@ -190,7 +191,7 @@ describe("ID Token - JOSE Header & Custom Claims Verification", () => {
             grant_types: ["authorization_code", "password"],
             response_types: ["code"],
             scope:
-              "openid profile email management claims:ex_sub claims:status claims:roles claims:permissions claims:assigned_tenants claims:assigned_organizations",
+              "openid profile email management claims:ex_sub claims:provider_id claims:status claims:roles claims:permissions claims:assigned_tenants claims:assigned_organizations",
             token_endpoint_auth_method: "client_secret_post",
           },
         },
@@ -224,6 +225,34 @@ describe("ID Token - JOSE Header & Custom Claims Verification", () => {
       expect(decoded.verifyResult).toBe(true);
       expect(decoded.payload.status).toBeDefined();
       expect(decoded.payload.status).toBe("REGISTERED");
+    });
+
+    it("claims:provider_id scope should include provider_id claim in ID token", async () => {
+      const tokenResponse = await requestToken({
+        endpoint: `${backendUrl}/${tenantId}/v1/tokens`,
+        grantType: "password",
+        username: userEmail,
+        password: userPassword,
+        scope: "openid claims:provider_id",
+        clientId: clientId,
+        clientSecret: clientSecret,
+      });
+      expect(tokenResponse.status).toBe(200);
+      expect(tokenResponse.data.id_token).toBeDefined();
+
+      const jwksResponse = await getJwks({
+        endpoint: `${backendUrl}/${tenantId}/v1/jwks`,
+      });
+      expect(jwksResponse.status).toBe(200);
+
+      const decoded = verifyAndDecodeJwt({
+        jwt: tokenResponse.data.id_token,
+        jwks: jwksResponse.data,
+      });
+
+      expect(decoded.verifyResult).toBe(true);
+      expect(decoded.payload.provider_id).toBeDefined();
+      expect(decoded.payload.provider_id).toBe("idp-server");
     });
 
     it("claims:roles and claims:permissions should include RBAC claims in ID token", async () => {

--- a/e2e/src/tests/spec/oidc_core_2_id_token_header_and_custom_claims.test.js
+++ b/e2e/src/tests/spec/oidc_core_2_id_token_header_and_custom_claims.test.js
@@ -1,6 +1,6 @@
 import { describe, expect, it, beforeAll } from "@jest/globals";
 
-import { getJwks, requestToken } from "../../api/oauthClient";
+import { getJwks, requestToken, getUserinfo } from "../../api/oauthClient";
 import { onboarding } from "../../api/managementClient";
 import {
   clientSecretPostClient,
@@ -253,6 +253,29 @@ describe("ID Token - JOSE Header & Custom Claims Verification", () => {
       expect(decoded.verifyResult).toBe(true);
       expect(decoded.payload.provider_id).toBeDefined();
       expect(decoded.payload.provider_id).toBe("idp-server");
+    });
+
+    it("claims:provider_id scope should include provider_id claim in the UserInfo response", async () => {
+      const tokenResponse = await requestToken({
+        endpoint: `${backendUrl}/${tenantId}/v1/tokens`,
+        grantType: "password",
+        username: userEmail,
+        password: userPassword,
+        scope: "openid claims:provider_id",
+        clientId: clientId,
+        clientSecret: clientSecret,
+      });
+      expect(tokenResponse.status).toBe(200);
+      expect(tokenResponse.data.access_token).toBeDefined();
+
+      const userinfoResponse = await getUserinfo({
+        endpoint: `${backendUrl}/${tenantId}/v1/userinfo`,
+        authorizationHeader: {
+          Authorization: `Bearer ${tokenResponse.data.access_token}`
+        },
+      });
+      expect(userinfoResponse.status).toBe(200);
+      expect(userinfoResponse.data.provider_id).toBe("idp-server");
     });
 
     it("claims:roles and claims:permissions should include RBAC claims in ID token", async () => {

--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/identity/User.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/identity/User.java
@@ -611,6 +611,10 @@ public class User implements JsonReadable, Serializable, UuidConvertable {
     return externalUserId != null && !externalUserId.isEmpty();
   }
 
+  public boolean hasProviderId() {
+    return providerId != null && !providerId.isEmpty();
+  }
+
   public boolean hasName() {
     return Objects.nonNull(name) && !name.isEmpty();
   }

--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/identity/id_token/plugin/ScopeMappingCustomClaimsCreator.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/identity/id_token/plugin/ScopeMappingCustomClaimsCreator.java
@@ -83,6 +83,10 @@ public class ScopeMappingCustomClaimsCreator implements CustomIndividualClaimsCr
         claims.put("ex_sub", user.externalUserId());
       }
 
+      if (claimName.equals("provider_id") && user.hasProviderId()) {
+        claims.put("provider_id", user.providerId());
+      }
+
       if (claimName.equals("roles") && user.hasRoles()) {
         claims.put("roles", user.roleNameAsListString());
       }

--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/token/plugin/ScopeMappingCustomClaimsCreator.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/token/plugin/ScopeMappingCustomClaimsCreator.java
@@ -73,6 +73,10 @@ public class ScopeMappingCustomClaimsCreator implements AccessTokenCustomClaimsC
         claims.put("ex_sub", user.externalUserId());
       }
 
+      if (claimName.equals("provider_id") && user.hasProviderId()) {
+        claims.put("provider_id", user.providerId());
+      }
+
       if (claimName.equals("roles") && user.hasRoles()) {
         claims.put("roles", user.roleNameAsListString());
       }

--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/userinfo/plugin/UserinfoScopeMappingCustomClaimsCreator.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/userinfo/plugin/UserinfoScopeMappingCustomClaimsCreator.java
@@ -72,6 +72,10 @@ public class UserinfoScopeMappingCustomClaimsCreator
         claims.put("ex_sub", user.externalUserId());
       }
 
+      if (claimName.equals("provider_id") && user.hasProviderId()) {
+        claims.put("provider_id", user.providerId());
+      }
+
       if (claimName.equals("roles") && user.hasRoles()) {
         claims.put("roles", user.roleNameAsListString());
       }


### PR DESCRIPTION
Closes #1380

## 概要
`claims:` プレフィックス付きスコープで `provider_id` クレームを取得できるようにする。認可画面が password 認証リクエストの `provider_id` フィールドを事前に取得し、認証失敗時の `tryResolveUserForLogging` が正しい `provider_id` でユーザーを検索できるようにするのが目的。

## 変更
- `User` に `hasProviderId()` を追加（`hasExternalUserId()` 等と同じスタイル）
- カスタムクレーム creator **3種すべて**に `provider_id` を追加:
  - `token/plugin/ScopeMappingCustomClaimsCreator`（Access Token）
  - `identity/id_token/plugin/ScopeMappingCustomClaimsCreator`（ID Token）
  - `userinfo/plugin/UserinfoScopeMappingCustomClaimsCreator`（UserInfo）

```java
if (claimName.equals("provider_id") && user.hasProviderId()) {
    claims.put("provider_id", user.providerId());
}
```

## Issue との差分（実装時に判明）
- Issue は対象を2ファイルとしていたが、**ID Token 用は別 creator**（`identity/id_token/plugin/...`）のため**3ファイル**に追加。利用シナリオ（Access Token / UserInfo / **ID Token**）を全てカバー
- Issue のコード例 `user.hasProviderId()` は同メソッドが未存在だったため新設（既存 `hasExternalUserId()` と同じ実装）

## 検証
- `./gradlew build -x test`（全モジュール compile）緑
- E2E `oidc_core_2_id_token_header_and_custom_claims`：`claims:provider_id` で ID Token に `provider_id: "idp-server"` が含まれることを実サーバで確認。スイート全体 **9/9 passed**（既存クレーム回帰なし）

## 補足（別 issue に分離）
本作業中、`claims:<custom_property>` の値が null のとき UserInfo で `"key": null` が返り OIDC Core §5.3.2（SHOULD NOT null/empty）に非準拠、という別論点を発見 → #1699 で分離。`provider_id` はデフォルト `"idp-server"` + `hasProviderId()` ガードで null にならないため本 PR の対象外。

🤖 Generated with [Claude Code](https://claude.com/claude-code)