### PR TITLE
fix(auth): federation マージ経路に same-user ガードを追加 (#1720)

### DIFF
--- a/e2e/src/tests/security/federation_identifier_switching.test.js
+++ b/e2e/src/tests/security/federation_identifier_switching.test.js
@@ -1,0 +1,132 @@
+import { describe, expect, it } from "@jest/globals";
+import { faker } from "@faker-js/faker";
+import {
+  backendUrl,
+  clientSecretPostClient,
+  federationServerConfig,
+  serverConfig,
+} from "../testConfig";
+import { postAuthentication, requestToken } from "../../api/oauthClient";
+import { get, post } from "../../lib/http";
+import { requestFederation } from "../../oauth/federation";
+import { requestAuthorizations } from "../../oauth/request";
+
+/**
+ * Security: Federation identifier switching.
+ *
+ * A federation step that runs after a user is already established in the transaction MUST bind to
+ * that user, not silently replace it. Here the transaction establishes user A via password
+ * (1st factor), then a federation callback returns a different user B. The merge must be rejected
+ * (invalid_request), mirroring the same-user guard on the standard interaction path.
+ *
+ * Federation is intentionally not part of this client's authentication policy, but invoking an
+ * unconfigured interaction does not error on that basis — so what we observe is the identity guard,
+ * not a policy rejection.
+ */
+describe("Security: Federation identifier switching", () => {
+  it("should reject a federation step that returns a different user than the established one", async () => {
+    const federatedUserB = {
+      email: faker.internet.email(),
+      name: faker.person.fullName(),
+      zoneinfo: "Asia/Tokyo",
+      locale: "ja-JP",
+      phone_number: faker.phone.number("090-####-####"),
+    };
+
+    let callbackStatus;
+    let callbackData;
+
+    // Authenticate user B at the mock federation IdP (email challenge + verify), mirroring
+    // scenario-02's federation login.
+    const federationInteraction = async (id, user) => {
+      await postAuthentication({
+        endpoint: `${backendUrl}/${federationServerConfig.tenantId}/v1/authorizations/{id}/email-authentication-challenge`,
+        id,
+        body: { email: user.email, email_template: "authentication" },
+      });
+
+      const adminTokenResponse = await requestToken({
+        endpoint: serverConfig.tokenEndpoint,
+        grantType: "password",
+        username: serverConfig.oauth.username,
+        password: serverConfig.oauth.password,
+        scope: clientSecretPostClient.scope,
+        clientId: clientSecretPostClient.clientId,
+        clientSecret: clientSecretPostClient.clientSecret,
+      });
+      expect(adminTokenResponse.status).toBe(200);
+      const accessToken = adminTokenResponse.data.access_token;
+
+      const transactionResponse = await get({
+        url: `${backendUrl}/v1/management/organizations/${serverConfig.organizationId}/tenants/${federationServerConfig.tenantId}/authentication-transactions?authorization_id=${id}`,
+        headers: { Authorization: `Bearer ${accessToken}` },
+      });
+      const transactionId = transactionResponse.data.list[0].id;
+
+      const interactionResponse = await get({
+        url: `${backendUrl}/v1/management/organizations/${serverConfig.organizationId}/tenants/${federationServerConfig.tenantId}/authentication-interactions/${transactionId}/email-authentication-challenge`,
+        headers: { Authorization: `Bearer ${accessToken}` },
+      });
+      const verificationCode = interactionResponse.data.payload.verification_code;
+
+      await postAuthentication({
+        endpoint: `${backendUrl}/${federationServerConfig.tenantId}/v1/authorizations/{id}/email-authentication`,
+        id,
+        body: { verification_code: verificationCode },
+      });
+    };
+
+    // 1st factor: password establishes user A (default seeded user ito.ichiro), then federation
+    // returns user B on the same transaction.
+    const interaction = async (id) => {
+      const passwordResponse = await postAuthentication({
+        endpoint: serverConfig.authorizationIdEndpoint.replace("{id}", id) + "password-authentication",
+        id,
+        body: { username: "ito.ichiro@gmail.com", password: "successUserCode001" },
+      });
+      expect(passwordResponse.status).toBe(200);
+
+      const viewResponse = await get({
+        url: `${backendUrl}/${serverConfig.tenantId}/v1/authorizations/${id}/view-data`,
+      });
+      expect(viewResponse.status).toBe(200);
+      const federationSetting = viewResponse.data.available_federations.find(
+        (federation) => federation.auto_selected,
+      );
+
+      const { params } = await requestFederation({
+        url: backendUrl,
+        authSessionId: id,
+        authSessionTenantId: serverConfig.tenantId,
+        type: federationSetting.type,
+        providerName: federationSetting.sso_provider,
+        federationTenantId: federationServerConfig.tenantId,
+        user: federatedUserB,
+        interaction: federationInteraction,
+      });
+
+      const callbackResponse = await post({
+        url: `${backendUrl}/${serverConfig.tenantId}/v1/authorizations/federations/oidc/callback`,
+        body: params.toString(),
+      });
+      callbackStatus = callbackResponse.status;
+      callbackData = callbackResponse.data;
+    };
+
+    await requestAuthorizations({
+      endpoint: serverConfig.authorizationEndpoint,
+      clientId: clientSecretPostClient.clientId,
+      responseType: "code",
+      state: "aiueo",
+      scope: "openid profile phone email " + clientSecretPostClient.scope,
+      redirectUri: clientSecretPostClient.redirectUri,
+      customParams: { organizationId: "123", organizationName: "test" },
+      interaction,
+    });
+
+    console.log("federation callback status:", callbackStatus);
+    console.log("federation callback data:", JSON.stringify(callbackData));
+
+    expect(callbackStatus).toBe(400);
+  });
+});

--- a/e2e/src/tests/security/federation_identifier_switching.test.js
+++ b/e2e/src/tests/security/federation_identifier_switching.test.js
@@ -127,6 +127,10 @@ describe("Security: Federation identifier switching", () => {
     console.log("federation callback status:", callbackStatus);
     console.log("federation callback data:", JSON.stringify(callbackData));
 
+    // Assert the exact guard response, not just any 400 — an unrelated validation failure would
+    // otherwise pass and mask a regression of the same-user guard.
     expect(callbackStatus).toBe(400);
+    expect(callbackData.error).toBe("invalid_request");
+    expect(callbackData.error_description).toBe("User is not the same as the request");
   });
 });

