### PR TITLE
refactor(platform): HttpRequestInputs 導入 + 全エンドポイント DTO を canonical 形に移行 (Phase 2 of #1527)

### DIFF
--- a/libs/idp-server-core-extension-ciba/src/main/java/org/idp/server/core/extension/ciba/CibaFlowApi.java
+++ b/libs/idp-server-core-extension-ciba/src/main/java/org/idp/server/core/extension/ciba/CibaFlowApi.java
@@ -16,13 +16,13 @@
 
 package org.idp.server.core.extension.ciba;
 
-import java.util.Map;
 import org.idp.server.core.extension.ciba.handler.io.CibaRequestResponse;
 import org.idp.server.core.extension.ciba.request.BackchannelAuthenticationRequestIdentifier;
 import org.idp.server.core.openid.authentication.AuthenticationInteractionRequest;
 import org.idp.server.core.openid.authentication.AuthenticationInteractionRequestResult;
 import org.idp.server.core.openid.authentication.AuthenticationInteractionType;
 import org.idp.server.core.openid.authentication.AuthenticationTransaction;
+import org.idp.server.platform.http.HttpRequestInputs;
 import org.idp.server.platform.multi_tenancy.tenant.Tenant;
 import org.idp.server.platform.multi_tenancy.tenant.TenantIdentifier;
 import org.idp.server.platform.type.RequestAttributes;
@@ -30,9 +30,7 @@ import org.idp.server.platform.type.RequestAttributes;
 public interface CibaFlowApi {
   CibaRequestResponse request(
       TenantIdentifier tenantIdentifier,
-      Map<String, String[]> params,
-      String authorizationHeader,
-      String clientCert,
+      HttpRequestInputs inputs,
       RequestAttributes requestAttributes);
 
   AuthenticationInteractionRequestResult interact(

--- a/libs/idp-server-core-extension-ciba/src/main/java/org/idp/server/core/extension/ciba/handler/io/CibaRequest.java
+++ b/libs/idp-server-core-extension-ciba/src/main/java/org/idp/server/core/extension/ciba/handler/io/CibaRequest.java
@@ -23,32 +23,25 @@ import org.idp.server.core.openid.oauth.type.oauth.ClientSecretBasic;
 import org.idp.server.core.openid.oauth.type.oauth.RequestedClientId;
 import org.idp.server.core.openid.token.AuthorizationHeaderHandlerable;
 import org.idp.server.platform.http.BasicAuth;
+import org.idp.server.platform.http.HttpRequestInputs;
 import org.idp.server.platform.multi_tenancy.tenant.Tenant;
 
 public class CibaRequest implements AuthorizationHeaderHandlerable {
 
   Tenant tenant;
-  String authorizationHeaders;
-  Map<String, String[]> params;
-  String clientCert;
+  HttpRequestInputs inputs;
 
-  public CibaRequest(Tenant tenant, String authorizationHeaders, Map<String, String[]> params) {
+  public CibaRequest(Tenant tenant, HttpRequestInputs inputs) {
     this.tenant = tenant;
-    this.authorizationHeaders = authorizationHeaders;
-    this.params = params;
-  }
-
-  public CibaRequest setClientCert(String clientCert) {
-    this.clientCert = clientCert;
-    return this;
+    this.inputs = inputs;
   }
 
   public Map<String, String[]> getParams() {
-    return params;
+    return inputs.bodyParameters();
   }
 
   public String clientCert() {
-    return clientCert;
+    return inputs.tlsClientCertPem();
   }
 
   public Tenant tenant() {
@@ -56,7 +49,7 @@ public class CibaRequest implements AuthorizationHeaderHandlerable {
   }
 
   public CibaRequestParameters toParameters() {
-    return new CibaRequestParameters(params);
+    return new CibaRequestParameters(inputs.bodyParameters());
   }
 
   /**
@@ -84,6 +77,7 @@ public class CibaRequest implements AuthorizationHeaderHandlerable {
     if (parameters.hasClientId()) {
       return parameters.clientId();
     }
+    String authorizationHeaders = inputs.authorizationHeader();
     if (isBasicAuth(authorizationHeaders)) {
       BasicAuth basicAuth = convertBasicAuth(authorizationHeaders);
       return new RequestedClientId(basicAuth.username());
@@ -99,6 +93,7 @@ public class CibaRequest implements AuthorizationHeaderHandlerable {
   }
 
   public ClientSecretBasic clientSecretBasic() {
+    String authorizationHeaders = inputs.authorizationHeader();
     if (isBasicAuth(authorizationHeaders)) {
       return new ClientSecretBasic(convertBasicAuth(authorizationHeaders));
     }
@@ -106,7 +101,7 @@ public class CibaRequest implements AuthorizationHeaderHandlerable {
   }
 
   public ClientCert toClientCert() {
-    return new ClientCert(clientCert);
+    return new ClientCert(inputs.tlsClientCertPem());
   }
 
   public boolean hasClientId() {

--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/identity/UserAuthenticationApi.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/identity/UserAuthenticationApi.java
@@ -16,18 +16,13 @@
 
 package org.idp.server.core.openid.identity;
 
-import java.util.List;
 import org.idp.server.core.openid.token.OAuthToken;
+import org.idp.server.platform.http.HttpRequestInputs;
 import org.idp.server.platform.multi_tenancy.tenant.TenantIdentifier;
 import org.idp.server.platform.type.Pairs;
 
 public interface UserAuthenticationApi {
 
   Pairs<User, OAuthToken> authenticate(
-      TenantIdentifier adminTenantIdentifier,
-      String authorizationHeader,
-      String clientCert,
-      List<String> dpopProofHeaders,
-      String httpMethod,
-      String httpUri);
+      TenantIdentifier adminTenantIdentifier, HttpRequestInputs inputs);
 }

--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/oauth/OAuthFlowApi.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/oauth/OAuthFlowApi.java
@@ -16,7 +16,6 @@
 
 package org.idp.server.core.openid.oauth;
 
-import java.util.List;
 import java.util.Map;
 import org.idp.server.core.openid.authentication.AuthenticationInteractionRequest;
 import org.idp.server.core.openid.authentication.AuthenticationInteractionRequestResult;
@@ -29,6 +28,7 @@ import org.idp.server.core.openid.federation.io.FederationRequestResponse;
 import org.idp.server.core.openid.federation.sso.SsoProvider;
 import org.idp.server.core.openid.oauth.io.*;
 import org.idp.server.core.openid.oauth.request.AuthorizationRequestIdentifier;
+import org.idp.server.platform.http.HttpRequestInputs;
 import org.idp.server.platform.multi_tenancy.tenant.Tenant;
 import org.idp.server.platform.multi_tenancy.tenant.TenantIdentifier;
 import org.idp.server.platform.type.RequestAttributes;
@@ -37,10 +37,7 @@ public interface OAuthFlowApi {
 
   OAuthPushedRequestResponse push(
       TenantIdentifier tenantIdentifier,
-      Map<String, String[]> params,
-      String authorizationHeader,
-      String clientCert,
-      List<String> dpopProofHeaders,
+      HttpRequestInputs inputs,
       RequestAttributes requestAttributes);
 
   OAuthRequestResponse request(

--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/oauth/handler/OAuthRequestHandler.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/oauth/handler/OAuthRequestHandler.java
@@ -208,7 +208,7 @@ public class OAuthRequestHandler {
       OAuthRequestParameters requestParameters,
       Tenant tenant,
       AuthorizationServerConfiguration authorizationServerConfiguration) {
-    if (pushedRequest.dpopProofHeaders() == null || pushedRequest.dpopProofHeaders().isEmpty()) {
+    if (pushedRequest.dpopProofHeaders().isEmpty()) {
       return requestParameters;
     }
     DPoPProof dpopProof = new DPoPProof(pushedRequest.dpopProofHeaders().get(0));

--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/oauth/io/OAuthPushedRequest.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/oauth/io/OAuthPushedRequest.java
@@ -25,63 +25,37 @@ import org.idp.server.core.openid.oauth.type.oauth.ClientSecretBasic;
 import org.idp.server.core.openid.oauth.type.oauth.RequestedClientId;
 import org.idp.server.core.openid.token.AuthorizationHeaderHandlerable;
 import org.idp.server.platform.http.BasicAuth;
+import org.idp.server.platform.http.HttpRequestInputs;
 import org.idp.server.platform.multi_tenancy.tenant.Tenant;
 
 public class OAuthPushedRequest implements AuthorizationHeaderHandlerable {
 
   Tenant tenant;
-  String authorizationHeaders;
-  Map<String, String[]> params;
-  String clientCert;
-  List<String> dpopProofHeaders;
-  String httpMethod;
-  String httpUri;
+  HttpRequestInputs inputs;
 
-  public OAuthPushedRequest(
-      Tenant tenant, String authorizationHeaders, Map<String, String[]> params) {
+  public OAuthPushedRequest(Tenant tenant, HttpRequestInputs inputs) {
     this.tenant = tenant;
-    this.authorizationHeaders = authorizationHeaders;
-    this.params = params;
-  }
-
-  public OAuthPushedRequest setClientCert(String clientCert) {
-    this.clientCert = clientCert;
-    return this;
-  }
-
-  public OAuthPushedRequest setDPoPProofHeaders(List<String> dpopProofHeaders) {
-    this.dpopProofHeaders = dpopProofHeaders;
-    return this;
+    this.inputs = inputs;
   }
 
   public List<String> dpopProofHeaders() {
-    return dpopProofHeaders;
-  }
-
-  public OAuthPushedRequest setHttpMethod(String httpMethod) {
-    this.httpMethod = httpMethod;
-    return this;
+    return inputs.headerValues("DPoP");
   }
 
   public String httpMethod() {
-    return httpMethod != null ? httpMethod : "POST";
-  }
-
-  public OAuthPushedRequest setHttpUri(String httpUri) {
-    this.httpUri = httpUri;
-    return this;
+    return inputs.httpMethod() != null ? inputs.httpMethod() : "POST";
   }
 
   public String httpUri() {
-    return httpUri != null ? httpUri : "";
+    return inputs.httpUri() != null ? inputs.httpUri() : "";
   }
 
   public Map<String, String[]> getParams() {
-    return params;
+    return inputs.bodyParameters();
   }
 
   public String clientCert() {
-    return clientCert;
+    return inputs.tlsClientCertPem();
   }
 
   public Tenant tenant() {
@@ -89,11 +63,11 @@ public class OAuthPushedRequest implements AuthorizationHeaderHandlerable {
   }
 
   public OAuthPushedRequestParameters toBackchannelParameters() {
-    return new OAuthPushedRequestParameters(params);
+    return new OAuthPushedRequestParameters(inputs.bodyParameters());
   }
 
   public OAuthRequestParameters toOAuthRequestParameters() {
-    return new OAuthRequestParameters(params);
+    return new OAuthRequestParameters(inputs.bodyParameters());
   }
 
   /**
@@ -116,6 +90,7 @@ public class OAuthPushedRequest implements AuthorizationHeaderHandlerable {
     if (parameters.hasClientId()) {
       return parameters.clientId();
     }
+    String authorizationHeaders = inputs.authorizationHeader();
     if (isBasicAuth(authorizationHeaders)) {
       BasicAuth basicAuth = convertBasicAuth(authorizationHeaders);
       return new RequestedClientId(basicAuth.username());
@@ -135,6 +110,7 @@ public class OAuthPushedRequest implements AuthorizationHeaderHandlerable {
   }
 
   public ClientSecretBasic clientSecretBasic() {
+    String authorizationHeaders = inputs.authorizationHeader();
     if (isBasicAuth(authorizationHeaders)) {
       return new ClientSecretBasic(convertBasicAuth(authorizationHeaders));
     }
@@ -142,6 +118,6 @@ public class OAuthPushedRequest implements AuthorizationHeaderHandlerable {
   }
 
   public ClientCert toClientCert() {
-    return new ClientCert(clientCert);
+    return new ClientCert(inputs.tlsClientCertPem());
   }
 }

--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/token/TokenApi.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/token/TokenApi.java
@@ -16,29 +16,21 @@
 
 package org.idp.server.core.openid.token;
 
-import java.util.List;
-import java.util.Map;
 import org.idp.server.core.openid.token.handler.token.io.TokenRequestResponse;
 import org.idp.server.core.openid.token.handler.tokenintrospection.io.TokenIntrospectionResponse;
 import org.idp.server.core.openid.token.handler.tokenrevocation.io.TokenRevocationResponse;
+import org.idp.server.platform.http.HttpRequestInputs;
 import org.idp.server.platform.multi_tenancy.tenant.TenantIdentifier;
 import org.idp.server.platform.type.RequestAttributes;
 
 public interface TokenApi {
 
   TokenRequestResponse request(
-      TenantIdentifier tenantId,
-      Map<String, String[]> params,
-      String authorizationHeader,
-      String clientCert,
-      List<String> dpopProofHeaders,
-      RequestAttributes requestAttributes);
+      TenantIdentifier tenantId, HttpRequestInputs inputs, RequestAttributes requestAttributes);
 
   TokenIntrospectionResponse inspect(
       TenantIdentifier tenantIdentifier,
-      Map<String, String[]> params,
-      String authorizationHeader,
-      String clientCert,
+      HttpRequestInputs inputs,
       RequestAttributes requestAttributes);
 
   /**
@@ -46,23 +38,17 @@ public interface TokenApi {
    *
    * <p>The Resource Server forwards the artifacts the Client presented at the resource endpoint via
    * the request body parameters: {@code client_cert} (mTLS, RFC 8705), {@code dpop_proof} (DPoP,
-   * RFC 9449) and the corresponding {@code dpop_htm} / {@code dpop_htu}. The {@code clientCert}
-   * parameter passed here is the RS's own TLS client certificate used to authenticate to the AS,
-   * which is independent from the token-binding cert.
+   * RFC 9449) and the corresponding {@code dpop_htm} / {@code dpop_htu}. The TLS client certificate
+   * carried in {@code inputs} is the RS's own certificate used to authenticate to the AS, which is
+   * independent from the token-binding cert.
    */
   TokenIntrospectionResponse inspectWithVerification(
       TenantIdentifier tenantIdentifier,
-      Map<String, String[]> params,
-      String authorizationHeader,
-      String clientCert,
+      HttpRequestInputs inputs,
       RequestAttributes requestAttributes);
 
   TokenRevocationResponse revoke(
-      TenantIdentifier tenantId,
-      Map<String, String[]> request,
-      String authorizationHeader,
-      String clientCert,
-      RequestAttributes requestAttributes);
+      TenantIdentifier tenantId, HttpRequestInputs inputs, RequestAttributes requestAttributes);
 
   /**
    * Deletes the access token if it carries the RAR {@code oneshot_token} flag.

--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/token/handler/token/io/TokenRequest.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/token/handler/token/io/TokenRequest.java
@@ -27,73 +27,49 @@ import org.idp.server.core.openid.oauth.type.oauth.RequestedClientId;
 import org.idp.server.core.openid.token.AuthorizationHeaderHandlerable;
 import org.idp.server.core.openid.token.TokenRequestParameters;
 import org.idp.server.platform.http.BasicAuth;
+import org.idp.server.platform.http.HttpRequestInputs;
 import org.idp.server.platform.multi_tenancy.tenant.Tenant;
 
 public class TokenRequest implements AuthorizationHeaderHandlerable {
   Tenant tenant;
-  String authorizationHeaders;
-  Map<String, String[]> params;
-  String clientCert;
-  List<String> dpopProofHeaders;
-  String httpMethod;
-  String httpUri;
+  HttpRequestInputs inputs;
   Map<String, Object> customProperties = new HashMap<>();
 
-  public TokenRequest(Tenant tenant, String authorizationHeaders, Map<String, String[]> params) {
+  public TokenRequest(Tenant tenant, HttpRequestInputs inputs) {
     this.tenant = tenant;
-    this.authorizationHeaders = authorizationHeaders;
-    this.params = params;
-  }
-
-  public TokenRequest setClientCert(String clientCert) {
-    this.clientCert = clientCert;
-    return this;
-  }
-
-  public TokenRequest setDPoPProofHeaders(List<String> dpopProofHeaders) {
-    this.dpopProofHeaders = dpopProofHeaders;
-    return this;
+    this.inputs = inputs;
   }
 
   public List<String> dpopProofHeaders() {
-    return dpopProofHeaders;
-  }
-
-  public TokenRequest setHttpMethod(String httpMethod) {
-    this.httpMethod = httpMethod;
-    return this;
-  }
-
-  public TokenRequest setHttpUri(String httpUri) {
-    this.httpUri = httpUri;
-    return this;
+    return inputs.headerValues("DPoP");
   }
 
   public DPoPProof toDPoPProof() {
-    if (dpopProofHeaders == null || dpopProofHeaders.isEmpty()) {
+    List<String> dpopProofHeaders = dpopProofHeaders();
+    if (dpopProofHeaders.isEmpty()) {
       return new DPoPProof();
     }
     return new DPoPProof(dpopProofHeaders.get(0));
   }
 
   public String httpMethod() {
-    return httpMethod != null ? httpMethod : "POST";
+    return inputs.httpMethod() != null ? inputs.httpMethod() : "POST";
   }
 
   public String httpUri() {
-    return httpUri != null ? httpUri : "";
+    return inputs.httpUri() != null ? inputs.httpUri() : "";
   }
 
   public String getAuthorizationHeaders() {
-    return authorizationHeaders;
+    return inputs.authorizationHeader();
   }
 
   public Map<String, String[]> getParams() {
-    return params;
+    return inputs.bodyParameters();
   }
 
   public String getClientCert() {
-    return clientCert;
+    return inputs.tlsClientCertPem();
   }
 
   public Map<String, Object> customProperties() {
@@ -130,6 +106,7 @@ public class TokenRequest implements AuthorizationHeaderHandlerable {
     if (parameters.hasClientId()) {
       return parameters.clientId();
     }
+    String authorizationHeaders = getAuthorizationHeaders();
     if (isBasicAuth(authorizationHeaders)) {
       BasicAuth basicAuth = convertBasicAuth(authorizationHeaders);
       return new RequestedClientId(basicAuth.username());
@@ -145,6 +122,7 @@ public class TokenRequest implements AuthorizationHeaderHandlerable {
   }
 
   public ClientSecretBasic clientSecretBasic() {
+    String authorizationHeaders = getAuthorizationHeaders();
     if (isBasicAuth(authorizationHeaders)) {
       return new ClientSecretBasic(convertBasicAuth(authorizationHeaders));
     }
@@ -156,7 +134,7 @@ public class TokenRequest implements AuthorizationHeaderHandlerable {
   }
 
   public TokenRequestParameters toParameters() {
-    return new TokenRequestParameters(params);
+    return new TokenRequestParameters(inputs.bodyParameters());
   }
 
   public CustomProperties toCustomProperties() {
@@ -164,7 +142,7 @@ public class TokenRequest implements AuthorizationHeaderHandlerable {
   }
 
   public ClientCert toClientCert() {
-    return new ClientCert(clientCert);
+    return new ClientCert(inputs.tlsClientCertPem());
   }
 
   public boolean isRefreshTokenGrant() {

--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/token/handler/tokenintrospection/io/TokenIntrospectionExtensionRequest.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/token/handler/tokenintrospection/io/TokenIntrospectionExtensionRequest.java
@@ -25,6 +25,7 @@ import org.idp.server.core.openid.oauth.type.oauth.Scopes;
 import org.idp.server.core.openid.token.AuthorizationHeaderHandlerable;
 import org.idp.server.core.openid.token.tokenintrospection.TokenIntrospectionRequestParameters;
 import org.idp.server.platform.http.BasicAuth;
+import org.idp.server.platform.http.HttpRequestInputs;
 import org.idp.server.platform.multi_tenancy.tenant.Tenant;
 
 /**
@@ -50,36 +51,27 @@ import org.idp.server.platform.multi_tenancy.tenant.Tenant;
  */
 public class TokenIntrospectionExtensionRequest implements AuthorizationHeaderHandlerable {
   Tenant tenant;
-  String authorizationHeaders;
-  Map<String, String[]> params;
-  String clientCert;
+  HttpRequestInputs inputs;
 
-  public TokenIntrospectionExtensionRequest(
-      Tenant tenant, String authorizationHeaders, Map<String, String[]> params) {
+  public TokenIntrospectionExtensionRequest(Tenant tenant, HttpRequestInputs inputs) {
     this.tenant = tenant;
-    this.authorizationHeaders = authorizationHeaders;
-    this.params = params;
-  }
-
-  public TokenIntrospectionExtensionRequest setClientCert(String clientCert) {
-    this.clientCert = clientCert;
-    return this;
+    this.inputs = inputs;
   }
 
   public String getAuthorizationHeaders() {
-    return authorizationHeaders;
+    return inputs.authorizationHeader();
   }
 
   public Map<String, String[]> getParams() {
-    return params;
+    return inputs.bodyParameters();
   }
 
   public String getClientCert() {
-    return clientCert;
+    return inputs.tlsClientCertPem();
   }
 
   public TokenIntrospectionRequestParameters toParameters() {
-    return new TokenIntrospectionRequestParameters(params);
+    return new TokenIntrospectionRequestParameters(inputs.bodyParameters());
   }
 
   public Tenant tenant() {
@@ -89,6 +81,7 @@ public class TokenIntrospectionExtensionRequest implements AuthorizationHeaderHa
   public RequestedClientId clientId() {
     TokenIntrospectionRequestParameters parameters = toParameters();
 
+    String authorizationHeaders = inputs.authorizationHeader();
     if (isBasicAuth(authorizationHeaders)) {
       BasicAuth basicAuth = convertBasicAuth(authorizationHeaders);
       return new RequestedClientId(basicAuth.username());
@@ -102,6 +95,7 @@ public class TokenIntrospectionExtensionRequest implements AuthorizationHeaderHa
   }
 
   public ClientSecretBasic clientSecretBasic() {
+    String authorizationHeaders = inputs.authorizationHeader();
     if (isBasicAuth(authorizationHeaders)) {
       return new ClientSecretBasic(convertBasicAuth(authorizationHeaders));
     }
@@ -110,19 +104,19 @@ public class TokenIntrospectionExtensionRequest implements AuthorizationHeaderHa
 
   public String token() {
     if (hasToken()) {
-      return params.get("token")[0];
+      return inputs.bodyParameters().get("token")[0];
     }
     return "";
   }
 
   public boolean hasToken() {
-    return params.containsKey("token");
+    return inputs.bodyParameters().containsKey("token");
   }
 
   public Scopes scopes() {
 
     if (hasScope()) {
-      String scopes = params.get("scope")[0];
+      String scopes = inputs.bodyParameters().get("scope")[0];
 
       return new Scopes(scopes);
     }
@@ -130,13 +124,13 @@ public class TokenIntrospectionExtensionRequest implements AuthorizationHeaderHa
   }
 
   public boolean hasScope() {
-    return params.containsKey("scope");
+    return inputs.bodyParameters().containsKey("scope");
   }
 
   public ClientCert clientCertForTokenBinding() {
 
     if (hasClientCertForTokenBinding()) {
-      String clientCert = params.get("client_cert")[0];
+      String clientCert = inputs.bodyParameters().get("client_cert")[0];
       return new ClientCert(clientCert);
     }
 
@@ -144,11 +138,11 @@ public class TokenIntrospectionExtensionRequest implements AuthorizationHeaderHa
   }
 
   public boolean hasClientCertForTokenBinding() {
-    return params.containsKey("client_cert");
+    return inputs.bodyParameters().containsKey("client_cert");
   }
 
   public ClientCert clientCertFormMtls() {
-    return new ClientCert(clientCert);
+    return new ClientCert(inputs.tlsClientCertPem());
   }
 
   /**
@@ -160,6 +154,7 @@ public class TokenIntrospectionExtensionRequest implements AuthorizationHeaderHa
    * introspection endpoint), which is not what we want to verify here.
    */
   public DPoPProof dpopProof() {
+    Map<String, String[]> params = inputs.bodyParameters();
     if (!params.containsKey("dpop_proof")) {
       return new DPoPProof();
     }
@@ -176,6 +171,7 @@ public class TokenIntrospectionExtensionRequest implements AuthorizationHeaderHa
    * to {@code POST} when not provided (typical for fresh proofs).
    */
   public String httpMethod() {
+    Map<String, String[]> params = inputs.bodyParameters();
     if (params.containsKey("dpop_htm")) {
       String value = params.get("dpop_htm")[0];
       if (value != null && !value.isEmpty()) {
@@ -191,6 +187,7 @@ public class TokenIntrospectionExtensionRequest implements AuthorizationHeaderHa
    * provided.
    */
   public String httpUri() {
+    Map<String, String[]> params = inputs.bodyParameters();
     if (params.containsKey("dpop_htu")) {
       String value = params.get("dpop_htu")[0];
       if (value != null && !value.isEmpty()) {

--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/token/handler/tokenintrospection/io/TokenIntrospectionRequest.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/token/handler/tokenintrospection/io/TokenIntrospectionRequest.java
@@ -24,40 +24,32 @@ import org.idp.server.core.openid.oauth.type.oauth.Scopes;
 import org.idp.server.core.openid.token.AuthorizationHeaderHandlerable;
 import org.idp.server.core.openid.token.tokenintrospection.TokenIntrospectionRequestParameters;
 import org.idp.server.platform.http.BasicAuth;
+import org.idp.server.platform.http.HttpRequestInputs;
 import org.idp.server.platform.multi_tenancy.tenant.Tenant;
 
 public class TokenIntrospectionRequest implements AuthorizationHeaderHandlerable {
   Tenant tenant;
-  String authorizationHeaders;
-  Map<String, String[]> params;
-  String clientCert;
+  HttpRequestInputs inputs;
 
-  public TokenIntrospectionRequest(
-      Tenant tenant, String authorizationHeaders, Map<String, String[]> params) {
+  public TokenIntrospectionRequest(Tenant tenant, HttpRequestInputs inputs) {
     this.tenant = tenant;
-    this.authorizationHeaders = authorizationHeaders;
-    this.params = params;
-  }
-
-  public TokenIntrospectionRequest setClientCert(String clientCert) {
-    this.clientCert = clientCert;
-    return this;
+    this.inputs = inputs;
   }
 
   public String getAuthorizationHeaders() {
-    return authorizationHeaders;
+    return inputs.authorizationHeader();
   }
 
   public Map<String, String[]> getParams() {
-    return params;
+    return inputs.bodyParameters();
   }
 
   public String getClientCert() {
-    return clientCert;
+    return inputs.tlsClientCertPem();
   }
 
   public TokenIntrospectionRequestParameters toParameters() {
-    return new TokenIntrospectionRequestParameters(params);
+    return new TokenIntrospectionRequestParameters(inputs.bodyParameters());
   }
 
   public Tenant tenant() {
@@ -67,6 +59,7 @@ public class TokenIntrospectionRequest implements AuthorizationHeaderHandlerable
   public RequestedClientId clientId() {
     TokenIntrospectionRequestParameters parameters = toParameters();
 
+    String authorizationHeaders = inputs.authorizationHeader();
     if (isBasicAuth(authorizationHeaders)) {
       BasicAuth basicAuth = convertBasicAuth(authorizationHeaders);
       return new RequestedClientId(basicAuth.username());
@@ -80,6 +73,7 @@ public class TokenIntrospectionRequest implements AuthorizationHeaderHandlerable
   }
 
   public ClientSecretBasic clientSecretBasic() {
+    String authorizationHeaders = inputs.authorizationHeader();
     if (isBasicAuth(authorizationHeaders)) {
       return new ClientSecretBasic(convertBasicAuth(authorizationHeaders));
     }
@@ -88,18 +82,18 @@ public class TokenIntrospectionRequest implements AuthorizationHeaderHandlerable
 
   public String token() {
     if (hasToken()) {
-      return params.get("token")[0];
+      return inputs.bodyParameters().get("token")[0];
     }
     return "";
   }
 
   public boolean hasToken() {
-    return params.containsKey("token");
+    return inputs.bodyParameters().containsKey("token");
   }
 
   public Scopes scopes() {
     if (hasScope()) {
-      String scopes = params.get("scope")[0];
+      String scopes = inputs.bodyParameters().get("scope")[0];
 
       return new Scopes(scopes);
     }
@@ -107,14 +101,14 @@ public class TokenIntrospectionRequest implements AuthorizationHeaderHandlerable
   }
 
   public boolean hasScope() {
-    return params.containsKey("scope");
+    return inputs.bodyParameters().containsKey("scope");
   }
 
   public boolean hasClientCert() {
-    return params.containsKey("client_cert");
+    return inputs.bodyParameters().containsKey("client_cert");
   }
 
   public ClientCert toClientCert() {
-    return new ClientCert(clientCert);
+    return new ClientCert(inputs.tlsClientCertPem());
   }
 }

--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/token/handler/tokenrevocation/io/TokenRevocationRequest.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/token/handler/tokenrevocation/io/TokenRevocationRequest.java
@@ -23,37 +23,29 @@ import org.idp.server.core.openid.oauth.type.oauth.RequestedClientId;
 import org.idp.server.core.openid.token.AuthorizationHeaderHandlerable;
 import org.idp.server.core.openid.token.tokenrevocation.TokenRevocationRequestParameters;
 import org.idp.server.platform.http.BasicAuth;
+import org.idp.server.platform.http.HttpRequestInputs;
 import org.idp.server.platform.multi_tenancy.tenant.Tenant;
 
 public class TokenRevocationRequest implements AuthorizationHeaderHandlerable {
 
   Tenant tenant;
-  String authorizationHeaders;
-  Map<String, String[]> params;
-  String clientCert;
+  HttpRequestInputs inputs;
 
-  public TokenRevocationRequest(
-      Tenant tenant, String authorizationHeaders, Map<String, String[]> params) {
+  public TokenRevocationRequest(Tenant tenant, HttpRequestInputs inputs) {
     this.tenant = tenant;
-    this.authorizationHeaders = authorizationHeaders;
-    this.params = params;
-  }
-
-  public TokenRevocationRequest setClientCert(String clientCert) {
-    this.clientCert = clientCert;
-    return this;
+    this.inputs = inputs;
   }
 
   public String getAuthorizationHeaders() {
-    return authorizationHeaders;
+    return inputs.authorizationHeader();
   }
 
   public Map<String, String[]> getParams() {
-    return params;
+    return inputs.bodyParameters();
   }
 
   public String getClientCert() {
-    return clientCert;
+    return inputs.tlsClientCertPem();
   }
 
   public Tenant tenant() {
@@ -63,6 +55,7 @@ public class TokenRevocationRequest implements AuthorizationHeaderHandlerable {
   public RequestedClientId clientId() {
     TokenRevocationRequestParameters parameters = toParameters();
 
+    String authorizationHeaders = inputs.authorizationHeader();
     if (isBasicAuth(authorizationHeaders)) {
       BasicAuth basicAuth = convertBasicAuth(authorizationHeaders);
       return new RequestedClientId(basicAuth.username());
@@ -76,6 +69,7 @@ public class TokenRevocationRequest implements AuthorizationHeaderHandlerable {
   }
 
   public ClientSecretBasic clientSecretBasic() {
+    String authorizationHeaders = inputs.authorizationHeader();
     if (isBasicAuth(authorizationHeaders)) {
       return new ClientSecretBasic(convertBasicAuth(authorizationHeaders));
     }
@@ -83,10 +77,10 @@ public class TokenRevocationRequest implements AuthorizationHeaderHandlerable {
   }
 
   public TokenRevocationRequestParameters toParameters() {
-    return new TokenRevocationRequestParameters(params);
+    return new TokenRevocationRequestParameters(inputs.bodyParameters());
   }
 
   public ClientCert toClientCert() {
-    return new ClientCert(clientCert);
+    return new ClientCert(inputs.tlsClientCertPem());
   }
 }

--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/userinfo/UserinfoApi.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/userinfo/UserinfoApi.java
@@ -16,17 +16,13 @@
 
 package org.idp.server.core.openid.userinfo;
 
-import java.util.List;
 import org.idp.server.core.openid.userinfo.handler.io.UserinfoRequestResponse;
+import org.idp.server.platform.http.HttpRequestInputs;
 import org.idp.server.platform.multi_tenancy.tenant.TenantIdentifier;
 import org.idp.server.platform.type.RequestAttributes;
 
 public interface UserinfoApi {
 
   UserinfoRequestResponse request(
-      TenantIdentifier tenantId,
-      String authorizationHeader,
-      String clientCert,
-      List<String> dpopProofHeaders,
-      RequestAttributes requestAttributes);
+      TenantIdentifier tenantId, HttpRequestInputs inputs, RequestAttributes requestAttributes);
 }

--- a/libs/idp-server-core/src/main/java/org/idp/server/core/openid/userinfo/handler/io/UserinfoRequest.java
+++ b/libs/idp-server-core/src/main/java/org/idp/server/core/openid/userinfo/handler/io/UserinfoRequest.java
@@ -21,27 +21,24 @@ import org.idp.server.core.openid.oauth.dpop.DPoPProof;
 import org.idp.server.core.openid.oauth.type.mtls.ClientCert;
 import org.idp.server.core.openid.oauth.type.oauth.AccessTokenEntity;
 import org.idp.server.core.openid.token.AuthorizationHeaderHandlerable;
+import org.idp.server.platform.http.HttpRequestInputs;
 import org.idp.server.platform.multi_tenancy.tenant.Tenant;
 
 public class UserinfoRequest implements AuthorizationHeaderHandlerable {
   Tenant tenant;
-  String authorizationHeaders;
-  String clientCert;
-  List<String> dpopProofHeaders;
-  String httpMethod;
-  String httpUri;
+  HttpRequestInputs inputs;
 
-  public UserinfoRequest(Tenant tenant, String authorizationHeaders) {
+  public UserinfoRequest(Tenant tenant, HttpRequestInputs inputs) {
     this.tenant = tenant;
-    this.authorizationHeaders = authorizationHeaders;
+    this.inputs = inputs;
   }
 
   public String getAuthorizationHeaders() {
-    return authorizationHeaders;
+    return inputs.authorizationHeader();
   }
 
   public String getClientCert() {
-    return clientCert;
+    return inputs.tlsClientCertPem();
   }
 
   public Tenant tenant() {
@@ -49,50 +46,31 @@ public class UserinfoRequest implements AuthorizationHeaderHandlerable {
   }
 
   public AccessTokenEntity toAccessToken() {
-    return extractAccessToken(authorizationHeaders);
+    return extractAccessToken(inputs.authorizationHeader());
   }
 
   public ClientCert toClientCert() {
-    return new ClientCert(clientCert);
-  }
-
-  public UserinfoRequest setClientCert(String clientCert) {
-    this.clientCert = clientCert;
-    return this;
+    return new ClientCert(inputs.tlsClientCertPem());
   }
 
   public DPoPProof dpopProof() {
-    if (dpopProofHeaders == null || dpopProofHeaders.isEmpty()) {
+    List<String> dpopProofHeaders = dpopProofHeaders();
+    if (dpopProofHeaders.isEmpty()) {
       return new DPoPProof();
     }
     return new DPoPProof(dpopProofHeaders.get(0));
   }
 
   public List<String> dpopProofHeaders() {
-    return dpopProofHeaders;
-  }
-
-  public UserinfoRequest setDPoPProofHeaders(List<String> dpopProofHeaders) {
-    this.dpopProofHeaders = dpopProofHeaders;
-    return this;
+    return inputs.headerValues("DPoP");
   }
 
   public String httpMethod() {
-    return httpMethod != null ? httpMethod : "GET";
-  }
-
-  public UserinfoRequest setHttpMethod(String httpMethod) {
-    this.httpMethod = httpMethod;
-    return this;
+    return inputs.httpMethod() != null ? inputs.httpMethod() : "GET";
   }
 
   public String httpUri() {
-    return httpUri != null ? httpUri : "";
-  }
-
-  public UserinfoRequest setHttpUri(String httpUri) {
-    this.httpUri = httpUri;
-    return this;
+    return inputs.httpUri() != null ? inputs.httpUri() : "";
   }
 
   public boolean hasToken() {

--- a/libs/idp-server-platform/src/main/java/org/idp/server/platform/http/HttpRequestInputs.java
+++ b/libs/idp-server-platform/src/main/java/org/idp/server/platform/http/HttpRequestInputs.java
@@ -16,6 +16,7 @@
 
 package org.idp.server.platform.http;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -89,16 +90,44 @@ public record HttpRequestInputs(
   }
 
   private static Map<String, List<String>> normalizeHeaders(Map<String, List<String>> raw) {
-    Map<String, List<String>> normalized = new LinkedHashMap<>(raw.size());
+    Map<String, List<String>> merged = new LinkedHashMap<>(raw.size());
     for (Map.Entry<String, List<String>> entry : raw.entrySet()) {
       if (entry.getKey() == null) {
         continue;
       }
-      List<String> values = entry.getValue();
-      normalized.put(
-          entry.getKey().toLowerCase(Locale.ROOT),
-          values == null ? List.of() : Collections.unmodifiableList(values));
+      String key = entry.getKey().toLowerCase(Locale.ROOT);
+      List<String> values = merged.computeIfAbsent(key, k -> new ArrayList<>());
+      if (entry.getValue() != null) {
+        values.addAll(entry.getValue());
+      }
+    }
+    Map<String, List<String>> normalized = new LinkedHashMap<>(merged.size());
+    for (Map.Entry<String, List<String>> entry : merged.entrySet()) {
+      normalized.put(entry.getKey(), Collections.unmodifiableList(entry.getValue()));
     }
     return Collections.unmodifiableMap(normalized);
+  }
+
+  /**
+   * Masks credential-bearing values: the authorization header, all header values (cookies, DPoP
+   * proofs, ...) and the client certificate never appear in logs or exception messages. Only header
+   * / body parameter names are exposed.
+   */
+  @Override
+  public String toString() {
+    return "HttpRequestInputs{"
+        + "authorizationHeader="
+        + (authorizationHeader != null ? "[redacted]" : "null")
+        + ", bodyParameters="
+        + bodyParameters.keySet()
+        + ", headers="
+        + headers.keySet()
+        + ", tlsClientCertPem="
+        + (tlsClientCertPem != null ? "[redacted]" : "null")
+        + ", httpMethod="
+        + httpMethod
+        + ", httpUri="
+        + httpUri
+        + '}';
   }
 }

--- a/libs/idp-server-platform/src/main/java/org/idp/server/platform/http/HttpRequestInputs.java
+++ b/libs/idp-server-platform/src/main/java/org/idp/server/platform/http/HttpRequestInputs.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2025 Hirokazu Kobayashi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.idp.server.platform.http;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Bundles the HTTP-level input channels of a single request into one value object.
+ *
+ * <p>OAuth/OIDC endpoints (Token / PAR / Userinfo / Introspection / Revocation / CIBA) all consume
+ * the same HTTP-derived inputs — body parameters, headers, the TLS-layer client certificate and the
+ * HTTP method/URI. Historically each endpoint DTO re-declared these fields, so introducing a new
+ * header-based spec (e.g. RFC 9449 DPoP, OAuth-Client-Attestation) required touching the
+ * Controller, the API interface, the EntryService and every DTO. With this record the adapter layer
+ * captures the full HTTP surface once, and a DTO exposes a new channel by adding a single accessor.
+ *
+ * <p>This record intentionally holds only {@code String} / {@code Map} values. Wrapping into
+ * protocol value objects ({@code DPoPProof}, {@code ClientCert}, ...) is the consuming DTO's
+ * responsibility, which keeps the platform → core dependency direction intact.
+ *
+ * <p>Header names are case-insensitive (RFC 9110 Section 5.1); keys of {@code headers} are
+ * normalized to lower case and lookups accept any casing.
+ *
+ * @param authorizationHeader raw {@code Authorization} header value (Basic / Bearer / DPoP), {@code
+ *     null} when absent
+ * @param bodyParameters form-urlencoded body parameters, never {@code null} (normalized to an empty
+ *     map)
+ * @param headers all HTTP headers, keys lower-cased, repeated headers kept as multiple values
+ * @param tlsClientCertPem PEM client certificate captured at the TLS layer (mTLS), {@code null}
+ *     when absent
+ * @param httpMethod HTTP method of the request (e.g. {@code "POST"}), referenced by DPoP {@code
+ *     htm} verification
+ * @param httpUri client-facing request URL, referenced by DPoP {@code htu} verification
+ */
+public record HttpRequestInputs(
+    String authorizationHeader,
+    Map<String, String[]> bodyParameters,
+    Map<String, List<String>> headers,
+    String tlsClientCertPem,
+    String httpMethod,
+    String httpUri) {
+
+  public HttpRequestInputs {
+    bodyParameters = bodyParameters == null ? Map.of() : bodyParameters;
+    headers = headers == null ? Map.of() : normalizeHeaders(headers);
+  }
+
+  /**
+   * Returns the first value of the given header.
+   *
+   * @param name header name, any casing
+   */
+  public Optional<String> firstHeader(String name) {
+    List<String> values = headers.get(name.toLowerCase(Locale.ROOT));
+    return values == null || values.isEmpty() ? Optional.empty() : Optional.of(values.get(0));
+  }
+
+  /**
+   * Returns all values of the given header. Repeated headers (e.g. multiple DPoP headers, an RFC
+   * 9449 Section 4.3 violation) are preserved so validators can detect them.
+   *
+   * @param name header name, any casing
+   */
+  public List<String> headerValues(String name) {
+    return headers.getOrDefault(name.toLowerCase(Locale.ROOT), List.of());
+  }
+
+  public boolean hasHeader(String name) {
+    return !headerValues(name).isEmpty();
+  }
+
+  private static Map<String, List<String>> normalizeHeaders(Map<String, List<String>> raw) {
+    Map<String, List<String>> normalized = new LinkedHashMap<>(raw.size());
+    for (Map.Entry<String, List<String>> entry : raw.entrySet()) {
+      if (entry.getKey() == null) {
+        continue;
+      }
+      List<String> values = entry.getValue();
+      normalized.put(
+          entry.getKey().toLowerCase(Locale.ROOT),
+          values == null ? List.of() : Collections.unmodifiableList(values));
+    }
+    return Collections.unmodifiableMap(normalized);
+  }
+}

--- a/libs/idp-server-platform/src/test/java/org/idp/server/platform/http/HttpRequestInputsTest.java
+++ b/libs/idp-server-platform/src/test/java/org/idp/server/platform/http/HttpRequestInputsTest.java
@@ -80,4 +80,43 @@ class HttpRequestInputsTest {
 
     assertEquals(2, inputs.headerValues("dpop").size());
   }
+
+  @Test
+  @DisplayName("mixed-casing keys are merged, not silently overwritten")
+  void mixedCasingKeysAreMerged() {
+    HttpRequestInputs inputs =
+        new HttpRequestInputs(
+            null,
+            Map.of(),
+            Map.of("DPoP", List.of("proof-1"), "dpop", List.of("proof-2")),
+            null,
+            "POST",
+            "https://server.example.com/token");
+
+    assertEquals(2, inputs.headerValues("dpop").size());
+  }
+
+  @Test
+  @DisplayName("toString masks credential-bearing values, exposing only names")
+  void toStringMasksCredentials() {
+    HttpRequestInputs inputs =
+        new HttpRequestInputs(
+            "Bearer secret-access-token",
+            Map.of("client_secret", new String[] {"secret-client-secret"}),
+            Map.of("Cookie", List.of("SESSION=secret-session"), "DPoP", List.of("secret-proof")),
+            "-----BEGIN CERTIFICATE-----secret-cert",
+            "POST",
+            "https://server.example.com/token");
+
+    String value = inputs.toString();
+
+    assertFalse(value.contains("secret-access-token"));
+    assertFalse(value.contains("secret-client-secret"));
+    assertFalse(value.contains("secret-session"));
+    assertFalse(value.contains("secret-proof"));
+    assertFalse(value.contains("secret-cert"));
+    assertTrue(value.contains("client_secret"));
+    assertTrue(value.contains("cookie"));
+    assertTrue(value.contains("https://server.example.com/token"));
+  }
 }

--- a/libs/idp-server-platform/src/test/java/org/idp/server/platform/http/HttpRequestInputsTest.java
+++ b/libs/idp-server-platform/src/test/java/org/idp/server/platform/http/HttpRequestInputsTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2025 Hirokazu Kobayashi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.idp.server.platform.http;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class HttpRequestInputsTest {
+
+  @Test
+  @DisplayName("header keys are normalized to lower case and looked up case-insensitively")
+  void headerLookupIsCaseInsensitive() {
+    HttpRequestInputs inputs =
+        new HttpRequestInputs(
+            null,
+            Map.of(),
+            Map.of("DPoP", List.of("proof-jwt"), "X-Custom", List.of("a", "b")),
+            null,
+            "POST",
+            "https://server.example.com/token");
+
+    assertEquals(List.of("proof-jwt"), inputs.headerValues("dpop"));
+    assertEquals(List.of("proof-jwt"), inputs.headerValues("DPOP"));
+    assertEquals("proof-jwt", inputs.firstHeader("dPoP").orElseThrow());
+    assertEquals(List.of("a", "b"), inputs.headerValues("x-custom"));
+    assertTrue(inputs.hasHeader("X-CUSTOM"));
+  }
+
+  @Test
+  @DisplayName("absent headers yield empty list / empty optional, never null")
+  void absentHeaderIsEmpty() {
+    HttpRequestInputs inputs =
+        new HttpRequestInputs(null, Map.of(), Map.of(), null, "POST", "https://example.com");
+
+    assertEquals(List.of(), inputs.headerValues("dpop"));
+    assertTrue(inputs.firstHeader("dpop").isEmpty());
+    assertFalse(inputs.hasHeader("dpop"));
+  }
+
+  @Test
+  @DisplayName("null bodyParameters / headers are normalized to empty maps")
+  void nullCollectionsAreNormalized() {
+    HttpRequestInputs inputs = new HttpRequestInputs(null, null, null, null, "GET", "");
+
+    assertNotNull(inputs.bodyParameters());
+    assertTrue(inputs.bodyParameters().isEmpty());
+    assertNotNull(inputs.headers());
+    assertTrue(inputs.headers().isEmpty());
+  }
+
+  @Test
+  @DisplayName("repeated header values are preserved for multiple-header violation detection")
+  void repeatedHeaderValuesArePreserved() {
+    HttpRequestInputs inputs =
+        new HttpRequestInputs(
+            null,
+            Map.of(),
+            Map.of("DPoP", List.of("proof-1", "proof-2")),
+            null,
+            "POST",
+            "https://server.example.com/token");
+
+    assertEquals(2, inputs.headerValues("dpop").size());
+  }
+}

--- a/libs/idp-server-springboot-adapter/src/main/java/org/idp/server/adapters/springboot/ProtectedResourceApiFilter.java
+++ b/libs/idp-server-springboot-adapter/src/main/java/org/idp/server/adapters/springboot/ProtectedResourceApiFilter.java
@@ -35,6 +35,7 @@ import org.idp.server.core.openid.token.tokenintrospection.exception.TokenInvali
 import org.idp.server.platform.exception.NotFoundException;
 import org.idp.server.platform.exception.UnSupportedException;
 import org.idp.server.platform.exception.UnauthorizedException;
+import org.idp.server.platform.http.HttpRequestInputs;
 import org.idp.server.platform.log.LoggerWrapper;
 import org.idp.server.platform.multi_tenancy.tenant.TenantIdentifier;
 import org.idp.server.platform.type.Pairs;
@@ -59,23 +60,13 @@ public class ProtectedResourceApiFilter extends OncePerRequestFilter
   protected void doFilterInternal(
       HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) {
 
-    String authorization = request.getHeader("Authorization");
-    String clientCert = request.getHeader("x-ssl-cert");
-    List<String> dpopProofHeaders = extractDPoPProofHeaders(request);
-    String httpMethod = request.getMethod();
-    String httpUri = resolveRequestUrl(request);
-    String authScheme = resolveAuthScheme(authorization);
+    HttpRequestInputs inputs = transformInputs(null, request);
+    String authScheme = resolveAuthScheme(inputs.authorizationHeader());
 
     try {
       TenantIdentifier adminTenantIdentifier = extractTenantIdentifier(request);
       Pairs<User, OAuthToken> result =
-          userAuthenticationApi.authenticate(
-              adminTenantIdentifier,
-              authorization,
-              clientCert,
-              dpopProofHeaders,
-              httpMethod,
-              httpUri);
+          userAuthenticationApi.authenticate(adminTenantIdentifier, inputs);
       User user = result.getLeft();
       OAuthToken oAuthToken = result.getRight();
 

--- a/libs/idp-server-springboot-adapter/src/main/java/org/idp/server/adapters/springboot/application/restapi/ParameterTransformable.java
+++ b/libs/idp-server-springboot-adapter/src/main/java/org/idp/server/adapters/springboot/application/restapi/ParameterTransformable.java
@@ -19,10 +19,48 @@ package org.idp.server.adapters.springboot.application.restapi;
 import jakarta.servlet.http.HttpServletRequest;
 import java.util.*;
 import org.idp.server.core.openid.token.AuthorizationHeaderHandlerable;
+import org.idp.server.platform.http.HttpRequestInputs;
 import org.idp.server.platform.type.RequestAttributes;
 import org.springframework.util.MultiValueMap;
 
 public interface ParameterTransformable extends AuthorizationHeaderHandlerable {
+
+  /**
+   * Captures the full HTTP input surface of the current request as {@link HttpRequestInputs}.
+   *
+   * <p>All headers are captured (multi-valued, case-insensitive), so protocol layers can consume
+   * new header-based specs without additional Controller wiring. The {@code httpUri} is resolved
+   * via {@link #resolveRequestUrl(HttpServletRequest)} so DPoP {@code htu} verification sees the
+   * client-facing URL even behind a reverse proxy.
+   *
+   * @param body form-urlencoded body of the request, {@code null} for body-less requests (e.g. GET
+   *     userinfo)
+   * @param request current servlet request
+   */
+  default HttpRequestInputs transformInputs(
+      MultiValueMap<String, String> body, HttpServletRequest request) {
+    return new HttpRequestInputs(
+        request.getHeader("Authorization"),
+        transform(body),
+        extractHeaders(request),
+        request.getHeader("x-ssl-cert"),
+        request.getMethod(),
+        resolveRequestUrl(request));
+  }
+
+  /** Extracts all HTTP headers with their full value lists (repeated headers preserved). */
+  default Map<String, List<String>> extractHeaders(HttpServletRequest request) {
+    Map<String, List<String>> headers = new LinkedHashMap<>();
+    Enumeration<String> names = request.getHeaderNames();
+    if (names == null) {
+      return headers;
+    }
+    while (names.hasMoreElements()) {
+      String name = names.nextElement();
+      headers.put(name, Collections.list(request.getHeaders(name)));
+    }
+    return headers;
+  }
 
   default Map<String, String[]> transform(MultiValueMap<String, String> request) {
     HashMap<String, String[]> map = new HashMap<>();
@@ -117,20 +155,5 @@ public interface ParameterTransformable extends AuthorizationHeaderHandlerable {
     }
     int comma = headerValue.indexOf(',');
     return (comma >= 0 ? headerValue.substring(0, comma) : headerValue).trim();
-  }
-
-  /**
-   * Extracts all values of the {@code DPoP} HTTP header.
-   *
-   * <p>The single-header invariant (RFC 9449 Section 4.3 Check 1) is enforced in the core layer by
-   * {@code DPoPHeaderValidator}. This method only handles the HTTP transport concern of enumerating
-   * header values.
-   */
-  default List<String> extractDPoPProofHeaders(HttpServletRequest request) {
-    Enumeration<String> headers = request.getHeaders("DPoP");
-    if (headers == null) {
-      return List.of();
-    }
-    return Collections.list(headers);
   }
 }

--- a/libs/idp-server-springboot-adapter/src/main/java/org/idp/server/adapters/springboot/application/restapi/ciba/CibaV1Api.java
+++ b/libs/idp-server-springboot-adapter/src/main/java/org/idp/server/adapters/springboot/application/restapi/ciba/CibaV1Api.java
@@ -17,10 +17,10 @@
 package org.idp.server.adapters.springboot.application.restapi.ciba;
 
 import jakarta.servlet.http.HttpServletRequest;
-import java.util.Map;
 import org.idp.server.adapters.springboot.application.restapi.ParameterTransformable;
 import org.idp.server.core.extension.ciba.CibaFlowApi;
 import org.idp.server.core.extension.ciba.handler.io.CibaRequestResponse;
+import org.idp.server.platform.http.HttpRequestInputs;
 import org.idp.server.platform.multi_tenancy.tenant.TenantIdentifier;
 import org.idp.server.platform.type.RequestAttributes;
 import org.idp.server.usecases.IdpServerApplication;
@@ -44,17 +44,13 @@ public class CibaV1Api implements ParameterTransformable {
   @PostMapping(consumes = MediaType.APPLICATION_FORM_URLENCODED_VALUE)
   public ResponseEntity<?> request(
       @RequestBody(required = false) MultiValueMap<String, String> body,
-      @RequestHeader(required = false, value = "Authorization") String authorizationHeader,
-      @RequestHeader(required = false, value = "x-ssl-cert") String clientCert,
       @PathVariable("tenant-id") TenantIdentifier tenantIdentifier,
       HttpServletRequest httpServletRequest) {
 
-    Map<String, String[]> params = transform(body);
+    HttpRequestInputs inputs = transformInputs(body, httpServletRequest);
     RequestAttributes requestAttributes = transform(httpServletRequest);
 
-    CibaRequestResponse response =
-        cibaFlowApi.request(
-            tenantIdentifier, params, authorizationHeader, clientCert, requestAttributes);
+    CibaRequestResponse response = cibaFlowApi.request(tenantIdentifier, inputs, requestAttributes);
 
     HttpHeaders httpHeaders = new HttpHeaders();
     httpHeaders.add("Content-Type", response.contentTypeValue());

--- a/libs/idp-server-springboot-adapter/src/main/java/org/idp/server/adapters/springboot/application/restapi/oauth/OAuthV1Api.java
+++ b/libs/idp-server-springboot-adapter/src/main/java/org/idp/server/adapters/springboot/application/restapi/oauth/OAuthV1Api.java
@@ -18,7 +18,6 @@ package org.idp.server.adapters.springboot.application.restapi.oauth;
 
 import jakarta.servlet.http.HttpServletRequest;
 import java.io.IOException;
-import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import org.idp.server.adapters.springboot.application.restapi.ParameterTransformable;
@@ -35,6 +34,7 @@ import org.idp.server.core.openid.oauth.OAuthFlowApi;
 import org.idp.server.core.openid.oauth.io.*;
 import org.idp.server.core.openid.oauth.io.OAuthAuthenticationStatusResponse;
 import org.idp.server.core.openid.oauth.request.AuthorizationRequestIdentifier;
+import org.idp.server.platform.http.HttpRequestInputs;
 import org.idp.server.platform.json.JsonNodeWrapper;
 import org.idp.server.platform.multi_tenancy.tenant.TenantIdentifier;
 import org.idp.server.platform.type.RequestAttributes;
@@ -59,23 +59,14 @@ public class OAuthV1Api implements ParameterTransformable, SecurityHeaderConfigu
   @PostMapping(value = "/push", consumes = MediaType.APPLICATION_FORM_URLENCODED_VALUE)
   public ResponseEntity<?> push(
       @PathVariable("tenant-id") TenantIdentifier tenantIdentifier,
-      @RequestHeader(required = false, value = "Authorization") String authorizationHeader,
-      @RequestHeader(required = false, value = "x-ssl-cert") String clientCert,
       @RequestParam(required = false) MultiValueMap<String, String> request,
       HttpServletRequest httpServletRequest) {
 
-    List<String> dpopProofHeaders = extractDPoPProofHeaders(httpServletRequest);
-    Map<String, String[]> params = transform(request);
+    HttpRequestInputs inputs = transformInputs(request, httpServletRequest);
     RequestAttributes requestAttributes = transform(httpServletRequest);
 
     OAuthPushedRequestResponse response =
-        oAuthFlowApi.push(
-            tenantIdentifier,
-            params,
-            authorizationHeader,
-            clientCert,
-            dpopProofHeaders,
-            requestAttributes);
+        oAuthFlowApi.push(tenantIdentifier, inputs, requestAttributes);
 
     HttpHeaders httpHeaders = createSecurityHeaders();
     httpHeaders.setCacheControl("no-store, private");

--- a/libs/idp-server-springboot-adapter/src/main/java/org/idp/server/adapters/springboot/application/restapi/token/TokenV1Api.java
+++ b/libs/idp-server-springboot-adapter/src/main/java/org/idp/server/adapters/springboot/application/restapi/token/TokenV1Api.java
@@ -17,14 +17,13 @@
 package org.idp.server.adapters.springboot.application.restapi.token;
 
 import jakarta.servlet.http.HttpServletRequest;
-import java.util.List;
-import java.util.Map;
 import org.idp.server.adapters.springboot.application.restapi.ParameterTransformable;
 import org.idp.server.adapters.springboot.application.restapi.SecurityHeaderConfigurable;
 import org.idp.server.core.openid.token.TokenApi;
 import org.idp.server.core.openid.token.handler.token.io.TokenRequestResponse;
 import org.idp.server.core.openid.token.handler.tokenintrospection.io.TokenIntrospectionResponse;
 import org.idp.server.core.openid.token.handler.tokenrevocation.io.TokenRevocationResponse;
+import org.idp.server.platform.http.HttpRequestInputs;
 import org.idp.server.platform.multi_tenancy.tenant.TenantIdentifier;
 import org.idp.server.platform.type.RequestAttributes;
 import org.idp.server.usecases.IdpServerApplication;
@@ -48,23 +47,13 @@ public class TokenV1Api implements ParameterTransformable, SecurityHeaderConfigu
   @PostMapping(consumes = MediaType.APPLICATION_FORM_URLENCODED_VALUE)
   public ResponseEntity<?> request(
       @PathVariable("tenant-id") TenantIdentifier tenantIdentifier,
-      @RequestHeader(required = false, value = "Authorization") String authorizationHeader,
-      @RequestHeader(required = false, value = "x-ssl-cert") String clientCert,
       @RequestBody(required = false) MultiValueMap<String, String> body,
       HttpServletRequest httpServletRequest) {
 
-    List<String> dpopProofHeaders = extractDPoPProofHeaders(httpServletRequest);
-    Map<String, String[]> request = transform(body);
+    HttpRequestInputs inputs = transformInputs(body, httpServletRequest);
     RequestAttributes requestAttributes = transform(httpServletRequest);
 
-    TokenRequestResponse response =
-        tokenApi.request(
-            tenantIdentifier,
-            request,
-            authorizationHeader,
-            clientCert,
-            dpopProofHeaders,
-            requestAttributes);
+    TokenRequestResponse response = tokenApi.request(tenantIdentifier, inputs, requestAttributes);
 
     HttpHeaders httpHeaders = createSecurityHeaders();
     httpHeaders.setAll(response.responseHeaders());
@@ -75,17 +64,14 @@ public class TokenV1Api implements ParameterTransformable, SecurityHeaderConfigu
   @PostMapping(value = "/introspection", consumes = MediaType.APPLICATION_FORM_URLENCODED_VALUE)
   public ResponseEntity<?> inspect(
       @PathVariable("tenant-id") TenantIdentifier tenantIdentifier,
-      @RequestHeader(required = false, value = "Authorization") String authorizationHeader,
-      @RequestHeader(required = false, value = "x-ssl-cert") String clientCert,
       @RequestBody(required = false) MultiValueMap<String, String> body,
       HttpServletRequest httpServletRequest) {
 
-    Map<String, String[]> request = transform(body);
+    HttpRequestInputs inputs = transformInputs(body, httpServletRequest);
     RequestAttributes requestAttributes = transform(httpServletRequest);
 
     TokenIntrospectionResponse response =
-        tokenApi.inspect(
-            tenantIdentifier, request, authorizationHeader, clientCert, requestAttributes);
+        tokenApi.inspect(tenantIdentifier, inputs, requestAttributes);
 
     if (response.hasOAuthToken() && response.oAuthToken().isOneshotToken()) {
       tokenApi.deleteOneshotTokenIfNeeded(tenantIdentifier, response.oAuthToken());
@@ -102,12 +88,10 @@ public class TokenV1Api implements ParameterTransformable, SecurityHeaderConfigu
       consumes = MediaType.APPLICATION_FORM_URLENCODED_VALUE)
   public ResponseEntity<?> inspectWithVerification(
       @PathVariable("tenant-id") TenantIdentifier tenantIdentifier,
-      @RequestHeader(required = false, value = "Authorization") String authorizationHeader,
-      @RequestHeader(required = false, value = "x-ssl-cert") String clientCert,
       @RequestBody(required = false) MultiValueMap<String, String> body,
       HttpServletRequest httpServletRequest) {
 
-    Map<String, String[]> request = transform(body);
+    HttpRequestInputs inputs = transformInputs(body, httpServletRequest);
     RequestAttributes requestAttributes = transform(httpServletRequest);
 
     // RS forwarding pattern (RFC 8705 §3 + RFC 9449 §7): the Resource Server forwards the
@@ -116,8 +100,7 @@ public class TokenV1Api implements ParameterTransformable, SecurityHeaderConfigu
     // endpoint is intentionally not consumed — it would belong to the RS's own request to the AS,
     // not to the resource access being verified.
     TokenIntrospectionResponse response =
-        tokenApi.inspectWithVerification(
-            tenantIdentifier, request, authorizationHeader, clientCert, requestAttributes);
+        tokenApi.inspectWithVerification(tenantIdentifier, inputs, requestAttributes);
 
     if (response.hasOAuthToken() && response.oAuthToken().isOneshotToken()) {
       tokenApi.deleteOneshotTokenIfNeeded(tenantIdentifier, response.oAuthToken());
@@ -132,17 +115,13 @@ public class TokenV1Api implements ParameterTransformable, SecurityHeaderConfigu
   @PostMapping(value = "/revocation", consumes = MediaType.APPLICATION_FORM_URLENCODED_VALUE)
   public ResponseEntity<?> revoke(
       @PathVariable("tenant-id") TenantIdentifier tenantIdentifier,
-      @RequestHeader(required = false, value = "Authorization") String authorizationHeader,
-      @RequestHeader(required = false, value = "x-ssl-cert") String clientCert,
       @RequestBody(required = false) MultiValueMap<String, String> body,
       HttpServletRequest httpServletRequest) {
 
-    Map<String, String[]> request = transform(body);
+    HttpRequestInputs inputs = transformInputs(body, httpServletRequest);
     RequestAttributes requestAttributes = transform(httpServletRequest);
 
-    TokenRevocationResponse response =
-        tokenApi.revoke(
-            tenantIdentifier, request, authorizationHeader, clientCert, requestAttributes);
+    TokenRevocationResponse response = tokenApi.revoke(tenantIdentifier, inputs, requestAttributes);
 
     HttpHeaders httpHeaders = createSecurityHeaders();
     httpHeaders.setAll(response.responseHeaders());

--- a/libs/idp-server-springboot-adapter/src/main/java/org/idp/server/adapters/springboot/application/restapi/userinfo/UserinfoV1Api.java
+++ b/libs/idp-server-springboot-adapter/src/main/java/org/idp/server/adapters/springboot/application/restapi/userinfo/UserinfoV1Api.java
@@ -17,11 +17,11 @@
 package org.idp.server.adapters.springboot.application.restapi.userinfo;
 
 import jakarta.servlet.http.HttpServletRequest;
-import java.util.List;
 import org.idp.server.adapters.springboot.application.restapi.ParameterTransformable;
 import org.idp.server.adapters.springboot.application.restapi.SecurityHeaderConfigurable;
 import org.idp.server.core.openid.userinfo.UserinfoApi;
 import org.idp.server.core.openid.userinfo.handler.io.UserinfoRequestResponse;
+import org.idp.server.platform.http.HttpRequestInputs;
 import org.idp.server.platform.multi_tenancy.tenant.TenantIdentifier;
 import org.idp.server.platform.type.RequestAttributes;
 import org.idp.server.usecases.IdpServerApplication;
@@ -43,46 +43,36 @@ public class UserinfoV1Api implements ParameterTransformable, SecurityHeaderConf
 
   @GetMapping
   public ResponseEntity<?> get(
-      @RequestHeader(required = false, value = "Authorization") String authorizationHeader,
-      @RequestHeader(required = false, value = "x-ssl-cert") String clientCert,
-      @PathVariable("tenant-id") TenantIdentifier tenantId,
-      HttpServletRequest httpServletRequest) {
+      @PathVariable("tenant-id") TenantIdentifier tenantId, HttpServletRequest httpServletRequest) {
 
-    List<String> dpopProofHeaders = extractDPoPProofHeaders(httpServletRequest);
+    HttpRequestInputs inputs = transformInputs(null, httpServletRequest);
     RequestAttributes requestAttributes = transform(httpServletRequest);
 
-    UserinfoRequestResponse response =
-        userinfoApi.request(
-            tenantId, authorizationHeader, clientCert, dpopProofHeaders, requestAttributes);
+    UserinfoRequestResponse response = userinfoApi.request(tenantId, inputs, requestAttributes);
 
     HttpHeaders httpHeaders = createSecurityHeaders();
     httpHeaders.setCacheControl("no-store, private");
     httpHeaders.setContentType(MediaType.APPLICATION_JSON);
     applyWwwAuthenticateIfUnauthorized(
-        httpHeaders, response.statusCode(), response.response(), authorizationHeader);
+        httpHeaders, response.statusCode(), response.response(), inputs.authorizationHeader());
     return new ResponseEntity<>(
         response.response(), httpHeaders, HttpStatus.valueOf(response.statusCode()));
   }
 
   @PostMapping
   public ResponseEntity<?> post(
-      @RequestHeader(required = false, value = "Authorization") String authorizationHeader,
-      @RequestHeader(required = false, value = "x-ssl-cert") String clientCert,
-      @PathVariable("tenant-id") TenantIdentifier tenantId,
-      HttpServletRequest httpServletRequest) {
+      @PathVariable("tenant-id") TenantIdentifier tenantId, HttpServletRequest httpServletRequest) {
 
-    List<String> dpopProofHeaders = extractDPoPProofHeaders(httpServletRequest);
+    HttpRequestInputs inputs = transformInputs(null, httpServletRequest);
     RequestAttributes requestAttributes = transform(httpServletRequest);
 
-    UserinfoRequestResponse response =
-        userinfoApi.request(
-            tenantId, authorizationHeader, clientCert, dpopProofHeaders, requestAttributes);
+    UserinfoRequestResponse response = userinfoApi.request(tenantId, inputs, requestAttributes);
 
     HttpHeaders httpHeaders = createSecurityHeaders();
     httpHeaders.setCacheControl("no-store, private");
     httpHeaders.setContentType(MediaType.APPLICATION_JSON);
     applyWwwAuthenticateIfUnauthorized(
-        httpHeaders, response.statusCode(), response.response(), authorizationHeader);
+        httpHeaders, response.statusCode(), response.response(), inputs.authorizationHeader());
     return new ResponseEntity<>(
         response.response(), httpHeaders, HttpStatus.valueOf(response.statusCode()));
   }

--- a/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/application/enduser/CibaFlowEntryService.java
+++ b/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/application/enduser/CibaFlowEntryService.java
@@ -36,6 +36,7 @@ import org.idp.server.core.openid.identity.hint.UserHintResolvers;
 import org.idp.server.core.openid.identity.repository.UserQueryRepository;
 import org.idp.server.core.openid.oauth.type.StandardAuthFlow;
 import org.idp.server.platform.datasource.Transaction;
+import org.idp.server.platform.http.HttpRequestInputs;
 import org.idp.server.platform.log.LoggerWrapper;
 import org.idp.server.platform.multi_tenancy.tenant.Tenant;
 import org.idp.server.platform.multi_tenancy.tenant.TenantIdentifier;
@@ -88,14 +89,11 @@ public class CibaFlowEntryService implements CibaFlowApi {
 
   public CibaRequestResponse request(
       TenantIdentifier tenantIdentifier,
-      Map<String, String[]> params,
-      String authorizationHeader,
-      String clientCert,
+      HttpRequestInputs inputs,
       RequestAttributes requestAttributes) {
 
     Tenant tenant = tenantQueryRepository.get(tenantIdentifier);
-    CibaRequest cibaRequest = new CibaRequest(tenant, authorizationHeader, params);
-    cibaRequest.setClientCert(clientCert);
+    CibaRequest cibaRequest = new CibaRequest(tenant, inputs);
 
     CibaProtocol cibaProtocol = cibaProtocols.get(tenant.authorizationProvider());
     CibaIssueResponse issueResponse =

--- a/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/application/enduser/OAuthFlowEntryService.java
+++ b/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/application/enduser/OAuthFlowEntryService.java
@@ -68,6 +68,7 @@ import org.idp.server.core.openid.session.OPSession;
 import org.idp.server.core.openid.session.SessionCookieDelegate;
 import org.idp.server.core.openid.session.SessionValidationResult;
 import org.idp.server.platform.datasource.Transaction;
+import org.idp.server.platform.http.HttpRequestInputs;
 import org.idp.server.platform.log.LoggerWrapper;
 import org.idp.server.platform.multi_tenancy.tenant.Tenant;
 import org.idp.server.platform.multi_tenancy.tenant.TenantIdentifier;
@@ -137,17 +138,10 @@ public class OAuthFlowEntryService implements OAuthFlowApi, OAuthUserDelegate {
   @Override
   public OAuthPushedRequestResponse push(
       TenantIdentifier tenantIdentifier,
-      Map<String, String[]> params,
-      String authorizationHeader,
-      String clientCert,
-      List<String> dpopProofHeaders,
+      HttpRequestInputs inputs,
       RequestAttributes requestAttributes) {
     Tenant tenant = tenantQueryRepository.get(tenantIdentifier);
-    OAuthPushedRequest pushedRequest = new OAuthPushedRequest(tenant, authorizationHeader, params);
-    pushedRequest.setClientCert(clientCert);
-    pushedRequest.setDPoPProofHeaders(dpopProofHeaders);
-    pushedRequest.setHttpMethod(requestAttributes.optValueAsString("action", "POST"));
-    pushedRequest.setHttpUri(requestAttributes.optValueAsString("request_url", ""));
+    OAuthPushedRequest pushedRequest = new OAuthPushedRequest(tenant, inputs);
 
     OAuthProtocol oAuthProtocol = oAuthProtocols.get(tenant.authorizationProvider());
 

--- a/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/application/enduser/TokenEntryService.java
+++ b/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/application/enduser/TokenEntryService.java
@@ -16,8 +16,6 @@
 
 package org.idp.server.usecases.application.enduser;
 
-import java.util.List;
-import java.util.Map;
 import org.idp.server.core.openid.identity.User;
 import org.idp.server.core.openid.identity.UserIdentifier;
 import org.idp.server.core.openid.identity.UserStatus;
@@ -37,6 +35,7 @@ import org.idp.server.core.openid.token.handler.tokenintrospection.io.TokenIntro
 import org.idp.server.core.openid.token.handler.tokenrevocation.io.TokenRevocationRequest;
 import org.idp.server.core.openid.token.handler.tokenrevocation.io.TokenRevocationResponse;
 import org.idp.server.platform.datasource.Transaction;
+import org.idp.server.platform.http.HttpRequestInputs;
 import org.idp.server.platform.multi_tenancy.tenant.Tenant;
 import org.idp.server.platform.multi_tenancy.tenant.TenantIdentifier;
 import org.idp.server.platform.multi_tenancy.tenant.TenantQueryRepository;
@@ -63,18 +62,11 @@ public class TokenEntryService implements TokenApi, TokenUserFindingDelegate {
 
   public TokenRequestResponse request(
       TenantIdentifier tenantIdentifier,
-      Map<String, String[]> params,
-      String authorizationHeader,
-      String clientCert,
-      List<String> dpopProofHeaders,
+      HttpRequestInputs inputs,
       RequestAttributes requestAttributes) {
 
     Tenant tenant = tenantQueryRepository.get(tenantIdentifier);
-    TokenRequest tokenRequest = new TokenRequest(tenant, authorizationHeader, params);
-    tokenRequest.setClientCert(clientCert);
-    tokenRequest.setDPoPProofHeaders(dpopProofHeaders);
-    tokenRequest.setHttpMethod(requestAttributes.optValueAsString("action", "POST"));
-    tokenRequest.setHttpUri(requestAttributes.optValueAsString("request_url", ""));
+    TokenRequest tokenRequest = new TokenRequest(tenant, inputs);
 
     TokenProtocol tokenProtocol = tokenProtocols.get(tenant.authorizationProvider());
 
@@ -94,15 +86,12 @@ public class TokenEntryService implements TokenApi, TokenUserFindingDelegate {
   @Transaction(readOnly = true)
   public TokenIntrospectionResponse inspect(
       TenantIdentifier tenantIdentifier,
-      Map<String, String[]> params,
-      String authorizationHeader,
-      String clientCert,
+      HttpRequestInputs inputs,
       RequestAttributes requestAttributes) {
 
     Tenant tenant = tenantQueryRepository.get(tenantIdentifier);
     TokenIntrospectionRequest tokenIntrospectionRequest =
-        new TokenIntrospectionRequest(tenant, authorizationHeader, params);
-    tokenIntrospectionRequest.setClientCert(clientCert);
+        new TokenIntrospectionRequest(tenant, inputs);
 
     TokenProtocol tokenProtocol = tokenProtocols.get(tenant.authorizationProvider());
 
@@ -119,17 +108,14 @@ public class TokenEntryService implements TokenApi, TokenUserFindingDelegate {
   @Transaction(readOnly = true)
   public TokenIntrospectionResponse inspectWithVerification(
       TenantIdentifier tenantIdentifier,
-      Map<String, String[]> params,
-      String authorizationHeader,
-      String clientCert,
+      HttpRequestInputs inputs,
       RequestAttributes requestAttributes) {
 
     Tenant tenant = tenantQueryRepository.get(tenantIdentifier);
-    TokenIntrospectionExtensionRequest tokenIntrospectionRequest =
-        new TokenIntrospectionExtensionRequest(tenant, authorizationHeader, params);
     // RS forwarding pattern: dpop_proof / dpop_htm / dpop_htu / client_cert はすべて body 渡し
     // (TokenIntrospectionExtensionRequest 内で参照される)。x-ssl-cert は RS 自身の AS 認証用 mTLS。
-    tokenIntrospectionRequest.setClientCert(clientCert);
+    TokenIntrospectionExtensionRequest tokenIntrospectionRequest =
+        new TokenIntrospectionExtensionRequest(tenant, inputs);
 
     TokenProtocol tokenProtocol = tokenProtocols.get(tenant.authorizationProvider());
 
@@ -156,15 +142,11 @@ public class TokenEntryService implements TokenApi, TokenUserFindingDelegate {
 
   public TokenRevocationResponse revoke(
       TenantIdentifier tenantIdentifier,
-      Map<String, String[]> request,
-      String authorizationHeader,
-      String clientCert,
+      HttpRequestInputs inputs,
       RequestAttributes requestAttributes) {
 
     Tenant tenant = tenantQueryRepository.get(tenantIdentifier);
-    TokenRevocationRequest revocationRequest =
-        new TokenRevocationRequest(tenant, authorizationHeader, request);
-    revocationRequest.setClientCert(clientCert);
+    TokenRevocationRequest revocationRequest = new TokenRevocationRequest(tenant, inputs);
 
     TokenProtocol tokenProtocol = tokenProtocols.get(tenant.authorizationProvider());
 

--- a/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/application/enduser/UserinfoEntryService.java
+++ b/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/application/enduser/UserinfoEntryService.java
@@ -16,7 +16,6 @@
 
 package org.idp.server.usecases.application.enduser;
 
-import java.util.List;
 import org.idp.server.core.openid.identity.User;
 import org.idp.server.core.openid.identity.UserIdentifier;
 import org.idp.server.core.openid.identity.repository.UserQueryRepository;
@@ -29,6 +28,7 @@ import org.idp.server.core.openid.userinfo.handler.UserinfoDelegate;
 import org.idp.server.core.openid.userinfo.handler.io.UserinfoRequest;
 import org.idp.server.core.openid.userinfo.handler.io.UserinfoRequestResponse;
 import org.idp.server.platform.datasource.Transaction;
+import org.idp.server.platform.http.HttpRequestInputs;
 import org.idp.server.platform.multi_tenancy.tenant.Tenant;
 import org.idp.server.platform.multi_tenancy.tenant.TenantIdentifier;
 import org.idp.server.platform.multi_tenancy.tenant.TenantQueryRepository;
@@ -62,17 +62,11 @@ public class UserinfoEntryService implements UserinfoApi, UserinfoDelegate {
 
   public UserinfoRequestResponse request(
       TenantIdentifier tenantIdentifier,
-      String authorizationHeader,
-      String clientCert,
-      List<String> dpopProofHeaders,
+      HttpRequestInputs inputs,
       RequestAttributes requestAttributes) {
 
     Tenant tenant = tenantQueryRepository.get(tenantIdentifier);
-    UserinfoRequest userinfoRequest = new UserinfoRequest(tenant, authorizationHeader);
-    userinfoRequest.setClientCert(clientCert);
-    userinfoRequest.setDPoPProofHeaders(dpopProofHeaders);
-    userinfoRequest.setHttpMethod(requestAttributes.optValueAsString("action", "GET"));
-    userinfoRequest.setHttpUri(requestAttributes.optValueAsString("request_url", ""));
+    UserinfoRequest userinfoRequest = new UserinfoRequest(tenant, inputs);
 
     UserinfoProtocol userinfoProtocol = userinfoProtocols.get(tenant.authorizationProvider());
 

--- a/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/application/system/UserAuthenticationEntryService.java
+++ b/libs/idp-server-use-cases/src/main/java/org/idp/server/usecases/application/system/UserAuthenticationEntryService.java
@@ -31,6 +31,7 @@ import org.idp.server.core.openid.token.handler.tokenintrospection.io.TokenIntro
 import org.idp.server.core.openid.token.tokenintrospection.verifier.DPoPBindingVerifier;
 import org.idp.server.platform.datasource.Transaction;
 import org.idp.server.platform.exception.UnauthorizedException;
+import org.idp.server.platform.http.HttpRequestInputs;
 import org.idp.server.platform.multi_tenancy.organization.OrganizationRepository;
 import org.idp.server.platform.multi_tenancy.tenant.Tenant;
 import org.idp.server.platform.multi_tenancy.tenant.TenantIdentifier;
@@ -58,18 +59,15 @@ public class UserAuthenticationEntryService implements UserAuthenticationApi {
 
   @Transaction(readOnly = true)
   public Pairs<User, OAuthToken> authenticate(
-      TenantIdentifier tenantIdentifier,
-      String authorizationHeader,
-      String clientCert,
-      List<String> dpopProofHeaders,
-      String httpMethod,
-      String httpUri) {
+      TenantIdentifier tenantIdentifier, HttpRequestInputs inputs) {
+    List<String> dpopProofHeaders = inputs.headerValues("DPoP");
     new DPoPHeaderValidator(dpopProofHeaders).validate();
 
     Tenant tenant = tenantQueryRepository.get(tenantIdentifier);
 
     TokenIntrospectionInternalRequest tokenIntrospectionInternalRequest =
-        new TokenIntrospectionInternalRequest(tenant, authorizationHeader, clientCert);
+        new TokenIntrospectionInternalRequest(
+            tenant, inputs.authorizationHeader(), inputs.tlsClientCertPem());
 
     TokenProtocol tokenProtocol = tokenProtocols.get(tenant.authorizationProvider());
 
@@ -82,10 +80,10 @@ public class UserAuthenticationEntryService implements UserAuthenticationApi {
 
     OAuthToken oAuthToken = introspectionResponse.oAuthToken();
 
-    String dpopProof =
-        (dpopProofHeaders == null || dpopProofHeaders.isEmpty()) ? null : dpopProofHeaders.get(0);
+    String dpopProof = dpopProofHeaders.isEmpty() ? null : dpopProofHeaders.get(0);
     DPoPBindingVerifier dpopBindingVerifier = new DPoPBindingVerifier();
-    dpopBindingVerifier.verify(new DPoPProof(dpopProof), httpMethod, httpUri, oAuthToken);
+    dpopBindingVerifier.verify(
+        new DPoPProof(dpopProof), inputs.httpMethod(), inputs.httpUri(), oAuthToken);
 
     if (introspectionResponse.isClientCredentialsGrant()) {
       return Pairs.of(User.notFound(), oAuthToken);


### PR DESCRIPTION
## Summary

#1527 の Phase 2 (`HttpRequestInputs`) を main の上に新規実装。

PR #1528 の PoC (Phase 2 コミット) は `@Deprecated` setter による段階移行方式だったが、本 PR は最初から canonical 形（Controller → `HttpRequestInputs` 直渡し）で全エンドポイントを一括移行し、移行残・deprecated API を残さない。

## 変更内容

### 新規（platform 層）
- `HttpRequestInputs` record — authorization header / body params / **全 HTTP ヘッダ**（小文字正規化・複数値保持, RFC 9110）/ TLS クライアント証明書 / httpMethod / httpUri を 1 つに集約。ユニットテスト付き
- `ParameterTransformable.transformInputs()` — Controller で全ヘッダを一括キャプチャ（httpUri は `resolveRequestUrl` 経由なので DPoP htu のリバースプロキシ対応もそのまま）

### 移行（全エンドポイント一括）
| 層 | 対象 |
|----|------|
| DTO 7 種 | `TokenRequest` / `OAuthPushedRequest` / `UserinfoRequest` / `TokenIntrospectionRequest` / `TokenIntrospectionExtensionRequest` / `TokenRevocationRequest` / `CibaRequest` |
| API interface 5 種 | `TokenApi`(4メソッド) / `OAuthFlowApi.push` / `UserinfoApi` / `CibaFlowApi` / `UserAuthenticationApi` |
| EntryService 5 種 | Token / OAuthFlow(push) / Userinfo / CibaFlow / UserAuthentication |
| Adapter | Controller 4 種 + `ProtectedResourceApiFilter` |

- DTO の公開アクセサ名は維持 → **Handler / Verifier 層は無変更**
- `RequestAttributes` の `"action"` / `"request_url"` キー経由で httpMethod / httpUri を運んでいた裏ルートを廃止（Controller から直接渡す）
- `extractDPoPProofHeaders` は利用者ゼロになったため削除
- introspection-extensions の body 渡し DPoP（RS forwarding パターン）は仕様のため維持

## 効果

新ヘッダ系仕様（DPoP nonce / OAuth-Client-Attestation 等）の追加コストが「Controller / API interface / EntryService / DTO の約 24 ファイル」→「**DTO にアクセサ 1 個**」に減る。差分は 25 ファイルで正味 -180 行（重複 plumbing の削減分）。

## 動作確認

- ✅ 全モジュール compile + spotless
- ✅ ユニットテスト全緑（新規 `HttpRequestInputsTest` 4 件含む）
- ✅ Docker 再ビルド + 実機起動確認
- ✅ E2E フルスイート **2,052 件全緑**（33 ignored）
  - 並列実行時はリードレプリカのラグで散発 fail するため直列実行で確認

## 関連

- Closes #1752（本 PR の対応 issue）
- refs #1527（親 issue の Phase 2。他 Phase が残るため close しない）
- PR #1528（PoC。本 PR は同 Phase の 0 からの再実装）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
