### PR TITLE
fix(dpop): RS側 DPoP エラーの§7.1統一 + htuポート比較 (#1736 クラスタB)

### DIFF
--- a/e2e/src/tests/spec/rfc9449_dpop.test.js
+++ b/e2e/src/tests/spec/rfc9449_dpop.test.js
@@ -739,6 +739,14 @@ describe("RFC 9449: OAuth 2.0 Demonstrating Proof of Possession (DPoP)", () => {
 
 
       expect(userinfoResponse.status).toBe(401);
+      // RFC 9449 §7.1: the resource server challenges with the DPoP authentication scheme and the
+      // invalid_token error (not the token-endpoint-only invalid_dpop_proof), and returns a
+      // WWW-Authenticate header carrying that challenge.
+      const wwwAuthenticate = userinfoResponse.headers["www-authenticate"];
+      expect(wwwAuthenticate).toBeDefined();
+      expect(wwwAuthenticate).toContain("DPoP");
+      expect(wwwAuthenticate).toContain('error="invalid_token"');
+      expect(userinfoResponse.data.error).toBe("invalid_token");
     });
 
     /**
@@ -1197,6 +1205,13 @@ describe("RFC 9449: OAuth 2.0 Demonstrating Proof of Possession (DPoP)", () => {
       });
 
       expect(response.status).toBe(401);
+      // RFC 9449 §7.1: DPoP-scheme WWW-Authenticate challenge with invalid_token, consistent with
+      // the UserInfo endpoint.
+      const wwwAuthenticate = response.headers["www-authenticate"];
+      expect(wwwAuthenticate).toBeDefined();
+      expect(wwwAuthenticate).toContain("DPoP");
+      expect(wwwAuthenticate).toContain('error="invalid_token"');
+      expect(response.data.error).toBe("invalid_token");
     });
 
     it("MUST reject /me request when DPoP proof is signed with different key", async () => {

--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/oauth/dpop/DPoPProofVerifier.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/oauth/dpop/DPoPProofVerifier.java
@@ -347,9 +347,13 @@ public class DPoPProofVerifier {
       log.error("Expected HTTP URI is not an absolute URI");
       throw new DPoPProofInvalidException("DPoP proof htu verification failed");
     }
-    // RFC 3986: scheme and host are case-insensitive, path is case-sensitive
+    // RFC 3986: scheme and host are case-insensitive, path is case-sensitive.
+    // The authority match includes the port: equalsPort normalizes the scheme's default
+    // port (https->443, http->80), so https://h/p matches https://h:443/p but not
+    // https://h:8443/p.
     if (!htuUri.equalsScheme(expectedUri)
         || !htuUri.equalsHost(expectedUri)
+        || !htuUri.equalsPort(expectedUri)
         || !htuUri.equalsPath(expectedUri)) {
       throw new DPoPProofInvalidException(
           String.format("DPoP proof htu claim '%s' does not match the expected HTTP URI.", htu));

--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/userinfo/handler/UserinfoErrorHandler.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/userinfo/handler/UserinfoErrorHandler.java
@@ -86,13 +86,18 @@ public class UserinfoErrorHandler {
     }
 
     if (exception instanceof DPoPProofInvalidException) {
+      // RFC 9449 Section 7.1: at the resource server (userinfo), a DPoP presentation failure
+      // (e.g. multiple DPoP headers rejected by DPoPHeaderValidator) is invalid_token / 401,
+      // consistent with the /me protected resource. The 400 invalid_dpop_proof code is
+      // token-endpoint-only (Section 5). Returning 401 also lets the controller attach the
+      // WWW-Authenticate: DPoP challenge.
       log.warn(
-          "Userinfo request failed: status=bad_request, error=invalid_dpop_proof, description={}",
+          "Userinfo request failed: status=unauthorized, error=invalid_token, description={}",
           exception.getMessage());
       return new UserinfoRequestResponse(
-          UserinfoRequestStatus.BAD_REQUEST,
+          UserinfoRequestStatus.UNAUTHORIZE,
           new UserinfoErrorResponse(
-              new Error("invalid_dpop_proof"), new ErrorDescription(exception.getMessage())));
+              new Error("invalid_token"), new ErrorDescription(exception.getMessage())));
     }
 
     if (exception instanceof ServerConfigurationNotFoundException) {

--- a/libs/idp-server-springboot-adapter/src/main/java/org/idp/server/adapters/springboot/ProtectedResourceApiFilter.java
+++ b/libs/idp-server-springboot-adapter/src/main/java/org/idp/server/adapters/springboot/ProtectedResourceApiFilter.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import org.idp.server.adapters.springboot.application.restapi.ParameterTransformable;
+import org.idp.server.adapters.springboot.application.restapi.SecurityHeaderConfigurable;
 import org.idp.server.adapters.springboot.application.restapi.model.IdPApplicationScope;
 import org.idp.server.adapters.springboot.application.restapi.model.ResourceOwnerPrincipal;
 import org.idp.server.core.openid.identity.User;
@@ -95,7 +96,10 @@ public class ProtectedResourceApiFilter extends OncePerRequestFilter
       writeErrorResponse(response, authScheme, "invalid_token", e.getMessage());
     } catch (DPoPProofInvalidException e) {
       logger.debug("DPoP proof validation failed: {}", e.getMessage());
-      writeErrorResponse(response, authScheme, "invalid_dpop_proof", e.getMessage());
+      // RFC 9449 Section 7.1: a resource server rejecting a DPoP-bound access token (invalid proof
+      // or binding mismatch) responds with the invalid_token error via the DPoP scheme, not the
+      // token-endpoint-only invalid_dpop_proof code.
+      writeErrorResponse(response, authScheme, "invalid_token", e.getMessage());
     } catch (UserNotFoundException e) {
       logger.warn("User not found for token authentication: {}", e.getMessage());
       writeErrorResponse(
@@ -116,10 +120,15 @@ public class ProtectedResourceApiFilter extends OncePerRequestFilter
   private void writeErrorResponse(
       HttpServletResponse response, String scheme, String error, String errorDescription) {
     try {
-      // Set WWW-Authenticate header per RFC 6750 / RFC 9449 Section 7.2
+      // Set WWW-Authenticate header per RFC 6750 / RFC 9449 Section 7.1.
+      // errorDescription can contain attacker-controlled input (e.g. the htu value echoed in a
+      // DPoP proof error), so it must be escaped for the RFC 7235 quoted-string: escape backslash
+      // and double-quote, and drop control characters (CR/LF) to prevent header injection.
+      String headerSafeDescription =
+          SecurityHeaderConfigurable.escapeHeaderQuotedString(errorDescription);
       String wwwAuthenticate =
           String.format(
-              "%s error=\"%s\", error_description=\"%s\"", scheme, error, errorDescription);
+              "%s error=\"%s\", error_description=\"%s\"", scheme, error, headerSafeDescription);
       response.setHeader(HttpHeaders.WWW_AUTHENTICATE, wwwAuthenticate);
 
       // Set status code
@@ -133,7 +142,7 @@ public class ProtectedResourceApiFilter extends OncePerRequestFilter
       String jsonErrorResponse =
           String.format(
               "{\"error\":\"%s\",\"error_description\":\"%s\"}",
-              error, errorDescription.replace("\"", "\\\""));
+              error, errorDescription.replace("\\", "\\\\").replace("\"", "\\\""));
 
       response.getWriter().write(jsonErrorResponse);
       response.getWriter().flush();

--- a/libs/idp-server-springboot-adapter/src/main/java/org/idp/server/adapters/springboot/ProtectedResourceApiFilter.java
+++ b/libs/idp-server-springboot-adapter/src/main/java/org/idp/server/adapters/springboot/ProtectedResourceApiFilter.java
@@ -138,11 +138,15 @@ public class ProtectedResourceApiFilter extends OncePerRequestFilter
       response.setContentType("application/json");
       response.setCharacterEncoding("UTF-8");
 
-      // Write JSON error response body
+      // Write JSON error response body. Reuse the shared escaper so the description is stripped of
+      // control chars (raw CR/LF would produce invalid JSON) and its backslash/quote are escaped —
+      // keeping the body and the WWW-Authenticate header consistent for the same
+      // attacker-controlled
+      // input (e.g. an htu value echoed in a DPoP error).
       String jsonErrorResponse =
           String.format(
               "{\"error\":\"%s\",\"error_description\":\"%s\"}",
-              error, errorDescription.replace("\\", "\\\\").replace("\"", "\\\""));
+              error, SecurityHeaderConfigurable.escapeHeaderQuotedString(errorDescription));
 
       response.getWriter().write(jsonErrorResponse);
       response.getWriter().flush();

--- a/libs/idp-server-springboot-adapter/src/main/java/org/idp/server/adapters/springboot/application/restapi/SecurityHeaderConfigurable.java
+++ b/libs/idp-server-springboot-adapter/src/main/java/org/idp/server/adapters/springboot/application/restapi/SecurityHeaderConfigurable.java
@@ -16,6 +16,7 @@
 
 package org.idp.server.adapters.springboot.application.restapi;
 
+import java.util.Map;
 import org.springframework.http.HttpHeaders;
 
 /**
@@ -111,5 +112,47 @@ public interface SecurityHeaderConfigurable {
     headers.set("X-Content-Type-Options", "nosniff");
     headers.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains");
     return headers;
+  }
+
+  /**
+   * Adds an RFC 9449 Section 7.1 / RFC 6750 {@code WWW-Authenticate} challenge to the response when
+   * the protected-resource outcome is 401 Unauthorized. The scheme is {@code DPoP} when the request
+   * presented a DPoP-scheme {@code Authorization} header, otherwise {@code Bearer}. The {@code
+   * error} / {@code error_description} are read from the error response body and escaped for the
+   * RFC 7235 quoted-string. Non-401 outcomes are left untouched.
+   */
+  default void applyWwwAuthenticateIfUnauthorized(
+      HttpHeaders headers,
+      int statusCode,
+      Map<String, Object> responseBody,
+      String authorizationHeader) {
+    if (statusCode != 401) {
+      return;
+    }
+    String scheme =
+        authorizationHeader != null && authorizationHeader.regionMatches(true, 0, "DPoP ", 0, 5)
+            ? "DPoP"
+            : "Bearer";
+    Object error = responseBody != null ? responseBody.get("error") : null;
+    Object description = responseBody != null ? responseBody.get("error_description") : null;
+    headers.set(
+        HttpHeaders.WWW_AUTHENTICATE,
+        String.format(
+            "%s error=\"%s\", error_description=\"%s\"",
+            scheme,
+            escapeHeaderQuotedString(error == null ? "invalid_token" : error.toString()),
+            escapeHeaderQuotedString(description == null ? "" : description.toString())));
+  }
+
+  /**
+   * Escapes a value for embedding in an HTTP header quoted-string (RFC 7235). Backslash and
+   * double-quote are backslash-escaped; control characters (CR, LF, etc.) are removed so the value
+   * cannot break out of the header or inject a new one.
+   */
+  static String escapeHeaderQuotedString(String value) {
+    if (value == null) {
+      return "";
+    }
+    return value.replaceAll("[\\x00-\\x1F\\x7F]", "").replace("\\", "\\\\").replace("\"", "\\\"");
   }
 }

