### PR TITLE
feat(introspection): RFC 7662 準拠強化 — confidential 限定・token_type/username・type confusion 対策 (#1707)

### DIFF
--- a/e2e/src/tests/spec/rfc7662_token_introspection.test.js
+++ b/e2e/src/tests/spec/rfc7662_token_introspection.test.js
@@ -6,6 +6,7 @@ import {
   clientSecretJwtClient,
   clientSecretPostClient,
   privateKeyJwtClient,
+  publicClient,
   serverConfig
 } from "../testConfig";
 import { requestAuthorizations } from "../../oauth/request";
@@ -51,6 +52,13 @@ describe("OAuth 2.0 Token Introspection", () => {
       console.log(JSON.stringify(introspectionResponse.data, null, 2));
       expect(introspectionResponse.status).toBe(200);
       expect(introspectionResponse.data.active).toBe(true);
+
+      // #1707 RFC 7662 Section 2.2: token_type (Bearer) and username (when the resource owner has a
+      // preferred_username). token_type is always present for an active access token.
+      expect(introspectionResponse.data.token_type).toBe("Bearer");
+      if (introspectionResponse.data.username !== undefined) {
+        expect(typeof introspectionResponse.data.username).toBe("string");
+      }
 
       // RFC 9068: Verify authentication information claims in JWT access token
       expect(introspectionResponse.data).toHaveProperty("auth_time");
@@ -262,6 +270,68 @@ describe("OAuth 2.0 Token Introspection", () => {
       expect(response.data.error_description).toBe(
         "Bad request. Content-Type header does not match supported values"
       );
+    });
+
+    it("To prevent token scanning attacks, the endpoint MUST require authorization — a public client (token_endpoint_auth_method=none) is rejected with invalid_client - RFC 7662 Section 2.1 (#1707)", async () => {
+      const { authorizationResponse } = await requestAuthorizations({
+        endpoint: serverConfig.authorizationEndpoint,
+        clientId: clientSecretPostClient.clientId,
+        responseType: "code",
+        state: "aiueo",
+        scope: "openid " + clientSecretPostClient.scope,
+        redirectUri: clientSecretPostClient.redirectUri,
+      });
+      const tokenResponse = await requestToken({
+        endpoint: serverConfig.tokenEndpoint,
+        code: authorizationResponse.code,
+        grantType: "authorization_code",
+        redirectUri: clientSecretPostClient.redirectUri,
+        clientId: clientSecretPostClient.clientId,
+        clientSecret: clientSecretPostClient.clientSecret,
+      });
+      expect(tokenResponse.status).toBe(200);
+
+      // A public client (no secret) is rejected at client authentication, before any token lookup.
+      const introspectionResponse = await inspectToken({
+        endpoint: serverConfig.tokenIntrospectionEndpoint,
+        token: tokenResponse.data.access_token,
+        clientId: publicClient.clientId,
+      });
+      console.log(JSON.stringify(introspectionResponse.data, null, 2));
+      expect(introspectionResponse.status).toBe(400);
+      expect(introspectionResponse.data).toHaveProperty("error", "invalid_client");
+    });
+
+    it("does not fall back to a refresh-token lookup — a refresh token introspects as active:false, avoiding token type confusion (#1707)", async () => {
+      const { authorizationResponse } = await requestAuthorizations({
+        endpoint: serverConfig.authorizationEndpoint,
+        clientId: clientSecretPostClient.clientId,
+        responseType: "code",
+        state: "aiueo",
+        scope: "openid " + clientSecretPostClient.scope,
+        redirectUri: clientSecretPostClient.redirectUri,
+      });
+      const tokenResponse = await requestToken({
+        endpoint: serverConfig.tokenEndpoint,
+        code: authorizationResponse.code,
+        grantType: "authorization_code",
+        redirectUri: clientSecretPostClient.redirectUri,
+        clientId: clientSecretPostClient.clientId,
+        clientSecret: clientSecretPostClient.clientSecret,
+      });
+      expect(tokenResponse.status).toBe(200);
+      expect(tokenResponse.data.refresh_token).toBeDefined();
+
+      // The refresh token value must NOT be returned as an active access token.
+      const introspectionResponse = await inspectToken({
+        endpoint: serverConfig.tokenIntrospectionEndpoint,
+        token: tokenResponse.data.refresh_token,
+        clientId: clientSecretPostClient.clientId,
+        clientSecret: clientSecretPostClient.clientSecret,
+      });
+      console.log(JSON.stringify(introspectionResponse.data, null, 2));
+      expect(introspectionResponse.status).toBe(200);
+      expect(introspectionResponse.data.active).toBe(false);
     });
   });
 

--- a/e2e/src/tests/spec/rfc7662_token_introspection.test.js
+++ b/e2e/src/tests/spec/rfc7662_token_introspection.test.js
@@ -53,13 +53,6 @@ describe("OAuth 2.0 Token Introspection", () => {
       expect(introspectionResponse.status).toBe(200);
       expect(introspectionResponse.data.active).toBe(true);
 
-      // #1707 RFC 7662 Section 2.2: token_type (Bearer) and username (when the resource owner has a
-      // preferred_username). token_type is always present for an active access token.
-      expect(introspectionResponse.data.token_type).toBe("Bearer");
-      if (introspectionResponse.data.username !== undefined) {
-        expect(typeof introspectionResponse.data.username).toBe("string");
-      }
-
       // RFC 9068: Verify authentication information claims in JWT access token
       expect(introspectionResponse.data).toHaveProperty("auth_time");
       expect(typeof introspectionResponse.data.auth_time).toBe("number");
@@ -332,6 +325,51 @@ describe("OAuth 2.0 Token Introspection", () => {
       console.log(JSON.stringify(introspectionResponse.data, null, 2));
       expect(introspectionResponse.status).toBe(200);
       expect(introspectionResponse.data.active).toBe(false);
+    });
+  });
+
+  describe("2.2. Introspection Response", () => {
+    const introspectActiveToken = async () => {
+      const { authorizationResponse } = await requestAuthorizations({
+        endpoint: serverConfig.authorizationEndpoint,
+        clientId: clientSecretPostClient.clientId,
+        responseType: "code",
+        state: "aiueo",
+        scope: "openid profile " + clientSecretPostClient.scope,
+        redirectUri: clientSecretPostClient.redirectUri,
+      });
+      const tokenResponse = await requestToken({
+        endpoint: serverConfig.tokenEndpoint,
+        code: authorizationResponse.code,
+        grantType: "authorization_code",
+        redirectUri: clientSecretPostClient.redirectUri,
+        clientId: clientSecretPostClient.clientId,
+        clientSecret: clientSecretPostClient.clientSecret,
+      });
+      expect(tokenResponse.status).toBe(200);
+      const introspectionResponse = await inspectToken({
+        endpoint: serverConfig.tokenIntrospectionEndpoint,
+        token: tokenResponse.data.access_token,
+        clientId: clientSecretPostClient.clientId,
+        clientSecret: clientSecretPostClient.clientSecret,
+      });
+      expect(introspectionResponse.status).toBe(200);
+      expect(introspectionResponse.data.active).toBe(true);
+      return introspectionResponse;
+    };
+
+    it("token_type OPTIONAL. Type of the token as defined in Section 5.1 of OAuth 2.0 [RFC6749] - RFC 7662 Section 2.2 (#1707)", async () => {
+      const introspectionResponse = await introspectActiveToken();
+      expect(introspectionResponse.data.token_type).toBe("Bearer");
+    });
+
+    it("username OPTIONAL. Human-readable identifier for the resource owner who authorized this token - RFC 7662 Section 2.2 (#1707)", async () => {
+      const introspectionResponse = await introspectActiveToken();
+      // The resource owner (ito.ichiro) has a preferred_username, so username is asserted
+      // unconditionally: a regression that drops username must fail this test.
+      expect(introspectionResponse.data).toHaveProperty("username");
+      expect(typeof introspectionResponse.data.username).toBe("string");
+      expect(introspectionResponse.data.username.length).toBeGreaterThan(0);
     });
   });
 

--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/token/handler/tokenintrospection/TokenIntrospectionExtensionHandler.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/token/handler/tokenintrospection/TokenIntrospectionExtensionHandler.java
@@ -25,7 +25,6 @@ import org.idp.server.core.openid.oauth.configuration.AuthorizationServerConfigu
 import org.idp.server.core.openid.oauth.configuration.client.ClientConfiguration;
 import org.idp.server.core.openid.oauth.configuration.client.ClientConfigurationQueryRepository;
 import org.idp.server.core.openid.oauth.type.oauth.AccessTokenEntity;
-import org.idp.server.core.openid.oauth.type.oauth.RefreshTokenEntity;
 import org.idp.server.core.openid.token.OAuthToken;
 import org.idp.server.core.openid.token.TokenUserFindingDelegate;
 import org.idp.server.core.openid.token.handler.tokenintrospection.io.TokenIntrospectionExtensionRequest;
@@ -36,6 +35,7 @@ import org.idp.server.core.openid.token.tokenintrospection.TokenIntrospectionCon
 import org.idp.server.core.openid.token.tokenintrospection.TokenIntrospectionRequestContext;
 import org.idp.server.core.openid.token.tokenintrospection.TokenIntrospectionRequestParameters;
 import org.idp.server.core.openid.token.tokenintrospection.validator.TokenIntrospectionValidator;
+import org.idp.server.core.openid.token.tokenintrospection.verifier.TokenIntrospectionClientAuthenticationVerifier;
 import org.idp.server.core.openid.token.tokenintrospection.verifier.TokenIntrospectionExtensionVerifier;
 import org.idp.server.core.openid.token.tokenintrospection.verifier.TokenIntrospectionUserVerifier;
 import org.idp.server.platform.multi_tenancy.tenant.Tenant;
@@ -77,6 +77,11 @@ public class TokenIntrospectionExtensionHandler {
             request.toParameters(),
             authorizationServerConfiguration,
             clientConfiguration);
+    // #1707 (RFC 7662 §2.1): introspection requires client authentication; reject public clients
+    // (token_endpoint_auth_method=none) before the shared handler lets `none` through unchecked.
+    new TokenIntrospectionClientAuthenticationVerifier(
+            clientConfiguration.clientAuthenticationType())
+        .verify();
     clientAuthenticationHandler.authenticate(introspectionRequestContext);
 
     OAuthToken oAuthToken = find(request);
@@ -110,12 +115,9 @@ public class TokenIntrospectionExtensionHandler {
     TokenIntrospectionRequestParameters parameters = request.toParameters();
     AccessTokenEntity accessTokenEntity = parameters.accessToken();
     Tenant tenant = request.tenant();
-    OAuthToken oAuthToken = oAuthTokenQueryRepository.find(tenant, accessTokenEntity);
-    if (oAuthToken.exists()) {
-      return oAuthToken;
-    } else {
-      RefreshTokenEntity refreshTokenEntity = parameters.refreshToken();
-      return oAuthTokenQueryRepository.find(tenant, refreshTokenEntity);
-    }
+    // #1707: introspect access tokens only. A refresh-token fallback would let a refresh token
+    // presented as a Bearer token be returned active with the access token's claims (token type
+    // confusion); introspecting a refresh token now yields active:false.
+    return oAuthTokenQueryRepository.find(tenant, accessTokenEntity);
   }
 }

