### PR TITLE
fix(federation): 設定更新で enabled が常に true に戻る問題を修正 + enabled 一貫性 (#1743)

### DIFF
--- a/documentation/openapi/swagger-cp-federation-ja.yaml
+++ b/documentation/openapi/swagger-cp-federation-ja.yaml
@@ -410,6 +410,9 @@ components:
       additionalProperties: false
     OrganizationFederationConfigUpdateRequest:
       type: object
+      description: >-
+        PUT は全置換です。GET で取得した完全な設定を送ってください（リクエストに含めなかったフィールドは
+        リセットされます）。
       properties:
         type:
           type: string
@@ -420,9 +423,7 @@ components:
           description: Federation type
         sso_provider:
           type: string
-          description: >-
-            SSO provider identifier. 省略した場合は既存の値を維持します（この項目を空にすると設定の引き当てが
-            破綻するため、部分更新で消去されないよう保全されます）。
+          description: SSO provider identifier（設定の引き当てキー。全置換のため GET の値を必ず含めること）
         payload:
           type: object
           description: Federation-specific configuration payload

--- a/e2e/src/tests/scenario/control_plane/organization/organization_federation_config_management.test.js
+++ b/e2e/src/tests/scenario/control_plane/organization/organization_federation_config_management.test.js
@@ -174,9 +174,22 @@ describe("organization federation configuration management api", () => {
         console.log("List Response 2:", listResponse2.data);
         expect(listResponse2.status).toBe(200);
 
+        // #1743: the management list includes disabled configs (like client management), so admins
+        // can see and manage disabled data. The disabled config still appears in the default list.
         const federationConfigsAfterUpdate = listResponse2.data.list.filter(config => config.id === createdFederationConfigId);
         expect(federationConfigsAfterUpdate.length).toBe(1);
-        console.log("✅ Federation config still appears in list after update");
+        console.log("✅ Disabled federation config still appears in the management list");
+
+        // #1743: the enabled query filter narrows results (like client) - enabled=true excludes it.
+        const listEnabledOnly = await get({
+          url: `${backendUrl}/v1/management/organizations/${orgId}/tenants/${tenantId}/federation-configurations?enabled=true`,
+          headers: {
+            Authorization: `Bearer ${accessToken}`
+          }
+        });
+        expect(listEnabledOnly.status).toBe(200);
+        expect(listEnabledOnly.data.list.filter(config => config.id === createdFederationConfigId).length).toBe(0);
+        console.log("✅ enabled=true filter excludes the disabled config");
 
         // Step 8: Verify individual federation config retrieval still works (enabled=false)
         const detailResponse2 = await get({
@@ -188,8 +201,9 @@ describe("organization federation configuration management api", () => {
         console.log("Detail Response 2:", detailResponse2.data);
         expect(detailResponse2.status).toBe(200);
         expect(detailResponse2.data.id).toBe(createdFederationConfigId);
-        // Note: enabled status may not be updated immediately or filtering may not be implemented
-        console.log("✅ Federation config detail still accessible after update");
+        // #1743: GET (findWithDisabled) returns the disabled config and enabled reflects the update.
+        expect(detailResponse2.data.enabled).toBe(false);
+        console.log("✅ Disabled federation config is retrievable by id with enabled=false");
 
         // Step 9: Delete the federation configuration
         // Note: Delete operation does not support dry-run in current implementation
@@ -388,6 +402,50 @@ describe("organization federation configuration management api", () => {
         expect(getAfterUpdate.status).toBe(200);
         expect(getAfterUpdate.data.sso_provider).toBe(ssoProvider);
         expect(getAfterUpdate.data.payload.client_id).toBe("updated-client-id");
+      } finally {
+        await deletion({
+          url: `${backendUrl}/v1/management/organizations/${orgId}/tenants/${tenantId}/federation-configurations/${federationConfigId}`,
+          headers
+        });
+      }
+    });
+
+    it("create with enabled=false is honored (#1743)", async () => {
+      const tokenResponse = await requestToken({
+        endpoint: `${backendUrl}/952f6906-3e95-4ed3-86b2-981f90f785f9/v1/tokens`,
+        grantType: "password",
+        username: "ito.ichiro@gmail.com",
+        password: "successUserCode001",
+        scope: "org-management account management",
+        clientId: "org-client",
+        clientSecret: "org-client-001"
+      });
+      expect(tokenResponse.status).toBe(200);
+      const accessToken = tokenResponse.data.access_token;
+      const headers = { Authorization: `Bearer ${accessToken}` };
+
+      const federationConfigId = uuidv4();
+      const createResponse = await postWithJson({
+        url: `${backendUrl}/v1/management/organizations/${orgId}/tenants/${tenantId}/federation-configurations`,
+        headers,
+        body: {
+          "id": federationConfigId,
+          "type": "oidc",
+          "sso_provider": `sso-${federationConfigId}`,
+          "payload": { "provider": "standard", "issuer": "https://accounts.google.com" },
+          "enabled": false
+        }
+      });
+      expect(createResponse.status).toBe(201);
+
+      try {
+        // #1743: enabled=false at create must be honored (not forced to true).
+        const getResponse = await get({
+          url: `${backendUrl}/v1/management/organizations/${orgId}/tenants/${tenantId}/federation-configurations/${federationConfigId}`,
+          headers
+        });
+        expect(getResponse.status).toBe(200);
+        expect(getResponse.data.enabled).toBe(false);
       } finally {
         await deletion({
           url: `${backendUrl}/v1/management/organizations/${orgId}/tenants/${tenantId}/federation-configurations/${federationConfigId}`,

--- a/e2e/src/tests/scenario/control_plane/organization/organization_federation_config_management_structured.test.js
+++ b/e2e/src/tests/scenario/control_plane/organization/organization_federation_config_management_structured.test.js
@@ -309,7 +309,9 @@ describe("Organization Federation Config Management API - Structured Tests", () 
           }
         });
 
-        expect(response.status).toBe(500); // API currently returns 500 for validation errors
+        // #1743: the full-replace create rejects the invalid body with 400 invalid_request
+        // (previously an unhandled NPE surfaced as 500).
+        expect(response.status).toBe(400);
       });
     });
   });

--- a/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/federation/handler/FederationConfigCreationService.java
+++ b/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/federation/handler/FederationConfigCreationService.java
@@ -16,6 +16,7 @@
 
 package org.idp.server.control_plane.management.federation.handler;
 
+import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 import org.idp.server.control_plane.management.federation.FederationConfigManagementContextBuilder;
@@ -27,7 +28,6 @@ import org.idp.server.core.openid.federation.repository.FederationConfigurationC
 import org.idp.server.core.openid.identity.User;
 import org.idp.server.core.openid.token.OAuthToken;
 import org.idp.server.platform.json.JsonConverter;
-import org.idp.server.platform.json.JsonNodeWrapper;
 import org.idp.server.platform.multi_tenancy.tenant.Tenant;
 import org.idp.server.platform.type.RequestAttributes;
 
@@ -77,19 +77,11 @@ public class FederationConfigCreationService
         FederationConfigManagementStatus.CREATED, contents);
   }
 
-  private FederationConfiguration createConfiguration(FederationConfigRequest request) {
-    JsonConverter jsonConverter = JsonConverter.snakeCaseInstance();
-    JsonNodeWrapper configJson = jsonConverter.readTree(request.toMap());
-
-    String id =
-        configJson.contains("id")
-            ? configJson.getValueOrEmptyAsString("id")
-            : UUID.randomUUID().toString();
-    String type = configJson.getValueOrEmptyAsString("type");
-    String ssoProvider = configJson.getValueOrEmptyAsString("sso_provider");
-    JsonNodeWrapper payloadJson = configJson.getValueAsJsonNode("payload");
-    Map<String, Object> payload = payloadJson.toMap();
-
-    return new FederationConfiguration(id, type, ssoProvider, payload);
+  FederationConfiguration createConfiguration(FederationConfigRequest request) {
+    // Full replacement, mirroring the update path / client management: deserialize the whole
+    // configuration from the request (honoring enabled), generating an id when the body omits one.
+    Map<String, Object> map = new HashMap<>(request.toMap());
+    map.putIfAbsent("id", UUID.randomUUID().toString());
+    return JsonConverter.snakeCaseInstance().read(map, FederationConfiguration.class);
   }
 }

--- a/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/federation/handler/FederationConfigUpdateService.java
+++ b/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/federation/handler/FederationConfigUpdateService.java
@@ -100,17 +100,11 @@ public class FederationConfigUpdateService
 
   FederationConfiguration updateConfiguration(
       FederationConfiguration before, FederationConfigRequest request) {
-    // PUT is a full replacement: the request body is deserialized into the configuration, like the
-    // other management update services (Tenant / User / IDA). toMap() now carries every field,
-    // including the sso_provider lookup key that used to be missing from GET, so a GET -> modify ->
-    // PUT round-trip preserves them. id comes from the path (not the body); enabled keeps its
-    // current behavior and is fixed separately (#1743).
-    FederationConfiguration requested =
-        JsonConverter.snakeCaseInstance().read(request.toMap(), FederationConfiguration.class);
-    return new FederationConfiguration(
-        before.identifier().value(),
-        requested.typeName(),
-        requested.ssoProvider().name(),
-        requested.payload());
+    // Full replacement, mirroring ClientUpdateService: inject the path id into the body and
+    // deserialize the whole configuration. Every field (sso_provider, enabled, ...) round-trips via
+    // GET -> modify -> PUT, since toMap() carries them all and the read path loads enabled (#1743).
+    Map<String, Object> map = new HashMap<>(request.toMap());
+    map.put("id", before.identifier().value());
+    return JsonConverter.snakeCaseInstance().read(map, FederationConfiguration.class);
   }
 }

