### PR TITLE
enhance(token): グラント消費のトランザクション整合性強化 — 認可コード / CIBA auth_req_id の single-use を並行リクエスト下でも保証する

### DIFF
--- a/e2e/src/tests/security/ciba_auth_req_id_single_use_race.test.js
+++ b/e2e/src/tests/security/ciba_auth_req_id_single_use_race.test.js
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "@jest/globals";
+
+import {
+  getAuthenticationDeviceAuthenticationTransaction,
+  postAuthenticationDeviceInteraction,
+  requestBackchannelAuthentications,
+  requestToken,
+} from "../../api/oauthClient";
+import { clientSecretPostClient, serverConfig } from "../testConfig";
+
+/**
+ * CIBA auth_req_id single-use under concurrent polling (TOCTOU).
+ *
+ * 脆弱性パターン:
+ * CibaGrantService.create() は find(auth_req_id) -> verify -> register(token) -> delete
+ * の順で、認可コード交換と同型の TOCTOU を持つ。同一 auth_req_id で並行に poll すると、
+ * 双方が「認可済み」の grant を読み取り、双方がトークンを発行し得る
+ * (1 auth_req_id からトークン2セット = single-use 違反)。
+ *
+ * 修正:
+ * CibaGrantService は CibaGrantRepository.findForUpdate(tenant, authReqId) で grant 行を
+ * SELECT ... FOR UPDATE ロックする。並行 poll は先行トランザクションの commit(grant 削除)
+ * までブロックし、その後は行なし -> invalid_grant。
+ *
+ * 期待: 並行 poll で成功は最大1つ。残りは invalid_grant。
+ *
+ * 重大度: High
+ * CWE: CWE-362 (Race Condition / Concurrent Execution using Shared Resource)
+ * 関連ファイル:
+ * - CibaGrantService.java (find -> findForUpdate)
+ * - ciba/grant/{Postgresql,Mysql}Executor.java (selectOneForUpdate + tenant_id)
+ */
+describe("CIBA auth_req_id single-use under concurrent polling", () => {
+  const ciba = serverConfig.ciba;
+
+  it("Concurrent token requests with the same auth_req_id issue at most one token set (single-use enforced under a race).", async () => {
+    const backchannelAuthenticationResponse = await requestBackchannelAuthentications({
+      endpoint: serverConfig.backchannelAuthenticationEndpoint,
+      clientId: clientSecretPostClient.clientId,
+      scope:
+        "openid profile email" +
+        (clientSecretPostClient.scope ? " " + clientSecretPostClient.scope : ""),
+      bindingMessage: ciba.bindingMessage,
+      userCode: ciba.userCode,
+      loginHint: ciba.loginHint,
+      clientSecret: clientSecretPostClient.clientSecret,
+    });
+    expect(backchannelAuthenticationResponse.status).toBe(200);
+    const authReqId = backchannelAuthenticationResponse.data.auth_req_id;
+
+    const authenticationTransactionResponse =
+      await getAuthenticationDeviceAuthenticationTransaction({
+        endpoint: serverConfig.authenticationDeviceEndpoint,
+        deviceId: serverConfig.ciba.authenticationDeviceId,
+        params: { "attributes.auth_req_id": authReqId },
+      });
+    expect(authenticationTransactionResponse.status).toBe(200);
+    const authenticationTransaction = authenticationTransactionResponse.data.list[0];
+
+    const completeResponse = await postAuthenticationDeviceInteraction({
+      endpoint: serverConfig.authenticationDeviceInteractionEndpoint,
+      flowType: authenticationTransaction.flow,
+      id: authenticationTransaction.id,
+      interactionType: "password-authentication",
+      body: {
+        username: serverConfig.ciba.username,
+        password: serverConfig.ciba.userCode,
+      },
+    });
+    expect(completeResponse.status).toBe(200);
+
+    // The grant is now authorized. Poll the token endpoint with the same auth_req_id
+    // several times in parallel; findForUpdate (SELECT ... FOR UPDATE) must let at
+    // most one exchange succeed.
+    const poll = () =>
+      requestToken({
+        endpoint: serverConfig.tokenEndpoint,
+        grantType: "urn:openid:params:grant-type:ciba",
+        authReqId,
+        clientId: clientSecretPostClient.clientId,
+        clientSecret: clientSecretPostClient.clientSecret,
+      });
+
+    const responses = await Promise.all([poll(), poll(), poll()]);
+    const succeeded = responses.filter((response) => response.status === 200);
+    const denied = responses.filter((response) => response.status !== 200);
+
+    expect(succeeded).toHaveLength(1);
+    denied.forEach((response) => {
+      expect(response.status).toBe(400);
+      expect(response.data.error).toEqual("invalid_grant");
+    });
+  });
+});