--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/token/handler/tokenintrospection/TokenIntrospectionHandler.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/token/handler/tokenintrospection/TokenIntrospectionHandler.java
@@ -25,7 +25,6 @@ import org.idp.server.core.openid.oauth.configuration.AuthorizationServerConfigu
 import org.idp.server.core.openid.oauth.configuration.client.ClientConfiguration;
 import org.idp.server.core.openid.oauth.configuration.client.ClientConfigurationQueryRepository;
 import org.idp.server.core.openid.oauth.type.oauth.AccessTokenEntity;
-import org.idp.server.core.openid.oauth.type.oauth.RefreshTokenEntity;
 import org.idp.server.core.openid.token.OAuthToken;
 import org.idp.server.core.openid.token.TokenUserFindingDelegate;
 import org.idp.server.core.openid.token.handler.tokenintrospection.io.TokenIntrospectionRequest;
@@ -36,6 +35,7 @@ import org.idp.server.core.openid.token.tokenintrospection.TokenIntrospectionCon
 import org.idp.server.core.openid.token.tokenintrospection.TokenIntrospectionRequestContext;
 import org.idp.server.core.openid.token.tokenintrospection.TokenIntrospectionRequestParameters;
 import org.idp.server.core.openid.token.tokenintrospection.validator.TokenIntrospectionValidator;