--- a/libs/idp-server-control-plane/src/test/java/org/idp/server/control_plane/management/federation/handler/FederationConfigCreationServiceTest.java
+++ b/libs/idp-server-control-plane/src/test/java/org/idp/server/control_plane/management/federation/handler/FederationConfigCreationServiceTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2025 Hirokazu Kobayashi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.idp.server.control_plane.management.federation.handler;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+
+import java.util.Map;
+import org.idp.server.control_plane.management.federation.io.FederationConfigRequest;
+import org.idp.server.core.openid.federation.FederationConfiguration;
+import org.idp.server.core.openid.federation.repository.FederationConfigurationCommandRepository;
+import org.junit.jupiter.api.Test;
+
+/**
+ * #1743: create is a full-replacement deserialization (like the update path / client management),
+ * so enabled is honored from the request instead of being forced to true. {@code
+ * createConfiguration} does not touch the repository, so a mock is enough.
+ */
+class FederationConfigCreationServiceTest {
+
+  private final FederationConfigCreationService service =
+      new FederationConfigCreationService(mock(FederationConfigurationCommandRepository.class));
+
+  @Test
+  void honorsEnabledFromRequest() {
+    FederationConfigRequest request =
+        new FederationConfigRequest(
+            Map.of(
+                "id",
+                "id-1",
+                "type",
+                "oidc",
+                "sso_provider",
+                "google",
+                "payload",
+                Map.of("provider", "standard"),
+                "enabled",
+                false));
+
+    FederationConfiguration created = service.createConfiguration(request);
+
+    assertFalse(created.isEnabled());
+  }
+
+  @Test
+  void generatesIdWhenAbsent() {
+    FederationConfigRequest request =
+        new FederationConfigRequest(
+            Map.of(
+                "type",
+                "oidc",
+                "sso_provider",
+                "google",
+                "payload",
+                Map.of("provider", "standard")));
+
+    FederationConfiguration created = service.createConfiguration(request);
+
+    assertNotNull(created.identifier().value());
+    assertFalse(created.identifier().value().isEmpty());
+  }
+
+  @Test
+  void usesIdFromRequestWhenPresent() {
+    FederationConfigRequest request =
+        new FederationConfigRequest(
+            Map.of(
+                "id",
+                "explicit-id",
+                "type",
+                "oidc",
+                "sso_provider",
+                "google",
+                "payload",
+                Map.of("provider", "standard")));
+
+    FederationConfiguration created = service.createConfiguration(request);
+
+    assertEquals("explicit-id", created.identifier().value());
+  }
+}