--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/authentication/AuthenticationTransaction.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/authentication/AuthenticationTransaction.java
@@ -161,9 +161,47 @@ public class AuthenticationTransaction {
     return request.updateWithUser(interactionRequestResult);
   }
 
+  /**
+   * Merges the federated user into the transaction with the same identifier-switching guard as the
+   * standard interaction path.
+   *
+   * <p>A federation step that runs after a user is already established (e.g. CIBA {@code
+   * login_hint} pre-resolves the user, or federation is configured as a later factor) MUST bind to
+   * that established user, never silently replace it. Without this gate, a flow that establishes
+   * user A and then runs a federation step returning user B would rebind the whole transaction to B
+   * — the federation counterpart of the 2nd-factor user binding.
+   *
+   * @param result the federation interaction result
+   * @return the updated authentication request
+   */
+  private AuthenticationRequest updateWithUser(FederationInteractionResult result) {
+    // No user in result - keep request unchanged (also covers federation error / notFound)
+    if (!result.hasUser()) {
+      return request;
+    }
+
+    // Don't bind user on failure (prevents transaction pollution, mirrors the standard path)
+    if (!result.isSuccess()) {
+      return request;
+    }
+
+    // First authenticated user in the transaction - establish it
+    if (!request.hasUser()) {
+      return request.updateWithUser(result);
+    }
+
+    // Established user must match the federated identity (same sub)
+    if (!request.isSameUser(result.user())) {
+      throw new BadRequestException("User is not the same as the request");
+    }
+
+    // Same user: refresh with the latest federated user data
+    return request.updateWithUser(result);
+  }
+
   public AuthenticationTransaction updateWith(FederationInteractionResult result) {
     Map<String, AuthenticationInteractionResult> resultMap = interactionResults.toMap();
-    AuthenticationRequest updatedRequest = request.updateWithUser(result);
+    AuthenticationRequest updatedRequest = updateWithUser(result);
 
     if (interactionResults.contains(result.interactionTypeName())) {
 

--- a/libs/idp-server-core/src/test/java/org/idp/server/core/openid/authentication/AuthenticationTransactionFederationGuardTest.java
+++ b/libs/idp-server-core/src/test/java/org/idp/server/core/openid/authentication/AuthenticationTransactionFederationGuardTest.java
@@ -18,6 +18,7 @@ package org.idp.server.core.openid.authentication;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import java.util.HashMap;
 import java.util.UUID;
 import org.idp.server.core.openid.authentication.policy.AuthenticationPolicy;
 import org.idp.server.core.openid.federation.FederationInteractionResult;
@@ -51,21 +52,28 @@ class AuthenticationTransactionFederationGuardTest {
         new AuthenticationTransactionAttributes());
   }
 
+  private OidcSsoSession session() {
+    return new OidcSsoSession(
+        UUID.randomUUID().toString(),
+        UUID.randomUUID().toString(),
+        UUID.randomUUID().toString(),
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null);
+  }
+
   private FederationInteractionResult federationSuccess(User user) {
-    OidcSsoSession session =
-        new OidcSsoSession(
-            UUID.randomUUID().toString(),
-            UUID.randomUUID().toString(),
-            UUID.randomUUID().toString(),
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null);
     return FederationInteractionResult.success(
-        new FederationType("oidc"), new SsoProvider("google"), session, user);
+        new FederationType("oidc"), new SsoProvider("google"), session(), user);
+  }
+
+  private FederationInteractionResult federationFailure() {
+    return FederationInteractionResult.error(
+        new FederationType("oidc"), new SsoProvider("google"), session(), 400, new HashMap<>());
   }
 
   @Test
