### PR TITLE
feat(cors): 認可エンドポイントを CORS 非対応にする (FAPI 2.0 SP §5.2.3.3 / OAuth 2.1)

### DIFF
--- a/e2e/src/tests/spec/fapi2_authorization_endpoint_cors.test.js
+++ b/e2e/src/tests/spec/fapi2_authorization_endpoint_cors.test.js
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "@jest/globals";
+import { options } from "../../lib/http";
+import { serverConfig } from "../testConfig";
+
+/**
+ * FAPI 2.0 Security Profile §5.2.3.3 / OAuth 2.1: Authorization Endpoint CORS.
+ *
+ * The authorization endpoint is reached via top-level browser navigation (redirect / form
+ * submission), not via XHR/fetch, so it MUST NOT support CORS. Endpoints that ARE legitimately
+ * accessed by JavaScript clients (PAR /push, /{id}/authorize, ...) continue to support CORS.
+ *
+ * `DynamicCorsFilter` always emits `Access-Control-Allow-Origin` when it runs (matching an
+ * allow-listed origin, or falling back to the tenant domain). Therefore:
+ * - authorization endpoint root: the filter is skipped -> header absent.
+ * - CORS-eligible subpaths: the filter runs -> header present.
+ */
+describe("FAPI 2.0 SP §5.2.3.3 / OAuth 2.1  Authorization Endpoint CORS", () => {
+  const origin = "https://spa.example.com";
+
+  it("The authorization endpoint MUST NOT support CORS (preflight returns no Access-Control-Allow-Origin)", async () => {
+    const response = await options({
+      url: serverConfig.authorizationEndpoint,
+      headers: {
+        Origin: origin,
+        "Access-Control-Request-Method": "GET",
+        "Access-Control-Request-Headers": "Content-Type",
+      },
+    });
+    expect(response.headers["access-control-allow-origin"]).toBeUndefined();
+  });
+
+  it("The PAR endpoint (/push) MUST continue to support CORS for JavaScript clients", async () => {
+    const response = await options({
+      url: serverConfig.pushedAuthorizationEndpoint,
+      headers: {
+        Origin: origin,
+        "Access-Control-Request-Method": "POST",
+        "Access-Control-Request-Headers": "Content-Type, Authorization",
+      },
+    });
+    expect(response.headers["access-control-allow-origin"]).toBeDefined();
+  });
+
+  it("The /{id}/authorize subpath MUST continue to support CORS for JavaScript clients", async () => {
+    const response = await options({
+      url: serverConfig.authorizeEndpoint.replace("{id}", "preflight-probe"),
+      headers: {
+        Origin: origin,
+        "Access-Control-Request-Method": "POST",
+        "Access-Control-Request-Headers": "Content-Type",
+      },
+    });
+    expect(response.headers["access-control-allow-origin"]).toBeDefined();
+  });
+});

