### PR TITLE
fix(oauth): 外部サービスOAuth設定で任意フィールド(scope等)欠落時のNPE/500を解消 (#1630)

### DIFF
--- a/e2e/src/tests/integration/ida/integration-23-oauth-optional-field-omitted.test.js
+++ b/e2e/src/tests/integration/ida/integration-23-oauth-optional-field-omitted.test.js
@@ -1,0 +1,127 @@
+import { describe, expect, it, beforeAll, afterAll } from "@jest/globals";
+import { postWithJson, deletion } from "../../../lib/http";
+import { requestToken } from "../../../api/oauthClient";
+import {
+  backendUrl,
+  clientSecretPostClient,
+  serverConfig,
+  federationServerConfig,
+  mockApiBaseUrl,
+} from "../../testConfig";
+import { createFederatedUser } from "../../../user";
+import { v4 as uuidv4 } from "uuid";
+
+/**
+ * #1630: an oauth_authorization that omits an OPTIONAL field (scope is OPTIONAL for
+ * client_credentials) must NOT crash while assembling the token request.
+ *
+ * Before the fix, OAuthAuthorizationConfiguration.toRequestValues() put scope=null and
+ * HttpQueryParams.add() passed it to URLEncoder.encode(null) → NullPointerException → 500
+ * server_error ("unexpected error is occurred"), before the token request was even sent.
+ *
+ * After the fix (HttpQueryParams.add skips null/empty), the request is assembled and sent. The token
+ * endpoint here is the always-401 mock (same as integration-17), so a successfully-sent request
+ * surfaces as the #1384 external-service error (502) — crucially NOT a 500 NPE. Asserting 502 (and
+ * explicitly not 500) proves assembly reached the network with scope omitted.
+ */
+describe("Identity Verification - external OAuth with optional field (scope) omitted does not NPE (#1630)", () => {
+  const orgId = serverConfig.organizationId;
+  const tenantId = serverConfig.tenantId;
+
+  let orgAccessToken;
+  let userAccessToken;
+  const type = uuidv4();
+  const configId = uuidv4();
+
+  beforeAll(async () => {
+    const orgAuthResponse = await requestToken({
+      endpoint: `${backendUrl}/${tenantId}/v1/tokens`,
+      grantType: "password",
+      username: "ito.ichiro@gmail.com",
+      password: "successUserCode001",
+      clientId: clientSecretPostClient.clientId,
+      clientSecret: clientSecretPostClient.clientSecret,
+      scope: "org-management account management",
+    });
+    expect(orgAuthResponse.status).toBe(200);
+    orgAccessToken = orgAuthResponse.data.access_token;
+
+    const { accessToken } = await createFederatedUser({
+      serverConfig: serverConfig,
+      federationServerConfig: federationServerConfig,
+      client: clientSecretPostClient,
+      adminClient: clientSecretPostClient,
+      scope:
+        "openid profile email identity_verification_application " +
+        clientSecretPostClient.identityVerificationScope,
+    });
+    userAccessToken = accessToken;
+
+    // oauth_authorization intentionally omits `scope` (OPTIONAL for client_credentials). The token
+    // endpoint is the always-401 mock, matching integration-17.
+    const create = await postWithJson({
+      url: `${backendUrl}/v1/management/organizations/${orgId}/tenants/${tenantId}/identity-verification-configurations`,
+      headers: {
+        Authorization: `Bearer ${orgAccessToken}`,
+        "Content-Type": "application/json",
+      },
+      body: {
+        id: configId,
+        type,
+        attributes: { enabled: true },
+        common: { auth_type: "none" },
+        processes: {
+          apply: {
+            request: { schema: { type: "object", properties: {} } },
+            execution: {
+              type: "http_request",
+              http_request: {
+                url: `${mockApiBaseUrl}/e2e/oauth-retry/401-always`,
+                method: "POST",
+                auth_type: "oauth2",
+                oauth_authorization: {
+                  type: "client_credentials",
+                  token_endpoint: `${mockApiBaseUrl}/e2e/oauth-retry/401-always`,
+                  client_authentication_type: "client_secret_post",
+                  client_id: "invalid-client",
+                  client_secret: "invalid-secret",
+                  // scope omitted on purpose (#1630)
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+    expect(create.status).toBe(201);
+  });
+
+  afterAll(async () => {
+    await deletion({
+      url: `${backendUrl}/v1/management/organizations/${orgId}/tenants/${tenantId}/identity-verification-configurations/${configId}`,
+      headers: { Authorization: `Bearer ${orgAccessToken}` },
+    });
+  });
+
+  it("omitting scope does not NPE: the request is assembled and sent (502, not 500 server_error)", async () => {
+    const applyUrl = serverConfig.identityVerificationApplyEndpoint
+      .replace("{type}", type)
+      .replace("{process}", "apply");
+
+    const response = await postWithJson({
+      url: applyUrl,
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${userAccessToken}`,
+      },
+      body: {},
+    });
+    console.log("apply response:", response.status, JSON.stringify(response.data, null, 2));
+
+    // Key assertion: NOT a 500 NPE. Before the #1630 fix, omitting scope threw NPE → 500.
+    expect(response.status).not.toBe(500);
+    // The request was assembled and sent; the always-401 mock surfaces as 502 (#1384 behavior).
+    expect(response.status).toBe(502);
+    expect(response.data).toHaveProperty("error", "external_service_error");
+  });
+});

--- a/libs/idp-server-platform/src/main/java/org/idp/server/platform/http/HttpQueryParams.java
+++ b/libs/idp-server-platform/src/main/java/org/idp/server/platform/http/HttpQueryParams.java
@@ -36,7 +36,16 @@ public class HttpQueryParams {
     return params;
   }
 
+  /**
+   * Adds a query parameter, skipping null or empty values instead of encoding them. {@link
+   * UrlParameterSanitizer#encodeQueryValue} would throw NPE on null ({@code URLEncoder.encode(null,
+   * ...)}), and {@link #params()} already omits empty values — so an omitted optional field (e.g.
+   * {@code scope} in {@code client_credentials}) must not break request assembly. (#1630)
+   */
   public void add(String key, String value) {
+    if (value == null || value.isEmpty()) {
+      return;
+    }
     String urlEncodedKey = UrlParameterSanitizer.encodeQueryKey(key);
     String urlEncodedValue = UrlParameterSanitizer.encodeQueryValue(value);
     values.put(urlEncodedKey, urlEncodedValue);

--- a/libs/idp-server-platform/src/main/java/org/idp/server/platform/http/HttpQueryParams.java
+++ b/libs/idp-server-platform/src/main/java/org/idp/server/platform/http/HttpQueryParams.java
@@ -32,7 +32,10 @@ public class HttpQueryParams {
 
   public static HttpQueryParams fromMapObject(Map<String, Object> values) {
     HttpQueryParams params = new HttpQueryParams();
-    values.forEach((k, v) -> params.add(k, v.toString()));
+    // Objects.toString(v, null) passes a null value through to add(), which skips it, rather than
+    // calling v.toString() and throwing NPE. A null value in a form-encoded body must not break
+    // assembly, mirroring the add() null guard. (#1630)
+    values.forEach((k, v) -> params.add(k, Objects.toString(v, null)));
     return params;
   }
 

--- a/libs/idp-server-platform/src/test/java/org/idp/server/platform/http/HttpQueryParamsTest.java
+++ b/libs/idp-server-platform/src/test/java/org/idp/server/platform/http/HttpQueryParamsTest.java
@@ -94,6 +94,17 @@ class HttpQueryParamsTest {
   }
 
   @Test
+  void fromMapObject_skipsNullValueWithoutNpe() {
+    // #1630: a null value in a form-encoded body (fromMapObject is used by HttpRequestBuilder) must
+    // not NPE via v.toString(). It is passed through as null and skipped, like the add() guard.
+    Map<String, Object> values = new HashMap<>();
+    values.put("grant_type", "client_credentials");
+    values.put("scope", null);
+    HttpQueryParams params = assertDoesNotThrow(() -> HttpQueryParams.fromMapObject(values));
+    assertEquals("grant_type=client_credentials", params.params());
+  }
+
+  @Test
   void params_handlesMultipleParameters() {
     HttpQueryParams params = new HttpQueryParams();
     params.add("key1", "value1");

--- a/libs/idp-server-platform/src/test/java/org/idp/server/platform/http/HttpQueryParamsTest.java
+++ b/libs/idp-server-platform/src/test/java/org/idp/server/platform/http/HttpQueryParamsTest.java
@@ -18,6 +18,7 @@ package org.idp.server.platform.http;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import java.util.HashMap;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 
@@ -71,6 +72,25 @@ class HttpQueryParamsTest {
     params.add("key", "");
     // Empty values should be skipped
     assertEquals("", params.params());
+  }
+
+  @Test
+  void add_skipsNullValueWithoutNpe() {
+    HttpQueryParams params = new HttpQueryParams();
+    // #1630: a null value must be skipped, not passed to URLEncoder.encode (which NPEs on null).
+    assertDoesNotThrow(() -> params.add("scope", null));
+    assertEquals("", params.params());
+  }
+
+  @Test
+  void constructor_skipsNullValueWithoutNpe() {
+    // #1630: an optional field omitted from oauth_authorization (e.g. scope in client_credentials)
+    // reaches assembly as a null map value. The request must still build, minus that parameter.
+    Map<String, String> values = new HashMap<>();
+    values.put("grant_type", "client_credentials");
+    values.put("scope", null);
+    HttpQueryParams params = assertDoesNotThrow(() -> new HttpQueryParams(values));
+    assertEquals("grant_type=client_credentials", params.params());
   }
 
   @Test


### PR DESCRIPTION
## 概要

外部サービス連携の `oauth_authorization` 設定で `scope` 等の **OPTIONAL フィールドを省略**すると、トークンリクエスト組み立て時に `NullPointerException` が発生し `500 server_error`（`unexpected error is occurred`）になっていた。`scope` は `client_credentials` では OAuth 上 OPTIONAL なので、仕様的に有効な設定で発生する。

Closes #1630

## 原因

トークン送信の**前**、リクエストパラメータ組み立て時に NPE：

```
OAuthAuthorizationConfiguration.toRequestValues()   map.put("scope", null)  ← null を無条件 put
  └ ClientCredentialsAuthorizationResolver.resolve() new HttpQueryParams(toRequestValues())
    └ HttpQueryParams.add()                          encodeQueryValue(null)  ← null チェック無し
      └ UrlParameterSanitizer.encodeQueryValue()     URLEncoder.encode(null, UTF_8) → NPE
```

`params()`（出力段）は null/empty をスキップするのに、`add()`（組み立て段）はスキップ前に `encodeQueryValue` を呼ぶのが原因。#1384（トークンendが非2xxを返す経路の502化）とは別の失敗モードで、そちらでは未対応だった。

## 修正

**`HttpQueryParams.add()` で null/empty 値をスキップ**（案1・横断的・最小）。`params()` の既存挙動と揃い、`encodeQueryValue(null)` に到達しなくなる。OPTIONAL フィールド欠落は「そのパラメータ無しのリクエスト」として正しく送信される（OAuth 的に正当）。

## テスト

- **ユニット**（`HttpQueryParamsTest`）: `add(key, null)` が NPE しない / **null を含む Map からの構築**（＝本件の実経路 `toRequestValues()→new HttpQueryParams`）が NPE せず該当パラメータを除いて組み立つ
- **E2E**（`integration-23`）: `scope` 省略の `oauth_authorization` で apply が **500(NPE) でなく 502 external_service_error** になることを確認
  - 修正前サーバ: `500 server_error`（red / バグ再現）
  - 修正後サーバ: `502 external_service_error`（green）を実サーバで確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)