--- a/libs/idp-server-control-plane/src/test/java/org/idp/server/control_plane/management/federation/handler/FederationConfigUpdateServiceTest.java
+++ b/libs/idp-server-control-plane/src/test/java/org/idp/server/control_plane/management/federation/handler/FederationConfigUpdateServiceTest.java
@@ -80,4 +80,24 @@ class FederationConfigUpdateServiceTest {
 
     assertEquals("id-1", after.identifier().value());
   }
+
+  @Test
+  void honorsEnabledFromRequest() {
+    // #1743: enabled is part of the full-replacement body and must not be forced back to true.
+    FederationConfigRequest request =
+        new FederationConfigRequest(
+            Map.of(
+                "type",
+                "oidc",
+                "sso_provider",
+                "google",
+                "payload",
+                Map.of("provider", "standard"),
+                "enabled",
+                false));
+
+    FederationConfiguration after = service.updateConfiguration(before, request);
+
+    assertFalse(after.isEnabled());
+  }
 }

--- a/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/federation/config/query/FederationConfigurationSqlExecutor.java
+++ b/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/federation/config/query/FederationConfigurationSqlExecutor.java
@@ -43,7 +43,4 @@ public interface FederationConfigurationSqlExecutor {
   Map<String, String> selectCount(Tenant tenant, FederationQueries queries);
 
   List<Map<String, String>> selectList(Tenant tenant, FederationQueries queries);
-
-  List<Map<String, String>> selectList(
-      Tenant tenant, FederationQueries queries, boolean includeDisabled);
 }