@@ -97,5 +105,14 @@ class AuthenticationTransactionFederationGuardTest {
         transaction.updateWith(federationSuccess(userWithSub("user-b")));
 
     assertEquals("user-b", updated.user().sub());
+  }
+
+  @Test
+  void preservesEstablishedUserOnFederationFailure() {
+    AuthenticationTransaction transaction = transactionWith(userWithSub("user-a"));
+
+    AuthenticationTransaction updated = transaction.updateWith(federationFailure());
+
+    assertEquals("user-a", updated.user().sub());
   }
 }

--- a/libs/idp-server-core/src/test/java/org/idp/server/core/openid/authentication/AuthenticationTransactionFederationGuardTest.java
+++ b/libs/idp-server-core/src/test/java/org/idp/server/core/openid/authentication/AuthenticationTransactionFederationGuardTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2025 Hirokazu Kobayashi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.idp.server.core.openid.authentication;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.UUID;
+import org.idp.server.core.openid.authentication.policy.AuthenticationPolicy;
+import org.idp.server.core.openid.federation.FederationInteractionResult;
+import org.idp.server.core.openid.federation.FederationType;
+import org.idp.server.core.openid.federation.sso.SsoProvider;
+import org.idp.server.core.openid.federation.sso.oidc.OidcSsoSession;
+import org.idp.server.core.openid.identity.User;
+import org.idp.server.platform.exception.BadRequestException;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The federation merge path must apply the same identifier-switching guard as the standard
+ * interaction path: once a user is established in the transaction, a federation step returning a
+ * different user must be rejected, not silently rebind the transaction.
+ */
+class AuthenticationTransactionFederationGuardTest {
+
+  private User userWithSub(String sub) {
+    return new User().setSub(sub);
+  }
+
+  private AuthenticationTransaction transactionWith(User user) {
+    AuthenticationRequest request =
+        new AuthenticationRequest(null, null, null, null, null, user, null, null, null, null);
+    return new AuthenticationTransaction(
+        new AuthenticationTransactionIdentifier(UUID.randomUUID().toString()),
+        new AuthorizationIdentifier(UUID.randomUUID().toString()),
+        request,
+        new AuthenticationPolicy(),
+        new AuthenticationInteractionResults(),
+        new AuthenticationTransactionAttributes());
+  }
+
+  private FederationInteractionResult federationSuccess(User user) {
+    OidcSsoSession session =
+        new OidcSsoSession(
+            UUID.randomUUID().toString(),
+            UUID.randomUUID().toString(),
+            UUID.randomUUID().toString(),
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null);
+    return FederationInteractionResult.success(
+        new FederationType("oidc"), new SsoProvider("google"), session, user);
+  }
+
+  @Test
+  void rejectsFederationUserSwitchWhenUserAlreadyEstablished() {
+    AuthenticationTransaction transaction = transactionWith(userWithSub("user-a"));
+
+    BadRequestException exception =
+        assertThrows(
+            BadRequestException.class,
+            () -> transaction.updateWith(federationSuccess(userWithSub("user-b"))));
+    assertEquals("User is not the same as the request", exception.getMessage());
+  }
+
+  @Test
+  void bindsToEstablishedUserWhenFederationReturnsSameSub() {
+    AuthenticationTransaction transaction = transactionWith(userWithSub("user-a"));
+
+    AuthenticationTransaction updated =
+        transaction.updateWith(federationSuccess(userWithSub("user-a")));
+
+    assertEquals("user-a", updated.user().sub());
+  }
+
+  @Test
+  void establishesUserWhenNoneYet() {
+    AuthenticationTransaction transaction = transactionWith(new User());
+
+    AuthenticationTransaction updated =
+        transaction.updateWith(federationSuccess(userWithSub("user-b")));
+
+    assertEquals("user-b", updated.user().sub());
+  }
+}


