### PR TITLE
feat: standard_claims: スコープで標準クレームをアクセストークンに選択付与する

### DIFF
--- a/documentation/docs/content_03_concepts/04-tokens-claims/concept-03-custom-claims.md
+++ b/documentation/docs/content_03_concepts/04-tokens-claims/concept-03-custom-claims.md
@@ -56,6 +56,30 @@ scope=openid verified_claims:given_name verified_claims:family_name
 
 検証された`given_name`と`family_name`のみが取得されます。
 
+## 標準クレームのアクセストークン付与
+
+標準 OIDC クレーム（`email` / `name` / `phone_number` 等）は通常 ID トークンと Userinfo でのみ提供されます。idp-server では `standard_claims:` プレフィックスを使うことで、これらを**アクセストークンにも選択的に含める**ことができます。リソースサーバが Userinfo エンドポイントを呼ばずに標準属性を参照したい場合に有用です。
+
+### 使用例
+
+```
+scope=openid standard_claims:email standard_claims:name
+```
+
+→ アクセストークン（JWT形式）に `email` と `name` が含まれます。値が無いクレームは省略されます（`null` では返しません）。
+
+### 有効化設定
+
+`claims:` の `custom_claims_scope_mapping` とは独立した専用フラグで opt-in します（デフォルト無効）。
+
+```
+access_token_selective_standard_claims=true
+```
+
+### プライバシー上の注意
+
+アクセストークンの受け手（audience）はリソースサーバであり、ログやキャッシュに残りやすい経路です。`email` などの PII をアクセストークンに載せる場合は、リソースサーバが本当に必要とするクレームのみに絞ってください。専用フラグに分離しているのは、PII をアクセストークンへ載せる能力を `claims:`（カスタムプロパティ）とは別の明示的な opt-in にするためです。
+
 ## 認証方式と組み合わせた動的スコープフィルタリング
 
 認証ポリシーと組み合わせることで、認証方式に応じて取得できるクレームを動的に制御できます。

--- a/documentation/docs/content_06_developer-guide/04-implementation-guides/oauth-oidc/scope-claims-management.md
+++ b/documentation/docs/content_06_developer-guide/04-implementation-guides/oauth-oidc/scope-claims-management.md
@@ -421,6 +421,18 @@ public class ScopeMappingCustomClaimsCreator implements AccessTokenCustomClaimsC
 - `claims:authentication_devices` - 認証デバイス一覧
 - `claims:{任意のカスタムプロパティ}` - ユーザーのカスタムプロパティ
 
+#### `standard_claims:` プレフィックス（標準クレームのアクセストークン付与）
+
+標準 OIDC クレーム（`email` / `name` / `phone_number` 等）は通常 ID トークン / UserInfo でのみ取得できるが、`standard_claims:<クレーム名>` スコープを付与すると **アクセストークンにも** 選択的に含められる。リソースサーバが UserInfo を呼ばずに標準属性を読みたい場合に使う。
+
+- **有効化（opt-in）**: `authorization_server.extension.access_token_selective_standard_claims` を `true` に設定（デフォルト `false`）。`claims:` の `custom_claims_scope_mapping` とは別の専用フラグ
+- **参考実装**: `AccessTokenSelectiveStandardClaimsCreator`（`AccessTokenSelectiveVerifiedClaimsCreator` と同じアクセストークン選択付与ファミリー）。プレフィックスは `startsWith` マッチのため `standard_claims:*` と `claims:*` は相互に干渉しない
+- **プライバシー注意**: アクセストークンの audience はリソースサーバでログ/キャッシュされやすい。PII（`email` 等）を載せる場合は必要なときのみ opt-in すること
+
+**対応している標準クレーム（19種）**: `name` / `given_name` / `family_name` / `middle_name` / `nickname` / `preferred_username` / `profile` / `picture` / `website` / `email` / `email_verified` / `gender` / `birthdate` / `zoneinfo` / `locale` / `phone_number` / `phone_number_verified` / `address` / `updated_at`
+
+例: `scope: "openid standard_claims:email"` → アクセストークンに `"email": "..."` が含まれる。値が無いクレームは省略される（`null` は emit しない）。
+
 ### 2. IDトークン用プラグイン
 
 `CustomIndividualClaimsCreator`インターフェースを実装します。

--- a/documentation/openapi/swagger-cp-tenant-ja.yaml
+++ b/documentation/openapi/swagger-cp-tenant-ja.yaml
@@ -756,6 +756,11 @@ components:
             access_token_selective_verified_claims:
               type: boolean
               description: アクセストークンおよび UserInfo での検証済みクレームの選択的包含を有効にする。
