### PR TITLE
fix(tenant): テナント更新で name が反映されない問題を修正 (#1745)

### DIFF
--- a/e2e/src/tests/scenario/control_plane/organization/organization_tenant_management.test.js
+++ b/e2e/src/tests/scenario/control_plane/organization/organization_tenant_management.test.js
@@ -297,13 +297,14 @@ describe("organization tenant management api", () => {
       expect(detailResponse.data).toHaveProperty("name");
 
       // Update tenant
+      const updatedTenantName = `Updated Organization Tenant ${timestamp}`;
       const updateResponse = await putWithJson({
         url: `${backendUrl}/v1/management/organizations/${orgId}/tenants/${tenantId}`,
         headers: {
           Authorization: `Bearer ${accessToken}`,
         },
         body: {
-          "name": `Updated Organization Tenant ${timestamp}`,
+          "name": updatedTenantName,
           "description": "Updated description for organization tenant",
           "domain": "BUSINESS"
         }
@@ -311,6 +312,18 @@ describe("organization tenant management api", () => {
       console.log("Update tenant response:", updateResponse.data);
       expect(updateResponse.status).toBe(200);
       expect(updateResponse.data).toHaveProperty("result");
+      // #1745: the request name must be reflected (previously before.name() was used, ignoring it).
+      expect(updateResponse.data.result.name).toBe(updatedTenantName);
+
+      // Confirm the new name is persisted.
+      const afterUpdateDetail = await get({
+        url: `${backendUrl}/v1/management/organizations/${orgId}/tenants/${tenantId}`,
+        headers: {
+          Authorization: `Bearer ${accessToken}`
+        }
+      });
+      expect(afterUpdateDetail.status).toBe(200);
+      expect(afterUpdateDetail.data.name).toBe(updatedTenantName);
 
       // Delete tenant
       const deleteResponse = await deletion({

--- a/e2e/src/tests/scenario/control_plane/organization/organization_tenant_management_structured.test.js
+++ b/e2e/src/tests/scenario/control_plane/organization/organization_tenant_management_structured.test.js
@@ -425,8 +425,8 @@ describe("Organization Tenant Management API - Structured Tests", () => {
         });
 
         expect(response.status).toBe(200);
-        // Note: API currently doesn't update name field, this is expected behavior
-        expect(response.data).toHaveProperty("result");
+        // #1745: the request name is now reflected (previously ignored via before.name()).
+        expect(response.data.result.name).toBe(updatedName);
 
         // Cleanup
         await deleteTestTenant(tenant.id);

--- a/e2e/src/tests/scenario/control_plane/organization/organization_tenant_management_structured.test.js
+++ b/e2e/src/tests/scenario/control_plane/organization/organization_tenant_management_structured.test.js
@@ -234,8 +234,9 @@ describe("Organization Tenant Management API - Structured Tests", () => {
         });
 
         expect(response.status).toBe(200);
-        // Note: API currently doesn't update the name field, this is expected behavior
         expect(response.data).toHaveProperty("result");
+        // #1745: the request name is now reflected (previously ignored via before.name()).
+        expect(response.data.result.name).toBe(updatedName);
 
         // Cleanup
         await deleteTestTenant(tenant.id);

--- a/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/tenant/handler/TenantUpdateService.java
+++ b/libs/idp-server-control-plane/src/main/java/org/idp/server/control_plane/management/tenant/handler/TenantUpdateService.java
@@ -148,7 +148,7 @@ public class TenantUpdateService implements TenantManagementService<TenantUpdate
 
     return new Tenant(
         before.identifier(),
-        before.name(),
+        tenantRequest.tenantName(),
         before.type(),
         tenantRequest.tenantDomain(),
         before.authorizationProvider(),


### PR DESCRIPTION
Closes #1745

## 概要

テナント更新API（PUT `/management/tenants/{id}`）で **request body に `name` を入れても反映されない**問題を修正。更新レスポンスの `diff` も空になっていた。

## 原因

`TenantUpdateService.updateTenant()` が `after` テナントを組む際、request の name ではなく **`before.name()`（既存 name）を渡していた**。before/after の name が一致するため diff が空になり、永続化しても変化しない。作成側 `TenantCreationService` は `tenantRequest.tenantName()` を使っており、更新側だけ不整合だった。

## 変更

- `before.name()` → `tenantRequest.tenantName()`（`identifier` / `type` / `authorizationProvider` / `mainOrganizationIdentifier` は不変項目として before 維持）。
- **E2E**: org / structured の tenant update テストは name 更新を検証しておらず、structured には `// API currently doesn't update name field, this is expected behavior` という**バグを追認する古いコメント**が残っていた。→ 両方で update レスポンスの `result.name`（+ org は GET で永続化）を検証するよう強化＋コメント修正。**デプロイ前 red（旧 name のまま）→ デプロイ後 green** を確認。

単体テストは `Tenant` が14引数の値オブジェクト構築で1行修正に対し過剰なため E2E で担保。

## 補足（別件・pre-existing / 本修正と無関係）

`organization_tenant_management.test.js` と `..._structured.test.js` を**並列実行**すると delete(403) / pagination が稀に落ちる。原因は**レプリカラグ**: テナント登録は primary、管理APIの参照（delete の認可チェック＝operator へのテナント割当確認 / pagination の一覧）は replica を読むため、create 直後に操作するとラグで割当・レコードが replica に未反映となり **403（未アサイン）/ 件数不一致**になる。並列実行は負荷でラグが増大するため顕在化しやすい。**各ファイル単独では全 green**（org 12 / structured 27）。テスト側で create 後に read-your-writes 待ち（retry/短 sleep）を入れるのが対処。