### PR DESCRIPTION
Closes #1720

## 概要

標準の interaction パスは「確立済みユーザーへのバインド」(same-user ガード、#1021)を持つが、
federation マージ経路 `AuthenticationTransaction.updateWith(FederationInteractionResult)` だけが
これを通らず、federation 結果の user で確立済みユーザーを無条件に上書きしていた。
federation パスを標準パスと同じガードに揃える。

## 変更内容

- private `updateWithUser(FederationInteractionResult)` を追加し、標準パスと同じゲートを共有
  (`hasUser → isSameUser → throw`、未確立/失敗は早期 return)
- federation パス(`updateWith(FederationInteractionResult)`)を、直接 `request.updateWithUser(result)`
  を呼ぶのをやめ、この guarded helper 経由に配線
- 副次的に、federation 失敗結果(`User.notFound()`)での user 上書きも防止

## 到達性・影響

- **標準の「federation を1段目(単独)」フローは影響なし**。federation 時点で確立済みユーザーが
  無く、正しく初回確立になる(大多数の構成)。
- 確立済みユーザーがある状態で federation が走る構成(例: 1段目で別 factor 確立後に federation /
  CIBA login_hint 後の federation)で identity 置換が成立していた。

## テスト

- **ユニット** `AuthenticationTransactionFederationGuardTest`: 置換拒否 / 同一 sub bind /
  未確立時の確立 の3分岐(pass)
- **E2E** `security/federation_identifier_switching.test.js`: password で A 確立 → 別ユーザー B で
  federation → `400 invalid_request "User is not the same as the request"`

### before / after(ローカルスタックで実測）

| | federation callback | 意味 |
|---|---|---|
| 修正前 | `200` + 認可コード発行 | 別ユーザー B の federation が黙って受理され置換成立(既存設定で再現) |
| 修正後 | `400 invalid_request` | ガードが identity 置換を拒否 |

## 関連

- #1021 — 標準 interaction パスの same-user バインド

🤖 Generated with [Claude Code](https://claude.com/claude-code)