--- a/libs/idp-server-springboot-adapter/src/main/java/org/idp/server/adapters/springboot/application/restapi/userinfo/UserinfoV1Api.java
+++ b/libs/idp-server-springboot-adapter/src/main/java/org/idp/server/adapters/springboot/application/restapi/userinfo/UserinfoV1Api.java
@@ -58,6 +58,8 @@ public class UserinfoV1Api implements ParameterTransformable, SecurityHeaderConf
     HttpHeaders httpHeaders = createSecurityHeaders();
     httpHeaders.setCacheControl("no-store, private");
     httpHeaders.setContentType(MediaType.APPLICATION_JSON);
+    applyWwwAuthenticateIfUnauthorized(
+        httpHeaders, response.statusCode(), response.response(), authorizationHeader);
     return new ResponseEntity<>(
         response.response(), httpHeaders, HttpStatus.valueOf(response.statusCode()));
   }
@@ -79,6 +81,8 @@ public class UserinfoV1Api implements ParameterTransformable, SecurityHeaderConf
     HttpHeaders httpHeaders = createSecurityHeaders();
     httpHeaders.setCacheControl("no-store, private");
     httpHeaders.setContentType(MediaType.APPLICATION_JSON);
+    applyWwwAuthenticateIfUnauthorized(
+        httpHeaders, response.statusCode(), response.response(), authorizationHeader);
     return new ResponseEntity<>(
         response.response(), httpHeaders, HttpStatus.valueOf(response.statusCode()));
   }