+            access_token_selective_standard_claims:
+              type: boolean
+              description: >-
+                `standard_claims:` プレフィックス付きスコープによる、アクセストークンでの標準 OIDC クレーム（email/name/phone_number 等）の選択的包含を有効にする。
+                デフォルト false。PII をアクセストークンに載せる能力のため、`custom_claims_scope_mapping` とは別の専用 opt-in。
     ErrorResponse:
       type: object
       properties:

--- a/documentation/openapi/swagger-rp-ja.yaml
+++ b/documentation/openapi/swagger-rp-ja.yaml
@@ -2494,7 +2494,10 @@ components:
             `claims:ex_sub` スコープが要求され、かつユーザーに外部ユーザーIDが設定されている場合のみ返却されます。
             `authorization_server.extension.custom_claims_scope_mapping` が `true` である必要があります。
       additionalProperties:
-        description: 任意の拡張プロパティ。テナントの設定などによりトークンに付与される。
+        description: |
+          任意の拡張プロパティ。テナントの設定などによりトークンに付与される。
+          標準 OIDC クレーム（`email`/`name`/`phone_number` 等）は、`standard_claims:<クレーム名>` スコープが要求され、
+          かつ `authorization_server.extension.access_token_selective_standard_claims` が `true` の場合にアクセストークンへ選択的に含まれる。
 
     TokenIntrospectionBadRequestResponse:
       type: object

--- a/e2e/src/tests/spec/oidc_core_2_id_token_header_and_custom_claims.test.js
+++ b/e2e/src/tests/spec/oidc_core_2_id_token_header_and_custom_claims.test.js
@@ -165,6 +165,7 @@ describe("ID Token - JOSE Header & Custom Claims Verification", () => {
               "claims:permissions",
               "claims:assigned_tenants",
               "claims:assigned_organizations",
+              "standard_claims:email",
             ],
             response_types_supported: ["code"],
             response_modes_supported: ["query"],
@@ -176,6 +177,7 @@ describe("ID Token - JOSE Header & Custom Claims Verification", () => {
               token_signed_key_id: "signing_key_1",
               id_token_signed_key_id: "signing_key_1",
               custom_claims_scope_mapping: true,
+              access_token_selective_standard_claims: true,
             },
           },
           user: {
@@ -191,7 +193,7 @@ describe("ID Token - JOSE Header & Custom Claims Verification", () => {
             grant_types: ["authorization_code", "password"],
             response_types: ["code"],
             scope:
-              "openid profile email management claims:ex_sub claims:provider_id claims:status claims:roles claims:permissions claims:assigned_tenants claims:assigned_organizations",
+              "openid profile email management claims:ex_sub claims:provider_id claims:status claims:roles claims:permissions claims:assigned_tenants claims:assigned_organizations standard_claims:email",
             token_endpoint_auth_method: "client_secret_post",
           },
         },
@@ -432,6 +434,50 @@ describe("ID Token - JOSE Header & Custom Claims Verification", () => {
       expect(decoded.payload.iss).toBeDefined();
       expect(decoded.payload.sub).toBeDefined();
       expect(decoded.payload.aud).toBeDefined();
+    });
+
+    it("standard_claims:email scope should include email claim in the access token (#standard-claims)", async () => {
+      const tokenResponse = await requestToken({
+        endpoint: `${backendUrl}/${tenantId}/v1/tokens`,
+        grantType: "password",
+        username: userEmail,
+        password: userPassword,
+        scope: "openid standard_claims:email",
+        clientId: clientId,
+        clientSecret: clientSecret,
+      });
+      expect(tokenResponse.status).toBe(200);
+      expect(tokenResponse.data.access_token).toBeDefined();
+
+      // Access token is a JWT; decode its payload directly.
+      const payload = JSON.parse(
+        Buffer.from(
+          tokenResponse.data.access_token.split(".")[1],
+          "base64url"
+        ).toString()
+      );
+      expect(payload.email).toBe(userEmail);
+    });
+
+    it("email scope alone must NOT put email in the access token (opt-in via standard_claims: only)", async () => {
+      const tokenResponse = await requestToken({
+        endpoint: `${backendUrl}/${tenantId}/v1/tokens`,
+        grantType: "password",
+        username: userEmail,
+        password: userPassword,
+        scope: "openid email",
+        clientId: clientId,
+        clientSecret: clientSecret,
+      });
+      expect(tokenResponse.status).toBe(200);
+
+      const payload = JSON.parse(
+        Buffer.from(
+          tokenResponse.data.access_token.split(".")[1],
+          "base64url"
+        ).toString()
+      );
+      expect(payload.email).toBeUndefined();
     });
   });
 });

