### PR TITLE
fix: claims: の custom_property が null のとき claim を省略する（OIDC Core §5.3.2 準拠） (#1699)

### DIFF
--- a/e2e/src/tests/spec/oidc_core_2_id_token_header_and_custom_claims.test.js
+++ b/e2e/src/tests/spec/oidc_core_2_id_token_header_and_custom_claims.test.js
@@ -166,6 +166,8 @@ describe("ID Token - JOSE Header & Custom Claims Verification", () => {
               "claims:assigned_tenants",
               "claims:assigned_organizations",
               "standard_claims:email",
+              "claims:nullprop",
+              "claims:realprop",
             ],
             response_types_supported: ["code"],
             response_modes_supported: ["query"],
@@ -185,6 +187,8 @@ describe("ID Token - JOSE Header & Custom Claims Verification", () => {
             provider_id: "idp-server",
             email: userEmail,
             raw_password: userPassword,
+            // #1699: a null-valued custom property must be omitted (not "key": null) in UserInfo
+            custom_properties: { nullprop: null, realprop: "real-value" },
           },
           client: {
             client_id: clientId,
@@ -193,7 +197,7 @@ describe("ID Token - JOSE Header & Custom Claims Verification", () => {
             grant_types: ["authorization_code", "password"],
             response_types: ["code"],
             scope:
-              "openid profile email management claims:ex_sub claims:provider_id claims:status claims:roles claims:permissions claims:assigned_tenants claims:assigned_organizations standard_claims:email",
+              "openid profile email management claims:ex_sub claims:provider_id claims:status claims:roles claims:permissions claims:assigned_tenants claims:assigned_organizations standard_claims:email claims:nullprop claims:realprop",
             token_endpoint_auth_method: "client_secret_post",
           },
         },
@@ -278,6 +282,32 @@ describe("ID Token - JOSE Header & Custom Claims Verification", () => {
       });
       expect(userinfoResponse.status).toBe(200);
       expect(userinfoResponse.data.provider_id).toBe("idp-server");
+    });
+
+    it("null custom property is omitted (not \"key\": null) from UserInfo, non-null is kept (#1699)", async () => {
+      const tokenResponse = await requestToken({
+        endpoint: `${backendUrl}/${tenantId}/v1/tokens`,
+        grantType: "password",
+        username: userEmail,
+        password: userPassword,
+        scope: "openid claims:nullprop claims:realprop",
+        clientId: clientId,
+        clientSecret: clientSecret,
+      });
+      expect(tokenResponse.status).toBe(200);
+
+      const userinfoResponse = await getUserinfo({
+        endpoint: `${backendUrl}/${tenantId}/v1/userinfo`,
+        authorizationHeader: {
+          Authorization: `Bearer ${tokenResponse.data.access_token}`,
+        },
+      });
+      expect(userinfoResponse.status).toBe(200);
+
+      // OIDC Core §5.3.2: the null-valued claim must be omitted entirely, not present as null.
+      expect(userinfoResponse.data).not.toHaveProperty("nullprop");
+      // The non-null custom property is still returned.
+      expect(userinfoResponse.data.realprop).toBe("real-value");
     });
 
     it("claims:roles and claims:permissions should include RBAC claims in ID token", async () => {

--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/identity/id_token/plugin/ScopeMappingCustomClaimsCreator.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/identity/id_token/plugin/ScopeMappingCustomClaimsCreator.java
@@ -72,8 +72,11 @@ public class ScopeMappingCustomClaimsCreator implements CustomIndividualClaimsCr
     for (String scope : filteredClaimsScope) {
       String claimName = scope.substring(prefix.length());
 
-      if (customProperties.contains(claimName)) {
-        claims.put(claimName, customProperties.getValue(claimName));
+      // A null custom property value must be omitted, not returned as "key": null
+      // (OIDC Core §5.3.2). Issue #1699.
+      Object customValue = customProperties.getValue(claimName);
+      if (customValue != null) {
+        claims.put(claimName, customValue);
       }
       if (claimName.equals("status")) {
         claims.put("status", user.status().name());

--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/token/plugin/ScopeMappingCustomClaimsCreator.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/token/plugin/ScopeMappingCustomClaimsCreator.java
@@ -61,8 +61,11 @@ public class ScopeMappingCustomClaimsCreator implements AccessTokenCustomClaimsC
     for (String scope : filteredClaimsScope) {
       String claimName = scope.substring(prefix.length());
 
-      if (customProperties.contains(claimName)) {
-        claims.put(claimName, customProperties.getValue(claimName));
+      // A null custom property value must be omitted, not returned as "key": null
+      // (OIDC Core §5.3.2). Issue #1699.
+      Object customValue = customProperties.getValue(claimName);
+      if (customValue != null) {
+        claims.put(claimName, customValue);
       }
 
       if (claimName.equals("status")) {

--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/userinfo/plugin/UserinfoScopeMappingCustomClaimsCreator.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/userinfo/plugin/UserinfoScopeMappingCustomClaimsCreator.java
@@ -60,8 +60,11 @@ public class UserinfoScopeMappingCustomClaimsCreator
     for (String scope : filteredClaimsScope) {
       String claimName = scope.substring(prefix.length());
 
-      if (customProperties.contains(claimName)) {
-        claims.put(claimName, customProperties.getValue(claimName));
+      // A null custom property value must be omitted, not returned as "key": null
+      // (OIDC Core §5.3.2). Issue #1699.
+      Object customValue = customProperties.getValue(claimName);
+      if (customValue != null) {
+        claims.put(claimName, customValue);
       }
 
       if (claimName.equals("status")) {

--- a/libs/idp-server-core/src/test/java/org/idp/server/core/openid/identity/id_token/plugin/ScopeMappingCustomClaimsCreatorTest.java
+++ b/libs/idp-server-core/src/test/java/org/idp/server/core/openid/identity/id_token/plugin/ScopeMappingCustomClaimsCreatorTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2025 Hirokazu Kobayashi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.idp.server.core.openid.identity.id_token.plugin;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import org.idp.server.core.openid.grant_management.grant.AuthorizationGrant;
+import org.idp.server.core.openid.grant_management.grant.AuthorizationGrantBuilder;
+import org.idp.server.core.openid.identity.User;
+import org.idp.server.core.openid.oauth.type.oauth.GrantType;
+import org.idp.server.core.openid.oauth.type.oauth.RequestedClientId;
+import org.idp.server.core.openid.oauth.type.oauth.Scopes;
+import org.idp.server.platform.multi_tenancy.tenant.TenantIdentifier;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Issue #1699: a {@code claims:<custom_property>} whose value is null must be omitted from the ID
+ * token (not put as {@code "key": null}).
+ */
+class ScopeMappingCustomClaimsCreatorTest {
+
+  @Test
+  void omitsNullCustomPropertyButKeepsNonNull() {
+    HashMap<String, Object> props = new HashMap<>();
+    props.put("nullprop", null);
+    props.put("realprop", "value");
+    User user = new User().setSub(UUID.randomUUID().toString()).setCustomProperties(props);
+
+    AuthorizationGrant grant =
+        new AuthorizationGrantBuilder(
+                new TenantIdentifier(UUID.randomUUID().toString()),
+                new RequestedClientId("test-client"),
+                GrantType.authorization_code,
+                new Scopes("claims:nullprop claims:realprop"))
+            .add(user)
+            .build();
+
+    ScopeMappingCustomClaimsCreator creator = new ScopeMappingCustomClaimsCreator();
+    Map<String, Object> claims = creator.create(user, null, grant, null, null, null, null);
+
+    assertFalse(claims.containsKey("nullprop"), "null custom property must be omitted");
+    assertEquals("value", claims.get("realprop"));
+  }
+}

--- a/libs/idp-server-core/src/test/java/org/idp/server/core/openid/token/plugin/ScopeMappingCustomClaimsCreatorTest.java
+++ b/libs/idp-server-core/src/test/java/org/idp/server/core/openid/token/plugin/ScopeMappingCustomClaimsCreatorTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2025 Hirokazu Kobayashi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.idp.server.core.openid.token.plugin;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import org.idp.server.core.openid.grant_management.grant.AuthorizationGrant;
+import org.idp.server.core.openid.grant_management.grant.AuthorizationGrantBuilder;
+import org.idp.server.core.openid.identity.User;
+import org.idp.server.core.openid.oauth.type.oauth.GrantType;
+import org.idp.server.core.openid.oauth.type.oauth.RequestedClientId;
+import org.idp.server.core.openid.oauth.type.oauth.Scopes;
+import org.idp.server.platform.multi_tenancy.tenant.TenantIdentifier;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Issue #1699: a {@code claims:<custom_property>} whose value is null must be omitted from the
+ * access token (not put as {@code "key": null}).
+ */
+class ScopeMappingCustomClaimsCreatorTest {
+
+  @Test
+  void omitsNullCustomPropertyButKeepsNonNull() {
+    HashMap<String, Object> props = new HashMap<>();
+    props.put("nullprop", null);
+    props.put("realprop", "value");
+    User user = new User().setSub(UUID.randomUUID().toString()).setCustomProperties(props);
+
+    AuthorizationGrant grant =
+        new AuthorizationGrantBuilder(
+                new TenantIdentifier(UUID.randomUUID().toString()),
+                new RequestedClientId("test-client"),
+                GrantType.authorization_code,
+                new Scopes("claims:nullprop claims:realprop"))
+            .add(user)
+            .build();
+
+    ScopeMappingCustomClaimsCreator creator = new ScopeMappingCustomClaimsCreator();
+    Map<String, Object> claims = creator.create(grant, null, null, null);
+
+    assertFalse(claims.containsKey("nullprop"), "null custom property must be omitted");
+    assertEquals("value", claims.get("realprop"));
+  }
+}

--- a/libs/idp-server-core/src/test/java/org/idp/server/core/openid/userinfo/plugin/UserinfoScopeMappingCustomClaimsCreatorTest.java
+++ b/libs/idp-server-core/src/test/java/org/idp/server/core/openid/userinfo/plugin/UserinfoScopeMappingCustomClaimsCreatorTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2025 Hirokazu Kobayashi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.idp.server.core.openid.userinfo.plugin;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import org.idp.server.core.openid.grant_management.grant.AuthorizationGrant;
+import org.idp.server.core.openid.grant_management.grant.AuthorizationGrantBuilder;
+import org.idp.server.core.openid.identity.User;
+import org.idp.server.core.openid.oauth.type.oauth.GrantType;
+import org.idp.server.core.openid.oauth.type.oauth.RequestedClientId;
+import org.idp.server.core.openid.oauth.type.oauth.Scopes;
+import org.idp.server.platform.multi_tenancy.tenant.TenantIdentifier;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Issue #1699: a {@code claims:<custom_property>} whose value is null must be omitted from the
+ * UserInfo response, not returned as {@code "key": null} (OIDC Core §5.3.2).
+ */
+class UserinfoScopeMappingCustomClaimsCreatorTest {
+
+  @Test
+  void omitsNullCustomPropertyButKeepsNonNull() {
+    HashMap<String, Object> props = new HashMap<>();
+    props.put("nullprop", null);
+    props.put("realprop", "value");
+    User user = new User().setSub(UUID.randomUUID().toString()).setCustomProperties(props);
+
+    AuthorizationGrant grant =
+        new AuthorizationGrantBuilder(
+                new TenantIdentifier(UUID.randomUUID().toString()),
+                new RequestedClientId("test-client"),
+                GrantType.authorization_code,
+                new Scopes("claims:nullprop claims:realprop"))
+            .add(user)
+            .build();
+
+    UserinfoScopeMappingCustomClaimsCreator creator = new UserinfoScopeMappingCustomClaimsCreator();
+    Map<String, Object> claims = creator.create(user, grant, null, null);
+
+    // The null-valued custom property is omitted entirely (no "nullprop": null).
+    assertFalse(claims.containsKey("nullprop"), "null custom property must be omitted");
+    // A non-null custom property is still surfaced.
+    assertEquals("value", claims.get("realprop"));
+  }
+}


### PR DESCRIPTION
Closes #1699

## 概要
`claims:<custom_property>` スコープで、custom_property の値が **null** のとき UserInfo が `"key": null` を返し OIDC Core §5.3.2（値の無い claim は省略すべき、`null`/空文字で返すな）に非準拠だった問題を修正。

## 原因
```java
if (customProperties.contains(claimName)) {         // containsKey → null 値でも true
    claims.put(claimName, customProperties.getValue(claimName));  // null を put
}
```
- `CustomProperties.contains()` は `containsKey()` のため、キーが null 値で存在すると true
- UserInfo は Jackson デフォルトで null を包含 → `"key": null` が露出
- （JWT は nimbus が null claim を省略するため ID/Access Token は元々準拠。挙動が endpoint 間で不整合だった）

## 修正
3つの custom-claims creator（Access Token / ID Token / UserInfo）の custom_properties 分岐で、値が null なら put しないようガード：
```java
Object customValue = customProperties.getValue(claimName);
if (customValue != null) {
    claims.put(claimName, customValue);
}
```
- 標準クレーム（`ex_sub`/`roles` 等）は既に `hasXxx()` ガード済みで影響なし
- `sid` 経路は `getValueAsStringOrEmpty` + `isEmpty()` で既に null-safe（対象外）

## 検証
- ユニット `UserinfoScopeMappingCustomClaimsCreatorTest`: null 値 custom property が省略され非 null は保持（green）
- E2E: null 値 custom_property を持つユーザーで `claims:nullprop` 要求 → UserInfo に `nullprop` が現れず `claims:realprop` は返る。**実サーバで確認**（custom-claims スイート 13/13 green）
- `build -x test` / `:idp-server-core:test` green

## 仕様根拠（OIDC Core 1.0 §5.3.2）
> If a Claim is not returned, that Claim Name SHOULD be omitted from the JSON object representing the Claims; it SHOULD NOT be present with a null or empty string value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)