--- a/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/federation/config/query/ModelConverter.java
+++ b/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/federation/config/query/ModelConverter.java
@@ -29,7 +29,16 @@ class ModelConverter {
     String payloadJson = result.get("payload");
     JsonNodeWrapper jsonNodeWrapper = JsonNodeWrapper.fromString(payloadJson);
     Map<String, Object> payload = jsonNodeWrapper.toMap();
+    boolean enabled = parseDatabaseBoolean(result.get("enabled"), true);
 
-    return new FederationConfiguration(id, type, ssoProvider, payload);
+    return new FederationConfiguration(id, type, ssoProvider, payload, enabled);
+  }
+
+  static boolean parseDatabaseBoolean(String value, boolean defaultValue) {
+    if (value == null || value.isEmpty()) {
+      return defaultValue;
+    }
+    String normalized = value.toLowerCase().trim();
+    return "t".equals(normalized) || "true".equals(normalized) || "1".equals(normalized);
   }
 }

--- a/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/federation/config/query/MysqlExecutor.java
+++ b/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/federation/config/query/MysqlExecutor.java
@@ -30,7 +30,7 @@ public class MysqlExecutor implements FederationConfigurationSqlExecutor {
 
   String selectSql =
       """
-            SELECT id, type, sso_provider, payload
+            SELECT id, type, sso_provider, payload, enabled
              FROM federation_configurations \n
           """;
 
@@ -123,6 +123,11 @@ public class MysqlExecutor implements FederationConfigurationSqlExecutor {
       params.add(queries.ssoProvider());
     }
 
+    if (queries.hasEnabled()) {
+      sql.append(" AND enabled = ?");
+      params.add(queries.enabled());
+    }
+
     if (queries.hasDetails()) {
       for (Map.Entry<String, String> entry : queries.details().entrySet()) {
         String key = entry.getKey();
@@ -138,12 +143,6 @@ public class MysqlExecutor implements FederationConfigurationSqlExecutor {
 
   @Override
   public List<Map<String, String>> selectList(Tenant tenant, FederationQueries queries) {
-    return selectList(tenant, queries, false);
-  }
-
-  @Override
-  public List<Map<String, String>> selectList(
-      Tenant tenant, FederationQueries queries, boolean includeDisabled) {
 
     SqlExecutor sqlExecutor = new SqlExecutor();
 
@@ -151,10 +150,6 @@ public class MysqlExecutor implements FederationConfigurationSqlExecutor {
 
     List<Object> params = new ArrayList<>();
     params.add(tenant.identifierValue());
-
-    if (!includeDisabled) {
-      sql.append("\n  AND enabled = true");
-    }
 
     if (queries.hasFrom()) {
       sql.append("\n  AND created_at >= ?");
@@ -176,6 +171,10 @@ public class MysqlExecutor implements FederationConfigurationSqlExecutor {
     if (queries.hasSsoProvider()) {
       sql.append("\n  AND sso_provider = ?");
       params.add(queries.ssoProvider());
+    }
+    if (queries.hasEnabled()) {
+      sql.append("\n  AND enabled = ?");
+      params.add(queries.enabled());
     }
 
     if (queries.hasDetails()) {

--- a/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/federation/config/query/PostgresqlExecutor.java
+++ b/libs/idp-server-core-adapter/src/main/java/org/idp/server/core/adapters/datasource/federation/config/query/PostgresqlExecutor.java
@@ -30,7 +30,7 @@ public class PostgresqlExecutor implements FederationConfigurationSqlExecutor {
 
   String selectSql =
       """
-            SELECT id, type, sso_provider, payload
+            SELECT id, type, sso_provider, payload, enabled
              FROM federation_configurations \n
           """;
 
@@ -123,6 +123,11 @@ public class PostgresqlExecutor implements FederationConfigurationSqlExecutor {
       params.add(queries.ssoProvider());
     }
 
+    if (queries.hasEnabled()) {
+      sql.append(" AND enabled = ?");
+      params.add(queries.enabled());
+    }
+
     if (queries.hasDetails()) {
       for (Map.Entry<String, String> entry : queries.details().entrySet()) {
         String key = entry.getKey();
@@ -138,12 +143,6 @@ public class PostgresqlExecutor implements FederationConfigurationSqlExecutor {
 
   @Override
   public List<Map<String, String>> selectList(Tenant tenant, FederationQueries queries) {
-    return selectList(tenant, queries, false);
-  }
-
-  @Override
-  public List<Map<String, String>> selectList(
-      Tenant tenant, FederationQueries queries, boolean includeDisabled) {
 
     SqlExecutor sqlExecutor = new SqlExecutor();
 
@@ -151,10 +150,6 @@ public class PostgresqlExecutor implements FederationConfigurationSqlExecutor {
 
     List<Object> params = new ArrayList<>();
     params.add(tenant.identifierUUID());
-
-    if (!includeDisabled) {
-      sql.append("\n  AND enabled = true");
-    }
 
     if (queries.hasFrom()) {
       sql.append("\n  AND created_at >= ?");
@@ -176,6 +171,10 @@ public class PostgresqlExecutor implements FederationConfigurationSqlExecutor {
     if (queries.hasSsoProvider()) {
       sql.append("\n  AND sso_provider = ?");
       params.add(queries.ssoProvider());
+    }
+    if (queries.hasEnabled()) {
+      sql.append("\n  AND enabled = ?");
+      params.add(queries.enabled());
     }
 
     if (queries.hasDetails()) {

--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/federation/FederationQueries.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/federation/FederationQueries.java
@@ -77,6 +77,14 @@ public class FederationQueries implements UuidConvertable {
     return values.containsKey("sso_provider");
   }
 
+  public boolean hasEnabled() {
+    return values.containsKey("enabled") && !values.get("enabled").isEmpty();
+  }
+
+  public Boolean enabled() {
+    return Boolean.valueOf(values.get("enabled"));
+  }
+
   public boolean hasDetails() {
     return !details().isEmpty();
   }


### PR DESCRIPTION
## 概要

Issue #1743。Federation 設定更新で `enabled` が常に `true` に戻り、無効化(`enabled=false`)が保存できない問題を修正。あわせて `ClientConfiguration` と比較して判明した enabled まわりの不整合（read/create/list）も揃える。

## 機序（不整合の全体像）

| 経路 | 修正前 | 原因 |
|---|---|---|
| **update** | `enabled=false` 送っても true に戻る | 4引数コンストラクタで再構築（enabled 固定） |
| **read (GET)** | 常に true | query の SELECT が `enabled` 列を取らず ModelConverter も4引数 |
| **create** | `enabled=false` 無視 | 手動抽出 + 4引数コンストラクタ |
| **list** | disabled が常に消える | selectList が hardcode `AND enabled = true`、`enabled` フィルタ無し |

`ClientConfiguration` / `ClientUpdateService` は全置換(`jsonConverter.read`)+ enabled 列/フィルタで一貫していたため、それに揃える。

## 変更

- **update / create**: `map.put("id", ...)` → `jsonConverter.read(map, FederationConfiguration.class)` で全置換（`ClientUpdateService` と同型）。`enabled`/`type`/`sso_provider` を request から反映、id は path 由来（update）/ 生成（create）。
- **read**: query `ModelConverter` が `enabled` 列を読む（両DB対応 `parseDatabaseBoolean`）+ PG/MySQL の SELECT に `enabled` 追加。
- **list**: `FederationQueries` に `enabled` フィルタ追加、`selectList`/`selectCount` を **default 全件 + `enabled` クエリフィルタ**に（管理リストで disabled も見える＝admin がデータ確認可能。client と同型）。`selectList(..., includeDisabled)` オーバーロードは除去。
  - **`selectOne` の `includeDisabled` は不変**（ランタイム federation フローが「enabled のみ取得」で依存）。
- **OpenAPI**: `OrganizationFederationConfigUpdateRequest` を全置換セマンティクスに（#1742 rework の記述漏れ追補含む）。

## テスト

- **単体**: `FederationConfigCreationServiceTest`（enabled 反映 / id 生成 / id 明示）+ `FederationConfigUpdateServiceTest`（全置換 / id は path / enabled 反映）+ `FederationConfigurationTest`（toMap）。
- **E2E**: disabled が管理 list に出る / `?enabled=true` で絞れる / GET は enabled=false / create enabled=false が honor / 不正 create は **400 invalid_request**（旧 NPE→500 から改善）。**デプロイ後 federation E2E 25件 green**。

## follow-up（別件・本PRスコープ外）

不正 create（`{invalid:"data"}`）の 400 レスポンスの `error_description` に**生の DB エラー（テーブル/カラム名・制約・失敗行の値）が漏れている**。これは「DB例外→invalid_request」マッピングが SQLException メッセージをそのまま echo する**全 constraint 違反共通の既存挙動**で、本PRが該当経路を露出させた。別 Issue で sanitize 対応予定。

🤖 Generated with [Claude Code](https://claude.com/claude-code)