### PR TITLE
feat(oauth): require_pushed_authorization_requests を全プロファイルで強制 (#1736 クラスタD / M-6)

### DIFF
--- a/config/examples/e2e/require-par-tenant/authorization-server/idp-server.json
+++ b/config/examples/e2e/require-par-tenant/authorization-server/idp-server.json
@@ -1,0 +1,371 @@
+{
+  "issuer": "https://api.local.test/018e12d0-ed2e-4b38-b045-493e96e9d400",
+  "authorization_endpoint": "https://api.local.test/018e12d0-ed2e-4b38-b045-493e96e9d400/v1/authorizations",
+  "token_endpoint": "https://api.local.test/018e12d0-ed2e-4b38-b045-493e96e9d400/v1/tokens",
+  "token_endpoint_auth_methods_supported": [
+    "client_secret_post",
+    "client_secret_basic",
+    "client_secret_jwt",
+    "private_key_jwt",
+    "tls_client_auth",
+    "self_signed_tls_client_auth",
+    "none"
+  ],
+  "token_endpoint_auth_signing_alg_values_supported": [
+    "RS256",
+    "ES256"
+  ],
+  "userinfo_endpoint": "https://api.local.test/018e12d0-ed2e-4b38-b045-493e96e9d400/v1/userinfo",
+  "jwks_uri": "https://api.local.test/018e12d0-ed2e-4b38-b045-493e96e9d400/v1/jwks",
+  "jwks": "{\n    \"keys\": [\n        {\n            \"kty\": \"EC\",\n            \"d\": \"yIWDrlhnCy3yL9xLuqZGOBFFq4PWGsCeM7Sc_lfeaQQ\",\n            \"use\": \"sig\",\n            \"crv\": \"P-256\",\n            \"kid\": \"access_token\",\n            \"x\": \"iWJINqt0ySv3kVEvlHbvNkPKY2pPSf1cG1PSx3tRfw0\",\n            \"y\": \"rW1FdfXK5AQcv-Go6Xho0CR5AbLai7Gp9IdLTIXTSIQ\",\n            \"alg\": \"ES256\"\n        }\n,{\n    \"kty\": \"EC\",\n    \"d\": \"HrgT4zqM2BvrlwUWagyeNnZ40nZ7rTY4gYG9k99oGJg\",\n    \"use\": \"enc\",\n    \"crv\": \"P-256\",\n    \"kid\": \"request_enc_key\",\n    \"x\": \"PM6be42POiKdNzRKGeZ1Gia8908XfmSSbS4cwPasWTo\",\n    \"y\": \"wksaan9a4h3L8R1UMmvc9w6rPB_F07IA-VHx7n7Add4\",\n    \"alg\": \"ECDH-ES\"\n},{\n    \"p\": \"3yO0t6JmIHnsW6SrAfHa_4Ynd3unyrTQnCpPCo1GAlzbIRUgyDWohcfKaQ9rFoeO67b91dcpDiH6jTuxdD1S95ph7KB2RuDTGhhD5jg5_VdEthnlK7Hw3GZhFRnsBAKxTmJuJ3R12tcm33054vEtxAZB3FWyVsf0WI36vbDYRU0\",\n    \"kty\": \"RSA\",\n    \"q\": \"n10rboIDPMk0Qyvug--W_s4yB1j7QdIvduBO-bZgrG_rLLXgFTzKbef_ArygXBlCqinwn7MSw6O5G6IKw5raK7IvehlDT_xC8mOtajiFcj_t9PkaUdHXNR-tbJdLJwohbJNwXvP28DhMCTUPLTxW005sVFfChbtFiQ22eJFsrF0\",\n    \"d\": \"azIA2jVLHvXr2jM0Eq9rQCErJqjNjtDu86k0-kmF3xfjuAS9IBuGnU9W0bkuaOaY85ngHEb0qf-nXRnOaF_6s7glSVm0mDM6mNgDOzNmgqHV14mJTkmixAmxrGmvVOix06mIUc2liG_wUO7OHVkd9kgNV5QVj-EF-VDULTin6FfNcJgcUsYAb59_MHASvS8foWNb3o9bSdPFLDDaT0mzl2nwEe8SERtIsLBrcbbKcedQHxm1SUq8sks-1L6E8Qfx6jFQJJMNLj-XBbwrFxww1DwrhmNz_1AOZM5VDTZg-kMDqjcBvgjHzmA2o9X9p1Gaa5xadO51msiZQAbPSMK1sQ\",\n    \"e\": \"AQAB\",\n    \"use\": \"sig\",\n    \"kid\": \"id_token_nextauth\",\n    \"qi\": \"A3s2bGrlaC6WU-vQGvugen8vx4ouqrTY60ZD-E1YRp6ADbC7g6318WZ7IZl-FoFGto--NvnMFOsNYkSMXrFcaroixNjJEo6HcNWs7BTqS7PICZmtmUWr5V2f9RENwJxbG9GnYDsZTQYM84j2PNsJxAzjmFQvQzygsfeEyuzAtJg\",\n    \"dp\": \"vUWmNtWz1vxUdm-49k9WOcRrmbfz3cd949knboXiyoJFBUzMn8aUCdYsZO1FIrkdi-eObGKzWl-MDVyC61xREeGMCpEZgomVxt6qSY-L8M6jY-uXLncjHXBiDOoN_mDiUODBGwp4JYa2XH_2J__3l_zOxLyUJ3Q4WR0lgN2OtUk\",\n    \"alg\": \"RS256\",\n    \"dq\": \"g1bKAJ1uBZ7dT67ZOCsxinZtjNis2qZbL-HVtL-2FOd4LrUGJPqg6suUw7CpiL3Yz10ZTsTK5in82OVHccYhoHmN31cKvtTsZ8_2j-BdOretaYQTSPNkJgghaamW6mnS-iTZK6htD7WWFNCB3YopFKVBapGZY5XfzQBcLinMIpE\",\n    \"n\": \"iuhjEgaY4KCS_rbvODf-QadNvj9DaoHx8PzPKpZdxx_g0aQx7wvachzc7A_F8RKkToM10qGrDtFFehTCzxcC44WHsFezRd3yxNNhdfVEfcHApLpMYaq8A3HAi8NMN-cMkfqQRIvsvDmbYtt8B6EZG8YsFhjMZRY-7gzF_LGdIMoh3Af0WUx-L_AWRIawXuAwDIm11OQh9bt3hdoJbZFd9B4Wf1H5oxbsJ5MZQAQ9ltc23F60zqoDt5RAehC30w7rMeYH8WKoKpS5-odhVUDqieAS5j8iVegjcl63CoxS2BRLmN9UYzQvuEo-HUeWbucBlXmqD4sdn6Ypyt5QZpzo-Q\"\n}]\n}",
+  "grant_types_supported": [
+    "authorization_code",
+    "refresh_token",
+    "password",
+    "client_credentials",
+    "urn:openid:params:grant-type:ciba"
+  ],
+  "scopes_supported": [
+    "openid",
+    "profile",
+    "email",
+    "address",
+    "phone",
+    "offline_access",
+    "account",
+    "transfers",
+    "read",
+    "write",
+    "identity_verification_application",
+    "identity_verification_application_delete",
+    "identity_verification_result",
+    "identity_credentials_update",
+    "management",
+    "claims:status",
+    "claims:ex_sub",
+    "claims:roles",
+    "claims:permissions",
+    "claims:assigned_tenants",
+    "claims:assigned_organizations",
+    "claims:authentication_devices",
+    "verified_claims:family_name"
+  ],
+  "response_types_supported": [
+    "code"
+  ],
+  "response_modes_supported": [
+    "query",
+    "jwt",
+    "query.jwt"
+  ],
+  "pushed_authorization_request_endpoint": "https://api.local.test/018e12d0-ed2e-4b38-b045-493e96e9d400/v1/authorizations/push",
+  "require_pushed_authorization_requests": true,
+  "authorization_response_iss_parameter_supported": true,
+  "code_challenge_methods_supported": [
+    "S256"
+  ],
+  "acr_values_supported": [
+    "urn:mace:incommon:iap:gold",
+    "urn:mace:incommon:iap:silver",
+    "urn:mace:incommon:iap:bronze"
+  ],
+  "subject_types_supported": [
+    "public",
+    "pairwise"
+  ],
+  "userinfo_signing_alg_values_supported": [
+    "ES256",
+    "PS256"
+  ],
+  "userinfo_encryption_alg_values_supported": [
+    "RSA1_5",
+    "A128KW"
+  ],
+  "userinfo_encryption_enc_values_supported": [
+    "A128CBC-HS256",
+    "A128GCM"
+  ],
+  "id_token_signing_alg_values_supported": [
+    "ES256",
+    "PS256"
+  ],
+  "id_token_encryption_alg_values_supported": [
+    "RSA1_5",
+    "A128KW",
+    "A256KW"
+  ],
+  "id_token_encryption_enc_values_supported": [
+    "A128CBC-HS256",
+    "A128GCM",
+    "A256GCM"
+  ],
+  "request_object_signing_alg_values_supported": [
+    "none",
+    "RS256",
+    "ES256"
+  ],
+  "display_values_supported": [
+    "page",
+    "popup"
+  ],
+  "claim_types_supported": [
+    "normal"
+  ],
+  "claims_supported": [
+    "sub",
+    "iss",
+    "auth_time",
+    "acr",
+    "name",
+    "given_name",
+    "family_name",
+    "nickname",
+    "profile",
+    "picture",
+    "website",
+    "email",
+    "email_verified",
+    "locale",
+    "zoneinfo",
+    "birthdate",
+    "gender",
+    "preferred_username",
+    "middle_name",
+    "address",
+    "phone_number",
+    "phone_number_verified",
+    "status",
+    "roles",
+    "permissions",
+    "assigned_tenants",
+    "assigned_organizations",
+    "authentication_devices"
+  ],
+  "claims_parameter_supported": true,
+  "service_documentation": "http://server.example.com/connect/service_documentation.html",
+  "ui_locales_supported": [
+    "en-US",
+    "en-GB",
+    "en-CA",
+    "fr-FR",
+    "fr-CA"
+  ],
+  "introspection_endpoint": "https://api.local.test/018e12d0-ed2e-4b38-b045-493e96e9d400/v1/tokens/introspection",
+  "revocation_endpoint": "https://api.local.test/018e12d0-ed2e-4b38-b045-493e96e9d400/v1/tokens/revocation",
+  "backchannel_token_delivery_modes_supported": [
+    "poll",
+    "ping",
+    "push"
+  ],
+  "backchannel_authentication_endpoint": "https://api.local.test/018e12d0-ed2e-4b38-b045-493e96e9d400/v1/backchannel/authentications",
+  "backchannel_authentication_request_signing_alg_values_supported": [
+    "RS256",
+    "ES256"
+  ],
+  "backchannel_user_code_parameter_supported": true,
+  "authorization_details_types_supported": [
+    "payment_initiation",
+    "account_information",
+    "openid_credential"
+  ],
+  "authorization_signing_alg_values_supported": [
+    "RS256",
+    "ES256",
+    "HS256"
+  ],
+  "authorization_encryption_alg_values_supported": [
+    "RSA1_5",
+    "A128KW"
+  ],
+  "authorization_encryption_enc_values_supported": [
+    "A128CBC-HS256",
+    "A128GCM"
+  ],
+  "tls_client_certificate_bound_access_tokens": false,
+  "dpop_signing_alg_values_supported": [],
+  "mtls_endpoint_aliases": {
+    "pushed_authorization_request_endpoint": "https://mtls.api.local.test/018e12d0-ed2e-4b38-b045-493e96e9d400/v1/authorizations/push",
+    "token_endpoint": "https://mtls.api.local.test/018e12d0-ed2e-4b38-b045-493e96e9d400/v1/tokens",
+    "revocation_endpoint": "https://mtls.api.local.test/018e12d0-ed2e-4b38-b045-493e96e9d400/v1/tokens/revocation",
+    "introspection_endpoint": "https://mtls.api.local.test/018e12d0-ed2e-4b38-b045-493e96e9d400/v1/tokens/introspection",
+    "userinfo_endpoint": "https://mtls.api.local.test/018e12d0-ed2e-4b38-b045-493e96e9d400/v1/userinfo",
+    "backchannel_authentication_endpoint": "https://mtls.api.local.test/018e12d0-ed2e-4b38-b045-493e96e9d400/v1/backchannel/authentications"
+  },
+  "extension": {
+    "access_token_type": "JWT",
+    "token_signed_key_id": "access_token",
+    "id_token_signed_key_id": "access_token",
+    "authorization_code_valid_duration": 10,
+    "access_token_duration": 3600,
+    "id_token_duration": 3600,
+    "id_token_strict_mode": false,
+    "default_max_age": 86400,
+    "rotate_refresh_token": false,
+    "fapi_baseline_scopes": [
+      "read"
+    ],
+    "fapi_advance_scopes": [
+      "write"
+    ],
+    "fapi20_scopes": [],
+    "required_identity_verification_scopes": [
+      "transfers"
+    ],
+    "backchannel_authentication_request_expires_in": 60,
+    "backchannel_authentication_polling_interval": 5,
+    "custom_claims_scope_mapping": true,
+    "access_token_user_custom_properties": true,
+    "access_token_selective_verified_claims": true
+  },
+  "verified_claims_supported": true,
+  "trust_frameworks_supported": [
+    "nist_800_63A_ial_2",
+    "nist_800_63A_ial_3"
+  ],
+  "evidence_supported": [
+    "id_document",
+    "utility_bill",
+    "qes"
+  ],
+  "id_documents_supported": [
+    "idcard",
+    "passport",
+    "driving_permit"
+  ],
+  "id_documents_verification_methods_supported": [
+    "pipp",
+    "sripp",
+    "eid"
+  ],
+  "claims_in_verified_claims_supported": [
+    "given_name",
+    "family_name",
+    "birthdate",
+    "place_of_birth",
+    "nationalities",
+    "address"
+  ],
+  "credential_issuer_metadata": {
+    "credential_issuer": "https://api.local.test/018e12d0-ed2e-4b38-b045-493e96e9d400",
+    "authorization_server": "https://api.local.test/018e12d0-ed2e-4b38-b045-493e96e9d400",
+    "credential_endpoint": "https://api.local.test/018e12d0-ed2e-4b38-b045-493e96e9d400/v1/credentials",
+    "batch_credential_endpoint": "https://api.local.test/018e12d0-ed2e-4b38-b045-493e96e9d400/v1/batch-credentials",
+    "deferred_credential_endpoint": "https://api.local.test/018e12d0-ed2e-4b38-b045-493e96e9d400/v1/deferred-credentials",
+    "credentials_supported": [
+      {
+        "format": "jwt_vc_json",
+        "id": "UniversityDegree_JWT",
+        "cryptographic_binding_methods_supported": [
+          "did:example"
+        ],
+        "cryptographic_suites_supported": [
+          "ES256K"
+        ],
+        "credential_definition": {
+          "type": [
+            "VerifiableCredential",
+            "UniversityDegreeCredential"
+          ],
+          "credentialSubject": {
+            "given_name": {
+              "display": [
+                {
+                  "name": "Given Name",
+                  "locale": "en-US"
+                }
+              ]
+            },
+            "last_name": {
+              "display": [
+                {
+                  "name": "Surname",
+                  "locale": "en-US"
+                }
+              ]
+            },
+            "degree": {},
+            "gpa": {
+              "display": [
+                {
+                  "name": "GPA"
+                }
+              ]
+            }
+          }
+        },
+        "proof_types_supported": [
+          "jwt"
+        ],
+        "display": [
+          {
+            "name": "University Credential",
+            "locale": "en-US",
+            "logo": {
+              "url": "https://exampleuniversity.com/public/logo.png",
+              "alt_text": "a square logo of a university"
+            },
+            "background_color": "#12107c",
+            "text_color": "#FFFFFF"
+          }
+        ]
+      },
+      {
+        "format": "ldp_vc",
+        "id": "UniversityDegree_ldp",
+        "cryptographic_binding_methods_supported": [
+          "did:example"
+        ],
+        "cryptographic_suites_supported": [
+          "ES256K"
+        ],
+        "credential_definition": {
+          "type": [
+            "VerifiableCredential",
+            "UniversityDegreeCredential"
+          ],
+          "credentialSubject": {
+            "given_name": {
+              "display": [
+                {
+                  "name": "Given Name",
+                  "locale": "en-US"
+                }
+              ]
+            },
+            "last_name": {
+              "display": [
+                {
+                  "name": "Surname",
+                  "locale": "en-US"
+                }
+              ]
+            },
+            "degree": {},
+            "gpa": {
+              "display": [
+                {
+                  "name": "GPA"
+                }
+              ]
+            }
+          }
+        },
+        "proof_types_supported": [
+          "jwt"
+        ],
+        "display": [
+          {
+            "name": "University Credential",
+            "locale": "en-US",
+            "logo": {
+              "url": "https://exampleuniversity.com/public/logo.png",
+              "alt_text": "a square logo of a university"
+            },
+            "background_color": "#12107c",
+            "text_color": "#FFFFFF"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/config/examples/e2e/require-par-tenant/clients/clientSecretPost.json
+++ b/config/examples/e2e/require-par-tenant/clients/clientSecretPost.json
@@ -1,0 +1,67 @@
+{
+  "client_id": "ffa38cde-d81d-49f1-99fb-842c901afa2c",
+  "client_id_alias": "requireParClientSecretPost",
+  "client_secret": "clientSecretPostPassword1234567890123456789012345678901234567890123456789012345678901234567890",
+  "client_id_issued_at": 2893256800,
+  "client_secret_expires_at": 2893276800,
+  "redirect_uris": [
+    "https://client.example.org/callback",
+    "https://client.example.org/callback2",
+    "http://localhost:8081/callback",
+    "https://www.certification.openid.net/test/a/idp_oidc_basic/callback",
+    "https://localhost.emobix.co.uk:8443/test/a/idp_oidc_basic/callback",
+    "https://localhost.emobix.co.uk:8443/test/a/idp_oidc_implicit/callback",
+    "https://localhost.emobix.co.uk:8443/test/a/idp_oidc_hybrid/callback"
+  ],
+  "response_types": [
+    "code",
+    "token",
+    "id_token",
+    "code token",
+    "code token id_token",
+    "token id_token",
+    "code id_token",
+    "none"
+  ],
+  "grant_types": [
+    "authorization_code",
+    "refresh_token",
+    "password",
+    "client_credentials",
+    "urn:openid:params:grant-type:ciba"
+  ],
+  "scope": "openid profile email address phone management verified_claims:family_name verified_claims:verification:trust_framework verified_claims:verification:evidence claims:ex_sub claims:status claims:authentication_devices claims:roles claims:permissions claims:assigned_tenants claims:assigned_organizations claims:authentication_devices claims:authentication_devices offline_access account transfers read write identity_verification_application identity_verification_application_delete identity_verification_result identity_credentials_update",
+  "client_name": "require-par tenant client (client_secret_post)",
+  "client_name#ja-Jpan-JP": "クライアント名",
+  "token_endpoint_auth_method": "client_secret_post",
+  "logo_uri": "https://client.example.org/logo.png",
+  "tos_uri": "https://idp-auth-frontend-diqt.vercel.app/terms",
+  "policy_uri": "https://idp-auth-frontend-diqt.vercel.app/privacy",
+  "jwks": "{\n    \"keys\": [{\n    \"kty\": \"EC\",\n    \"d\": \"uj7jNVQIfSCBdiV4A_yVnY8htLZS7nskIXAGIVDb9oM\",\n    \"use\": \"sig\",\n    \"crv\": \"P-256\",\n    \"kid\": \"request_secret_post\",\n    \"x\": \"H4E6D5GqxTrZshUvkG-z0sAWNkbixERVSpm3YjcIU1U\",\n    \"y\": \"413NbE2n5PeQJlG1Nfq_nCbqR_ZKbVAzsyyrmYph7Fs\",\n    \"alg\": \"ES256\"\n}]\n}",
+  "backchannel_token_delivery_mode": "poll",
+  "backchannel_client_notification_endpoint": "",
+  "backchannel_authentication_request_signing_alg": "ES256",
+  "backchannel_user_code_parameter": true,
+  "application_type": "web",
+  "authorization_details_types": [
+    "payment_initiation",
+    "account_information",
+    "openid_credential"
+  ],
+  "post_logout_redirect_uris": [
+    "https://client.example.org/logout-callback",
+    "http://localhost:8081/logout-callback"
+  ],
+  "extension": {
+    "access_token_duration": 120,
+    "available_federations": [
+      {
+        "id": "b7481833-c95a-4c7a-9481-94b30008c8ef",
+        "type": "oidc",
+        "sso_provider": "b7481833-c95a-4c7a-9481-94b30008c8ef",
+        "auto_selected": true
+      }
+    ],
+    "default_ciba_authentication_interaction_type": "authentication-device-notification-no-action"
+  }
+}

--- a/config/examples/e2e/require-par-tenant/tenants/require-par-tenant.json
+++ b/config/examples/e2e/require-par-tenant/tenants/require-par-tenant.json
@@ -1,0 +1,417 @@
+{
+  "tenant": {
+    "id": "018e12d0-ed2e-4b38-b045-493e96e9d400",
+    "name": "require-par-tenant",
+    "domain": "https://api.local.test/018e12d0-ed2e-4b38-b045-493e96e9d400",
+    "authorization_provider": "idp-server",
+    "database_type": "postgresql",
+    "ui_config": {
+      "base_url": "https://auth.local.test",
+      "signin_page": "/signin/fido2/",
+      "signup_page": "/signup/"
+    },
+    "session_config": {
+      "cookie_name": "REQUIRE_PAR_TENANT_IDP_SERVER_SESSION",
+      "use_secure_cookie": false
+    },
+    "cors_config": {
+      "allow_origins": [
+        "https://localhost.emobix.co.uk:8443",
+        "https://api.local.test",
+        "https://mtls.api.local.test",
+        "https://auth.local.test"
+      ],
+      "allow_headers": "Authorization, Content-Type, Accept, x-device-id, X-SSL-Client-Cert, DPoP",
+      "allow_methods": "GET, POST, PUT, PATCH, DELETE, OPTIONS",
+      "allow_credentials": true
+    },
+    "security_event_log_config": {
+      "format": "structured_json",
+      "stage": "processed",
+      "include_user_id": true,
+      "include_client_id": true,
+      "include_ip_address": true,
+      "persistence_enabled": true,
+      "include_event_detail": true,
+      "statistics_enabled": true
+    },
+    "identity_policy_config": {
+      "identity_unique_key_type": "EMAIL",
+      "authentication_device_rule": {
+        "max_devices": 100,
+        "required_identity_verification": false
+      }
+    }
+  },
+  "authorization_server": {
+    "issuer": "https://api.local.test/018e12d0-ed2e-4b38-b045-493e96e9d400",
+    "authorization_endpoint": "https://api.local.test/018e12d0-ed2e-4b38-b045-493e96e9d400/v1/authorizations",
+    "token_endpoint": "https://api.local.test/018e12d0-ed2e-4b38-b045-493e96e9d400/v1/tokens",
+    "token_endpoint_auth_methods_supported": [
+      "client_secret_post",
+      "client_secret_basic",
+      "client_secret_jwt",
+      "private_key_jwt",
+      "tls_client_auth",
+      "self_signed_tls_client_auth",
+      "none"
+    ],
+    "token_endpoint_auth_signing_alg_values_supported": [
+      "RS256",
+      "ES256"
+    ],
+    "userinfo_endpoint": "https://api.local.test/018e12d0-ed2e-4b38-b045-493e96e9d400/v1/userinfo",
+    "jwks_uri": "https://api.local.test/018e12d0-ed2e-4b38-b045-493e96e9d400/v1/jwks",
+    "jwks": "{\n    \"keys\": [\n        {\n            \"kty\": \"EC\",\n            \"d\": \"yIWDrlhnCy3yL9xLuqZGOBFFq4PWGsCeM7Sc_lfeaQQ\",\n            \"use\": \"sig\",\n            \"crv\": \"P-256\",\n            \"kid\": \"access_token\",\n            \"x\": \"iWJINqt0ySv3kVEvlHbvNkPKY2pPSf1cG1PSx3tRfw0\",\n            \"y\": \"rW1FdfXK5AQcv-Go6Xho0CR5AbLai7Gp9IdLTIXTSIQ\",\n            \"alg\": \"ES256\"\n        }\n,{\n    \"kty\": \"EC\",\n    \"d\": \"HrgT4zqM2BvrlwUWagyeNnZ40nZ7rTY4gYG9k99oGJg\",\n    \"use\": \"enc\",\n    \"crv\": \"P-256\",\n    \"kid\": \"request_enc_key\",\n    \"x\": \"PM6be42POiKdNzRKGeZ1Gia8908XfmSSbS4cwPasWTo\",\n    \"y\": \"wksaan9a4h3L8R1UMmvc9w6rPB_F07IA-VHx7n7Add4\",\n    \"alg\": \"ECDH-ES\"\n},{\n    \"p\": \"3yO0t6JmIHnsW6SrAfHa_4Ynd3unyrTQnCpPCo1GAlzbIRUgyDWohcfKaQ9rFoeO67b91dcpDiH6jTuxdD1S95ph7KB2RuDTGhhD5jg5_VdEthnlK7Hw3GZhFRnsBAKxTmJuJ3R12tcm33054vEtxAZB3FWyVsf0WI36vbDYRU0\",\n    \"kty\": \"RSA\",\n    \"q\": \"n10rboIDPMk0Qyvug--W_s4yB1j7QdIvduBO-bZgrG_rLLXgFTzKbef_ArygXBlCqinwn7MSw6O5G6IKw5raK7IvehlDT_xC8mOtajiFcj_t9PkaUdHXNR-tbJdLJwohbJNwXvP28DhMCTUPLTxW005sVFfChbtFiQ22eJFsrF0\",\n    \"d\": \"azIA2jVLHvXr2jM0Eq9rQCErJqjNjtDu86k0-kmF3xfjuAS9IBuGnU9W0bkuaOaY85ngHEb0qf-nXRnOaF_6s7glSVm0mDM6mNgDOzNmgqHV14mJTkmixAmxrGmvVOix06mIUc2liG_wUO7OHVkd9kgNV5QVj-EF-VDULTin6FfNcJgcUsYAb59_MHASvS8foWNb3o9bSdPFLDDaT0mzl2nwEe8SERtIsLBrcbbKcedQHxm1SUq8sks-1L6E8Qfx6jFQJJMNLj-XBbwrFxww1DwrhmNz_1AOZM5VDTZg-kMDqjcBvgjHzmA2o9X9p1Gaa5xadO51msiZQAbPSMK1sQ\",\n    \"e\": \"AQAB\",\n    \"use\": \"sig\",\n    \"kid\": \"id_token_nextauth\",\n    \"qi\": \"A3s2bGrlaC6WU-vQGvugen8vx4ouqrTY60ZD-E1YRp6ADbC7g6318WZ7IZl-FoFGto--NvnMFOsNYkSMXrFcaroixNjJEo6HcNWs7BTqS7PICZmtmUWr5V2f9RENwJxbG9GnYDsZTQYM84j2PNsJxAzjmFQvQzygsfeEyuzAtJg\",\n    \"dp\": \"vUWmNtWz1vxUdm-49k9WOcRrmbfz3cd949knboXiyoJFBUzMn8aUCdYsZO1FIrkdi-eObGKzWl-MDVyC61xREeGMCpEZgomVxt6qSY-L8M6jY-uXLncjHXBiDOoN_mDiUODBGwp4JYa2XH_2J__3l_zOxLyUJ3Q4WR0lgN2OtUk\",\n    \"alg\": \"RS256\",\n    \"dq\": \"g1bKAJ1uBZ7dT67ZOCsxinZtjNis2qZbL-HVtL-2FOd4LrUGJPqg6suUw7CpiL3Yz10ZTsTK5in82OVHccYhoHmN31cKvtTsZ8_2j-BdOretaYQTSPNkJgghaamW6mnS-iTZK6htD7WWFNCB3YopFKVBapGZY5XfzQBcLinMIpE\",\n    \"n\": \"iuhjEgaY4KCS_rbvODf-QadNvj9DaoHx8PzPKpZdxx_g0aQx7wvachzc7A_F8RKkToM10qGrDtFFehTCzxcC44WHsFezRd3yxNNhdfVEfcHApLpMYaq8A3HAi8NMN-cMkfqQRIvsvDmbYtt8B6EZG8YsFhjMZRY-7gzF_LGdIMoh3Af0WUx-L_AWRIawXuAwDIm11OQh9bt3hdoJbZFd9B4Wf1H5oxbsJ5MZQAQ9ltc23F60zqoDt5RAehC30w7rMeYH8WKoKpS5-odhVUDqieAS5j8iVegjcl63CoxS2BRLmN9UYzQvuEo-HUeWbucBlXmqD4sdn6Ypyt5QZpzo-Q\"\n}]\n}",
+    "grant_types_supported": [
+      "authorization_code",
+      "refresh_token",
+      "password",
+      "client_credentials",
+      "urn:openid:params:grant-type:ciba"
+    ],
+    "scopes_supported": [
+      "openid",
+      "profile",
+      "email",
+      "address",
+      "phone",
+      "offline_access",
+      "account",
+      "transfers",
+      "read",
+      "write",
+      "identity_verification_application",
+      "identity_verification_application_delete",
+      "identity_verification_result",
+      "identity_credentials_update",
+      "management",
+      "claims:status",
+      "claims:ex_sub",
+      "claims:roles",
+      "claims:permissions",
+      "claims:assigned_tenants",
+      "claims:assigned_organizations",
+      "claims:authentication_devices",
+      "verified_claims:family_name"
+    ],
+    "response_types_supported": [
+      "code"
+    ],
+    "response_modes_supported": [
+      "query",
+      "jwt",
+      "query.jwt"
+    ],
+    "pushed_authorization_request_endpoint": "https://api.local.test/018e12d0-ed2e-4b38-b045-493e96e9d400/v1/authorizations/push",
+    "require_pushed_authorization_requests": true,
+    "authorization_response_iss_parameter_supported": true,
+    "code_challenge_methods_supported": [
+      "S256"
+    ],
+    "dpop_signing_alg_values_supported": [],
+    "acr_values_supported": [
+      "urn:mace:incommon:iap:gold",
+      "urn:mace:incommon:iap:silver",
+      "urn:mace:incommon:iap:bronze"
+    ],
+    "subject_types_supported": [
+      "public",
+      "pairwise"
+    ],
+    "userinfo_signing_alg_values_supported": [
+      "ES256",
+      "PS256"
+    ],
+    "userinfo_encryption_alg_values_supported": [
+      "RSA1_5",
+      "A128KW"
+    ],
+    "userinfo_encryption_enc_values_supported": [
+      "A128CBC-HS256",
+      "A128GCM"
+    ],
+    "id_token_signing_alg_values_supported": [
+      "ES256",
+      "PS256"
+    ],
+    "id_token_encryption_alg_values_supported": [
+      "RSA1_5",
+      "A128KW",
+      "A256KW"
+    ],
+    "id_token_encryption_enc_values_supported": [
+      "A128CBC-HS256",
+      "A128GCM",
+      "A256GCM"
+    ],
+    "request_object_signing_alg_values_supported": [
+      "none",
+      "RS256",
+      "ES256"
+    ],
+    "display_values_supported": [
+      "page",
+      "popup"
+    ],
+    "claim_types_supported": [
+      "normal"
+    ],
+    "claims_supported": [
+      "sub",
+      "iss",
+      "auth_time",
+      "acr",
+      "name",
+      "given_name",
+      "family_name",
+      "nickname",
+      "profile",
+      "picture",
+      "website",
+      "email",
+      "email_verified",
+      "locale",
+      "zoneinfo",
+      "birthdate",
+      "gender",
+      "preferred_username",
+      "middle_name",
+      "address",
+      "phone_number",
+      "phone_number_verified",
+      "status",
+      "roles",
+      "permissions",
+      "assigned_tenants",
+      "assigned_organizations",
+      "authentication_devices"
+    ],
+    "claims_parameter_supported": true,
+    "service_documentation": "http://server.example.com/connect/service_documentation.html",
+    "ui_locales_supported": [
+      "en-US",
+      "en-GB",
+      "en-CA",
+      "fr-FR",
+      "fr-CA"
+    ],
+    "introspection_endpoint": "https://api.local.test/018e12d0-ed2e-4b38-b045-493e96e9d400/v1/tokens/introspection",
+    "revocation_endpoint": "https://api.local.test/018e12d0-ed2e-4b38-b045-493e96e9d400/v1/tokens/revocation",
+    "backchannel_token_delivery_modes_supported": [
+      "poll",
+      "ping",
+      "push"
+    ],
+    "backchannel_authentication_endpoint": "https://api.local.test/018e12d0-ed2e-4b38-b045-493e96e9d400/v1/backchannel/authentications",
+    "backchannel_authentication_request_signing_alg_values_supported": [
+      "RS256",
+      "ES256"
+    ],
+    "backchannel_user_code_parameter_supported": true,
+    "authorization_details_types_supported": [
+      "payment_initiation",
+      "account_information",
+      "openid_credential"
+    ],
+    "authorization_signing_alg_values_supported": [
+      "RS256",
+      "ES256",
+      "HS256"
+    ],
+    "authorization_encryption_alg_values_supported": [
+      "RSA1_5",
+      "A128KW"
+    ],
+    "authorization_encryption_enc_values_supported": [
+      "A128CBC-HS256",
+      "A128GCM"
+    ],
+    "tls_client_certificate_bound_access_tokens": false,
+    "mtls_endpoint_aliases": {
+      "pushed_authorization_request_endpoint": "https://mtls.api.local.test/018e12d0-ed2e-4b38-b045-493e96e9d400/v1/authorizations/push",
+      "token_endpoint": "https://mtls.api.local.test/018e12d0-ed2e-4b38-b045-493e96e9d400/v1/tokens",
+      "revocation_endpoint": "https://mtls.api.local.test/018e12d0-ed2e-4b38-b045-493e96e9d400/v1/tokens/revocation",
+      "introspection_endpoint": "https://mtls.api.local.test/018e12d0-ed2e-4b38-b045-493e96e9d400/v1/tokens/introspection",
+      "userinfo_endpoint": "https://mtls.api.local.test/018e12d0-ed2e-4b38-b045-493e96e9d400/v1/userinfo",
+      "backchannel_authentication_endpoint": "https://mtls.api.local.test/018e12d0-ed2e-4b38-b045-493e96e9d400/v1/backchannel/authentications"
+    },
+    "extension": {
+      "access_token_type": "JWT",
+      "token_signed_key_id": "access_token",
+      "id_token_signed_key_id": "access_token",
+      "authorization_code_valid_duration": 10,
+      "access_token_duration": 3600,
+      "id_token_duration": 3600,
+      "id_token_strict_mode": false,
+      "default_max_age": 86400,
+      "rotate_refresh_token": false,
+      "fapi_baseline_scopes": [
+        "read"
+      ],
+      "fapi_advance_scopes": [
+        "write"
+      ],
+      "fapi20_scopes": [],
+      "required_identity_verification_scopes": [
+        "transfers"
+      ],
+      "backchannel_authentication_request_expires_in": 60,
+      "backchannel_authentication_polling_interval": 5,
+      "custom_claims_scope_mapping": true,
+      "access_token_user_custom_properties": true,
+      "access_token_selective_verified_claims": true
+    },
+    "verified_claims_supported": true,
+    "trust_frameworks_supported": [
+      "nist_800_63A_ial_2",
+      "nist_800_63A_ial_3"
+    ],
+    "evidence_supported": [
+      "id_document",
+      "utility_bill",
+      "qes"
+    ],
+    "id_documents_supported": [
+      "idcard",
+      "passport",
+      "driving_permit"
+    ],
+    "id_documents_verification_methods_supported": [
+      "pipp",
+      "sripp",
+      "eid"
+    ],
+    "claims_in_verified_claims_supported": [
+      "given_name",
+      "family_name",
+      "birthdate",
+      "place_of_birth",
+      "nationalities",
+      "address"
+    ],
+    "credential_issuer_metadata": {
+      "credential_issuer": "https://api.local.test/018e12d0-ed2e-4b38-b045-493e96e9d400",
+      "authorization_server": "https://api.local.test/018e12d0-ed2e-4b38-b045-493e96e9d400",
+      "credential_endpoint": "https://api.local.test/018e12d0-ed2e-4b38-b045-493e96e9d400/v1/credentials",
+      "batch_credential_endpoint": "https://api.local.test/018e12d0-ed2e-4b38-b045-493e96e9d400/v1/batch-credentials",
+      "deferred_credential_endpoint": "https://api.local.test/018e12d0-ed2e-4b38-b045-493e96e9d400/v1/deferred-credentials",
+      "credentials_supported": [
+        {
+          "format": "jwt_vc_json",
+          "id": "UniversityDegree_JWT",
+          "cryptographic_binding_methods_supported": [
+            "did:example"
+          ],
+          "cryptographic_suites_supported": [
+            "ES256K"
+          ],
+          "credential_definition": {
+            "type": [
+              "VerifiableCredential",
+              "UniversityDegreeCredential"
+            ],
+            "credentialSubject": {
+              "given_name": {
+                "display": [
+                  {
+                    "name": "Given Name",
+                    "locale": "en-US"
+                  }
+                ]
+              },
+              "last_name": {
+                "display": [
+                  {
+                    "name": "Surname",
+                    "locale": "en-US"
+                  }
+                ]
+              },
+              "degree": {},
+              "gpa": {
+                "display": [
+                  {
+                    "name": "GPA"
+                  }
+                ]
+              }
+            }
+          },
+          "proof_types_supported": [
+            "jwt"
+          ],
+          "display": [
+            {
+              "name": "University Credential",
+              "locale": "en-US",
+              "logo": {
+                "url": "https://exampleuniversity.com/public/logo.png",
+                "alt_text": "a square logo of a university"
+              },
+              "background_color": "#12107c",
+              "text_color": "#FFFFFF"
+            }
+          ]
+        },
+        {
+          "format": "ldp_vc",
+          "id": "UniversityDegree_ldp",
+          "cryptographic_binding_methods_supported": [
+            "did:example"
+          ],
+          "cryptographic_suites_supported": [
+            "ES256K"
+          ],
+          "credential_definition": {
+            "type": [
+              "VerifiableCredential",
+              "UniversityDegreeCredential"
+            ],
+            "credentialSubject": {
+              "given_name": {
+                "display": [
+                  {
+                    "name": "Given Name",
+                    "locale": "en-US"
+                  }
+                ]
+              },
+              "last_name": {
+                "display": [
+                  {
+                    "name": "Surname",
+                    "locale": "en-US"
+                  }
+                ]
+              },
+              "degree": {},
+              "gpa": {
+                "display": [
+                  {
+                    "name": "GPA"
+                  }
+                ]
+              }
+            }
+          },
+          "proof_types_supported": [
+            "jwt"
+          ],
+          "display": [
+            {
+              "name": "University Credential",
+              "locale": "en-US",
+              "logo": {
+                "url": "https://exampleuniversity.com/public/logo.png",
+                "alt_text": "a square logo of a university"
+              },
+              "background_color": "#12107c",
+              "text_color": "#FFFFFF"
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/config/scripts/e2e-test-data.sh
+++ b/config/scripts/e2e-test-data.sh
@@ -468,3 +468,34 @@ FAPI2_NO_SENDER_TENANT_ID="d2a23128-043d-4ad7-8136-e7132663dfe3"
   -b "${AUTHORIZATION_SERVER_URL}" \
   -a "${ACCESS_TOKEN}" \
   -d "${DRY_RUN}"
+
+# require-par-tenant: M-6 (RFC 9126 §5) require_pushed_authorization_requests の
+# 汎用強制検証用 (プレーン OIDC + flag=true。fapi20_scopes は空にして FAPI2 経路を無効化)
+echo "-------------------------------------------------"
+echo ""
+echo "require-par-tenant"
+
+./config/scripts/upsert-tenant.sh \
+  -f "./config/examples/e2e/require-par-tenant/tenants/require-par-tenant.json" \
+  -o "${ORGANIZATION_ID}" \
+  -b "${AUTHORIZATION_SERVER_URL}" \
+  -a "${ACCESS_TOKEN}" \
+  -d "${DRY_RUN}"
+
+REQUIRE_PAR_TENANT_ID="018e12d0-ed2e-4b38-b045-493e96e9d400"
+
+./config/scripts/upsert-authorization-server.sh \
+  -t "${REQUIRE_PAR_TENANT_ID}" \
+  -o "${ORGANIZATION_ID}" \
+  -f "./config/examples/e2e/require-par-tenant/authorization-server/idp-server.json" \
+  -b "${AUTHORIZATION_SERVER_URL}" \
+  -a "${ACCESS_TOKEN}" \
+  -d "${DRY_RUN}"
+
+./config/scripts/upsert-client.sh \
+  -t "${REQUIRE_PAR_TENANT_ID}" \
+  -o "${ORGANIZATION_ID}" \
+  -f "./config/examples/e2e/require-par-tenant/clients/clientSecretPost.json" \
+  -b "${AUTHORIZATION_SERVER_URL}" \
+  -a "${ACCESS_TOKEN}" \
+  -d "${DRY_RUN}"

--- a/e2e/src/tests/spec/rfc9126_par_required.test.js
+++ b/e2e/src/tests/spec/rfc9126_par_required.test.js
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "@jest/globals";
+
+import { get } from "../../lib/http";
+import { pushAuthorizations, requestAuthorizations } from "../../oauth/request";
+import { calculateCodeChallengeWithS256, generateCodeVerifier } from "../../lib/oauth";
+import {
+  requireParClientSecretPostClient,
+  requireParServerConfig,
+} from "../testConfig";
+
+/**
+ * RFC 9126 Section 5 — `require_pushed_authorization_requests`.
+ *
+ * These tests use a dedicated plain OIDC tenant (require-par-tenant) whose authorization server
+ * advertises `require_pushed_authorization_requests: true` and whose `fapi20_scopes` is empty, so
+ * the enforcement observed here is driven by the RFC 9126 flag itself — not by the FAPI 2.0
+ * profile (which mandates PAR independently via a requested fapi-2.0 scope). This is the M-6
+ * follow-up: previously the flag was advertised in discovery but never enforced.
+ */
+describe("RFC 9126 OAuth 2.0 Pushed Authorization Requests", () => {
+  describe("5. Authorization Server Metadata", () => {
+    const config = requireParServerConfig;
+    const client = requireParClientSecretPostClient;
+
+    it("require_pushed_authorization_requests Boolean parameter indicating whether the authorization server accepts authorization request data only via PAR - RFC 9126 Section 5 (advertised in discovery)", async () => {
+      const discovery = await get({ url: config.discoveryEndpoint });
+
+      expect(discovery.status).toBe(200);
+      expect(discovery.data.require_pushed_authorization_requests).toBe(true);
+    });
+
+    it("When require_pushed_authorization_requests is true, the authorization server accepts authorization request data only via PAR - a direct authorization request MUST be rejected - RFC 9126 Section 5", async () => {
+      const codeVerifier = generateCodeVerifier(64);
+      const codeChallenge = calculateCodeChallengeWithS256(codeVerifier);
+
+      const { error } = await requestAuthorizations({
+        endpoint: config.authorizationEndpoint,
+        responseType: "code",
+        clientId: client.clientId,
+        redirectUri: client.redirectUri,
+        scope: client.scope,
+        state: "state-require-par",
+        codeChallenge,
+        codeChallengeMethod: "S256",
+      });
+
+      // The flag (not the FAPI 2.0 profile) rejects the direct request via a redirectable error.
+      expect(error.error).toBe("invalid_request");
+      expect(error.error_description).toContain("Pushed Authorization Requests");
+    });
+
+    it("A request sent through the PAR endpoint is accepted and a request_uri is issued - RFC 9126 Section 2.2 / 5", async () => {
+      const codeVerifier = generateCodeVerifier(64);
+      const codeChallenge = calculateCodeChallengeWithS256(codeVerifier);
+
+      const parResponse = await pushAuthorizations({
+        endpoint: config.pushedAuthorizationEndpoint,
+        responseType: "code",
+        state: "state-require-par",
+        scope: client.scope,
+        redirectUri: client.redirectUri,
+        clientId: client.clientId,
+        codeChallenge,
+        codeChallengeMethod: "S256",
+        clientSecret: client.clientSecret,
+      });
+
+      expect(parResponse.status).toBe(201);
+      expect(parResponse.data).toHaveProperty("request_uri");
+    });
+  });
+});

--- a/e2e/src/tests/testConfig.js
+++ b/e2e/src/tests/testConfig.js
@@ -242,6 +242,17 @@ export const fapi2ClientSecretJwtClient = {
  */
 const fapi2NoSenderTenantId = "d2a23128-043d-4ad7-8136-e7132663dfe3";
 export const fapi2NoSenderServerConfig = createServerConfig(fapi2NoSenderTenantId);
+
+// require-par-tenant: plain OIDC tenant with require_pushed_authorization_requests=true (M-6).
+const requireParTenantId = "018e12d0-ed2e-4b38-b045-493e96e9d400";
+export const requireParServerConfig = createServerConfig(requireParTenantId);
+export const requireParClientSecretPostClient = {
+  clientId: "requireParClientSecretPost",
+  clientSecret:
+    "clientSecretPostPassword1234567890123456789012345678901234567890123456789012345678901234567890",
+  redirectUri: "https://client.example.org/callback",
+  scope: "openid profile email",
+};
 export const fapi2NoSenderPrivateKeyJwtClient = {
   clientId: "fapi2NoSenderPrivateKeyJwt",
   clientIdUuid: "f441d38c-9ed3-4f9c-8418-efc8f31e49d0",

--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/oauth/configuration/AuthorizationServerConfiguration.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/oauth/configuration/AuthorizationServerConfiguration.java
@@ -414,6 +414,13 @@ public class AuthorizationServerConfiguration implements JsonReadable, Configura
     return pushedAuthorizationRequestEndpoint;
   }
 
+  /**
+   * RFC 9126 Section 5 {@code require_pushed_authorization_requests}. Advertised in discovery
+   * metadata and enforced across all profiles by {@code RequirePushedAuthorizationRequestVerifier}:
+   * when {@code true}, direct authorization requests are rejected and only PAR-originated requests
+   * are accepted. FAPI 2.0 tenants require PAR through {@code FapiSecurity20Verifier} regardless of
+   * this flag.
+   */
   public boolean requirePushedAuthorizationRequests() {
     return requirePushedAuthorizationRequests;
   }

--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/oauth/verifier/OAuthRequestVerifier.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/oauth/verifier/OAuthRequestVerifier.java
@@ -24,6 +24,7 @@ import org.idp.server.core.openid.oauth.verifier.extension.JarmVerifier;
 import org.idp.server.core.openid.oauth.verifier.extension.OAuthAuthorizationDetailsVerifier;
 import org.idp.server.core.openid.oauth.verifier.extension.PushedAuthorizationRequestVerifier;
 import org.idp.server.core.openid.oauth.verifier.extension.RequestObjectVerifier;
+import org.idp.server.core.openid.oauth.verifier.extension.RequirePushedAuthorizationRequestVerifier;
 import org.idp.server.core.openid.plugin.request.AuthorizationRequestExtensionVerifierPluginLoader;
 import org.idp.server.core.openid.plugin.request.AuthorizationRequestVerifierPluginLoader;
 import org.idp.server.platform.exception.UnSupportedException;
@@ -46,6 +47,7 @@ public class OAuthRequestVerifier {
     List<AuthorizationRequestExtensionVerifier> loadedExtensionVerifiers =
         AuthorizationRequestExtensionVerifierPluginLoader.load();
     extensionVerifiers.addAll(loadedExtensionVerifiers);
+    extensionVerifiers.add(new RequirePushedAuthorizationRequestVerifier());
     extensionVerifiers.add(new PushedAuthorizationRequestVerifier());
     extensionVerifiers.add(new RequestObjectVerifier());
     extensionVerifiers.add(new OAuthAuthorizationDetailsVerifier());

--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/oauth/verifier/extension/RequirePushedAuthorizationRequestVerifier.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/oauth/verifier/extension/RequirePushedAuthorizationRequestVerifier.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2025 Hirokazu Kobayashi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.idp.server.core.openid.oauth.verifier.extension;
+
+import org.idp.server.core.openid.oauth.OAuthRequestContext;
+import org.idp.server.core.openid.oauth.exception.OAuthRedirectableBadRequestException;
+import org.idp.server.core.openid.oauth.verifier.AuthorizationRequestExtensionVerifier;
+
+/**
+ * Enforces the server-wide {@code require_pushed_authorization_requests} metadata (RFC 9126 Section
+ * 5) across every authorization profile.
+ *
+ * <p>When the authorization server advertises {@code require_pushed_authorization_requests: true},
+ * per RFC 9126 it "accepts authorization request data only via PAR". This verifier rejects any
+ * direct authorization request (one that did not originate from a {@code request_uri} issued by the
+ * PAR endpoint), so the advertised metadata is truthful for OAuth 2.0 / OIDC tenants as well — not
+ * only for FAPI 2.0, which mandates PAR through {@code FapiSecurity20Verifier} regardless of this
+ * flag.
+ *
+ * <p>The check is skipped at the PAR endpoint itself ({@link
+ * OAuthRequestContext#isAtPushedEndpoint()} {@code == true}), where the request is by definition
+ * being pushed. It runs as an extension verifier, i.e. after the base verifier has validated {@code
+ * redirect_uri} / client, so a redirectable error can be returned safely.
+ *
+ * @see <a href="https://www.rfc-editor.org/rfc/rfc9126.html#section-5">RFC 9126 Section 5</a>
+ */
+public class RequirePushedAuthorizationRequestVerifier
+    implements AuthorizationRequestExtensionVerifier {
+
+  @Override
+  public boolean shouldVerify(OAuthRequestContext oAuthRequestContext) {
+    return oAuthRequestContext.serverConfiguration().requirePushedAuthorizationRequests()
+        && !oAuthRequestContext.isAtPushedEndpoint();
+  }
+
+  @Override
+  public void verify(OAuthRequestContext oAuthRequestContext) {
+    if (!oAuthRequestContext.isPushedRequest()) {
+      throw new OAuthRedirectableBadRequestException(
+          "invalid_request",
+          "This authorization server requires Pushed Authorization Requests (PAR, RFC 9126)."
+              + " Direct authorization requests are not allowed.",
+          oAuthRequestContext);
+    }
+  }
+}

--- a/libs/idp-server-core/src/main/resources/schema/1.0/authorization-server.json
+++ b/libs/idp-server-core/src/main/resources/schema/1.0/authorization-server.json
@@ -671,6 +671,11 @@
           },
           "description": "List of scopes indicating FAPI 2.0 Security Profile Final conformance. When any of these scopes is requested, the server enforces FAPI 2.0 SP requirements (PAR mandatory, response_type=code only, public client prohibited, sender-constrained tokens via mTLS or DPoP)."
         },
+        "require_pushed_authorization_requests": {
+          "type": "boolean",
+          "default": false,
+          "description": "RFC 9126 Section 5. When true, the server accepts authorization request data only via Pushed Authorization Requests (PAR); direct authorization requests are rejected with invalid_request across all profiles. Advertised in discovery metadata. FAPI 2.0 tenants already require PAR via fapi20_scopes regardless of this flag."
+        },
         "required_identity_verification_scopes": {
           "type": "array",
           "items": {

--- a/libs/idp-server-core/src/test/java/org/idp/server/core/openid/oauth/verifier/extension/RequirePushedAuthorizationRequestVerifierTest.java
+++ b/libs/idp-server-core/src/test/java/org/idp/server/core/openid/oauth/verifier/extension/RequirePushedAuthorizationRequestVerifierTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2025 Hirokazu Kobayashi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.idp.server.core.openid.oauth.verifier.extension;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.idp.server.core.openid.oauth.OAuthRequestContext;
+import org.idp.server.core.openid.oauth.configuration.AuthorizationServerConfiguration;
+import org.idp.server.core.openid.oauth.exception.OAuthRedirectableBadRequestException;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link RequirePushedAuthorizationRequestVerifier} (M-6, RFC 9126 §5). The verifier
+ * only consults three booleans on the context, so a lightweight subclass test double is enough (no
+ * mocking framework is available in this module).
+ */
+class RequirePushedAuthorizationRequestVerifierTest {
+
+  private final RequirePushedAuthorizationRequestVerifier verifier =
+      new RequirePushedAuthorizationRequestVerifier();
+
+  /** Test double: overrides only the three signals the verifier reads. */
+  private static OAuthRequestContext context(
+      boolean requirePar, boolean atPushedEndpoint, boolean pushedRequest) {
+    AuthorizationServerConfiguration serverConfiguration =
+        new AuthorizationServerConfiguration() {
+          @Override
+          public boolean requirePushedAuthorizationRequests() {
+            return requirePar;
+          }
+        };
+    return new OAuthRequestContext() {
+      @Override
+      public AuthorizationServerConfiguration serverConfiguration() {
+        return serverConfiguration;
+      }
+
+      @Override
+      public boolean isAtPushedEndpoint() {
+        return atPushedEndpoint;
+      }
+
+      @Override
+      public boolean isPushedRequest() {
+        return pushedRequest;
+      }
+    };
+  }
+
+  @Test
+  void shouldVerifyWhenFlagEnabledAtAuthorizationEndpoint() {
+    // require=true, not the PAR endpoint -> the enforcement gate is active.
+    assertTrue(verifier.shouldVerify(context(true, false, false)));
+  }
+
+  @Test
+  void shouldNotVerifyAtPushedEndpoint() {
+    // The PAR endpoint itself is where the request is pushed; enforcing there would be circular.
+    assertFalse(verifier.shouldVerify(context(true, true, false)));
+  }
+
+  @Test
+  void shouldNotVerifyWhenFlagDisabled() {
+    // Flag off -> no enforcement regardless of how the request arrives (default behavior
+    // preserved).
+    assertFalse(verifier.shouldVerify(context(false, false, false)));
+  }
+
+  @Test
+  void rejectsDirectAuthorizationRequest() {
+    // Flag on and the request did not originate from PAR -> reject with invalid_request.
+    OAuthRedirectableBadRequestException ex =
+        assertThrows(
+            OAuthRedirectableBadRequestException.class,
+            () -> verifier.verify(context(true, false, false)));
+    assertEquals("invalid_request", ex.error().value());
+  }
+
+  @Test
+  void allowsPushedRequest() {
+    // Flag on but the request came via a PAR-issued request_uri -> allowed.
+    assertDoesNotThrow(() -> verifier.verify(context(true, false, true)));
+  }
+}


### PR DESCRIPTION
## 概要

Issue #1736 クラスタ D（**M-6**）。RFC 9126 §5 の `require_pushed_authorization_requests` は discovery で広告されるだけで、どの verifier からも参照されない **dead flag** だった（実際の PAR 強制は `fapi20_scopes` 由来の FAPI 2.0 プロファイル限定）。広告メタデータと実挙動の乖離を解消し、フラグ `true` 時は**全プロファイルで PAR を強制**する。

## 背景（裏取り済み）

- 設定フィールド `AuthorizationServerConfiguration.requirePushedAuthorizationRequests`（default false）は存在するが、どの verifier からも参照されていなかった。
- discovery（`ServerConfigurationResponseCreator`）は無条件で広告。
- 実 PAR 強制は `FapiSecurity20Verifier.throwExceptionIfNotPushedRequest`（`fapi20_scopes` 経由の FAPI2 プロファイル時のみ）。
- → 非 FAPI テナントがフラグを立ててもメタデータ通りに動かない。

## 変更

- **`RequirePushedAuthorizationRequestVerifier`** を新設し `OAuthRequestVerifier` の extension verifier 列に登録（既存 PAR 検証の前）。
  - `shouldVerify` = `requirePushedAuthorizationRequests() && !isAtPushedEndpoint()`
  - `verify` = `!isPushedRequest()` なら `invalid_request`（redirectable）。FAPI2 の PAR 強制と同じ `isPushedRequest()` 判定を流用。
  - base verifier の後に走るため redirect_uri/client は検証済み。**default false のため既存テナントは無影響**、opt-in したテナントのみ強制。
- `schema/1.0/authorization-server.json` に `require_pushed_authorization_requests`（boolean, default false）を追記。
- `AuthorizationServerConfiguration` の getter に「全プロファイルで強制」Javadoc。

## テスト

- **単体**: `RequirePushedAuthorizationRequestVerifierTest` 5 件（`shouldVerify` マトリクス + `verify` 拒否/許可。Mockito 不使用の test double）。core フルスイート green。
- **E2E**: 専用の plain OIDC テナント `require-par-tenant`（`require_pushed=true`, `fapi20_scopes=[]` で FAPI2 経路を無効化）を追加。`rfc9126_par_required.test.js` で以下を検証（**3 件 green**）:
  1. discovery が `require_pushed_authorization_requests: true` を広告
  2. **直接認可リクエストが `invalid_request` で拒否**（フラグ由来。redirect に `error_description=This authorization server requires Pushed Authorization Requests (PAR, RFC 9126)...` を実証）
  3. PAR push が受理され `request_uri` が発行される
- **回帰**: fapi2 / par 系 spec テスト 43 件 green。fapi2 テナント（`require_pushed=true`）を使うのは PAR 経由の fapi2 テスト2本のみで影響なし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)