--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/identity/StandardClaims.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/identity/StandardClaims.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2025 Hirokazu Kobayashi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.idp.server.core.openid.identity;
+
+import java.util.Optional;
+
+/**
+ * Resolves a single OIDC standard claim value from a {@link User} by claim name.
+ *
+ * <p>Centralizes the claim-name → user-field mapping for the OIDC Core §5.1 standard claims. Each
+ * claim is guarded by the corresponding {@code User#hasXxx()} so a value is only returned when it
+ * is actually present. Unknown names and absent values both yield {@link Optional#empty()} — the
+ * claim must then be omitted (never emitted as {@code null}), consistent with OIDC Core §5.3.2.
+ *
+ * <p>Used by the {@code standard_claims:} scope mapping to surface standard claims where they are
+ * not otherwise available (e.g. the access token).
+ */
+public final class StandardClaims {
+
+  private StandardClaims() {}
+
+  public static Optional<Object> resolve(User user, String claimName) {
+    return switch (claimName) {
+      case "name" -> user.hasName() ? Optional.of(user.name()) : Optional.empty();
+      case "given_name" -> user.hasGivenName() ? Optional.of(user.givenName()) : Optional.empty();
+      case "family_name" ->
+          user.hasFamilyName() ? Optional.of(user.familyName()) : Optional.empty();
+      case "middle_name" ->
+          user.hasMiddleName() ? Optional.of(user.middleName()) : Optional.empty();
+      case "nickname" -> user.hasNickname() ? Optional.of(user.nickname()) : Optional.empty();
+      case "preferred_username" ->
+          user.hasPreferredUsername() ? Optional.of(user.preferredUsername()) : Optional.empty();
+      case "profile" -> user.hasProfile() ? Optional.of(user.profile()) : Optional.empty();
+      case "picture" -> user.hasPicture() ? Optional.of(user.picture()) : Optional.empty();
+      case "website" -> user.hasWebsite() ? Optional.of(user.website()) : Optional.empty();
+      case "email" -> user.hasEmail() ? Optional.of(user.email()) : Optional.empty();
+      case "email_verified" ->
+          user.hasEmailVerified() ? Optional.of(user.emailVerified()) : Optional.empty();
+      case "gender" -> user.hasGender() ? Optional.of(user.gender()) : Optional.empty();
+      case "birthdate" -> user.hasBirthdate() ? Optional.of(user.birthdate()) : Optional.empty();
+      case "zoneinfo" -> user.hasZoneinfo() ? Optional.of(user.zoneinfo()) : Optional.empty();
+      case "locale" -> user.hasLocale() ? Optional.of(user.locale()) : Optional.empty();
+      case "phone_number" ->
+          user.hasPhoneNumber() ? Optional.of(user.phoneNumber()) : Optional.empty();
+      case "phone_number_verified" ->
+          user.hasPhoneNumberVerified()
+              ? Optional.of(user.phoneNumberVerified())
+              : Optional.empty();
+      case "address" -> user.hasAddress() ? Optional.of(user.address().toMap()) : Optional.empty();
+      case "updated_at" ->
+          user.hasUpdatedAt() ? Optional.of(user.updateAtAsLong()) : Optional.empty();
+      default -> Optional.empty();
+    };
+  }
+}

--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/oauth/configuration/AuthorizationServerConfiguration.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/oauth/configuration/AuthorizationServerConfiguration.java
@@ -630,6 +630,10 @@ public class AuthorizationServerConfiguration implements JsonReadable, Configura
     return extension.enabledAccessTokenSelectiveVerifiedClaims();
   }
 
+  public boolean enabledAccessTokenSelectiveStandardClaims() {
+    return extension.enabledAccessTokenSelectiveStandardClaims();
+  }
+
   public boolean verifiedClaimsSupported() {
     return verifiedClaimsSupported;
   }