--- a/libs/idp-server-springboot-adapter/src/main/java/org/idp/server/adapters/springboot/DynamicCorsFilter.java
+++ b/libs/idp-server-springboot-adapter/src/main/java/org/idp/server/adapters/springboot/DynamicCorsFilter.java
@@ -42,6 +42,19 @@ public class DynamicCorsFilter extends OncePerRequestFilter {
   private static final Pattern ORG_PATH_PATTERN =
       Pattern.compile("^/v1/management/organizations/([^/]+)/");
 
+  /**
+   * FAPI 2.0 SP §5.2.3.3 / OAuth 2.1 best practice: the authorization endpoint MUST NOT support
+   * CORS. The endpoint is intended to be reached via top-level browser navigation (redirect / form
+   * submission), not via XHR/fetch.
+   *
+   * <p>This pattern matches only the root path of the authorization endpoint ({@code
+   * /{tenant}/v1/authorizations} for GET/POST). Subpaths such as {@code /push} (PAR), {@code
+   * /{id}/view-data}, {@code /{id}/authorize}, {@code /federations/*} continue to receive CORS
+   * headers because they are legitimately accessed by JavaScript clients.
+   */
+  private static final Pattern AUTHORIZATION_ENDPOINT_PATTERN =
+      Pattern.compile("^/[^/]+/v1/authorizations/?$");
+
   TenantMetaDataApi tenantMetaDataApi;
   OrganizationTenantResolverApi organizationTenantResolverApi;
   LoggerWrapper log = LoggerWrapper.getLogger(DynamicCorsFilter.class);
@@ -142,12 +155,23 @@ public class DynamicCorsFilter extends OncePerRequestFilter {
   @Override
   protected boolean shouldNotFilter(HttpServletRequest request) {
     String uri = request.getRequestURI();
+    String method = request.getMethod();
     // Skip CORS for actuator endpoints and simple /health, but allow CORS for tenant-specific
     // /v1/health
     return uri.equals("/health")
         || uri.startsWith("/actuator/")
         || uri.contains("/admin")
         || uri.contains("/backchannel")
-        || uri.contains("/auth-views/");
+        || uri.contains("/auth-views/")
+        || isAuthorizationEndpoint(uri, method);
+  }
+
+  private boolean isAuthorizationEndpoint(String uri, String method) {
+    if (!"GET".equalsIgnoreCase(method)
+        && !"POST".equalsIgnoreCase(method)
+        && !"OPTIONS".equalsIgnoreCase(method)) {
+      return false;
+    }
+    return AUTHORIZATION_ENDPOINT_PATTERN.matcher(uri).matches();
   }
 }


### PR DESCRIPTION
## 概要

FAPI 2.0 Security Profile §5.2.3.3 / OAuth 2.1 に従い、**認可エンドポイントのルート（`/{tenant}/v1/authorizations`）を CORS 非対応**にする。認可エンドポイントはトップレベルのブラウザ遷移（リダイレクト / フォーム送信）で到達する設計で、XHR/fetch 用ではないため CORS を提供すべきではない。

FAPI 2.0 ブランチ（`feat/fapi-2.0-sp-final`）で実装済みだが、**単一ファイルで完結し他の FAPI 2.0 変更に依存しない**ため先行リリースする。

`Closes #1717`

## 変更内容

- `DynamicCorsFilter.shouldNotFilter()`: 認可エンドポイントのルート（`^/[^/]+/v1/authorizations/?$` の GET/POST/OPTIONS）を CORS 対象外に
- サブパス（PAR `/push`、`/{id}/view-data`、`/{id}/authorize`、`/federations/*` 等）は JavaScript クライアントから正当にアクセスされるため CORS を継続提供

## 挙動

`DynamicCorsFilter` はフィルタが動けば必ず `Access-Control-Allow-Origin` を付与する（許可 origin か tenant.domain フォールバック）。したがって:

- 認可エンドポイントのルート: フィルタがスキップされ CORS ヘッダ**無し**
- CORS 対象のサブパス: フィルタが動き CORS ヘッダ**有り**

## ⚠️ CodeQL 誤検知（dismiss 予定）

CodeQL が `isAuthorizationEndpoint(uri, method)` に **"User-controlled bypass of sensitive method"（High）** を報告するが**誤検知**。FAPI 2.0 ブランチでも Dismissed 済み。

- スキップされるのは **CORS ヘッダ付与**であり認証・認可のゲートではない（CORS はブラウザ側が強制する助言的機構）。認証/consent/PKCE/redirect_uri 検証は下流のコントローラが担い、本フィルタでは迂回されない
- CORS ヘッダを**外す**方向 = クロスオリジンアクセスを**厳しくする**。攻撃者を利する CORS 緩和とは真逆で、新たに取れるアクセスは無い
- 既存の `shouldNotFilter`（`/admin` `/backchannel` `/auth-views/` `/actuator/`）も同種のユーザー制御 URI ベースのスキップで新しい攻撃面ではない
- パターンは厳密アンカー（`^...$`）で他エンドポイントの誤マッチ不可

→ マージ後に dismiss（reason: false positive）する。詳細は #1717。

## Test plan
- [x] spec E2E `fapi2_authorization_endpoint_cors`（3件オールグリーン）
  - [x] 認可エンドポイントのルートは preflight で `Access-Control-Allow-Origin` を返さない（MUST NOT）
  - [x] PAR `/push` は CORS 継続
  - [x] `/{id}/authorize` サブパスは CORS 継続
- [x] 既存 `control-plane-02-organization-cors` 回帰なし
- [x] 実サーバーで preflight 手動確認（ルート=ヘッダ無し / サブパス=ヘッダ有り）

## 参照
- FAPI 2.0 Security Profile §5.2.3.3 / OAuth 2.1
- 実装元: `feat/fapi-2.0-sp-final` ブランチ

🤖 Generated with [Claude Code](https://claude.com/claude-code)