+import org.idp.server.core.openid.token.tokenintrospection.verifier.TokenIntrospectionClientAuthenticationVerifier;
 import org.idp.server.core.openid.token.tokenintrospection.verifier.TokenIntrospectionUserVerifier;
 import org.idp.server.core.openid.token.tokenintrospection.verifier.TokenIntrospectionVerifier;
 import org.idp.server.platform.multi_tenancy.tenant.Tenant;
@@ -77,6 +77,11 @@ public class TokenIntrospectionHandler {
             request.toParameters(),
             authorizationServerConfiguration,
             clientConfiguration);
+    // #1707 (RFC 7662 §2.1): introspection requires client authentication; reject public clients
+    // (token_endpoint_auth_method=none) before the shared handler lets `none` through unchecked.
+    new TokenIntrospectionClientAuthenticationVerifier(
+            clientConfiguration.clientAuthenticationType())
+        .verify();
     clientAuthenticationHandler.authenticate(introspectionRequestContext);
 
     OAuthToken oAuthToken = find(request);
@@ -109,12 +114,9 @@ public class TokenIntrospectionHandler {
     TokenIntrospectionRequestParameters parameters = request.toParameters();
     AccessTokenEntity accessTokenEntity = parameters.accessToken();
     Tenant tenant = request.tenant();
-    OAuthToken oAuthToken = oAuthTokenQueryRepository.find(tenant, accessTokenEntity);
-    if (oAuthToken.exists()) {
-      return oAuthToken;
-    } else {
-      RefreshTokenEntity refreshTokenEntity = parameters.refreshToken();
-      return oAuthTokenQueryRepository.find(tenant, refreshTokenEntity);
-    }
+    // #1707: introspect access tokens only. A refresh-token fallback would let a refresh token
+    // presented as a Bearer token be returned active with the access token's claims (token type
+    // confusion); introspecting a refresh token now yields active:false.
+    return oAuthTokenQueryRepository.find(tenant, accessTokenEntity);
   }
 }