--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/oauth/configuration/AuthorizationServerExtensionConfiguration.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/oauth/configuration/AuthorizationServerExtensionConfiguration.java
@@ -50,6 +50,7 @@ public class AuthorizationServerExtensionConfiguration implements JsonReadable {
   boolean customClaimsScopeMapping = false;
   boolean accessTokenSelectiveUserCustomProperties = false;
   boolean accessTokenSelectiveVerifiedClaims = false;
+  boolean accessTokenSelectiveStandardClaims = false;
 
   public AuthorizationServerExtensionConfiguration() {}
 
@@ -177,6 +178,10 @@ public class AuthorizationServerExtensionConfiguration implements JsonReadable {
     return accessTokenSelectiveVerifiedClaims;
   }
 
+  public boolean enabledAccessTokenSelectiveStandardClaims() {
+    return accessTokenSelectiveStandardClaims;
+  }
+
   public AuthenticationInteractionType defaultCibaAuthenticationInteractionType() {
     return new AuthenticationInteractionType(defaultCibaAuthenticationInteractionType);
   }
@@ -212,6 +217,7 @@ public class AuthorizationServerExtensionConfiguration implements JsonReadable {
     map.put(
         "access_token_selective_user_custom_properties", accessTokenSelectiveUserCustomProperties);
     map.put("access_token_selective_verified_claims", accessTokenSelectiveVerifiedClaims);
+    map.put("access_token_selective_standard_claims", accessTokenSelectiveStandardClaims);
     return map;
   }
 }