--- a/libs/idp-server-springboot-adapter/src/test/java/org/idp/server/adapters/springboot/application/restapi/SecurityHeaderConfigurableTest.java
+++ b/libs/idp-server-springboot-adapter/src/test/java/org/idp/server/adapters/springboot/application/restapi/SecurityHeaderConfigurableTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2025 Hirokazu Kobayashi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.idp.server.adapters.springboot.application.restapi;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+
+class SecurityHeaderConfigurableTest {
+
+  /** Minimal implementor to exercise the interface's default methods. */
+  private final SecurityHeaderConfigurable target = new SecurityHeaderConfigurable() {};
+
+  @Test
+  void escapeHeaderQuotedString_escapesQuoteAndBackslash() {
+    assertEquals(
+        "he said \\\"hi\\\"",
+        SecurityHeaderConfigurable.escapeHeaderQuotedString("he said \"hi\""));
+    assertEquals("a\\\\b", SecurityHeaderConfigurable.escapeHeaderQuotedString("a\\b"));
+  }
+
+  @Test
+  void escapeHeaderQuotedString_stripsControlCharsToPreventHeaderInjection() {
+    // CR/LF must not survive, otherwise a crafted description could inject a new header.
+    String malicious = "bad\r\nSet-Cookie: pwned=1";
+    String escaped = SecurityHeaderConfigurable.escapeHeaderQuotedString(malicious);
+    assertFalse(escaped.contains("\r"));
+    assertFalse(escaped.contains("\n"));
+    assertEquals("badSet-Cookie: pwned=1", escaped);
+  }
+
+  @Test
+  void escapeHeaderQuotedString_nullBecomesEmpty() {
+    assertEquals("", SecurityHeaderConfigurable.escapeHeaderQuotedString(null));
+  }
+
+  @Test
+  void applyWwwAuthenticate_setsDPoPSchemeWhenAuthorizationIsDpop() {
+    HttpHeaders headers = new HttpHeaders();
+    target.applyWwwAuthenticateIfUnauthorized(
+        headers,
+        401,
+        Map.of("error", "invalid_token", "error_description", "token is expired"),
+        "DPoP eyJ...");
+
+    assertEquals(
+        "DPoP error=\"invalid_token\", error_description=\"token is expired\"",
+        headers.getFirst(HttpHeaders.WWW_AUTHENTICATE));
+  }
+
+  @Test
+  void applyWwwAuthenticate_defaultsToBearerScheme() {
+    HttpHeaders headers = new HttpHeaders();
+    target.applyWwwAuthenticateIfUnauthorized(
+        headers, 401, Map.of("error", "invalid_token", "error_description", "nope"), "Bearer abc");
+
+    assertTrue(headers.getFirst(HttpHeaders.WWW_AUTHENTICATE).startsWith("Bearer error="));
+  }
+
+  @Test
+  void applyWwwAuthenticate_escapesAttackerControlledDescription() {
+    HttpHeaders headers = new HttpHeaders();
+    target.applyWwwAuthenticateIfUnauthorized(
+        headers,
+        401,
+        // htu-style value echoed into the description containing a quote + CRLF injection attempt.
+        Map.of("error", "invalid_token", "error_description", "htu 'https://evil\"\r\nX: y' bad"),
+        "DPoP proof");
+
+    String header = headers.getFirst(HttpHeaders.WWW_AUTHENTICATE);
+    assertFalse(header.contains("\r"));
+    assertFalse(header.contains("\n"));
+    // the inner quote is escaped, so the quoted-string is not broken
+    assertTrue(header.contains("evil\\\""));
+  }
+
+  @Test
+  void applyWwwAuthenticate_noHeaderWhenNotUnauthorized() {
+    HttpHeaders headers = new HttpHeaders();
+    target.applyWwwAuthenticateIfUnauthorized(headers, 200, Map.of(), "DPoP x");
+    assertNull(headers.getFirst(HttpHeaders.WWW_AUTHENTICATE));
+  }
+
+  @Test
+  void applyWwwAuthenticate_missingErrorFieldsFallBackToInvalidToken() {
+    HttpHeaders headers = new HttpHeaders();
+    target.applyWwwAuthenticateIfUnauthorized(headers, 401, Map.of(), null);
+    assertEquals(
+        "Bearer error=\"invalid_token\", error_description=\"\"",
+        headers.getFirst(HttpHeaders.WWW_AUTHENTICATE));
+  }
+}