--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/token/handler/tokenintrospection/TokenIntrospectionInternalHandler.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/token/handler/tokenintrospection/TokenIntrospectionInternalHandler.java
@@ -30,6 +30,20 @@ import org.idp.server.core.openid.token.tokenintrospection.verifier.TokenIntrosp
 import org.idp.server.platform.log.LoggerWrapper;
 import org.idp.server.platform.multi_tenancy.tenant.Tenant;
 
+/**
+ * Internal (server-side) token introspection for trusted in-process callers only, e.g. {@code
+ * UserAuthenticationEntryService} validating an access token already in hand.
+ *
+ * <p>Unlike {@link TokenIntrospectionHandler} / {@link TokenIntrospectionExtensionHandler}, this
+ * handler performs NO client authentication — there is no client credential on this path — so the
+ * confidential-client guard (Issue #1707, RFC 7662 §2.1) does not apply here. It looks up access
+ * tokens only (no refresh-token fallback), matching the public handlers, to avoid token type
+ * confusion.
+ *
+ * <p><b>Must never be exposed on a public endpoint.</b> It is intentionally unreachable from any
+ * Controller; wiring it to an external route would permit unauthenticated introspection and defeat
+ * the confidential-client requirement enforced on the public endpoints.
+ */
 public class TokenIntrospectionInternalHandler {
 
   OAuthTokenQueryRepository oAuthTokenQueryRepository;

--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/token/tokenintrospection/TokenIntrospectionContentsCreator.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/token/tokenintrospection/TokenIntrospectionContentsCreator.java
@@ -19,6 +19,7 @@ package org.idp.server.core.openid.token.tokenintrospection;
 import java.util.HashMap;
 import java.util.Map;
 import org.idp.server.core.openid.authentication.Authentication;
+import org.idp.server.core.openid.identity.User;
 import org.idp.server.core.openid.token.AccessToken;
 import org.idp.server.core.openid.token.OAuthToken;
 import org.idp.server.platform.date.SystemDateTime;
@@ -35,6 +36,16 @@ public class TokenIntrospectionContentsCreator {
     }
     contents.put("client_id", accessToken.requestedClientId().value());
     contents.put("scope", accessToken.scopes().toStringValues());
+    // RFC 7662 §2.2: token_type (e.g. Bearer / DPoP) and username (human-readable resource owner
+    // identifier). token_type is omitted when undefined; username is omitted for client_credentials
+    // tokens, which carry no user.
+    if (accessToken.tokenType().isDefined()) {
+      contents.put("token_type", accessToken.tokenType().name());
+    }
+    User user = accessToken.user();
+    if (user.exists() && user.hasPreferredUsername()) {
+      contents.put("username", user.preferredUsername());
+    }
     if (accessToken.hasCustomClaims()) {
       contents.putAll(accessToken.customClaims().toMap());
     }

--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/token/tokenintrospection/verifier/TokenIntrospectionClientAuthenticationVerifier.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/token/tokenintrospection/verifier/TokenIntrospectionClientAuthenticationVerifier.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2025 Hirokazu Kobayashi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.idp.server.core.openid.token.tokenintrospection.verifier;
+
+import org.idp.server.core.openid.oauth.clientauthenticator.exception.ClientUnAuthorizedException;
+import org.idp.server.core.openid.oauth.type.oauth.ClientAuthenticationType;
+
+/**
+ * Requires token introspection to be performed by a confidential client (Issue #1707, RFC 7662
+ * §2.1).
+ *
+ * <p>RFC 7662 §2.1 requires the introspection endpoint to require authorization to prevent token
+ * scanning attacks. A public client ({@code token_endpoint_auth_method=none}) presents no
+ * credential, so the shared {@code ClientAuthenticationHandler} would let it through the {@code
+ * none} authenticator unchecked. This verifier rejects that case up front so only confidential
+ * clients (client_secret_*, private_key_jwt, tls_client_auth, ...) can introspect; those are then
+ * authenticated by {@code ClientAuthenticationHandler} as usual.
+ *
+ * <p>The thrown {@link ClientUnAuthorizedException} is mapped to {@code invalid_client} by {@code
+ * TokenIntrospectionErrorHandler}.
+ */
+public class TokenIntrospectionClientAuthenticationVerifier {
+
+  ClientAuthenticationType clientAuthenticationType;
+
+  public TokenIntrospectionClientAuthenticationVerifier(
+      ClientAuthenticationType clientAuthenticationType) {
+    this.clientAuthenticationType = clientAuthenticationType;
+  }
+
+  public void verify() {
+    if (clientAuthenticationType.isNone()) {
+      throw new ClientUnAuthorizedException(
+          "Token introspection requires client authentication; a public client"
+              + " (token_endpoint_auth_method=none) is not allowed to introspect.");
+    }
+  }
+}

--- a/libs/idp-server-core/src/test/java/org/idp/server/core/openid/token/tokenintrospection/verifier/TokenIntrospectionClientAuthenticationVerifierTest.java
+++ b/libs/idp-server-core/src/test/java/org/idp/server/core/openid/token/tokenintrospection/verifier/TokenIntrospectionClientAuthenticationVerifierTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2025 Hirokazu Kobayashi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.idp.server.core.openid.token.tokenintrospection.verifier;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.idp.server.core.openid.oauth.clientauthenticator.exception.ClientUnAuthorizedException;
+import org.idp.server.core.openid.oauth.type.oauth.ClientAuthenticationType;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+/** Issue #1707 (RFC 7662 §2.1): token introspection must be limited to confidential clients. */
+class TokenIntrospectionClientAuthenticationVerifierTest {
+
+  @Test
+  void rejectsPublicClient() {
+    // token_endpoint_auth_method=none presents no credential, so it must not be able to introspect.
+    TokenIntrospectionClientAuthenticationVerifier verifier =
+        new TokenIntrospectionClientAuthenticationVerifier(ClientAuthenticationType.none);
+    assertThrows(ClientUnAuthorizedException.class, verifier::verify);
+  }
+
+  @ParameterizedTest
+  @EnumSource(
+      value = ClientAuthenticationType.class,
+      names = {"none"},
+      mode = EnumSource.Mode.EXCLUDE)
+  void allowsConfidentialClients(ClientAuthenticationType confidentialType) {
+    // Every non-none method (client_secret_*, private_key_jwt, tls_client_auth, ...) is a
+    // confidential client and passes; it is then authenticated by ClientAuthenticationHandler.
+    TokenIntrospectionClientAuthenticationVerifier verifier =
+        new TokenIntrospectionClientAuthenticationVerifier(confidentialType);
+    assertDoesNotThrow(verifier::verify);
+  }
+}


### PR DESCRIPTION
## 概要

Token Introspection（RFC 7662）の条項と実装を対比し、不足していた準拠事項とセキュリティ対策を実装する。Issue #1707 の対応。

Closes #1707

## 変更内容

### クライアント認証を confidential client 限定に（RFC 7662 §2.1）
- introspection のクライアント認証は token endpoint 共通の `ClientAuthenticationHandler` を使うため、`token_endpoint_auth_method=none` の public client が `PublicClientAuthenticator` で無検証通過できていた。
- `TokenIntrospectionClientAuthenticationVerifier` を新設し、標準 `/introspection`・拡張 `/introspection-extensions` の認証前で public client（`isNone()`）を拒否 → `invalid_client`。§2.1 の「token scanning 防止のため authorization を要求」を満たす。
- 内部ハンドラ（`TokenIntrospectionInternalHandler`）は Controller 非露出・サーバ内部専用のため対象外。その旨を Javadoc に明記。

### token type confusion 対策（refresh フォールバック削除）
- 従来は `find()` が access token → refresh token の順でフォールバック検索し、**refresh token を Bearer として提示すると access token の情報が `active:true` で返る**型混同があった。
- access token のみ検索に変更（refresh へのフォールバックを削除）。refresh token 値を introspect すると `active:false`。Keycloak も hint 尊重・フォールバックなしで同方針。
- 標準・拡張ハンドラを変更（内部ハンドラは元から access-only）。3経路で一致。

### レスポンスクレーム追加（RFC 7662 §2.2）
- `token_type`（`Bearer`、`undefined` 時は省略）と `username`（`preferred_username`、client_credentials では省略）を追加。

## テスト
- **単体**: `TokenIntrospectionClientAuthenticationVerifierTest` — public(none) を拒否 / confidential 6種を通過。
- **E2E**（`rfc7662_token_introspection.test.js`）: public client → `invalid_client` / refresh token → `active:false` / `token_type=Bearer`。実サーバで **7/7 green**（デプロイ前は red でバグ再現を確認済み）。

## スコープ外（別Issueに切り出し予定）
- RFC MAY クレーム `nbf` / `aud` / `jti`（データモデルへの保持が前提）
- `invalid_client` の 401 + `WWW-Authenticate`（RFC 6749 §5.2 SHOULD）
- 拡張エンドポイントの非アクティブ応答の最小化（§2.2）
- **type confusion の根本対策**: refresh token を introspect したら refresh token 自身の状態（active/exp）を返す（現状は access-only 検索で悪用経路を塞ぐに留める）

🤖 Generated with [Claude Code](https://claude.com/claude-code)