--- a/e2e/src/tests/spec/rfc6749_4_1_code.test.js
+++ b/e2e/src/tests/spec/rfc6749_4_1_code.test.js
@@ -141,6 +141,80 @@ describe("The OAuth 2.0 Authorization Framework code", () => {
       expect(reAuthorizationResponse.code).not.toBeNull();
       expect(reAuthorizationResponse.state).toBeNull();
     });
+
+    it("The client MUST NOT use the authorization code more than once.  If an authorization code is used more than once, the authorization server MUST deny the request.", async () => {
+      const { authorizationResponse } = await requestAuthorizations({
+        endpoint: serverConfig.authorizationEndpoint,
+        clientId: clientSecretPostClient.clientId,
+        responseType: "code",
+        state: "aiueo",
+        scope: clientSecretPostClient.scope,
+        redirectUri: clientSecretPostClient.redirectUri,
+      });
+      expect(authorizationResponse.code).not.toBeNull();
+
+      const firstResponse = await requestToken({
+        endpoint: serverConfig.tokenEndpoint,
+        code: authorizationResponse.code,
+        grantType: "authorization_code",
+        redirectUri: clientSecretPostClient.redirectUri,
+        clientId: clientSecretPostClient.clientId,
+        clientSecret: clientSecretPostClient.clientSecret,
+      });
+      expect(firstResponse.status).toBe(200);
+
+      const secondResponse = await requestToken({
+        endpoint: serverConfig.tokenEndpoint,
+        code: authorizationResponse.code,
+        grantType: "authorization_code",
+        redirectUri: clientSecretPostClient.redirectUri,
+        clientId: clientSecretPostClient.clientId,
+        clientSecret: clientSecretPostClient.clientSecret,
+      });
+      console.log(secondResponse.data);
+      expect(secondResponse.status).toBe(400);
+      expect(secondResponse.data.error).toEqual("invalid_grant");
+
+      // The same "MUST deny" requirement must hold under a race, not only on
+      // sequential reuse: exchanging one code concurrently issues at most one token
+      // set (the token exchange locks the code row with SELECT ... FOR UPDATE).
+      const { authorizationResponse: concurrentAuthorizationResponse } =
+        await requestAuthorizations({
+          endpoint: serverConfig.authorizationEndpoint,
+          clientId: clientSecretPostClient.clientId,
+          responseType: "code",
+          state: "aiueo",
+          scope: clientSecretPostClient.scope,
+          redirectUri: clientSecretPostClient.redirectUri,
+        });
+      expect(concurrentAuthorizationResponse.code).not.toBeNull();
+
+      const exchange = () =>
+        requestToken({
+          endpoint: serverConfig.tokenEndpoint,
+          code: concurrentAuthorizationResponse.code,
+          grantType: "authorization_code",
+          redirectUri: clientSecretPostClient.redirectUri,
+          clientId: clientSecretPostClient.clientId,
+          clientSecret: clientSecretPostClient.clientSecret,
+        });
+
+      const concurrentResponses = await Promise.all([exchange(), exchange(), exchange()]);
+      const succeeded = concurrentResponses.filter((response) => response.status === 200);
+      const denied = concurrentResponses.filter((response) => response.status !== 200);
+
+      expect(succeeded).toHaveLength(1);
+      denied.forEach((response) => {
+        expect(response.status).toBe(400);
+        expect(response.data.error).toEqual("invalid_grant");
+      });
+    });
+
+    xit("If an authorization code is used more than once, the authorization server ... SHOULD revoke (when possible) all tokens previously issued based on that authorization code.", async () => {
+      // Not yet implemented. Phase 1 enforces single-use (deny on reuse) only.
+      // Revocation of tokens previously issued from a reused code (reuse-detection,
+      // OAuth 2.0 Security BCP 4.5.3) is planned as a follow-up.
+    });
   });
 
   describe("4.1.2.1.  Error Response", () => {

--- a/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/ciba/grant/CibaGrantDataSource.java
+++ b/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/ciba/grant/CibaGrantDataSource.java
@@ -55,6 +55,17 @@ public class CibaGrantDataSource implements CibaGrantRepository {
   }
 
   @Override
+  public CibaGrant findForUpdate(Tenant tenant, AuthReqId authReqId) {
+    Map<String, String> stringMap = executor.selectOneForUpdate(tenant, authReqId);
+
+    if (Objects.isNull(stringMap) || stringMap.isEmpty()) {
+      return new CibaGrant();
+    }
+
+    return ModelConverter.convert(stringMap);
+  }
+
+  @Override
   public CibaGrant get(
       Tenant tenant,
       BackchannelAuthenticationRequestIdentifier backchannelAuthenticationRequestIdentifier) {

--- a/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/ciba/grant/CibaGrantSqlExecutor.java
+++ b/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/ciba/grant/CibaGrantSqlExecutor.java
@@ -20,6 +20,7 @@ import java.util.Map;
 import org.idp.server.core.extension.ciba.grant.CibaGrant;
 import org.idp.server.core.extension.ciba.request.BackchannelAuthenticationRequestIdentifier;
 import org.idp.server.core.openid.oauth.type.ciba.AuthReqId;
+import org.idp.server.platform.multi_tenancy.tenant.Tenant;
 
 public interface CibaGrantSqlExecutor {
 
@@ -28,6 +29,8 @@ public interface CibaGrantSqlExecutor {
   void update(CibaGrant cibaGrant);
 
   Map<String, String> selectOne(AuthReqId authReqId);
+
+  Map<String, String> selectOneForUpdate(Tenant tenant, AuthReqId authReqId);
 
   Map<String, String> selectOne(
       BackchannelAuthenticationRequestIdentifier backchannelAuthenticationRequestIdentifier);

--- a/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/ciba/grant/MysqlExecutor.java
+++ b/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/ciba/grant/MysqlExecutor.java
@@ -150,12 +150,9 @@ public class MysqlExecutor implements CibaGrantSqlExecutor {
   @Override
   public Map<String, String> selectOne(AuthReqId authReqId) {
     SqlExecutor sqlExecutor = new SqlExecutor();
-    String sqlTemplate =
-        """
-            SELECT backchannel_authentication_request_id, tenant_id, auth_req_id, expires_at, polling_interval, status, user_id, user_payload, authentication, client_id, client_payload, scopes, id_token_claims, userinfo_claims, custom_properties, authorization_details, consent_claims
-            FROM ciba_grant
-            WHERE auth_req_id = ?;
-            """;
+    String sqlTemplate = selectSql + """
+             WHERE auth_req_id = ?;
+         """;
 
     List<Object> params = new ArrayList<>();
     params.add(authReqId.value());
@@ -167,13 +164,12 @@ public class MysqlExecutor implements CibaGrantSqlExecutor {
   public Map<String, String> selectOneForUpdate(Tenant tenant, AuthReqId authReqId) {
     SqlExecutor sqlExecutor = new SqlExecutor();
     String sqlTemplate =
-        """
-            SELECT backchannel_authentication_request_id, tenant_id, auth_req_id, expires_at, polling_interval, status, user_id, user_payload, authentication, client_id, client_payload, scopes, id_token_claims, userinfo_claims, custom_properties, authorization_details, consent_claims
-            FROM ciba_grant
-            WHERE auth_req_id = ?
-            AND tenant_id = ?
-            FOR UPDATE;
-            """;
+        selectSql
+            + """
+             WHERE auth_req_id = ?
+             AND tenant_id = ?
+             FOR UPDATE;
+         """;
 
     List<Object> params = new ArrayList<>();
     params.add(authReqId.value());

--- a/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/ciba/grant/MysqlExecutor.java
+++ b/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/ciba/grant/MysqlExecutor.java
@@ -25,6 +25,7 @@ import org.idp.server.core.openid.grant_management.grant.AuthorizationGrant;
 import org.idp.server.core.openid.oauth.type.ciba.AuthReqId;
 import org.idp.server.platform.datasource.SqlExecutor;
 import org.idp.server.platform.json.JsonConverter;
+import org.idp.server.platform.multi_tenancy.tenant.Tenant;
 
 public class MysqlExecutor implements CibaGrantSqlExecutor {
 
@@ -158,6 +159,25 @@ public class MysqlExecutor implements CibaGrantSqlExecutor {
 
     List<Object> params = new ArrayList<>();
     params.add(authReqId.value());
+
+    return sqlExecutor.selectOne(sqlTemplate, params);
+  }
+
+  @Override
+  public Map<String, String> selectOneForUpdate(Tenant tenant, AuthReqId authReqId) {
+    SqlExecutor sqlExecutor = new SqlExecutor();
+    String sqlTemplate =
+        """
+            SELECT backchannel_authentication_request_id, tenant_id, auth_req_id, expires_at, polling_interval, status, user_id, user_payload, authentication, client_id, client_payload, scopes, id_token_claims, userinfo_claims, custom_properties, authorization_details, consent_claims
+            FROM ciba_grant
+            WHERE auth_req_id = ?
+            AND tenant_id = ?
+            FOR UPDATE;
+            """;
+
+    List<Object> params = new ArrayList<>();
+    params.add(authReqId.value());
+    params.add(tenant.identifier().value());
 
     return sqlExecutor.selectOne(sqlTemplate, params);
   }

--- a/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/ciba/grant/PostgresqlExecutor.java
+++ b/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/ciba/grant/PostgresqlExecutor.java
@@ -25,6 +25,7 @@ import org.idp.server.core.openid.grant_management.grant.AuthorizationGrant;
 import org.idp.server.core.openid.oauth.type.ciba.AuthReqId;
 import org.idp.server.platform.datasource.SqlExecutor;
 import org.idp.server.platform.json.JsonConverter;
+import org.idp.server.platform.multi_tenancy.tenant.Tenant;
 
 public class PostgresqlExecutor implements CibaGrantSqlExecutor {
 
@@ -156,6 +157,25 @@ public class PostgresqlExecutor implements CibaGrantSqlExecutor {
 
     List<Object> params = new ArrayList<>();
     params.add(authReqId.value());
+
+    return sqlExecutor.selectOne(sqlTemplate, params);
+  }
+
+  @Override
+  public Map<String, String> selectOneForUpdate(Tenant tenant, AuthReqId authReqId) {
+    SqlExecutor sqlExecutor = new SqlExecutor();
+    String sqlTemplate =
+        selectSql
+            + " "
+            + """
+                WHERE auth_req_id = ?
+                AND tenant_id = ?::uuid
+                FOR UPDATE;
+                """;
+
+    List<Object> params = new ArrayList<>();
+    params.add(authReqId.value());
+    params.add(tenant.identifier().valueAsUuid());
 
     return sqlExecutor.selectOne(sqlTemplate, params);
   }

--- a/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/oidc/code/AuthorizationCodeGrantDataSource.java
+++ b/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/oidc/code/AuthorizationCodeGrantDataSource.java
@@ -47,6 +47,16 @@ public class AuthorizationCodeGrantDataSource implements AuthorizationCodeGrantR
   }
 
   @Override
+  public AuthorizationCodeGrant findForUpdate(Tenant tenant, AuthorizationCode authorizationCode) {
+    Map<String, String> stringMap = executor.selectOneForUpdate(tenant, authorizationCode);
+
+    if (Objects.isNull(stringMap) || stringMap.isEmpty()) {
+      return new AuthorizationCodeGrant();
+    }
+    return ModelConverter.convert(stringMap);
+  }
+
+  @Override
   public void delete(Tenant tenant, AuthorizationCodeGrant authorizationCodeGrant) {
     executor.delete(tenant, authorizationCodeGrant);
   }

--- a/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/oidc/code/AuthorizationCodeGrantExecutor.java
+++ b/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/oidc/code/AuthorizationCodeGrantExecutor.java
@@ -27,5 +27,7 @@ public interface AuthorizationCodeGrantExecutor {
 
   Map<String, String> selectOne(Tenant tenant, AuthorizationCode authorizationCode);
 
+  Map<String, String> selectOneForUpdate(Tenant tenant, AuthorizationCode authorizationCode);
+
   void delete(Tenant tenant, AuthorizationCodeGrant authorizationCodeGrant);
 }

--- a/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/oidc/code/MysqlExecutor.java
+++ b/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/oidc/code/MysqlExecutor.java
@@ -155,6 +155,41 @@ public class MysqlExecutor implements AuthorizationCodeGrantExecutor {
     return sqlExecutor.selectOne(sqlTemplate, params);
   }
 
+  public Map<String, String> selectOneForUpdate(
+      Tenant tenant, AuthorizationCode authorizationCode) {
+    SqlExecutor sqlExecutor = new SqlExecutor();
+    String sqlTemplate =
+        """
+                SELECT
+                authorization_request_id,
+                tenant_id,
+                authorization_code,
+                user_id,
+                user_payload,
+                authentication,
+                client_id,
+                client_payload,
+                grant_type,
+                scopes,
+                id_token_claims,
+                userinfo_claims,
+                custom_properties,
+                authorization_details,
+                expires_at,
+                consent_claims
+                FROM authorization_code_grant
+                WHERE authorization_code = ?
+                AND tenant_id = ?
+                FOR UPDATE;
+                """;
+
+    List<Object> params = new ArrayList<>();
+    params.add(authorizationCode.value());
+    params.add(tenant.identifier().value());
+
+    return sqlExecutor.selectOne(sqlTemplate, params);
+  }
+
   public void delete(Tenant tenant, AuthorizationCodeGrant authorizationCodeGrant) {
     SqlExecutor sqlExecutor = new SqlExecutor();
     String sqlTemplate =

--- a/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/oidc/code/PostgresqlExecutor.java
+++ b/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/oidc/code/PostgresqlExecutor.java
@@ -155,6 +155,41 @@ public class PostgresqlExecutor implements AuthorizationCodeGrantExecutor {
     return sqlExecutor.selectOne(sqlTemplate, params);
   }
 
+  public Map<String, String> selectOneForUpdate(
+      Tenant tenant, AuthorizationCode authorizationCode) {
+    SqlExecutor sqlExecutor = new SqlExecutor();
+    String sqlTemplate =
+        """
+                SELECT
+                authorization_request_id,
+                tenant_id,
+                authorization_code,
+                user_id,
+                user_payload,
+                authentication,
+                client_id,
+                client_payload,
+                grant_type,
+                scopes,
+                id_token_claims,
+                userinfo_claims,
+                custom_properties,
+                authorization_details,
+                expires_at,
+                consent_claims
+                FROM authorization_code_grant
+                WHERE authorization_code = ?
+                AND tenant_id = ?::uuid
+                FOR UPDATE;
+                """;
+
+    List<Object> params = new ArrayList<>();
+    params.add(authorizationCode.value());
+    params.add(tenant.identifier().valueAsUuid());
+
+    return sqlExecutor.selectOne(sqlTemplate, params);
+  }
+
   public void delete(Tenant tenant, AuthorizationCodeGrant authorizationCodeGrant) {
     SqlExecutor sqlExecutor = new SqlExecutor();
     String sqlTemplate =

--- a/libs/idp-server-core-extension-ciba/src/main/java/org/idp/server/core/extension/ciba/repository/CibaGrantRepository.java
+++ b/libs/idp-server-core-extension-ciba/src/main/java/org/idp/server/core/extension/ciba/repository/CibaGrantRepository.java
@@ -29,6 +29,16 @@ public interface CibaGrantRepository {
 
   CibaGrant find(Tenant tenant, AuthReqId authReqId);
 
+  /**
+   * Locks the CIBA grant row for the current transaction (SELECT ... FOR UPDATE) and scopes the
+   * lookup by tenant.
+   *
+   * <p>Used by the CIBA token issuance to enforce single-use: a concurrent poll of the same
+   * auth_req_id blocks until this transaction commits (which deletes the grant), then finds no row
+   * and is rejected. The tenant predicate is the sole tenant boundary on MySQL (no RLS there).
+   */
+  CibaGrant findForUpdate(Tenant tenant, AuthReqId authReqId);
+
   CibaGrant get(
       Tenant tenant,
       BackchannelAuthenticationRequestIdentifier backchannelAuthenticationRequestIdentifier);

--- a/libs/idp-server-core-extension-ciba/src/main/java/org/idp/server/core/extension/ciba/token/CibaGrantService.java
+++ b/libs/idp-server-core-extension-ciba/src/main/java/org/idp/server/core/extension/ciba/token/CibaGrantService.java
@@ -73,7 +73,7 @@ public class CibaGrantService implements OAuthTokenCreationService, RefreshToken
 
     Tenant tenant = tokenRequestContext.tenant();
     AuthReqId authReqId = tokenRequestContext.authReqId();
-    CibaGrant cibaGrant = cibaGrantRepository.find(tenant, authReqId);
+    CibaGrant cibaGrant = cibaGrantRepository.findForUpdate(tenant, authReqId);
 
     if (!cibaGrant.exists()) {
       throw new TokenBadRequestException(

--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/oauth/repository/AuthorizationCodeGrantRepository.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/oauth/repository/AuthorizationCodeGrantRepository.java
@@ -25,5 +25,16 @@ public interface AuthorizationCodeGrantRepository {
 
   AuthorizationCodeGrant find(Tenant tenant, AuthorizationCode authorizationCode);
 
+  /**
+   * Locks the authorization code grant row for the duration of the current transaction (SELECT ...
+   * FOR UPDATE).
+   *
+   * <p>Used by the authorization_code token exchange to enforce single-use: a concurrent exchange
+   * of the same code blocks until this transaction commits (which deletes the row), then finds no
+   * row and is rejected. Prevents the find-verify-delete race that would otherwise issue two token
+   * sets from one code.
+   */
+  AuthorizationCodeGrant findForUpdate(Tenant tenant, AuthorizationCode authorizationCode);
+
   void delete(Tenant tenant, AuthorizationCodeGrant authorizationCodeGrant);
 }

--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/token/service/AuthorizationCodeGrantService.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/token/service/AuthorizationCodeGrantService.java
@@ -128,7 +128,7 @@ public class AuthorizationCodeGrantService
     Tenant tenant = tokenRequestContext.tenant();
     AuthorizationCode code = tokenRequestContext.code();
     AuthorizationCodeGrant authorizationCodeGrant =
-        authorizationCodeGrantRepository.find(tenant, code);
+        authorizationCodeGrantRepository.findForUpdate(tenant, code);
 
     if (!authorizationCodeGrant.exists()) {
       throw new TokenBadRequestException("invalid_grant", "not found authorization code.");


### PR DESCRIPTION
Closes #1713

## 概要

トークンエンドポイントのグラント消費(`find → verify → register → delete`)を
`SELECT ... FOR UPDATE` の行ロックで直列化し、認可コード / CIBA auth_req_id の
single-use を並行リクエスト下でも構造的に保証する。

- RFC 6749 §4.1.2: "The client MUST NOT use the authorization code more than once.
  If an authorization code is used more than once, the authorization server MUST deny the request."
- 後続の並行リクエストは先行トランザクションの commit(=グラント削除)を待ってから
  not found → `invalid_grant` となり、成功は常に最大1件になる。

## 変更内容

- `AuthorizationCodeGrantRepository` / `CibaGrantRepository` に `findForUpdate(Tenant, ...)` を追加
  - DataSource / PostgresqlExecutor / MysqlExecutor に `selectOneForUpdate` を実装(両DB対応)
- `AuthorizationCodeGrantService` / `CibaGrantService` のグラント読み取りを `findForUpdate` に置き換え
- CIBA 側の新規 SQL は `tenant_id` を WHERE に含め、テナントスコープを明示

## テスト

- `e2e/src/tests/spec/rfc6749_4_1_code.test.js`
  - 逐次再利用の拒否(§4.1.2 MUST)
  - 並行3連交換で成功が最大1件、残りは `invalid_grant`
  - 再利用検知時のトークン失効(Security BCP §4.5.3 SHOULD)は未対応として xit で台帳化
- `e2e/src/tests/security/ciba_auth_req_id_single_use_race.test.js`(新規)
  - CIBA 並行ポーリングで成功が最大1件、残りは `invalid_grant`
- E2E 通過確認済み

## スコープ外(フォローアップ)

- 再利用検知時の発行済みトークン失効(BCP §4.5.3)
- 他リポジトリの既存 SELECT へのテナントスコープ明示の横展開

🤖 Generated with [Claude Code](https://claude.com/claude-code)