### PR DESCRIPTION
#1736 の残指摘、クラスタB（DPoP リソースサーバ側の一貫性・正確性）。全項目を実コードで裏取りし、全モジュール test green。

## 対応内容

| 指摘 | 内容 |
|---|---|
| **M-3** | RSエンドポイント間の DPoP エラー応答を RFC 9449 §7.1 に統一。**/me** は `invalid_dpop_proof` → `invalid_token`（`invalid_dpop_proof` はトークンエンドポイント専用）。**/userinfo** は従来 WWW-Authenticate ヘッダ無しだったのを追加（401時に DPoP/Bearer スキーム付きチャレンジ） |
| **M-4** | `DPoPProofVerifier.verifyHtu` に**ポート比較**を追加。従来 scheme/host/path のみで authority のポートを無視（doc は "authority" と記載）。`UriWrapper.equalsPort` はデフォルトポート正規化済み（https→443/http→80）なので `https://h/p` と `https://h:443/p` は一致、`https://h:8443/p` は不一致 |
| **L-1** | WWW-Authenticate の `error_description` を RFC 7235 quoted-string 用にエスケープ（バックスラッシュ/引用符 + 制御文字除去）。攻撃者制御の htu 値が素でヘッダに入り、**ヘッダインジェクション / quoted-string 破壊**の恐れがあった。JSONボディ側のバックスラッシュ未エスケープも併せて修正 |

