### PR TITLE
feat(grant): grant 管理 API のレスポンスに不足フィールドを追加 (#1729)

### DIFF
--- a/.claude/skills/spec-grant/skill.md
+++ b/.claude/skills/spec-grant/skill.md
@@ -110,7 +110,10 @@ public class AuthorizationGranted {
     LocalDateTime updatedAt;
 
     public Map<String, Object> toMap() {
-        // id, user, client, scopes, created_at, updated_at を返す
+        // 常時: id, user, client, grant_type, scopes, created_at, updated_at
+        // 存在時のみ: authorization_details, id_token_claims, userinfo_claims,
+        //           custom_properties, consent_claims
+        // （#1729 で grant_type / authorization_details / *_claims / custom_properties を追加）
     }
 }
 ```
@@ -205,11 +208,38 @@ public class ConsentClaim {
 | `OAuthAuthorizeContext.java` | AuthorizationGrant生成時にConsentClaimsを含める |
 | `ClientConfiguration.java` | クライアントの tosUri / policyUri を保持 |
 
-## Grantが作成されるタイミング
+## Grant更新フローと grant_type
 
-- Authorization Code Flowでの同意時
-- Password Grantでのトークン発行時（スコープはマージされる）
-- その他のGrant Typeでのトークン発行時
+### 永続化トリガ（user+client 単位で register または merge-update）
+
+いずれも `registerOrUpdateAuthorizationGranted` パターン。既存 grant があれば
+`latest.merge(new)` → `update`、無ければ `register`。
+
+| フロー | grant_type | ハンドラ |
+|--------|-----------|---------|
+| 認可コード | `authorization_code` | `OAuthAuthorizeHandler`（`OAuthAuthorizeContext` が設定） |
+| Password | `password` | `ResourceOwnerPasswordCredentialsGrantService` |
+| CIBA | `ciba` | `CibaAuthorizeHandler` |
+
+### grant_type は last-wins（scopes は累積）
+
+`AuthorizationGrant.merge()` は **grant_type を `newAuthorizationGrant.grantType()` で置換**する一方、
+scopes は和集合でマージする。DB も `UPDATE authorization_granted SET ... grant_type = ?` で置換値を永続化。
+→ 同一 user+client が異なるフローで再確立されると、grant_type は**最後のフロー**を指し、
+scopes は累積値になる（両者の由来がズレうる）。
+
+### この API に現れない grant_type
+
+- **client_credentials**: ユーザー同意が無く `authorization_granted` 行を作らない（`oauth_token` のみ register）
+  → Grant 管理には出てこない。
+- **refresh_token**: `authorization_granted` を更新しない → grant_type を変えない。
+
+→ `authorization_granted.grant_type` は実質 **{authorization_code, password, ciba}** のみ。
+
+### 型
+
+grant_type は単一スカラー（`GrantType` enum / DB `VARCHAR(255) NOT NULL`）。複数値は保持できない。
+未知・不正値は `GrantType.of()` が `GrantType.unknown`（value `""`）に落とす（クラッシュしない）。
 
 ## E2Eテスト
 

--- a/documentation/openapi/swagger-cp-grant-management-ja.yaml
+++ b/documentation/openapi/swagger-cp-grant-management-ja.yaml
@@ -102,6 +102,7 @@ paths:
                     client:
                       client_id: "my-client-app"
                       client_name: "My Application"
+                    grant_type: "authorization_code"
                     scopes:
                       - "openid"
                       - "profile"
@@ -159,10 +160,22 @@ paths:
                 client:
                   client_id: "my-client-app"
                   client_name: "My Application"
+                grant_type: "authorization_code"
                 scopes:
                   - "openid"
                   - "profile"
                   - "email"
+                authorization_details:
+                  - type: "payment_initiation"
+                    actions:
+                      - "initiate"
+                id_token_claims:
+                  - "sub"
+                  - "email"
+                userinfo_claims:
+                  - "name"
+                custom_properties:
+                  department: "sales"
                 created_at: "2025-01-15T10:30:00Z"
                 updated_at: "2025-01-20T14:00:00Z"
         '401':
@@ -323,11 +336,37 @@ components:
           $ref: '#/components/schemas/GrantUser'
         client:
           $ref: '#/components/schemas/GrantClient'
+        grant_type:
+          type: string
+          description: |
+            グラントのフロー種別。
+            authorization_code / client_credentials / refresh_token 等。
+            client_credentials（ユーザー同意なし）と authorization_code の判別に使用します。
+          example: "authorization_code"
         scopes:
           type: array
           items:
             type: string
           description: 付与されたスコープの一覧
+        authorization_details:
+          type: array
+          items:
+            type: object
+          description: 付与された authorization_details（RFC 9396 RAR）。存在する場合のみ出力されます。
+        id_token_claims:
+          type: array
+          items:
+            type: string
+          description: ID Token に対して要求・許可されたクレーム名の一覧。存在する場合のみ出力されます。
+        userinfo_claims:
+          type: array
+          items:
+            type: string
+          description: UserInfo に対して要求・許可されたクレーム名の一覧。存在する場合のみ出力されます。
+        custom_properties:
+          type: object
+          additionalProperties: true
+          description: グラントに紐づくカスタムプロパティ。存在する場合のみ出力されます。
         created_at:
           type: string
           format: date-time
@@ -340,6 +379,7 @@ components:
         - id
         - user
         - client
+        - grant_type
         - scopes
 
     GrantUser:

--- a/documentation/openapi/swagger-cp-grant-management-ja.yaml
+++ b/documentation/openapi/swagger-cp-grant-management-ja.yaml
@@ -339,9 +339,15 @@ components:
         grant_type:
           type: string
           description: |
-            グラントのフロー種別。
-            authorization_code / client_credentials / refresh_token 等。
-            client_credentials（ユーザー同意なし）と authorization_code の判別に使用します。
+            このグラントを最後に確立/更新した user-consent フローの種別（last-wins）。
+            値は `authorization_code` / `password` / `ciba` のいずれか。
+
+            - scopes は複数フローで累積マージされるが grant_type は最新フローで置換されるため、
+              同一 user+client が異なるフローで再確立されると grant_type は最後のフローを指し、
+              累積された scopes の由来とは一致しないことがある。
+            - `client_credentials` はユーザー同意が無くグラント（authorization_granted）を作らないため、
+              このAPIには現れない。
+            - `refresh_token` はグラントを更新しないため grant_type を変更しない。
           example: "authorization_code"
         scopes:
           type: array

--- a/e2e/src/tests/scenario/control_plane/organization/organization_grant_management.test.js
+++ b/e2e/src/tests/scenario/control_plane/organization/organization_grant_management.test.js
@@ -64,14 +64,17 @@ describe("organization grant management api", () => {
       expect(listResponse.data).toHaveProperty("limit", 10);
       expect(listResponse.data).toHaveProperty("offset", 0);
 
-      // Save grant ID for subsequent tests
-      if (listResponse.data.list.length > 0) {
-        grantId = listResponse.data.list[0].id;
-        console.log("Found grant ID:", grantId);
-        // #1729: grant_type must be present on list entries so client_credentials
-        // (no user consent) can be distinguished from authorization_code grants.
-        expect(listResponse.data.list[0]).toHaveProperty("grant_type");
-      }
+      // beforeAll issues a password grant (which creates an authorization_granted row) and
+      // this tenant persists across runs, so the list must be non-empty. Assert it instead of
+      // silently skipping, then verify grant_type is exposed on every entry.
+      expect(listResponse.data.list.length).toBeGreaterThan(0);
+      grantId = listResponse.data.list[0].id;
+      console.log("Found grant ID:", grantId);
+      // #1729: grant_type is exposed on list entries. In this API it is always one of
+      // authorization_code / password / ciba (client_credentials creates no grant row).
+      listResponse.data.list.forEach((grant) =>
+        expect(grant).toHaveProperty("grant_type")
+      );
     });
 
     it("get specific grant details", async () => {

--- a/e2e/src/tests/scenario/control_plane/organization/organization_grant_management.test.js
+++ b/e2e/src/tests/scenario/control_plane/organization/organization_grant_management.test.js
@@ -68,6 +68,9 @@ describe("organization grant management api", () => {
       if (listResponse.data.list.length > 0) {
         grantId = listResponse.data.list[0].id;
         console.log("Found grant ID:", grantId);
+        // #1729: grant_type must be present on list entries so client_credentials
+        // (no user consent) can be distinguished from authorization_code grants.
+        expect(listResponse.data.list[0]).toHaveProperty("grant_type");
       }
     });
 
@@ -87,6 +90,13 @@ describe("organization grant management api", () => {
       console.log("Grant detail response:", JSON.stringify(detailResponse.data, null, 2));
       expect(detailResponse.status).toBe(200);
       expect(detailResponse.data).toHaveProperty("id", grantId);
+      // #1729: grant_type (and scopes) must be exposed. list[0] is an arbitrary grant in a
+      // shared tenant, so assert the field is present and well-formed rather than a fixed value.
+      // The exact grant_type/optional-field serialization is pinned by AuthorizationGrantedTest.
+      expect(detailResponse.data).toHaveProperty("grant_type");
+      expect(typeof detailResponse.data.grant_type).toBe("string");
+      expect(detailResponse.data.grant_type.length).toBeGreaterThan(0);
+      expect(Array.isArray(detailResponse.data.scopes)).toBe(true);
     });
 
     it("filter grants by user_id", async () => {

--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/grant_management/AuthorizationGranted.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/grant_management/AuthorizationGranted.java
@@ -17,6 +17,7 @@
 package org.idp.server.core.openid.grant_management;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 import org.idp.server.core.openid.grant_management.grant.AuthorizationGrant;
@@ -123,8 +124,34 @@ public class AuthorizationGranted {
       }
       map.put("client", clientMap);
 
+      if (authorizationGrant.grantType() != null) {
+        map.put("grant_type", authorizationGrant.grantType().value());
+      }
+
       if (authorizationGrant.scopes() != null) {
         map.put("scopes", authorizationGrant.scopes().toStringList());
+      }
+
+      if (authorizationGrant.authorizationDetails() != null
+          && authorizationGrant.authorizationDetails().exists()) {
+        map.put("authorization_details", authorizationGrant.authorizationDetails().toMapValues());
+      }
+
+      if (authorizationGrant.idTokenClaims() != null
+          && authorizationGrant.idTokenClaims().exists()) {
+        map.put(
+            "id_token_claims", new ArrayList<>(authorizationGrant.idTokenClaims().toStringSet()));
+      }
+
+      if (authorizationGrant.userinfoClaims() != null
+          && authorizationGrant.userinfoClaims().exists()) {
+        map.put(
+            "userinfo_claims", new ArrayList<>(authorizationGrant.userinfoClaims().toStringSet()));
+      }
+
+      if (authorizationGrant.customProperties() != null
+          && authorizationGrant.customProperties().exists()) {
+        map.put("custom_properties", authorizationGrant.customProperties().values());
       }
 
       if (authorizationGrant.consentClaims() != null

--- a/libs/idp-server-core/src/test/java/org/idp/server/core/openid/grant_management/AuthorizationGrantedTest.java
+++ b/libs/idp-server-core/src/test/java/org/idp/server/core/openid/grant_management/AuthorizationGrantedTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2025 Hirokazu Kobayashi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.idp.server.core.openid.grant_management;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.idp.server.core.openid.grant_management.grant.AuthorizationGrant;
+import org.idp.server.core.openid.grant_management.grant.AuthorizationGrantBuilder;
+import org.idp.server.core.openid.grant_management.grant.GrantIdTokenClaims;
+import org.idp.server.core.openid.grant_management.grant.GrantUserinfoClaims;
+import org.idp.server.core.openid.oauth.configuration.client.ClientAttributes;
+import org.idp.server.core.openid.oauth.rar.AuthorizationDetails;
+import org.idp.server.core.openid.oauth.type.extension.CustomProperties;
+import org.idp.server.core.openid.oauth.type.oauth.GrantType;
+import org.idp.server.core.openid.oauth.type.oauth.RequestedClientId;
+import org.idp.server.core.openid.oauth.type.oauth.Scopes;
+import org.idp.server.platform.multi_tenancy.tenant.TenantIdentifier;
+import org.junit.jupiter.api.Test;
+
+/** #1729: the grant management response must expose the fields the model actually carries. */
+class AuthorizationGrantedTest {
+
+  private AuthorizationGrantBuilder baseBuilder(GrantType grantType, Scopes scopes) {
+    return new AuthorizationGrantBuilder(
+            new TenantIdentifier("11111111-1111-1111-1111-111111111111"),
+            new RequestedClientId("client-x"),
+            grantType,
+            scopes)
+        .add(new ClientAttributes("client-x", null, "My App", null, null, null, null, null));
+  }
+
+  @Test
+  void toMap_exposesAuthorizationGrantModelFields() {
+    AuthorizationGrant grant =
+        baseBuilder(GrantType.authorization_code, new Scopes("openid profile email"))
+            .add(new GrantIdTokenClaims(Set.of("sub", "email")))
+            .add(new GrantUserinfoClaims(Set.of("name")))
+            .add(new CustomProperties(Map.of("department", "sales")))
+            .add(AuthorizationDetails.fromString("[{\"type\":\"payment_initiation\"}]"))
+            .build();
+
+    Map<String, Object> map =
+        new AuthorizationGranted(new AuthorizationGrantedIdentifier("grant-1"), grant).toMap();
+
+    assertEquals("authorization_code", map.get("grant_type"));
+
+    assertEquals(
+        Set.of("openid", "profile", "email"), new HashSet<>(asStringList(map.get("scopes"))));
+
+    @SuppressWarnings("unchecked")
+    List<Map<String, Object>> details =
+        (List<Map<String, Object>>) map.get("authorization_details");
+    assertEquals(1, details.size());
+    assertEquals("payment_initiation", details.get(0).get("type"));
+
+    assertEquals(Set.of("sub", "email"), new HashSet<>(asStringList(map.get("id_token_claims"))));
+    assertEquals(Set.of("name"), new HashSet<>(asStringList(map.get("userinfo_claims"))));
+
+    @SuppressWarnings("unchecked")
+    Map<String, Object> customProperties = (Map<String, Object>) map.get("custom_properties");
+    assertEquals("sales", customProperties.get("department"));
+  }
+
+  @Test
+  void toMap_omitsEmptyOptionalFields() {
+    AuthorizationGrant grant =
+        baseBuilder(GrantType.client_credentials, new Scopes("openid")).build();
+
+    Map<String, Object> map =
+        new AuthorizationGranted(new AuthorizationGrantedIdentifier("grant-2"), grant).toMap();
+
+    // grant_type is always present; it distinguishes client_credentials from authorization_code.
+    assertEquals("client_credentials", map.get("grant_type"));
+    // Optional fields are only emitted when present, matching the existing consent_claims behavior.
+    assertFalse(map.containsKey("authorization_details"));
+    assertFalse(map.containsKey("id_token_claims"));
+    assertFalse(map.containsKey("userinfo_claims"));
+    assertFalse(map.containsKey("custom_properties"));
+  }
+
+  @SuppressWarnings("unchecked")
+  private List<String> asStringList(Object value) {
+    return (List<String>) value;
+  }
+}


### PR DESCRIPTION
Closes #1729

## 概要

grant 管理 API のレスポンスが `AuthorizationGrant` モデルの一部しか返しておらず、特にフロー種別を判別する **`grant_type` が欠落**していた。監査・調査でグラントの実体（種別 / RAR / claims / custom properties）を確認できるよう、不足フィールドを追加する。

## 対象

- `GET /v1/management/organizations/{org}/tenants/{tenant}/grants`（一覧）
- `GET /v1/management/organizations/{org}/tenants/{tenant}/grants/{grant-id}`（詳細）

list / detail は共に `AuthorizationGranted.toMap()` を通る（`GrantFindListService` / `GrantFindService`）ため、**1箇所の追加で両エンドポイントを是正**。

## 変更

`AuthorizationGranted.toMap()` に以下を追加。いずれも読み取り経路 `ModelConverter.convert()` で DB から復元済みで、**追加クエリは発生しない**。

| フィールド | 出力条件 | 用途 |
|---|---|---|
| `grant_type` | **常時** | client_credentials（同意なし）と authorization_code の判別（最優先） |
| `authorization_details` | 存在時のみ | RFC 9396 RAR |
| `id_token_claims` | 存在時のみ | ID Token に要求・許可されたクレーム名 |
| `userinfo_claims` | 存在時のみ | UserInfo に要求・許可されたクレーム名 |
| `custom_properties` | 存在時のみ | グラント紐づきカスタムプロパティ |

optional フィールドの「存在時のみ出力」は既存の `consent_claims` と同じ方針。

## 検証

- **Unit** `AuthorizationGrantedTest`（新規）: 全フィールドの出力内容 + 空の場合に optional が省略されることを固定
- **E2E** `organization_grant_management.test.js`: detail に `grant_type`/`scopes`、list に `grant_type` 存在を追加 → **10/10 green**
  - ※ 共有テナントの list は最新グラントが不定のため、E2E は「フィールドが実スタックを通って出る」ことの確認に留め、正確な値は unit で担保
- **OpenAPI** `swagger-cp-grant-management-ja.yaml`: `Grant` スキーマに5フィールド追加、`grant_type` を required に、例を更新