### PR TITLE
fix(login-social): federation の redirect_uri をフロント sso-callback 画面に修正

### DIFF
--- a/config/examples/login-social/federation-config-google.json
+++ b/config/examples/login-social/federation-config-google.json
@@ -21,6 +21,6 @@
     "grant_types_supported": ["authorization_code"],
     "client_id": "your-google-client-id",
     "client_secret": "your-google-client-secret",
-    "redirect_uri": "https://api.local.test/11111111-3333-1111-1111-111111111111/v1/authorizations/federations/oidc/callback"
+    "redirect_uri": "https://auth.local.test/signin/sso-callback/"
   }
 }

--- a/config/templates/use-cases/login-social/README.md
+++ b/config/templates/use-cases/login-social/README.md
@@ -21,11 +21,11 @@
 | ファイル | 用途 | API |
 |---------|------|-----|
 | `onboarding-template.json` | Organization + Organizer Tenant + Admin User + Client | `POST /v1/management/onboarding` |
-| `public-tenant-template.json` | Public Tenant（パスワードポリシー + セッション設定） | `POST /v1/management/tenants` |
-| `authentication-config-initial-registration.json` | ユーザー登録スキーマ | `POST /v1/management/tenants/{id}/authentication-configurations` |
-| `authentication-policy.json` | パスワードのみ認証ポリシー | `POST /v1/management/tenants/{id}/authentication-policies` |
-| `federation-config-template.json` | Google OIDC フェデレーション設定 | `POST /v1/management/tenants/{id}/federation-configurations` |
-| `public-client-template.json` | アプリケーションクライアント | `POST /v1/management/tenants/{id}/clients` |
+| `public-tenant-template.json` | Public Tenant（パスワードポリシー + セッション設定） | `POST /v1/management/organizations/{org-id}/tenants` |
+| `authentication-config-initial-registration.json` | ユーザー登録スキーマ | `POST /v1/management/organizations/{org-id}/tenants/{id}/authentication-configurations` |
+| `authentication-policy.json` | パスワードのみ認証ポリシー | `POST /v1/management/organizations/{org-id}/tenants/{id}/authentication-policies` |
+| `federation-config-template.json` | Google OIDC フェデレーション設定 | `POST /v1/management/organizations/{org-id}/tenants/{id}/federation-configurations` |
+| `public-client-template.json` | アプリケーションクライアント | `POST /v1/management/organizations/{org-id}/tenants/{id}/clients` |
 | `setup.sh` | 上記を順番に実行するスクリプト | - |
 
 ## セットアップ手順
@@ -177,5 +177,6 @@ Google ソーシャルログインを使用するには、Google Cloud Console �
 4. 「認証情報を作成」→「OAuth クライアント ID」を選択
 5. アプリケーションの種類：「ウェブアプリケーション」
 6. 承認済みのリダイレクト URI に以下を追加：
-   - `{AUTHORIZATION_SERVER_URL}/{PUBLIC_TENANT_ID}/v1/authorizations/federations/oidc/callback`
+   - `{UI_BASE_URL}/signin/sso-callback/`（デフォルト `https://auth.local.test/signin/sso-callback/`）
+   - ここは app-view の SSO コールバック**画面**。Google はブラウザを GET でここへリダイレクトし、画面がバックエンドの callback API へ橋渡しする。バックエンド API パス（`/v1/authorizations/...`）は POST 専用のため直接登録しないこと。
 7. 作成後、クライアント ID とクライアントシークレットを `.env` に設定

--- a/config/templates/use-cases/login-social/federation-config-template.json
+++ b/config/templates/use-cases/login-social/federation-config-template.json
@@ -50,7 +50,7 @@
     ],
     "client_id": "${GOOGLE_CLIENT_ID}",
     "client_secret": "${GOOGLE_CLIENT_SECRET}",
-    "redirect_uri": "${BASE_URL}/${PUBLIC_TENANT_ID}/v1/authorizations/federations/oidc/callback",
+    "redirect_uri": "${UI_BASE_URL}/signin/sso-callback/",
     "userinfo_mapping_rules": [
       {"from": "$.http_request.response_body.sub", "to": "external_user_id"},
       {"from": "$.http_request.response_body.email", "to": "email"},

--- a/config/templates/use-cases/login-social/setup.sh
+++ b/config/templates/use-cases/login-social/setup.sh
@@ -392,6 +392,7 @@ FEDERATION_ID="${FEDERATION_ID:-$(uuidgen | tr '[:upper:]' '[:lower:]')}"
 FEDERATION_JSON=$(substitute_template "${SCRIPT_DIR}/federation-config-template.json" \
   "FEDERATION_ID" "${FEDERATION_ID}" \
   "BASE_URL" "${AUTHORIZATION_SERVER_URL}" \
+  "UI_BASE_URL" "${UI_BASE_URL}" \
   "PUBLIC_TENANT_ID" "${PUBLIC_TENANT_ID}" \
   "GOOGLE_CLIENT_ID" "${GOOGLE_CLIENT_ID}" \
   "GOOGLE_CLIENT_SECRET" "${GOOGLE_CLIENT_SECRET}")


### PR DESCRIPTION
## 概要

`config/templates/use-cases/login-social`（および sibling の `config/examples/login-social`）で、Google フェデレーションの **`redirect_uri` がバックエンドの POST 専用 callback API を指しており、実際の Google ソーシャルログインが 405 で失敗する**問題を修正。E2E はモック経由のため露見していなかった。

## 機序（コードで裏取り）

federation OIDC リクエストは config の `redirect_uri` を **そのまま Google の OAuth `redirect_uri` として送る**（`OidcSsoSessionCreator:62`）。Google はそこへ **GET でリダイレクト**する（`response_type=code` のみ、`response_mode=form_post` 未使用）。

現行テンプレの redirect_uri は **バックエンド callback API**（`.../v1/authorizations/federations/oidc/callback`）を指すが、これは **`@PostMapping`（POST 専用）**（`OAuthV1Api:221`）。→ Google の GET リダイレクトで **405**。

正しい着地先は **app-view の sso-callback 画面**で、そこが GET を受け → `state` から tenantId を復号 → バックエンドへ POST する（`app-view/src/pages/signin/sso-callback/index.tsx`）。

## 正しい値

```
${UI_BASE_URL}/signin/sso-callback/
```

- `UI_BASE_URL` は既存変数（`setup.sh`、default `https://auth.local.test`）。tenant の `ui_config.base_url` にも使用。
- 末尾スラッシュ形（`app-view/next.config.ts` が `output:export` + `trailingSlash:true`）。
- 動作実績: `config/examples/e2e/test-tenant/federation/oidc/google.json` の redirect_uri = `https://api.local.test/signin/sso-callback/index.html`（フロント画面）で E2E が通っている。

## 変更

1. `federation-config-template.json`: redirect_uri → `${UI_BASE_URL}/signin/sso-callback/`
2. `setup.sh` Step 8: 置換に `UI_BASE_URL` を追加（未受け渡しだった）
3. `examples/login-social/federation-config-google.json`: redirect_uri → `https://auth.local.test/signin/sso-callback/`
4. `README.md`: Google Console 登録手順をフロント画面 URL に修正＋「バックエンド API は POST 専用なので直接登録しない」注記
5. `README.md`: ファイル構成表の API パスを org-level に統一（setup.sh の実挙動と整合）

## 補足（別途・app-view 側 / 本PRスコープ外）

`app-view/src/pages/signin/sso-callback/google/index.tsx` は `.../federations/oidc/google/callback`（tenant prefix なし・実在しないパス）へ POST しており dead 疑い。canonical は generic な `/signin/sso-callback`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)