## 設計

- WWW-Authenticate チャレンジ生成とエスケープを `SecurityHeaderConfigurable`（既存の共有インターフェース）に集約：
  - `applyWwwAuthenticateIfUnauthorized(...)`（401限定・スキーム判定・エスケープ込み）
  - `escapeHeaderQuotedString(...)`（static）
- `UserinfoV1Api` は default メソッド経由で利用、`ProtectedResourceApiFilter` は static エスケープを共有（重複解消）

## L-2 は後続に切り出し

「DPoP-bound トークンの Bearer スキーム提示拒否」は本PRに含めず後続対応とする。/me はスキーム照合可能だが、**/userinfo 側は `UserinfoVerifier` にスキームが伝播しておらず**、一貫修正には複数層のプラミングが必要。Low severity かつ **DPoP binding 自体は検証済み**（鍵なしで盗用トークンは使えない）ため、片方だけ直して M-3 の一貫性を崩すより専用対応が適切と判断。

## 検証

- 全モジュール `./gradlew test` green
- `SecurityHeaderConfigurableTest` 8件追加（エスケープ・CRLF除去によるヘッダインジェクション防止・スキーム判定・401限定・フォールバック）
- E2E は RS 側で 401 ステータスのみアサートしており、エラーコード変更（/me invalid_token）と WWW-Authenticate 追加はステータス期待を壊さないことを確認
- htu ポート比較は E2E の §4.3 Check 9（htu 検証）でカバー、`verifyHtu` は private のため既存 E2E に委譲

残りクラスタ（C: セキュリティ強化 / D: スキーマ / E: リファクタ / F: テスト構造 + L-2）は後続PR。

🤖 Generated with [Claude Code](https://claude.com/claude-code)