### PR TITLE
test(e2e): extension 期待値に access_token_selective_standard_claims を追加（#1701 回帰修正）

### DIFF
--- a/e2e/src/tests/scenario/control_plane/organization/organization_authorization_server_management.test.js
+++ b/e2e/src/tests/scenario/control_plane/organization/organization_authorization_server_management.test.js
@@ -350,7 +350,8 @@ describe("organization authorization server management api", () => {
           "required_identity_verification_scopes": ["identity_verification"],
           "custom_claims_scope_mapping": true,
           "access_token_selective_user_custom_properties": true,
-          "access_token_selective_verified_claims": true
+          "access_token_selective_verified_claims": true,
+          "access_token_selective_standard_claims": true
         }
       };
 
@@ -451,7 +452,7 @@ describe("organization authorization server management api", () => {
           "default_ciba_authentication_interaction_type", "oauth_authorization_request_expires_in",
           "fapi_baseline_scopes", "fapi_advance_scopes", "required_identity_verification_scopes",
           "custom_claims_scope_mapping", "access_token_selective_user_custom_properties",
-          "access_token_selective_verified_claims"
+          "access_token_selective_verified_claims", "access_token_selective_standard_claims"
         ];
 
         extensionFields.forEach(field => {


### PR DESCRIPTION
## 概要
#1701（standard_claims:）で `AuthorizationServerExtensionConfiguration.toMap()` に `access_token_selective_standard_claims` を追加したが、extension マップ全体を deep-equal で検証する E2E の期待値を更新しておらず、返却マップに増えたフィールドで `toEqual` が失敗していた回帰を修正。

```
- Expected  - 0
+ Received  + 1
+   "access_token_selective_standard_claims": false,
    "access_token_selective_user_custom_properties": true,
    "access_token_selective_verified_claims": true,
  at organization_authorization_server_management.test.js:427
```

## 修正
`organization_authorization_server_management.test.js`:
- `comprehensiveConfig.extension` に `access_token_selective_standard_claims: true` を追加（round-trip で一致）
- `extensionFields` カバレッジリストにも追加

## 影響範囲
- 他の extension 参照テスト（`organization_tenant_management` / `ekyc-01`）は input のみで全マップ deep-equal を持たないため影響なし（確認済み）

## 検証
- `organization_authorization_server_management` 4/4 green（実サーバ）

🤖 Generated with [Claude Code](https://claude.com/claude-code)