--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/token/plugin/AccessTokenCustomClaimsCreators.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/token/plugin/AccessTokenCustomClaimsCreators.java
@@ -35,6 +35,7 @@ public class AccessTokenCustomClaimsCreators {
   public AccessTokenCustomClaimsCreators() {
     this.creators = new ArrayList<>();
     this.creators.add(new ScopeMappingCustomClaimsCreator());
+    this.creators.add(new AccessTokenSelectiveStandardClaimsCreator());
     creators.addAll(AccessTokenCustomClaimsCreationPluginLoader.load());
   }
 

--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/token/plugin/AccessTokenSelectiveStandardClaimsCreator.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/token/plugin/AccessTokenSelectiveStandardClaimsCreator.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2025 Hirokazu Kobayashi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.idp.server.core.openid.token.plugin;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.idp.server.core.openid.grant_management.grant.AuthorizationGrant;
+import org.idp.server.core.openid.identity.StandardClaims;
+import org.idp.server.core.openid.identity.User;
+import org.idp.server.core.openid.oauth.clientauthenticator.clientcredentials.ClientCredentials;
+import org.idp.server.core.openid.oauth.configuration.AuthorizationServerConfiguration;
+import org.idp.server.core.openid.oauth.configuration.client.ClientConfiguration;
+import org.idp.server.core.openid.oauth.type.oauth.Scopes;
+
+/**
+ * Adds OIDC standard claims to the JWT access token via the {@code standard_claims:} scope prefix.
+ *
+ * <p>Standard profile claims (name, email, phone_number, …) are otherwise only available on the ID
+ * Token / UserInfo (via the profile/email/… scopes). This creator lets a client opt in to surfacing
+ * a specific standard claim on the access token — e.g. {@code standard_claims:email} — so a
+ * resource server can read it without a UserInfo round-trip.
+ *
+ * <p>Sibling of the access-token selective claim creators (verified claims / user custom
+ * properties): access-token-only and gated by its own {@code
+ * access_token_selective_standard_claims} flag. Distinct from {@link
+ * ScopeMappingCustomClaimsCreator} ({@code claims:} prefix), which maps custom_properties and
+ * system claims across access token / ID token / UserInfo. The prefixes are matched by {@code
+ * startsWith}, so {@code standard_claims:*} never collides with {@code claims:*}.
+ *
+ * <p>Note (privacy): the access token audience is the resource server and tokens are frequently
+ * logged/cached, so only opt in to standard claims (especially PII) on the access token when the
+ * resource server genuinely needs them.
+ */
+public class AccessTokenSelectiveStandardClaimsCreator implements AccessTokenCustomClaimsCreator {
+
+  private static final String prefix = "standard_claims:";
+
+  @Override
+  public boolean shouldCreate(
+      AuthorizationGrant authorizationGrant,
+      AuthorizationServerConfiguration authorizationServerConfiguration,
+      ClientConfiguration clientConfiguration,
+      ClientCredentials clientCredentials) {
+
+    if (!authorizationServerConfiguration.enabledAccessTokenSelectiveStandardClaims()) {
+      return false;
+    }
+
+    return authorizationGrant.scopes().hasScopeMatchedPrefix(prefix);
+  }
+
+  @Override
+  public Map<String, Object> create(
+      AuthorizationGrant authorizationGrant,
+      AuthorizationServerConfiguration authorizationServerConfiguration,
+      ClientConfiguration clientConfiguration,
+      ClientCredentials clientCredentials) {
+
+    User user = authorizationGrant.user();
+    Map<String, Object> claims = new HashMap<>();
+
+    Scopes filteredClaimsScope = authorizationGrant.scopes().filterMatchedPrefix(prefix);
+
+    for (String scope : filteredClaimsScope) {
+      String claimName = scope.substring(prefix.length());
+      StandardClaims.resolve(user, claimName).ifPresent(value -> claims.put(claimName, value));
+    }
+
+    return claims;
+  }
+}

--- a/libs/idp-server-core/src/test/java/org/idp/server/core/openid/identity/StandardClaimsTest.java
+++ b/libs/idp-server-core/src/test/java/org/idp/server/core/openid/identity/StandardClaimsTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2025 Hirokazu Kobayashi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.idp.server.core.openid.identity;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+class StandardClaimsTest {
+
+  @Test
+  void resolvesPresentStandardClaimsFromUserFields() {
+    User user =
+        new User().setName("Alice Example").setEmail("alice@example.com").setEmailVerified(true);
+
+    assertEquals(Optional.of("Alice Example"), StandardClaims.resolve(user, "name"));
+    assertEquals(Optional.of("alice@example.com"), StandardClaims.resolve(user, "email"));
+    assertEquals(Optional.of(true), StandardClaims.resolve(user, "email_verified"));
+  }
+
+  @Test
+  void returnsEmptyForAbsentStandardClaims() {
+    User user = new User().setEmail("alice@example.com");
+
+    // set but not requested-here fields resolve, unset ones are empty (never null)
+    assertTrue(StandardClaims.resolve(user, "given_name").isEmpty());
+    assertTrue(StandardClaims.resolve(user, "phone_number").isEmpty());
+    assertTrue(StandardClaims.resolve(user, "address").isEmpty());
+    assertTrue(StandardClaims.resolve(user, "email_verified").isEmpty());
+  }
+
+  @Test
+  void returnsEmptyForUnknownOrNonStandardClaimNames() {
+    User user = new User().setName("Alice").setEmail("alice@example.com");
+
+    // "sub" is always present on the token itself and is intentionally not a standard_claims target
+    assertTrue(StandardClaims.resolve(user, "sub").isEmpty());
+    // arbitrary / custom_property-style names are not resolved by the standard resolver
+    assertTrue(StandardClaims.resolve(user, "roles").isEmpty());
+    assertTrue(StandardClaims.resolve(user, "not_a_claim").isEmpty());
+    assertTrue(StandardClaims.resolve(user, "").isEmpty());
+  }
+}


### PR DESCRIPTION
## 概要
アクセストークンには標準 OIDC クレーム（email/name/phone_number 等）を載せる経路が無く、リソースサーバが UserInfo を叩かずに標準属性を得る手段がなかった。opt-in の `standard_claims:` スコープでこれを可能にする。

```
scope: "openid standard_claims:email"  →  access_token に "email": "..." が入る
```

## 実装
- **`StandardClaims`**（新）: 19標準クレームを名前→User フィールドで解決する正準リゾルバ。`hasX()` ガードで値が無ければ `Optional.empty`（**null は emit しない** — OIDC Core §5.3.2 準拠、#1699 の教訓を反映）
- **`AccessTokenSelectiveStandardClaimsCreator`**（新）: `standard_claims:` プレフィックスを処理し **AT にのみ**付与。`AccessTokenSelectiveVerifiedClaimsCreator` と同じ「AT 選択付与」ファミリー
- **`access_token_selective_standard_claims`** フラグ（default false）で opt-in。`claims:` の `custom_claims_scope_mapping`（AT/ID/UserInfo 横断）とは**別の専用ゲート**

## 設計判断
- **AT 限定**: id_token/userinfo は既に `profile`/`email` スコープで標準クレームを出せるため対象外
- **専用フラグ**: `standard_claims:` は PII（email 等）を AT に載せる、`claims:` とは別次元の能力。同じフラグに相乗りさせず専用 opt-in にして secure by default。命名も AT 専用の `access_token_selective_*` ファミリーに整合（`custom_claims_scope_mapping` の cross-token 系ではない）
- **衝突なし**: prefix は `startsWith` マッチのため `standard_claims:*` と `claims:*` は非衝突
- **PII 注意**: AT の audience はリソースサーバでログ/キャッシュされやすい。javadoc に「必要な場合のみ opt-in」と明示

## 検証
- ユニット `StandardClaimsTest`: present→値 / absent→empty / unknown→empty（3/3）
- E2E: `standard_claims:email` で AT に email が載り、`email` スコープ単体では載らないことを実サーバで確認。スイート全体 **10/10 passed**
- `build -x test` 全モジュール緑

## 補足
- ドキュメント（`standard_claims:` スコープ / `access_token_selective_standard_claims` フラグ）は follow-up で追加予定
- 独立機能のため既存 issue とは紐付けなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)
